### PR TITLE
ci: enable CodeRabbit auto review for dev drafts

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,7 +3,9 @@
 reviews:
   auto_review:
     enabled: true
-    drafts: false
+    drafts: true
+    base_branches:
+      - 'dev'
   auto_title_instructions: |
     Follow Conventional Commits format: '<type>: <description>'
     Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert


### PR DESCRIPTION
## Summary
- enable CodeRabbit auto review for PRs targeting `dev`
- allow automatic reviews on draft PRs so stacked draft PRs get feedback early

## Why
- the repo default branch is `main`, but active review flow also uses `dev`
- current config skipped draft PRs entirely

## Validation
- `./node_modules/.bin/prettier --check .coderabbit.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**No user-facing changes.** This release contains internal configuration updates only. The adjustments to development tooling do not affect application functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->