### PR TITLE
refactor(team): wire scroll owners for MessagesPanel layouts

### DIFF
--- a/src/renderer/components/team/TeamDetailView.tsx
+++ b/src/renderer/components/team/TeamDetailView.tsx
@@ -39,8 +39,8 @@ import {
 } from '@renderer/store/slices/teamSlice';
 import { createChipFromSelection } from '@renderer/utils/chipUtils';
 import { sumContextInjectionTokens } from '@renderer/utils/contextMath';
-import { formatProjectPath } from '@renderer/utils/pathDisplay';
 import { buildMemberColorMap } from '@renderer/utils/memberHelpers';
+import { formatProjectPath } from '@renderer/utils/pathDisplay';
 import { buildTaskCountsByOwner, normalizePath } from '@renderer/utils/pathNormalize';
 import { nameColorSet } from '@renderer/utils/projectColor';
 import { resolveProjectIdByPath } from '@renderer/utils/projectLookup';
@@ -2011,6 +2011,7 @@ export const TeamDetailView = ({
       onReplyToMessage: handleReplyToMessage,
       onRestartTeam: handleRestartTeam,
       onTaskIdClick: handleTaskIdClick,
+      inlineScrollContainerRef: contentRef,
     }),
     [
       activeMembers,

--- a/src/renderer/components/team/messages/MessagesPanel.tsx
+++ b/src/renderer/components/team/messages/MessagesPanel.tsx
@@ -1,4 +1,13 @@
-import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import {
+  memo,
+  type RefObject,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { Sheet, type SheetRef } from 'react-modal-sheet';
 
 import { Badge } from '@renderer/components/ui/badge';
@@ -91,6 +100,13 @@ interface MessagesPanelProps {
   onRestartTeam?: () => void;
   /** Callback when a task ID link is clicked. */
   onTaskIdClick?: (taskId: string) => void;
+  /**
+   * Scroll container owned by the parent view when `position === 'inline'`.
+   * MessagesPanel does not own this element — the viewport lives in
+   * TeamDetailView's content scroll area. Plumbed for future viewport
+   * consumers (virtualization); unused in this release.
+   */
+  inlineScrollContainerRef?: RefObject<HTMLDivElement | null>;
 }
 
 export function reconcilePendingRepliesByMember(
@@ -214,6 +230,11 @@ export const MessagesPanel = memo(function MessagesPanel({
   const sidebarScrollRef = useRef<HTMLDivElement | null>(null);
   const bottomSheetRef = useRef<SheetRef>(null);
   const bottomSheetStickyTopRef = useRef<HTMLDivElement | null>(null);
+  // Scroll container inside `Sheet.Content` for the bottom-sheet layout.
+  // react-modal-sheet merges this ref with its own internal scroll ref.
+  // Held here so future viewport consumers (virtualization) can observe the
+  // true scrolling element in bottom-sheet mode.
+  const bottomSheetScrollRef = useRef<HTMLDivElement | null>(null);
   const handleExpandContent = useCallback(() => {
     // no-op: user is reading expanded content, not composing
   }, []);
@@ -1063,6 +1084,7 @@ export const MessagesPanel = memo(function MessagesPanel({
             <Sheet.Content
               className="min-h-0 bg-[var(--color-surface-sidebar)]"
               scrollClassName="flex min-h-full flex-col"
+              scrollRef={bottomSheetScrollRef}
               disableDrag={(state) => state.scrollPosition !== 'top'}
             >
               <div


### PR DESCRIPTION
## Summary

First of 6 sequential PRs toward virtualizing `ActivityTimeline`, per the design Mike and I agreed on in Discord. This PR only wires scroll owners through the component tree. No render-time behavior changes, no virtualization yet.

## What this PR does

- **Inline layout** — `TeamDetailView` forwards its existing `contentRef` to `MessagesPanel` as a new optional prop `inlineScrollContainerRef`. MessagesPanel accepts it and holds it for a follow-up; it is intentionally unused in this release.
- **Bottom-sheet layout** — `MessagesPanel` creates `bottomSheetScrollRef` and passes it to `Sheet.Content scrollRef`. `react-modal-sheet` merges our ref with its internal scroll ref (same DOM node), so we get a handle to the true scroller without any layout change.
- **Sidebar layout** — already owned by `MessagesPanel` via `sidebarScrollRef`; no change.

## What this PR does *not* do

- No changes to `ActivityTimeline`.
- No `useVirtualizer`, no `renderRows`, no observer-root rewiring. Those are the next PRs.
- No behavior change end-to-end.

## Roadmap (agreed with Mike)

1. ✅ **#1 — Scroll owner wiring** (this PR)
2. Viewport contract + observer root move
3. `renderRows` flatten (no UI change)
4. Virtualizer skeleton + measured `scrollMargin`
5. `measureElement` + merged refs for dynamic height
6. Tests + threshold + cleanup

Each PR lands independently and preserves behavior.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm exec eslint` on both changed files — 0 errors (existing warnings unchanged)
- [x] `pnpm exec vitest run test/renderer/components/team/messages/ test/renderer/components/team/activity/` — 50/50 pass

## Notes

- `inlineScrollContainerRef` is an optional prop. All existing consumers remain compatible.
- `SharedTeamMessagesPanelProps` (the `Omit<...>` derived from `MessagesPanelProps`) picks up the new prop automatically; the single producer `sharedMessagesPanelProps` in `TeamDetailView` is the only place that needs to populate it.
- The file also picks up a trivial import-sort correction in `TeamDetailView` (`buildMemberColorMap` / `formatProjectPath`) from `eslint --fix`. Happy to split that out if you'd rather keep this commit even narrower.