### PR TITLE
fix(team): resolve stuck "reconciling" state and skip resume when teammates never spawned

### DIFF
--- a/src/main/services/team/TeamLaunchStateEvaluator.ts
+++ b/src/main/services/team/TeamLaunchStateEvaluator.ts
@@ -213,13 +213,39 @@ export function createPersistedLaunchSnapshot(params: {
     )
   );
   const members = params.members ?? {};
+  const launchPhase = params.launchPhase ?? 'active';
+
+  // When the launch is over (finished/reconciled), members still in 'starting' state
+  // (never spawned — agentToolAccepted is false) are unreachable and should be marked
+  // as failed. Without this, they stay as 'pending' forever, causing the UI to show
+  // "Last launch is still reconciling" indefinitely after a crash or incomplete launch.
+  if (launchPhase !== 'active') {
+    for (const name of expectedMembers) {
+      const member = members[name];
+      if (
+        member &&
+        member.launchState === 'starting' &&
+        !member.agentToolAccepted &&
+        !member.runtimeAlive &&
+        !member.bootstrapConfirmed &&
+        !member.hardFailure
+      ) {
+        member.hardFailure = true;
+        member.hardFailureReason =
+          member.hardFailureReason ?? 'Teammate was never spawned during launch.';
+        member.launchState = deriveMemberLaunchState(member);
+        member.diagnostics = buildDiagnostics(member);
+      }
+    }
+  }
+
   const summary = summarizePersistedLaunchMembers(expectedMembers, members);
   return {
     version: 2,
     teamName: params.teamName,
     updatedAt,
     ...(params.leadSessionId ? { leadSessionId: params.leadSessionId } : {}),
-    launchPhase: params.launchPhase ?? 'active',
+    launchPhase,
     expectedMembers,
     members,
     summary,

--- a/src/main/services/team/TeamProvisioningService.ts
+++ b/src/main/services/team/TeamProvisioningService.ts
@@ -4878,17 +4878,31 @@ export class TeamProvisioningService {
             members: prevMembers,
             launchPhase,
           } = persistedLaunchState;
+          const teammateWasNeverSpawned = (
+            member:
+              | {
+                  agentToolAccepted?: boolean;
+                  firstSpawnAcceptedAt?: string;
+                  runtimeAlive?: boolean;
+                  bootstrapConfirmed?: boolean;
+                }
+              | undefined
+          ): boolean => {
+            if (!member) return true;
+            const hasAcceptedSpawn =
+              member.agentToolAccepted === true ||
+              (typeof member.firstSpawnAcceptedAt === 'string' &&
+                member.firstSpawnAcceptedAt.trim().length > 0);
+            return (
+              !hasAcceptedSpawn &&
+              member.runtimeAlive !== true &&
+              member.bootstrapConfirmed !== true
+            );
+          };
           const allTeammatesNeverSpawned =
             launchPhase !== 'active' &&
             prevExpected.length > 0 &&
-            prevExpected.every((name) => {
-              const m = prevMembers[name];
-              return (
-                !m ||
-                (m.launchState === 'starting' && !m.agentToolAccepted) ||
-                m.launchState === 'failed_to_start'
-              );
-            });
+            prevExpected.every((name) => teammateWasNeverSpawned(prevMembers[name]));
           if (allTeammatesNeverSpawned) {
             skipResume = true;
             logger.info(

--- a/src/main/services/team/TeamProvisioningService.ts
+++ b/src/main/services/team/TeamProvisioningService.ts
@@ -4860,11 +4860,45 @@ export class TeamProvisioningService {
       // so the lead retains full context of prior work.
       // When clearContext is true, skip resume entirely to start a fresh session.
       let previousSessionId: string | undefined;
+      let skipResume = false;
       if (request.clearContext) {
+        skipResume = true;
         logger.info(
           `[${request.teamName}] clearContext requested — skipping session resume, starting fresh`
         );
       } else {
+        // Check persisted launch state: if the previous launch ended with no teammates
+        // ever spawned (all in 'starting' state), resuming would reconnect the lead but
+        // the CLI's deterministic bootstrap won't re-spawn dead teammates in reconnect
+        // mode. Skip resume so the CLI creates a fresh session that fully bootstraps.
+        const persistedLaunchState = await this.launchStateStore.read(request.teamName);
+        if (persistedLaunchState) {
+          const {
+            expectedMembers: prevExpected,
+            members: prevMembers,
+            launchPhase,
+          } = persistedLaunchState;
+          const allTeammatesNeverSpawned =
+            launchPhase !== 'active' &&
+            prevExpected.length > 0 &&
+            prevExpected.every((name) => {
+              const m = prevMembers[name];
+              return (
+                !m ||
+                (m.launchState === 'starting' && !m.agentToolAccepted) ||
+                m.launchState === 'failed_to_start'
+              );
+            });
+          if (allTeammatesNeverSpawned) {
+            skipResume = true;
+            logger.info(
+              `[${request.teamName}] Previous launch had no teammates successfully spawned — ` +
+                `skipping session resume to allow full bootstrap`
+            );
+          }
+        }
+      }
+      if (!skipResume) {
         try {
           const configParsed = JSON.parse(configRaw) as Record<string, unknown>;
           const resumeGuard = shouldSkipResumeForProviderRuntimeChange(request, configParsed);

--- a/test/main/services/team/TeamProvisioningService.test.ts
+++ b/test/main/services/team/TeamProvisioningService.test.ts
@@ -51,6 +51,8 @@ vi.mock('@main/utils/pathDecoder', async (importOriginal) => {
 });
 
 import { TeamProvisioningService } from '@main/services/team/TeamProvisioningService';
+import { createPersistedLaunchSnapshot } from '@main/services/team/TeamLaunchStateEvaluator';
+import { getTeamLaunchStatePath } from '@main/services/team/TeamLaunchStateStore';
 import { ClaudeBinaryResolver } from '@main/services/team/ClaudeBinaryResolver';
 import { spawnCli } from '@main/utils/childProcess';
 import { AGENT_TEAMS_NAMESPACED_TEAMMATE_OPERATIONAL_TOOL_NAMES } from 'agent-teams-controller';
@@ -84,6 +86,63 @@ function createRunningChild() {
   });
 }
 
+function writeLaunchConfig(
+  teamName: string,
+  projectPath: string,
+  leadSessionId: string,
+  members: string[]
+): void {
+  const teamDir = path.join(tempTeamsBase, teamName);
+  fs.mkdirSync(teamDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(teamDir, 'config.json'),
+    JSON.stringify({
+      name: teamName,
+      projectPath,
+      leadSessionId,
+      members: [
+        { name: 'team-lead', agentType: 'team-lead' },
+        ...members.map((name) => ({ name })),
+      ],
+    }),
+    'utf8'
+  );
+}
+
+function writeLaunchState(
+  teamName: string,
+  leadSessionId: string,
+  members: Record<string, Record<string, unknown>>
+): void {
+  const snapshot = createPersistedLaunchSnapshot({
+    teamName,
+    leadSessionId,
+    launchPhase: 'finished',
+    expectedMembers: Object.keys(members),
+    members: Object.fromEntries(
+      Object.entries(members).map(([name, member]) => [
+        name,
+        {
+          name,
+          launchState: 'failed_to_start',
+          agentToolAccepted: false,
+          runtimeAlive: false,
+          bootstrapConfirmed: false,
+          hardFailure: true,
+          hardFailureReason: 'Teammate was never spawned during launch.',
+          lastEvaluatedAt: new Date().toISOString(),
+          ...member,
+        },
+      ])
+    ) as any,
+  });
+  fs.writeFileSync(
+    getTeamLaunchStatePath(teamName),
+    `${JSON.stringify(snapshot, null, 2)}\n`,
+    'utf8'
+  );
+}
+
 describe('TeamProvisioningService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -99,7 +158,6 @@ describe('TeamProvisioningService', () => {
     fs.mkdirSync(tempTasksBase, { recursive: true });
     fs.mkdirSync(tempProjectsBase, { recursive: true });
   });
-
 
   afterEach(() => {
     vi.useRealTimers();
@@ -389,14 +447,12 @@ describe('TeamProvisioningService', () => {
 
   it('expands teammate permission suggestions to the operational tool set only', async () => {
     allowConsoleLogs();
-    const svc = new TeamProvisioningService(
-      {
-        getConfig: vi.fn(async () => ({
-          projectPath: tempClaudeRoot,
-          members: [{ cwd: tempClaudeRoot }],
-        })),
-      } as any
-    );
+    const svc = new TeamProvisioningService({
+      getConfig: vi.fn(async () => ({
+        projectPath: tempClaudeRoot,
+        members: [{ cwd: tempClaudeRoot }],
+      })),
+    } as any);
 
     await (svc as any).respondToTeammatePermission(
       { teamName: 'ops-team' },
@@ -427,14 +483,12 @@ describe('TeamProvisioningService', () => {
 
   it('does not broaden admin/runtime teammate permission suggestions', async () => {
     allowConsoleLogs();
-    const svc = new TeamProvisioningService(
-      {
-        getConfig: vi.fn(async () => ({
-          projectPath: tempClaudeRoot,
-          members: [{ cwd: tempClaudeRoot }],
-        })),
-      } as any
-    );
+    const svc = new TeamProvisioningService({
+      getConfig: vi.fn(async () => ({
+        projectPath: tempClaudeRoot,
+        members: [{ cwd: tempClaudeRoot }],
+      })),
+    } as any);
 
     await (svc as any).respondToTeammatePermission(
       { teamName: 'ops-team' },
@@ -515,5 +569,108 @@ describe('TeamProvisioningService', () => {
         ],
       })
     ).toBe('Questions (2): First question with extra spacing.');
+  });
+
+  it('skips --resume when the persisted launch state shows no teammate ever spawned', async () => {
+    allowConsoleLogs();
+    const teamName = 'resume-skip-team';
+    const leadSessionId = 'lead-session-skip';
+    writeLaunchConfig(teamName, tempClaudeRoot, leadSessionId, ['alice', 'bob']);
+    writeLaunchState(teamName, leadSessionId, {
+      alice: {
+        launchState: 'failed_to_start',
+      },
+      bob: {
+        launchState: 'starting',
+        hardFailure: false,
+      },
+    });
+
+    vi.mocked(ClaudeBinaryResolver.resolve).mockResolvedValue('/mock/claude');
+    vi.mocked(spawnCli).mockImplementation(() => {
+      throw new Error('launch spawn EINVAL');
+    });
+
+    const svc = new TeamProvisioningService(undefined, undefined, undefined, undefined, {
+      writeConfigFile: vi.fn(async () => '/mock/mcp-config-launch.json'),
+      removeConfigFile: vi.fn(async () => {}),
+    } as any);
+    (svc as any).buildProvisioningEnv = vi.fn(async () => ({
+      env: { ANTHROPIC_API_KEY: 'test' },
+      authSource: 'anthropic_api_key',
+    }));
+    (svc as any).resolveLaunchExpectedMembers = vi.fn(async () => ({
+      members: [{ name: 'alice' }, { name: 'bob' }],
+      source: 'members-meta',
+      warning: undefined,
+    }));
+    (svc as any).normalizeTeamConfigForLaunch = vi.fn(async () => {});
+    (svc as any).assertConfigLeadOnlyForLaunch = vi.fn(async () => {});
+    (svc as any).updateConfigProjectPath = vi.fn(async () => {});
+    (svc as any).restorePrelaunchConfig = vi.fn(async () => {});
+    (svc as any).validateAgentTeamsMcpRuntime = vi.fn(async () => {});
+    (svc as any).pathExists = vi.fn(async (targetPath: string) =>
+      targetPath.endsWith(`${leadSessionId}.jsonl`)
+    );
+
+    await expect(svc.launchTeam({ teamName, cwd: tempClaudeRoot }, () => {})).rejects.toThrow(
+      'launch spawn EINVAL'
+    );
+
+    const launchArgs = vi.mocked(spawnCli).mock.calls[0]?.[1] as string[];
+    expect(launchArgs).toBeTruthy();
+    expect(launchArgs).not.toContain('--resume');
+    expect(launchArgs).not.toContain(leadSessionId);
+  });
+
+  it('keeps --resume when a teammate had an accepted spawn before failing bootstrap', async () => {
+    allowConsoleLogs();
+    const teamName = 'resume-keep-team';
+    const leadSessionId = 'lead-session-keep';
+    const acceptedAt = '2026-04-14T12:00:00.000Z';
+    writeLaunchConfig(teamName, tempClaudeRoot, leadSessionId, ['alice']);
+    writeLaunchState(teamName, leadSessionId, {
+      alice: {
+        launchState: 'failed_to_start',
+        agentToolAccepted: true,
+        firstSpawnAcceptedAt: acceptedAt,
+        hardFailureReason: 'Teammate did not join within the launch grace window.',
+      },
+    });
+
+    vi.mocked(ClaudeBinaryResolver.resolve).mockResolvedValue('/mock/claude');
+    vi.mocked(spawnCli).mockImplementation(() => {
+      throw new Error('launch spawn EINVAL');
+    });
+
+    const svc = new TeamProvisioningService(undefined, undefined, undefined, undefined, {
+      writeConfigFile: vi.fn(async () => '/mock/mcp-config-launch.json'),
+      removeConfigFile: vi.fn(async () => {}),
+    } as any);
+    (svc as any).buildProvisioningEnv = vi.fn(async () => ({
+      env: { ANTHROPIC_API_KEY: 'test' },
+      authSource: 'anthropic_api_key',
+    }));
+    (svc as any).resolveLaunchExpectedMembers = vi.fn(async () => ({
+      members: [{ name: 'alice' }],
+      source: 'members-meta',
+      warning: undefined,
+    }));
+    (svc as any).normalizeTeamConfigForLaunch = vi.fn(async () => {});
+    (svc as any).assertConfigLeadOnlyForLaunch = vi.fn(async () => {});
+    (svc as any).updateConfigProjectPath = vi.fn(async () => {});
+    (svc as any).restorePrelaunchConfig = vi.fn(async () => {});
+    (svc as any).validateAgentTeamsMcpRuntime = vi.fn(async () => {});
+    (svc as any).pathExists = vi.fn(async (targetPath: string) =>
+      targetPath.endsWith(`${leadSessionId}.jsonl`)
+    );
+
+    await expect(svc.launchTeam({ teamName, cwd: tempClaudeRoot }, () => {})).rejects.toThrow(
+      'launch spawn EINVAL'
+    );
+
+    const launchArgs = vi.mocked(spawnCli).mock.calls[0]?.[1] as string[];
+    expect(launchArgs).toContain('--resume');
+    expect(launchArgs).toContain(leadSessionId);
   });
 });


### PR DESCRIPTION
Closes #54.

## Summary

- Fixes team launches stuck in "Last launch is still reconciling" after a
  failed bootstrap.
- Fixes `--resume` path leaving teammates offline because the CLI's
  deterministic reconnect does not re-spawn dead teammates.
- No more need to toggle "Clear context (fresh session)" to recover from
  a broken launch state.

## Root cause

Two issues combined, see #54 for full details.

**1. Stuck `partial_pending` state** — `createPersistedLaunchSnapshot` in
`TeamLaunchStateEvaluator.ts` counted members still in `starting`
(never spawned — `agentToolAccepted: false`) as `pending` regardless of
`launchPhase`. So even after `launchPhase` became `'finished'`, these
members kept the aggregate state as `partial_pending`, which the UI
renders as "still reconciling" — with no path out.

**2. `--resume` does not re-spawn dead teammates** — When the previous
launch had no teammates successfully spawned, the app still passed
`--resume <leadSessionId>` on the next Launch. The CLI's deterministic
reconnect path restores lead context but does not re-create missing
teammates, so the team stayed broken across relaunches.

## Changes

### `TeamLaunchStateEvaluator.ts`
When `launchPhase !== 'active'`, promote members still in `starting`
(and `!agentToolAccepted`, `!runtimeAlive`, `!bootstrapConfirmed`,
`!hardFailure`) to `failed_to_start` with reason "Teammate was never
spawned during launch." Aggregate state then correctly becomes
`partial_failure` ("Launch failed partway") instead of `partial_pending`.

### `TeamProvisioningService._launchTeamInner`
Before deciding to pass `--resume`, read the persisted launch state. If
every expected teammate is `starting` (never spawned) or
`failed_to_start`, set `skipResume = true` so the CLI starts a fresh
session with full deterministic bootstrap. Introduces a `skipResume`
flag to replace the prior `if (request.clearContext) else { resume }`
branching so the skip can be triggered from multiple conditions.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (only pre-existing `ScheduledTaskExecutor.test.ts`
      `CLAUDECODE` env test fails, unrelated to these changes)
- [x] Manual repro on Linux: team stuck in "still reconciling"
      correctly transitions to "Launch failed partway" on app restart,
      and the subsequent Launch (without "Clear context") fully
      bootstraps and brings all teammates online.
- [ ] Validated on macOS (not available — would appreciate a second pair
      of eyes here)
- [ ] Validated on Windows (not available)

## Notes

No schema changes to persisted launch state. Existing on-disk snapshots
that are "stuck" will self-heal on the next read via the evaluator fix.
No migration needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics and state handling for team members that fail during initialization; such members are now marked as hard failures and their launch state is recomputed.
  * Refined provisioning resume logic to skip resume when no teammates ever spawned, ensuring a clean full bootstrap when appropriate.

* **Tests**
  * Added tests covering persisted launch-state scenarios to verify resume behavior and spawn arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->