### PR TITLE
fix(watcher): ignore transient ENOENT on ephemeral .lock files

### DIFF
--- a/src/main/services/infrastructure/FileWatcher.ts
+++ b/src/main/services/infrastructure/FileWatcher.ts
@@ -485,7 +485,14 @@ export class FileWatcher extends EventEmitter {
     watcher: fs.FSWatcher,
     watcherType: 'projects' | 'todos' | 'teams' | 'tasks'
   ): void {
-    watcher.on('error', (error) => {
+    watcher.on('error', (error: NodeJS.ErrnoException) => {
+      // Ephemeral .lock files cause harmless ENOENT when the recursive watcher
+      // tries to scandir a path that was already deleted. Log as debug and skip
+      // the teardown/retry — the watcher is still healthy.
+      if (error.code === 'ENOENT' && error.path?.endsWith('.lock')) {
+        logger.debug(`FileWatcher: ${watcherType} ignoring transient ENOENT on lock file`);
+        return;
+      }
       logger.error(`FileWatcher: ${watcherType} watcher error:`, error);
       if (watcherType === 'projects') {
         this.projectsWatcher = null;


### PR DESCRIPTION
## Summary
- Filter ENOENT errors on `.lock` files in `attachWatcherRecovery()` — log as debug instead of error
- Skip watcher teardown and retry for these harmless race conditions
- The recursive `fs.watch` on Linux triggers `readdirSync` on ephemeral lock files that are already deleted by the time Node scans them

Fixes #46

## Test plan
- [x] `pnpm typecheck` — clean
- [ ] Manual: launch a team with multiple members, verify no ENOENT `.lock` errors in logs
- [ ] Verify real watcher errors (e.g. directory deletion) still trigger recovery

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file watcher error handling for lock file scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->