### PR TITLE
fix(team): prevent double [1m] suffix on model string during re-launch

### DIFF
--- a/src/renderer/components/team/dialogs/LaunchTeamDialog.tsx
+++ b/src/renderer/components/team/dialogs/LaunchTeamDialog.tsx
@@ -575,6 +575,7 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
         multimodelEnabled,
         storedProviderId,
         storedEffort: storedEffort === null ? 'medium' : storedEffort,
+        storedLimitContext: localStorage.getItem('team:lastLimitContext') === 'true',
         getStoredModel: getStoredTeamModel,
       });
       setSavedLaunchProviderId(savedProviderId);
@@ -590,10 +591,7 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
       setSelectedProviderIdRaw(launchPrefill.providerId);
       setSelectedModelRaw(launchPrefill.model);
       setSelectedEffortRaw(launchPrefill.effort);
-      setLimitContextRaw(
-        savedRequest?.limitContext === true ||
-          localStorage.getItem('team:lastLimitContext') === 'true'
-      );
+      setLimitContextRaw(launchPrefill.limitContext);
       setSkipPermissionsRaw(
         savedRequest?.skipPermissions ??
           localStorage.getItem('team:lastSkipPermissions') !== 'false'

--- a/src/renderer/components/team/dialogs/TeamModelSelector.tsx
+++ b/src/renderer/components/team/dialogs/TeamModelSelector.tsx
@@ -99,7 +99,9 @@ export function computeEffectiveTeamModel(
   limitContext: boolean,
   providerId: 'anthropic' | 'codex' | 'gemini' = 'anthropic'
 ): string | undefined {
-  const base = selectedModel || undefined;
+  const raw = selectedModel || undefined;
+  // Strip any existing [1m] suffix to avoid double-appending (e.g. 'opus[1m]' → 'opus')
+  const base = raw?.replace(/\[1m\]$/, '') || undefined;
   if (providerId !== 'anthropic') return base;
   if (limitContext) return base;
   if (base === 'haiku') return base;

--- a/src/renderer/components/team/dialogs/TeamModelSelector.tsx
+++ b/src/renderer/components/team/dialogs/TeamModelSelector.tsx
@@ -16,6 +16,7 @@ import {
   GEMINI_UI_DISABLED_REASON,
   isGeminiUiFrozen,
 } from '@renderer/utils/geminiUiFreeze';
+import { stripTrailingOneMillionSuffixes } from '@renderer/utils/teamModelContext';
 import {
   doesTeamModelCarryProviderBrand,
   getProviderScopedTeamModelLabel,
@@ -99,9 +100,7 @@ export function computeEffectiveTeamModel(
   limitContext: boolean,
   providerId: 'anthropic' | 'codex' | 'gemini' = 'anthropic'
 ): string | undefined {
-  const raw = selectedModel || undefined;
-  // Strip any existing [1m] suffix to avoid double-appending (e.g. 'opus[1m]' → 'opus')
-  const base = raw?.replace(/\[1m\]$/, '') || undefined;
+  const base = stripTrailingOneMillionSuffixes(selectedModel);
   if (providerId !== 'anthropic') return base;
   if (limitContext) return base;
   if (base === 'haiku') return base;

--- a/src/renderer/components/team/dialogs/launchDialogPrefill.ts
+++ b/src/renderer/components/team/dialogs/launchDialogPrefill.ts
@@ -32,7 +32,8 @@ function normalizeModelCandidate(model: string | undefined): string {
   if (!trimmed || trimmed === 'default' || trimmed === '__default__') {
     return '';
   }
-  return trimmed;
+  // Strip [1m] suffix — the UI stores base model names; computeEffectiveTeamModel adds it back
+  return trimmed.replace(/\[1m\]$/, '');
 }
 
 function canReuseModelForSelectedProvider(

--- a/src/renderer/components/team/dialogs/launchDialogPrefill.ts
+++ b/src/renderer/components/team/dialogs/launchDialogPrefill.ts
@@ -1,4 +1,5 @@
 import { normalizeCreateLaunchProviderForUi } from '@renderer/utils/geminiUiFreeze';
+import { stripTrailingOneMillionSuffixes } from '@renderer/utils/teamModelContext';
 import { normalizeTeamModelForUi } from '@renderer/utils/teamModelAvailability';
 import { isLeadMember } from '@shared/utils/leadDetection';
 import { normalizeOptionalTeamProviderId } from '@shared/utils/teamProvider';
@@ -9,6 +10,7 @@ interface PreviousLaunchParamsLike {
   providerId?: TeamProviderId;
   model?: string;
   effort?: string;
+  limitContext?: boolean;
 }
 
 interface LaunchDialogPrefillInput {
@@ -18,6 +20,7 @@ interface LaunchDialogPrefillInput {
   multimodelEnabled: boolean;
   storedProviderId: TeamProviderId;
   storedEffort: string;
+  storedLimitContext: boolean;
   getStoredModel: (providerId: TeamProviderId) => string;
 }
 
@@ -25,6 +28,7 @@ interface LaunchDialogPrefillResult {
   providerId: TeamProviderId;
   model: string;
   effort: string;
+  limitContext: boolean;
 }
 
 function normalizeModelCandidate(model: string | undefined): string {
@@ -32,8 +36,7 @@ function normalizeModelCandidate(model: string | undefined): string {
   if (!trimmed || trimmed === 'default' || trimmed === '__default__') {
     return '';
   }
-  // Strip [1m] suffix — the UI stores base model names; computeEffectiveTeamModel adds it back
-  return trimmed.replace(/\[1m\]$/, '');
+  return stripTrailingOneMillionSuffixes(trimmed) ?? '';
 }
 
 function canReuseModelForSelectedProvider(
@@ -53,6 +56,7 @@ export function resolveLaunchDialogPrefill({
   multimodelEnabled,
   storedProviderId,
   storedEffort,
+  storedLimitContext,
   getStoredModel,
 }: LaunchDialogPrefillInput): LaunchDialogPrefillResult {
   const currentLead = members.find((member) => isLeadMember(member));
@@ -89,6 +93,8 @@ export function resolveLaunchDialogPrefill({
 
   const effort =
     currentLead?.effort ?? savedRequest?.effort ?? previousLaunchParams?.effort ?? storedEffort;
+  const limitContext =
+    previousLaunchParams?.limitContext ?? savedRequest?.limitContext ?? storedLimitContext;
 
   return {
     providerId,
@@ -96,5 +102,6 @@ export function resolveLaunchDialogPrefill({
       ? normalizeTeamModelForUi(providerId, matchingModel)
       : getStoredModel(providerId),
     effort,
+    limitContext,
   };
 }

--- a/src/renderer/store/slices/teamSlice.ts
+++ b/src/renderer/store/slices/teamSlice.ts
@@ -6,6 +6,7 @@ import {
   canDisplayTaskChangesForOptions,
   type TaskChangeRequestOptions,
 } from '@renderer/utils/taskChangeRequest';
+import { stripTrailingOneMillionSuffixes } from '@renderer/utils/teamModelContext';
 import { IpcError, unwrapIpc } from '@renderer/utils/unwrapIpc';
 import { stripAgentBlocks } from '@shared/constants/agentBlocks';
 import { createLogger } from '@shared/utils/logger';
@@ -1220,8 +1221,7 @@ function saveLaunchParams(teamName: string, params: TeamLaunchParams): void {
  * E.g. 'opus[1m]' → 'opus', 'sonnet' → 'sonnet', undefined → undefined.
  */
 function extractBaseModel(raw?: string): string | undefined {
-  if (!raw) return undefined;
-  return raw.replace(/\[1m\]$/, '') || undefined;
+  return stripTrailingOneMillionSuffixes(raw);
 }
 
 const TOOL_APPROVAL_PREFIX = 'team:toolApprovalSettings:';

--- a/src/renderer/utils/teamModelContext.ts
+++ b/src/renderer/utils/teamModelContext.ts
@@ -1,0 +1,8 @@
+export function stripTrailingOneMillionSuffixes(model: string | undefined): string | undefined {
+  const trimmed = model?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  return trimmed.replace(/(?:\[1m\])+$/, '') || undefined;
+}

--- a/test/renderer/components/team/TeamModelSelector.test.ts
+++ b/test/renderer/components/team/TeamModelSelector.test.ts
@@ -49,6 +49,7 @@ describe('computeEffectiveTeamModel', () => {
   it('does not double-append [1m] when input already has it', () => {
     expect(computeEffectiveTeamModel('opus[1m]', false, 'anthropic')).toBe('opus[1m]');
     expect(computeEffectiveTeamModel('sonnet[1m]', false, 'anthropic')).toBe('sonnet[1m]');
+    expect(computeEffectiveTeamModel('opus[1m][1m]', false, 'anthropic')).toBe('opus[1m]');
   });
 
   it('defaults to opus[1m] when no model selected', () => {
@@ -58,6 +59,7 @@ describe('computeEffectiveTeamModel', () => {
   it('returns base model without [1m] when limitContext is true', () => {
     expect(computeEffectiveTeamModel('opus', true, 'anthropic')).toBe('opus');
     expect(computeEffectiveTeamModel('opus[1m]', true, 'anthropic')).toBe('opus');
+    expect(computeEffectiveTeamModel('opus[1m][1m]', true, 'anthropic')).toBe('opus');
   });
 
   it('returns haiku as-is', () => {

--- a/test/renderer/components/team/TeamModelSelector.test.ts
+++ b/test/renderer/components/team/TeamModelSelector.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatTeamModelSummary } from '@renderer/components/team/dialogs/TeamModelSelector';
+import {
+  computeEffectiveTeamModel,
+  formatTeamModelSummary,
+} from '@renderer/components/team/dialogs/TeamModelSelector';
 import {
   GPT_5_1_CODEX_MINI_UI_DISABLED_REASON,
   GPT_5_3_CODEX_SPARK_UI_DISABLED_REASON,
@@ -34,5 +37,34 @@ describe('formatTeamModelSummary', () => {
     expect(normalizeTeamModelForUi('codex', 'gpt-5.1-codex-mini')).toBe('');
     expect(normalizeTeamModelForUi('codex', 'gpt-5.3-codex-spark')).toBe('');
     expect(normalizeTeamModelForUi('codex', 'gpt-5.4-mini')).toBe('gpt-5.4-mini');
+  });
+});
+
+describe('computeEffectiveTeamModel', () => {
+  it('appends [1m] for anthropic models', () => {
+    expect(computeEffectiveTeamModel('opus', false, 'anthropic')).toBe('opus[1m]');
+    expect(computeEffectiveTeamModel('sonnet', false, 'anthropic')).toBe('sonnet[1m]');
+  });
+
+  it('does not double-append [1m] when input already has it', () => {
+    expect(computeEffectiveTeamModel('opus[1m]', false, 'anthropic')).toBe('opus[1m]');
+    expect(computeEffectiveTeamModel('sonnet[1m]', false, 'anthropic')).toBe('sonnet[1m]');
+  });
+
+  it('defaults to opus[1m] when no model selected', () => {
+    expect(computeEffectiveTeamModel('', false, 'anthropic')).toBe('opus[1m]');
+  });
+
+  it('returns base model without [1m] when limitContext is true', () => {
+    expect(computeEffectiveTeamModel('opus', true, 'anthropic')).toBe('opus');
+    expect(computeEffectiveTeamModel('opus[1m]', true, 'anthropic')).toBe('opus');
+  });
+
+  it('returns haiku as-is', () => {
+    expect(computeEffectiveTeamModel('haiku', false, 'anthropic')).toBe('haiku');
+  });
+
+  it('returns non-anthropic models as-is', () => {
+    expect(computeEffectiveTeamModel('gpt-5.4', false, 'codex')).toBe('gpt-5.4');
   });
 });

--- a/test/renderer/components/team/dialogs/launchDialogPrefill.test.ts
+++ b/test/renderer/components/team/dialogs/launchDialogPrefill.test.ts
@@ -38,6 +38,7 @@ describe('resolveLaunchDialogPrefill', () => {
       multimodelEnabled: true,
       storedProviderId: 'anthropic',
       storedEffort: 'medium',
+      storedLimitContext: false,
       getStoredModel: createStoredModelGetter({
         anthropic: 'haiku',
         codex: 'gpt-5.4',
@@ -48,6 +49,7 @@ describe('resolveLaunchDialogPrefill', () => {
       providerId: 'codex',
       model: 'gpt-5.4',
       effort: 'medium',
+      limitContext: false,
     });
   });
 
@@ -78,6 +80,7 @@ describe('resolveLaunchDialogPrefill', () => {
       multimodelEnabled: true,
       storedProviderId: 'anthropic',
       storedEffort: 'medium',
+      storedLimitContext: false,
       getStoredModel: createStoredModelGetter({
         anthropic: 'haiku',
         codex: 'gpt-5.4',
@@ -88,6 +91,7 @@ describe('resolveLaunchDialogPrefill', () => {
       providerId: 'codex',
       model: 'gpt-5.4',
       effort: 'medium',
+      limitContext: false,
     });
   });
 
@@ -103,6 +107,7 @@ describe('resolveLaunchDialogPrefill', () => {
       multimodelEnabled: true,
       storedProviderId: 'anthropic',
       storedEffort: 'medium',
+      storedLimitContext: false,
       getStoredModel: createStoredModelGetter({
         anthropic: 'haiku',
         codex: 'gpt-5.4',
@@ -113,6 +118,7 @@ describe('resolveLaunchDialogPrefill', () => {
       providerId: 'codex',
       model: 'gpt-5.3-codex',
       effort: 'high',
+      limitContext: false,
     });
   });
 
@@ -134,6 +140,7 @@ describe('resolveLaunchDialogPrefill', () => {
       multimodelEnabled: true,
       storedProviderId: 'anthropic',
       storedEffort: 'medium',
+      storedLimitContext: false,
       getStoredModel: createStoredModelGetter({
         anthropic: 'haiku',
         codex: 'gpt-5.4',
@@ -144,6 +151,34 @@ describe('resolveLaunchDialogPrefill', () => {
       providerId: 'anthropic',
       model: 'haiku',
       effort: 'medium',
+      limitContext: false,
+    });
+  });
+
+  it('prefers per-team launch params for limitContext over stale global storage', () => {
+    const result = resolveLaunchDialogPrefill({
+      members: [],
+      savedRequest: null,
+      previousLaunchParams: {
+        providerId: 'anthropic',
+        model: 'opus[1m][1m]',
+        effort: 'high',
+        limitContext: true,
+      },
+      multimodelEnabled: true,
+      storedProviderId: 'anthropic',
+      storedEffort: 'medium',
+      storedLimitContext: false,
+      getStoredModel: createStoredModelGetter({
+        anthropic: 'haiku',
+      }),
+    });
+
+    expect(result).toEqual({
+      providerId: 'anthropic',
+      model: 'opus',
+      effort: 'high',
+      limitContext: true,
     });
   });
 });


### PR DESCRIPTION
## Summary
- Strip `[1m]` suffix in `normalizeModelCandidate()` so the UI always stores base model names (`opus`, not `opus[1m]`)
- Make `computeEffectiveTeamModel()` idempotent by stripping existing `[1m]` before re-appending
- Add 6 test cases covering the double-suffix scenario, defaults, limitContext, haiku, and non-anthropic providers

Fixes #45

## Test plan
- [x] `pnpm vitest run test/renderer/components/team/TeamModelSelector.test.ts` — 10 tests pass
- [x] `pnpm typecheck` — clean
- [ ] Manual: launch team with Opus 1M, stop, re-launch — model should be `opus[1m]` not `opus[1m][1m]`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented repeated "[1m]" suffixes from appearing on model names when selecting or pre-filling team models.
  * Ensured models that should keep their base form (e.g., special cases) are not incorrectly modified.

* **Improvements**
  * Unified model-name normalization so prefill and launch flows respect stored context settings consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->