### PR TITLE
fix(ci): restore dev validate after virtualization merge

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,7 +3,9 @@
 reviews:
   auto_review:
     enabled: true
-    drafts: false
+    drafts: true
+    base_branches:
+      - '.*'
   auto_title_instructions: |
     Follow Conventional Commits format: '<type>: <description>'
     Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert

--- a/src/main/services/team/TeamProvisioningService.ts
+++ b/src/main/services/team/TeamProvisioningService.ts
@@ -1131,7 +1131,7 @@ async function waitForTmuxPanesToExit(
   }
 
   if (lastError) {
-    throw (lastError instanceof Error ? lastError : new Error(getErrorMessage(lastError)));
+    throw lastError instanceof Error ? lastError : new Error(getErrorMessage(lastError));
   }
   return remainingPaneIds;
 }

--- a/src/main/services/team/TeamProvisioningService.ts
+++ b/src/main/services/team/TeamProvisioningService.ts
@@ -38,6 +38,7 @@ import { getMemberColorByName } from '@shared/constants/memberColors';
 import { DEFAULT_TOOL_APPROVAL_SETTINGS } from '@shared/types/team';
 import { resolveLanguageName } from '@shared/utils/agentLanguage';
 import { getAnthropicDefaultTeamModel } from '@shared/utils/anthropicModelDefaults';
+import { getErrorMessage } from '@shared/utils/errorHandling';
 import { buildTeamMemberColorMap } from '@shared/utils/teamMemberColors';
 import { parseCliArgs } from '@shared/utils/cliArgsParser';
 import { deriveContextMetrics, inferContextWindowTokens } from '@shared/utils/contextMetrics';
@@ -1130,7 +1131,7 @@ async function waitForTmuxPanesToExit(
   }
 
   if (lastError) {
-    throw lastError;
+    throw (lastError instanceof Error ? lastError : new Error(getErrorMessage(lastError)));
   }
   return remainingPaneIds;
 }


### PR DESCRIPTION
## Summary
- fix the `only-throw-error` CI blocker in `TeamProvisioningService`
- sync `.coderabbit.yaml` on `dev` with the current repo config from `main`

## Why
- `dev` push CI for merge commit `6929ab2a` failed in `validate` on `throw lastError`
- `dev` was still carrying the old CodeRabbit config

## Validation
- inspected failing GitHub Actions run `24650949710` and isolated the single ESLint error
- `./node_modules/.bin/prettier --check .coderabbit.yaml`
- local full `pnpm check` was started and progressed through typecheck and workspace tests without hitting the previous blocker