### PR TITLE
refactor(team): flatten ActivityTimeline render into atomic rows

### DIFF
--- a/src/renderer/components/team/activity/ActivityTimeline.tsx
+++ b/src/renderer/components/team/activity/ActivityTimeline.tsx
@@ -21,8 +21,31 @@ import {
 } from './LeadThoughtsGroup';
 import { useNewItemKeys } from './useNewItemKeys';
 
-import type { TimelineItem } from './LeadThoughtsGroup';
+import type { LeadThoughtGroup, TimelineItem } from './LeadThoughtsGroup';
 import type { InboxMessage, ResolvedTeamMember } from '@shared/types';
+
+/**
+ * A single visual row in the timeline. The render phase maps 1:1 from this
+ * list into JSX, which is the shape a windowing library (e.g.
+ * `@tanstack/react-virtual`) expects. Grouping happens earlier, in
+ * `groupTimelineItems`; this layer flattens groups/separators/dividers into
+ * atomic rows so each one can be measured and rendered independently.
+ *
+ * The `itemIndex` fields point back into `timelineItems` so per-item state
+ * (collapse mode, zebra shading, "is new" flag, session anchor) can still be
+ * resolved without threading it through every row entry.
+ */
+type TimelineRow =
+  | { kind: 'session-separator'; key: string }
+  | {
+      kind: 'lead-thought-group';
+      key: string;
+      itemIndex: number;
+      group: LeadThoughtGroup;
+      isPinned: boolean;
+    }
+  | { kind: 'compaction-divider'; key: string; message: InboxMessage }
+  | { kind: 'message-row'; key: string; itemIndex: number; message: InboxMessage };
 
 /**
  * Viewport contract — describes the scroll container that hosts the timeline
@@ -489,6 +512,66 @@ export const ActivityTimeline = React.memo(function ActivityTimeline({
   const pinnedThoughtGroup = timelineItems[0]?.type === 'lead-thoughts' ? timelineItems[0] : null;
   const startIndex = pinnedThoughtGroup ? 1 : 0;
 
+  // Flatten timelineItems into atomic render rows. Each row maps to exactly
+  // one visual element — no Fragment bundles session separators with their
+  // owning item, because a windowing layer (landing in a follow-up PR) needs
+  // each row to be measurable and addressable independently.
+  const renderRows = useMemo<readonly TimelineRow[]>(() => {
+    const rows: TimelineRow[] = [];
+    if (pinnedThoughtGroup) {
+      rows.push({
+        kind: 'lead-thought-group',
+        key: getThoughtGroupKey(pinnedThoughtGroup.group),
+        itemIndex: 0,
+        group: pinnedThoughtGroup.group,
+        isPinned: true,
+      });
+    }
+    for (let i = startIndex; i < timelineItems.length; i += 1) {
+      const item = timelineItems[i];
+      if (i > 0) {
+        const currSessionId = getItemSessionAnchorId(item);
+        const prevSessionId = previousSessionAnchorByIndex[i];
+        if (prevSessionId && currSessionId && prevSessionId !== currSessionId) {
+          // Include itemIndex in the key so a repeated transition (e.g. lead
+          // sessions A→B→A→B) does not collide on key `A->B` twice — React
+          // treats duplicate keys as the same element and reuses state
+          // across unrelated separators.
+          rows.push({
+            kind: 'session-separator',
+            key: `session-separator-${i}-${prevSessionId}->${currSessionId}`,
+          });
+        }
+      }
+      if (item.type === 'lead-thoughts') {
+        rows.push({
+          kind: 'lead-thought-group',
+          key: getThoughtGroupKey(item.group),
+          itemIndex: i,
+          group: item.group,
+          isPinned: false,
+        });
+        continue;
+      }
+      const message = item.message;
+      if (isCompactionMessage(message)) {
+        rows.push({
+          kind: 'compaction-divider',
+          key: `compaction-${toMessageKey(message)}`,
+          message,
+        });
+        continue;
+      }
+      rows.push({
+        kind: 'message-row',
+        key: toMessageKey(message),
+        itemIndex: i,
+        message,
+      });
+    }
+    return rows;
+  }, [pinnedThoughtGroup, previousSessionAnchorByIndex, startIndex, timelineItems]);
+
   // Determine the index of the "newest" non-thought timeline item (for auto-expand).
   const newestMessageIndex = useMemo(() => {
     return findNewestMessageIndex(timelineItems);
@@ -530,6 +613,113 @@ export const ActivityTimeline = React.memo(function ActivityTimeline({
     [allCollapsed, newestMessageIndex, pinnedThoughtGroup, expandOverrides, onToggleExpandOverride]
   );
 
+  // Render a single atomic row. Logic per kind mirrors the previous inline
+  // render path; separators and dividers are their own rows rather than
+  // being bundled into Fragments, which is the contract the virtualizer will
+  // consume in a follow-up PR.
+  const renderTimelineRow = (row: TimelineRow): React.JSX.Element | null => {
+    switch (row.kind) {
+      case 'session-separator':
+        return (
+          <div
+            key={row.key}
+            className="flex items-center gap-3"
+            style={{ paddingTop: 45, paddingBottom: 45 }}
+          >
+            <div className="h-px flex-1 bg-blue-600/30 dark:bg-blue-400/30" />
+            <span className="whitespace-nowrap text-[11px] font-medium text-blue-600 dark:text-blue-400">
+              New session
+            </span>
+            <div className="h-px flex-1 bg-blue-600/30 dark:bg-blue-400/30" />
+          </div>
+        );
+      case 'compaction-divider':
+        return <CompactionDivider key={row.key} message={row.message} />;
+      case 'lead-thought-group': {
+        const { group, itemIndex, isPinned, key } = row;
+        const firstThought = group.thoughts[0];
+        const info = memberInfo.get(firstThought.from);
+        const collapseProps = getItemCollapseProps(key, itemIndex);
+        const pinnedCanBeLive = isPinned
+          ? currentLeadSessionId
+            ? firstThought.leadSessionId === currentLeadSessionId
+            : true
+          : false;
+        return (
+          <LeadThoughtsGroupRow
+            key={key}
+            group={group}
+            memberColor={info?.color}
+            canBeLive={pinnedCanBeLive}
+            isTeamAlive={pinnedCanBeLive ? isTeamAlive : undefined}
+            leadActivity={pinnedCanBeLive ? leadActivity : undefined}
+            leadContextUpdatedAt={pinnedCanBeLive ? leadContextUpdatedAt : undefined}
+            isNew={newItemKeys.has(key)}
+            onVisible={onMessageVisible}
+            observerRoot={observerRoot}
+            zebraShade={zebraShadeSet.has(itemIndex)}
+            collapseMode={collapseProps.collapseMode}
+            isCollapsed={collapseProps.isCollapsed}
+            canToggleCollapse={collapseProps.canToggleCollapse}
+            collapseToggleKey={collapseProps.collapseToggleKey}
+            onToggleCollapse={onToggleExpandOverride}
+            onTaskIdClick={onTaskIdClick}
+            memberColorMap={colorMap}
+            onReply={onReplyToMessage}
+            compactHeader={compactHeader}
+            teamNames={teamNames}
+            teamColorByName={teamColorByName}
+            onTeamClick={onTeamClick}
+            onExpand={compactHeader ? onExpandItem : undefined}
+            expandItemKey={compactHeader ? key : undefined}
+          />
+        );
+      }
+      case 'message-row': {
+        const { message, itemIndex, key } = row;
+        const renderProps = resolveMessageRenderProps(message, ctx);
+        const collapseProps = getItemCollapseProps(key, itemIndex);
+        const isUnread = readState
+          ? !message.read && !readState.readSet.has(readState.getMessageKey(message))
+          : !message.read;
+        return (
+          <MemoizedMessageRowWithObserver
+            key={key}
+            message={message}
+            teamName={teamName}
+            memberRole={renderProps.memberRole}
+            memberColor={renderProps.memberColor}
+            recipientColor={renderProps.recipientColor}
+            isUnread={isUnread}
+            isNew={newItemKeys.has(key)}
+            zebraShade={zebraShadeSet.has(itemIndex)}
+            memberColorMap={colorMap}
+            localMemberNames={localMemberNames}
+            onMemberNameClick={onMemberClick ? handleMemberNameClick : undefined}
+            onCreateTask={onCreateTaskFromMessage}
+            onReply={onReplyToMessage}
+            onVisible={onMessageVisible}
+            onTaskIdClick={onTaskIdClick}
+            onRestartTeam={onRestartTeam}
+            collapseMode={collapseProps.collapseMode}
+            isCollapsed={collapseProps.isCollapsed}
+            canToggleCollapse={collapseProps.canToggleCollapse}
+            collapseToggleKey={collapseProps.collapseToggleKey}
+            onToggleCollapse={onToggleExpandOverride}
+            compactHeader={compactHeader}
+            teamNames={teamNames}
+            teamColorByName={teamColorByName}
+            onTeamClick={onTeamClick}
+            onExpand={compactHeader ? onExpandItem : undefined}
+            expandItemKey={compactHeader ? key : undefined}
+            observerRoot={observerRoot}
+            onExpandContent={onExpandContent}
+          />
+        );
+      }
+    }
+  };
+
   if (messages.length === 0) {
     return (
       <div className="rounded-md border border-[var(--color-border)] p-3 pl-5 text-xs text-[var(--color-text-muted)]">
@@ -541,168 +731,7 @@ export const ActivityTimeline = React.memo(function ActivityTimeline({
 
   return (
     <div ref={rootRef} className="space-y-1">
-      {/* Pinned (newest) thought group — always at top */}
-      {pinnedThoughtGroup &&
-        (() => {
-          const { group } = pinnedThoughtGroup;
-          const firstThought = group.thoughts[0];
-          const pinnedCanBeLive = currentLeadSessionId
-            ? firstThought.leadSessionId === currentLeadSessionId
-            : true;
-          const info = memberInfo.get(firstThought.from);
-          const itemKey = getThoughtGroupKey(group);
-          const stableKey = itemKey;
-          const collapseProps = getItemCollapseProps(stableKey, 0);
-          return (
-            <LeadThoughtsGroupRow
-              key={itemKey}
-              group={group}
-              memberColor={info?.color}
-              canBeLive={pinnedCanBeLive}
-              isTeamAlive={pinnedCanBeLive ? isTeamAlive : undefined}
-              leadActivity={pinnedCanBeLive ? leadActivity : undefined}
-              leadContextUpdatedAt={pinnedCanBeLive ? leadContextUpdatedAt : undefined}
-              isNew={newItemKeys.has(itemKey)}
-              onVisible={onMessageVisible}
-              observerRoot={observerRoot}
-              zebraShade={zebraShadeSet.has(0)}
-              collapseMode={collapseProps.collapseMode}
-              isCollapsed={collapseProps.isCollapsed}
-              canToggleCollapse={collapseProps.canToggleCollapse}
-              collapseToggleKey={collapseProps.collapseToggleKey}
-              onToggleCollapse={onToggleExpandOverride}
-              onTaskIdClick={onTaskIdClick}
-              memberColorMap={colorMap}
-              onReply={onReplyToMessage}
-              compactHeader={compactHeader}
-              teamNames={teamNames}
-              teamColorByName={teamColorByName}
-              onTeamClick={onTeamClick}
-              onExpand={compactHeader ? onExpandItem : undefined}
-              expandItemKey={compactHeader ? itemKey : undefined}
-            />
-          );
-        })()}
-
-      {/* Remaining items */}
-      {timelineItems.slice(startIndex).map((item, index) => {
-        const realIndex = index + startIndex;
-
-        // Session boundary separator (messages sorted desc — new on top)
-        let sessionSeparator: React.JSX.Element | null = null;
-        if (realIndex > 0) {
-          const currSessionId = getItemSessionAnchorId(item);
-          const prevSessionId = previousSessionAnchorByIndex[realIndex];
-          if (prevSessionId && currSessionId && prevSessionId !== currSessionId) {
-            sessionSeparator = (
-              <div
-                className="flex items-center gap-3"
-                style={{ paddingTop: 45, paddingBottom: 45 }}
-              >
-                <div className="h-px flex-1 bg-blue-600/30 dark:bg-blue-400/30" />
-                <span className="whitespace-nowrap text-[11px] font-medium text-blue-600 dark:text-blue-400">
-                  New session
-                </span>
-                <div className="h-px flex-1 bg-blue-600/30 dark:bg-blue-400/30" />
-              </div>
-            );
-          }
-        }
-
-        if (item.type === 'lead-thoughts') {
-          const { group } = item;
-          const firstThought = group.thoughts[0];
-          const info = memberInfo.get(firstThought.from);
-          const itemKey = getThoughtGroupKey(group);
-          const stableKey = itemKey;
-          const collapseProps = getItemCollapseProps(stableKey, realIndex);
-          return (
-            <React.Fragment key={itemKey}>
-              {sessionSeparator}
-              <LeadThoughtsGroupRow
-                group={group}
-                memberColor={info?.color}
-                canBeLive={false}
-                isNew={newItemKeys.has(itemKey)}
-                onVisible={onMessageVisible}
-                observerRoot={observerRoot}
-                zebraShade={zebraShadeSet.has(realIndex)}
-                collapseMode={collapseProps.collapseMode}
-                isCollapsed={collapseProps.isCollapsed}
-                canToggleCollapse={collapseProps.canToggleCollapse}
-                collapseToggleKey={collapseProps.collapseToggleKey}
-                onToggleCollapse={onToggleExpandOverride}
-                onTaskIdClick={onTaskIdClick}
-                memberColorMap={colorMap}
-                onReply={onReplyToMessage}
-                compactHeader={compactHeader}
-                teamNames={teamNames}
-                teamColorByName={teamColorByName}
-                onTeamClick={onTeamClick}
-                onExpand={compactHeader ? onExpandItem : undefined}
-                expandItemKey={compactHeader ? itemKey : undefined}
-              />
-            </React.Fragment>
-          );
-        }
-
-        const { message } = item;
-
-        // Compaction boundary — render as a divider instead of a regular message card
-        if (isCompactionMessage(message)) {
-          const messageKey = toMessageKey(message);
-          return (
-            <React.Fragment key={messageKey}>
-              {sessionSeparator}
-              <CompactionDivider message={message} />
-            </React.Fragment>
-          );
-        }
-
-        const renderProps = resolveMessageRenderProps(message, ctx);
-        const messageKey = toMessageKey(message);
-        const stableKey = messageKey;
-        const collapseProps = getItemCollapseProps(stableKey, realIndex);
-        const isUnread = readState
-          ? !message.read && !readState.readSet.has(readState.getMessageKey(message))
-          : !message.read;
-        return (
-          <React.Fragment key={messageKey}>
-            {sessionSeparator}
-            <MemoizedMessageRowWithObserver
-              message={message}
-              teamName={teamName}
-              memberRole={renderProps.memberRole}
-              memberColor={renderProps.memberColor}
-              recipientColor={renderProps.recipientColor}
-              isUnread={isUnread}
-              isNew={newItemKeys.has(messageKey)}
-              zebraShade={zebraShadeSet.has(realIndex)}
-              memberColorMap={colorMap}
-              localMemberNames={localMemberNames}
-              onMemberNameClick={onMemberClick ? handleMemberNameClick : undefined}
-              onCreateTask={onCreateTaskFromMessage}
-              onReply={onReplyToMessage}
-              onVisible={onMessageVisible}
-              onTaskIdClick={onTaskIdClick}
-              onRestartTeam={onRestartTeam}
-              collapseMode={collapseProps.collapseMode}
-              isCollapsed={collapseProps.isCollapsed}
-              canToggleCollapse={collapseProps.canToggleCollapse}
-              collapseToggleKey={collapseProps.collapseToggleKey}
-              onToggleCollapse={onToggleExpandOverride}
-              compactHeader={compactHeader}
-              teamNames={teamNames}
-              teamColorByName={teamColorByName}
-              onTeamClick={onTeamClick}
-              onExpand={compactHeader ? onExpandItem : undefined}
-              expandItemKey={compactHeader ? messageKey : undefined}
-              observerRoot={observerRoot}
-              onExpandContent={onExpandContent}
-            />
-          </React.Fragment>
-        );
-      })}
+      {renderRows.map((row) => renderTimelineRow(row))}
       {hiddenCount > 0 && (
         <div className="relative flex justify-center pb-3 pt-1">
           {/* Bottom-up shadow gradient: darkest at bottom edge, fades upward */}

--- a/src/renderer/components/team/activity/ActivityTimeline.tsx
+++ b/src/renderer/components/team/activity/ActivityTimeline.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { type RefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
   areInboxMessagesEquivalentForRender,
@@ -23,6 +23,34 @@ import { useNewItemKeys } from './useNewItemKeys';
 
 import type { TimelineItem } from './LeadThoughtsGroup';
 import type { InboxMessage, ResolvedTeamMember } from '@shared/types';
+
+/**
+ * Viewport contract — describes the scroll container that hosts the timeline
+ * and how ActivityTimeline should report visibility against it. When omitted,
+ * ActivityTimeline falls back to the document viewport (current behavior).
+ *
+ * This contract is grouped intentionally so consumers pass a single coherent
+ * object rather than threading several refs and flags. Virtualizer wiring
+ * lands in a follow-up; for now only `observerRoot` has an observable effect.
+ */
+export interface TimelineViewport {
+  /** The element that actually scrolls. */
+  scrollElementRef: RefObject<HTMLElement | null>;
+  /**
+   * Root element for IntersectionObserver-based visibility tracking.
+   * Typically the same node as `scrollElementRef`, but left separate so
+   * future code can observe a more specific inner container when needed.
+   */
+  observerRoot?: RefObject<HTMLElement | null>;
+  /**
+   * Distance from the scroll container's scroll origin to the timeline root,
+   * measured from the DOM. Zero in this release; used by the virtualizer in a
+   * follow-up change.
+   */
+  scrollMargin?: number;
+  /** Enable virtualization (wired in a follow-up; ignored for now). */
+  virtualizationEnabled?: boolean;
+}
 
 interface ActivityTimelineProps {
   messages: InboxMessage[];
@@ -66,6 +94,14 @@ interface ActivityTimelineProps {
   onExpandItem?: (key: string) => void;
   /** Called when ExpandableContent is expanded via "Show more" in any ActivityItem. */
   onExpandContent?: () => void;
+  /**
+   * Optional viewport contract. When provided, IntersectionObserver uses the
+   * passed `observerRoot` instead of the document viewport, which is required
+   * for correctness inside scrollable layouts (sidebar, bottom-sheet) where
+   * the row may be clipped by its scroll parent while still intersecting the
+   * page viewport.
+   */
+  viewport?: TimelineViewport;
 }
 
 const VIEWPORT_THRESHOLD = 0.15;
@@ -141,6 +177,7 @@ const MessageRowWithObserver = ({
   onExpand,
   expandItemKey,
   onExpandContent,
+  observerRoot,
 }: {
   message: InboxMessage;
   teamName: string;
@@ -170,6 +207,7 @@ const MessageRowWithObserver = ({
   onExpand?: (key: string) => void;
   expandItemKey?: string;
   onExpandContent?: () => void;
+  observerRoot?: RefObject<HTMLElement | null>;
 }): React.JSX.Element => {
   const ref = useRef<HTMLDivElement>(null);
   const reportedRef = useRef(false);
@@ -185,6 +223,10 @@ const MessageRowWithObserver = ({
     if (!onVisible) return;
     const el = ref.current;
     if (!el) return;
+    // Resolve the observer root at effect-time. Falls back to the document
+    // viewport (null) when no root is provided — preserves pre-contract
+    // behavior for layouts without a known scroll owner.
+    const root = observerRoot?.current ?? null;
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (!entry?.isIntersecting) return;
@@ -195,11 +237,11 @@ const MessageRowWithObserver = ({
         reportedRef.current = true;
         cb(msg);
       },
-      { threshold: VIEWPORT_THRESHOLD, rootMargin: '0px' }
+      { root, threshold: VIEWPORT_THRESHOLD, rootMargin: '0px' }
     );
     observer.observe(el);
     return () => observer.disconnect();
-  }, [onVisible]);
+  }, [onVisible, observerRoot]);
 
   return (
     <AnimatedHeightReveal animate={isNew} containerRef={ref}>
@@ -265,6 +307,7 @@ const MemoizedMessageRowWithObserver = React.memo(
     prev.onExpand === next.onExpand &&
     prev.expandItemKey === next.expandItemKey &&
     prev.onExpandContent === next.onExpandContent &&
+    prev.observerRoot === next.observerRoot &&
     areInboxMessagesEquivalentForRender(prev.message, next.message)
 );
 
@@ -291,7 +334,9 @@ export const ActivityTimeline = React.memo(function ActivityTimeline({
   onTeamClick,
   onExpandItem,
   onExpandContent,
+  viewport,
 }: ActivityTimelineProps): React.JSX.Element {
+  const observerRoot = viewport?.observerRoot ?? viewport?.scrollElementRef;
   const [visibleCount, setVisibleCount] = useState(MESSAGES_PAGE_SIZE);
   const rootRef = useRef<HTMLDivElement>(null);
   const [compactHeader, setCompactHeader] = useState(false);
@@ -519,6 +564,7 @@ export const ActivityTimeline = React.memo(function ActivityTimeline({
               leadContextUpdatedAt={pinnedCanBeLive ? leadContextUpdatedAt : undefined}
               isNew={newItemKeys.has(itemKey)}
               onVisible={onMessageVisible}
+              observerRoot={observerRoot}
               zebraShade={zebraShadeSet.has(0)}
               collapseMode={collapseProps.collapseMode}
               isCollapsed={collapseProps.isCollapsed}
@@ -579,6 +625,7 @@ export const ActivityTimeline = React.memo(function ActivityTimeline({
                 canBeLive={false}
                 isNew={newItemKeys.has(itemKey)}
                 onVisible={onMessageVisible}
+                observerRoot={observerRoot}
                 zebraShade={zebraShadeSet.has(realIndex)}
                 collapseMode={collapseProps.collapseMode}
                 isCollapsed={collapseProps.isCollapsed}
@@ -650,6 +697,7 @@ export const ActivityTimeline = React.memo(function ActivityTimeline({
               onTeamClick={onTeamClick}
               onExpand={compactHeader ? onExpandItem : undefined}
               expandItemKey={compactHeader ? messageKey : undefined}
+              observerRoot={observerRoot}
               onExpandContent={onExpandContent}
             />
           </React.Fragment>

--- a/src/renderer/components/team/activity/LeadThoughtsGroup.tsx
+++ b/src/renderer/components/team/activity/LeadThoughtsGroup.tsx
@@ -1,6 +1,7 @@
 import {
   type JSX,
   memo,
+  type RefObject,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -157,6 +158,14 @@ interface LeadThoughtsGroupRowProps {
   memberColor?: string;
   isNew?: boolean;
   onVisible?: (message: InboxMessage) => void;
+  /**
+   * Root element for IntersectionObserver-based visibility tracking. When
+   * omitted, the observer falls back to the document viewport — correct for
+   * top-level renders, incorrect when the row is inside a scroll container
+   * (sidebar, bottom-sheet) that can clip the row while the document
+   * viewport still contains it.
+   */
+  observerRoot?: RefObject<HTMLElement | null>;
   /** When false, the live indicator is always off (for historical thought groups). */
   canBeLive?: boolean;
   /** Whether the owning team is currently alive. */
@@ -528,6 +537,7 @@ const LeadThoughtsGroupRowComponent = ({
   memberColor,
   isNew,
   onVisible,
+  observerRoot,
   canBeLive,
   isTeamAlive,
   leadActivity,
@@ -637,6 +647,9 @@ const LeadThoughtsGroupRowComponent = ({
     if (!onVisible) return;
     const el = ref.current;
     if (!el) return;
+    // Resolve observer root at effect-time. Falls back to the document
+    // viewport when no root is provided — preserves pre-contract behavior.
+    const root = observerRoot?.current ?? null;
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (!entry?.isIntersecting) return;
@@ -647,11 +660,11 @@ const LeadThoughtsGroupRowComponent = ({
         }
         reportedCountRef.current = thoughts.length;
       },
-      { threshold: VIEWPORT_THRESHOLD, rootMargin: '0px' }
+      { root, threshold: VIEWPORT_THRESHOLD, rootMargin: '0px' }
     );
     observer.observe(el);
     return () => observer.disconnect();
-  }, [onVisible, thoughts]);
+  }, [onVisible, observerRoot, thoughts]);
 
   const clearPendingScrollSync = useCallback(() => {
     if (scrollSyncFrameRef.current !== null) {
@@ -1134,5 +1147,6 @@ export const LeadThoughtsGroupRow = memo(
     prev.compactHeader === next.compactHeader &&
     prev.onExpand === next.onExpand &&
     prev.expandItemKey === next.expandItemKey &&
+    prev.observerRoot === next.observerRoot &&
     areThoughtGroupsEquivalent(prev.group, next.group)
 );

--- a/src/renderer/components/team/messages/MessagesPanel.tsx
+++ b/src/renderer/components/team/messages/MessagesPanel.tsx
@@ -36,7 +36,7 @@ import {
 } from 'lucide-react';
 import { useShallow } from 'zustand/react/shallow';
 
-import { ActivityTimeline } from '../activity/ActivityTimeline';
+import { ActivityTimeline, type TimelineViewport } from '../activity/ActivityTimeline';
 import { getThoughtGroupKey, groupTimelineItems } from '../activity/LeadThoughtsGroup';
 import { MessageExpandDialog } from '../activity/MessageExpandDialog';
 import { CollapsibleTeamSection } from '../CollapsibleTeamSection';
@@ -183,6 +183,7 @@ export const MessagesPanel = memo(function MessagesPanel({
   onReplyToMessage,
   onRestartTeam,
   onTaskIdClick,
+  inlineScrollContainerRef,
 }: MessagesPanelProps): React.JSX.Element {
   const {
     sendTeamMessage,
@@ -235,6 +236,28 @@ export const MessagesPanel = memo(function MessagesPanel({
   // Held here so future viewport consumers (virtualization) can observe the
   // true scrolling element in bottom-sheet mode.
   const bottomSheetScrollRef = useRef<HTMLDivElement | null>(null);
+
+  // Resolve the active scroll owner for the current layout. This is the
+  // ref that ActivityTimeline's IntersectionObserver will use as its root,
+  // so visibility is measured against the real scroll container rather
+  // than the document viewport. Virtualizer consumers will hook into the
+  // same ref in a follow-up change.
+  const activeScrollContainerRef =
+    position === 'inline'
+      ? (inlineScrollContainerRef ?? null)
+      : position === 'sidebar'
+        ? sidebarScrollRef
+        : bottomSheetScrollRef;
+
+  const activityTimelineViewport = useMemo<TimelineViewport | undefined>(() => {
+    if (!activeScrollContainerRef) return undefined;
+    return {
+      scrollElementRef: activeScrollContainerRef,
+      observerRoot: activeScrollContainerRef,
+      scrollMargin: 0,
+      virtualizationEnabled: false,
+    };
+  }, [activeScrollContainerRef]);
   const handleExpandContent = useCallback(() => {
     // no-op: user is reading expanded content, not composing
   }, []);
@@ -678,6 +701,7 @@ export const MessagesPanel = memo(function MessagesPanel({
         onTaskIdClick={onTaskIdClick}
         onExpandItem={handleExpandItem}
         onExpandContent={handleExpandContent}
+        viewport={activityTimelineViewport}
       />
       {hasMore && (
         <div className="flex justify-center py-2">
@@ -863,6 +887,7 @@ export const MessagesPanel = memo(function MessagesPanel({
             onTaskIdClick={onTaskIdClick}
             onExpandItem={handleExpandItem}
             onExpandContent={handleExpandContent}
+            viewport={activityTimelineViewport}
           />
           {hasMore && (
             <div className="flex justify-center py-2">
@@ -1150,6 +1175,7 @@ export const MessagesPanel = memo(function MessagesPanel({
                   onTaskIdClick={onTaskIdClick}
                   onExpandItem={handleExpandItem}
                   onExpandContent={handleExpandContent}
+                  viewport={activityTimelineViewport}
                 />
                 {hasMore && (
                   <div className="flex justify-center py-2">

--- a/test/renderer/components/team/activity/ActivityTimeline.test.ts
+++ b/test/renderer/components/team/activity/ActivityTimeline.test.ts
@@ -289,6 +289,60 @@ describe('ActivityTimeline session separators', () => {
       root.unmount();
     });
   });
+
+  it('renders each separator distinctly when the same session transition repeats', async () => {
+    const warnSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const root = createRoot(container);
+    const messages: InboxMessage[] = [
+      makeMessage({
+        messageId: 'thought-b-2',
+        text: 'b second',
+        leadSessionId: 'lead-session-b',
+        from: 'team-lead',
+        source: 'lead_session',
+      }),
+      makeMessage({
+        messageId: 'thought-a-2',
+        text: 'a second',
+        leadSessionId: 'lead-session-a',
+        from: 'team-lead',
+        source: 'lead_session',
+      }),
+      makeMessage({
+        messageId: 'thought-b-1',
+        text: 'b first',
+        leadSessionId: 'lead-session-b',
+        from: 'team-lead',
+        source: 'lead_session',
+      }),
+      makeMessage({
+        messageId: 'thought-a-1',
+        text: 'a first',
+        leadSessionId: 'lead-session-a',
+        from: 'team-lead',
+        source: 'lead_session',
+      }),
+    ];
+
+    await act(async () => {
+      root.render(React.createElement(ActivityTimeline, { messages, teamName: 'demo-team' }));
+    });
+
+    // Three transitions: b→a, a→b, b→a. All three separators must render.
+    const matches = container.textContent?.match(/New session/g) ?? [];
+    expect(matches.length).toBe(3);
+
+    // React warns via `console.error` when duplicate keys are detected.
+    const duplicateKeyWarnings = warnSpy.mock.calls.filter((call) =>
+      String(call[0]).includes('unique "key"')
+    );
+    expect(duplicateKeyWarnings).toHaveLength(0);
+
+    warnSpy.mockRestore();
+    await act(async () => {
+      root.unmount();
+    });
+  });
 });
 
 describe('ActivityTimeline viewport observerRoot', () => {

--- a/test/renderer/components/team/activity/ActivityTimeline.test.ts
+++ b/test/renderer/components/team/activity/ActivityTimeline.test.ts
@@ -13,8 +13,13 @@ vi.mock('@renderer/components/team/activity/ActivityItem', () => ({
 
 vi.mock('@renderer/components/team/activity/AnimatedHeightReveal', () => ({
   ENTRY_REVEAL_ANIMATION_MS: 220,
-  AnimatedHeightReveal: ({ children }: { children: React.ReactNode }) =>
-    React.createElement(React.Fragment, null, children),
+  AnimatedHeightReveal: ({
+    children,
+    containerRef,
+  }: {
+    children: React.ReactNode;
+    containerRef?: React.RefObject<HTMLDivElement | null>;
+  }) => React.createElement('div', { ref: containerRef }, children),
 }));
 
 vi.mock('@renderer/components/team/activity/useNewItemKeys', () => ({
@@ -283,5 +288,125 @@ describe('ActivityTimeline session separators', () => {
     await act(async () => {
       root.unmount();
     });
+  });
+});
+
+describe('ActivityTimeline viewport observerRoot', () => {
+  let container: HTMLDivElement;
+  let capturedRoots: Array<Element | Document | null>;
+  let originalIntersectionObserver:
+    | typeof globalThis.IntersectionObserver
+    | undefined;
+
+  beforeEach(() => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+
+    capturedRoots = [];
+    originalIntersectionObserver = globalThis.IntersectionObserver;
+    class FakeIntersectionObserver {
+      public readonly root: Element | Document | null;
+      public readonly rootMargin: string;
+      public readonly thresholds: ReadonlyArray<number>;
+      constructor(
+        _callback: IntersectionObserverCallback,
+        options?: IntersectionObserverInit
+      ) {
+        this.root = options?.root ?? null;
+        this.rootMargin = options?.rootMargin ?? '0px';
+        this.thresholds = Array.isArray(options?.threshold)
+          ? options.threshold
+          : typeof options?.threshold === 'number'
+            ? [options.threshold]
+            : [0];
+        capturedRoots.push(this.root);
+      }
+      observe(): void {}
+      unobserve(): void {}
+      disconnect(): void {}
+      takeRecords(): IntersectionObserverEntry[] {
+        return [];
+      }
+    }
+    vi.stubGlobal('IntersectionObserver', FakeIntersectionObserver);
+  });
+
+  afterEach(() => {
+    if (originalIntersectionObserver) {
+      globalThis.IntersectionObserver = originalIntersectionObserver;
+    }
+    container.remove();
+    document.body.innerHTML = '';
+    vi.unstubAllGlobals();
+  });
+
+  it('creates IntersectionObservers with root=null when no viewport is passed', async () => {
+    const root = createRoot(container);
+    const messages: InboxMessage[] = [
+      makeMessage({
+        messageId: 'msg-1',
+        text: 'hello',
+        from: 'alice',
+        source: 'inbox',
+      }),
+    ];
+
+    await act(async () => {
+      root.render(
+        React.createElement(ActivityTimeline, {
+          messages,
+          teamName: 'demo-team',
+          onMessageVisible: () => {},
+        })
+      );
+    });
+
+    expect(capturedRoots.length).toBeGreaterThan(0);
+    expect(capturedRoots.every((r) => r === null)).toBe(true);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('creates IntersectionObservers with the provided root when viewport.observerRoot is set', async () => {
+    const scrollHost = document.createElement('div');
+    document.body.appendChild(scrollHost);
+    const scrollRef = { current: scrollHost };
+
+    const root = createRoot(container);
+    const messages: InboxMessage[] = [
+      makeMessage({
+        messageId: 'msg-1',
+        text: 'hello',
+        from: 'alice',
+        source: 'inbox',
+      }),
+    ];
+
+    await act(async () => {
+      root.render(
+        React.createElement(ActivityTimeline, {
+          messages,
+          teamName: 'demo-team',
+          onMessageVisible: () => {},
+          viewport: {
+            scrollElementRef: scrollRef,
+            observerRoot: scrollRef,
+            scrollMargin: 0,
+            virtualizationEnabled: false,
+          },
+        })
+      );
+    });
+
+    expect(capturedRoots.length).toBeGreaterThan(0);
+    expect(capturedRoots.every((r) => r === scrollHost)).toBe(true);
+
+    await act(async () => {
+      root.unmount();
+    });
+    scrollHost.remove();
   });
 });


### PR DESCRIPTION
## Summary

PR #3 of 6. Pure refactor, no UI change, no virtualization yet. This lands the flat `TimelineRow` contract so the follow-up can attach `useVirtualizer` to a straightforward atomic-row list.

**Stacked on top of #71.** The diff here currently includes the `TimelineViewport` contract + observer root move from #71 because cross-fork PRs can only target a branch in the upstream repo. After #71 lands, I'll rebase this PR onto `dev` and the diff will shrink to just this PR's scope (~188/-163, net +25).

## What this PR adds (scoped to renderRows work)

- Introduces `TimelineRow`, a discriminated union: `session-separator`, `lead-thought-group` (`isPinned` flag covers the sticky pinned case), `compaction-divider`, `message-row`.
- Adds a `renderRows` useMemo that walks `timelineItems` once and emits atomic rows. Session separators are hoisted out of the Fragment bundle that used to pair them with their owning item, so every row is independently measurable — the contract the virtualizer needs.
- Extracts a local `renderTimelineRow(row)` helper with one `switch (row.kind)` branch per row type. JSX per branch is identical to the previous inline code (keys, memoization, collapse props, pinned `canBeLive` semantics).
- The render body collapses from two blocks (`pinnedThoughtGroup && ...` + `timelineItems.slice(startIndex).map(...)`) into a single `renderRows.map(renderTimelineRow)`.

## What this PR does *not* do

- No virtualization. `scrollMargin` / `virtualizationEnabled` from the viewport contract stay untouched.
- No changes to `groupTimelineItems`, `visibleCount`, `Show more` / `Show all`, collapse state, zebra striping, or the hidden-count footer.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm exec vitest run test/renderer/components/team/activity/` — 45/45 pass, including the existing session-separator order/boundary tests which implicitly verify the flatten preserves visual order.

## Roadmap

1. ✅ **#70 — Scroll owner wiring** (merged)
2. 🔄 **#71 — Viewport contract + observer root move** (draft)
3. 🔄 **#72 — `renderRows` flatten** (this PR, draft, stacked on #71)
4. Virtualizer skeleton + measured `scrollMargin`
5. `measureElement` + merged refs for dynamic height
6. Tests + threshold + cleanup