### PR TITLE
fix(team): propagate cross-provider member args to lead subprocess

### DIFF
--- a/src/main/services/team/TeamProvisioningService.ts
+++ b/src/main/services/team/TeamProvisioningService.ts
@@ -12947,6 +12947,16 @@ export class TeamProvisioningService {
       }
       launchArgs.push(...parseCliArgs(request.extraCliArgs));
       launchArgs.push(...providerArgs);
+      // When the lead uses a different provider than some teammates (e.g., anthropic lead
+      // with codex teammates), the lead needs the teammate provider's launch args so they
+      // can be inherited by the teammate subprocess via buildInheritedCliFlags.
+      // Without this, a codex teammate spawned from an anthropic lead has no way to learn
+      // about the required forced_login_method (chatgpt/api) and fails to start.
+      const crossProviderMemberArgs = await this.buildCrossProviderMemberArgs(
+        resolvedProviderId,
+        effectiveMemberSpecs
+      );
+      launchArgs.push(...crossProviderMemberArgs);
       const finalLaunchArgs = mergeJsonSettingsArgs(launchArgs);
       const runtimeWarning = buildRuntimeLaunchWarning(request, shellEnv, {
         geminiRuntimeAuth,
@@ -21415,6 +21425,33 @@ export class TeamProvisioningService {
       geminiRuntimeAuth: null,
       providerArgs: providerEnvResult.providerArgs,
     };
+  }
+
+  private async buildCrossProviderMemberArgs(
+    primaryProviderId: TeamProviderId,
+    memberSpecs: TeamCreateRequest['members']
+  ): Promise<string[]> {
+    const crossProviderIds = new Set<TeamProviderId>();
+    for (const member of memberSpecs) {
+      const memberId = resolveTeamProviderId(
+        normalizeTeamMemberProviderId(member.providerId) ?? primaryProviderId
+      );
+      if (memberId !== primaryProviderId) {
+        crossProviderIds.add(memberId);
+      }
+    }
+    const args: string[] = [];
+    for (const providerId of crossProviderIds) {
+      try {
+        const env = await this.buildProvisioningEnv(providerId);
+        if (env.providerArgs) {
+          args.push(...env.providerArgs);
+        }
+      } catch {
+        // Best-effort: don't block launch if cross-provider env resolution fails
+      }
+    }
+    return args;
   }
 
   private async resolveControlApiBaseUrl(): Promise<string | null> {

--- a/src/main/services/team/TeamProvisioningService.ts
+++ b/src/main/services/team/TeamProvisioningService.ts
@@ -21447,7 +21447,11 @@ export class TeamProvisioningService {
         if (env.providerArgs) {
           args.push(...env.providerArgs);
         }
-      } catch {
+      } catch (error) {
+        console.error(
+          `[TeamProvisioningService] Failed to build cross-provider args for provider "${providerId}"`,
+          error
+        );
         // Best-effort: don't block launch if cross-provider env resolution fails
       }
     }


### PR DESCRIPTION
## Summary

- When a team has an anthropic lead and codex teammates, the lead was launched without `--settings {"codex":{"forced_login_method":"chatgpt"}}`
- `buildInheritedCliFlags` in the lead had nothing to propagate, so the codex teammate started without knowing the required auth method and crashed with "no CODEX_API_KEY or OPENAI_API_KEY configured"
- Adds `buildCrossProviderMemberArgs` — collects provider launch args for member providers that differ from the primary and merges them into the lead's args so teammates inherit them

## Why

`TeamProvisioningService.buildProvisioningEnv` only builds args for the primary provider. Per-member provider envs were resolved internally (to detect models/issues) but their `providerArgs` were never included in the lead's launch args. The codex `--settings {"codex":{"forced_login_method":"chatgpt"}}` arg was effectively lost.

## Test plan

- [ ] Create a team with anthropic lead + codex member (ChatGPT account mode)
- [ ] Confirm codex teammate joins and processes tasks without the API key error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launch process now includes provider-specific arguments for team members who use different providers, ensuring those providers' environment settings are applied.
  * Cross-provider resolution is performed asynchronously with best-effort error handling (issues are logged but won’t block launches), improving robustness for mixed-provider teams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->