### PR TITLE
ci: enable CodeRabbit auto review for all branches

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,7 +5,7 @@ reviews:
     enabled: true
     drafts: true
     base_branches:
-      - 'dev'
+      - '.*'
   auto_title_instructions: |
     Follow Conventional Commits format: '<type>: <description>'
     Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert


### PR DESCRIPTION
## Summary
- expand CodeRabbit auto review from `dev` to all target branches
- keep draft PR auto reviews enabled

## Why
- review should run for PRs targeting `main`, `dev`, and any other active base branch
- CodeRabbit supports this via `base_branches: [".*"]`

## Validation
- `./node_modules/.bin/prettier --check .coderabbit.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated code review configuration to enable automatic reviews across all base branches. Previously, automatic code reviews were limited to the development branch exclusively. This change expands the scope of automated code review processes to consistently apply across the entire repository's branch structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->