### PR TITLE
test(team): strengthen tmux decoupling checks

### DIFF
--- a/test/main/services/team/TeamProvisioningService.test.ts
+++ b/test/main/services/team/TeamProvisioningService.test.ts
@@ -636,6 +636,7 @@ describe('TeamProvisioningService', () => {
       await svc.getTeamAgentRuntimeSnapshot('runtime-team');
 
       expect(listTmuxPaneRuntimeInfoForCurrentPlatform).not.toHaveBeenCalled();
+      expect(listTmuxPanePidsForCurrentPlatform).not.toHaveBeenCalled();
     });
 
     it('exposes providerBackendId from the live run request when available', async () => {

--- a/test/renderer/components/common/TokenUsageDisplay.test.ts
+++ b/test/renderer/components/common/TokenUsageDisplay.test.ts
@@ -54,10 +54,6 @@ async function flushReact(): Promise<void> {
   await Promise.resolve();
 }
 
-function withoutNumberGroupSeparators(value: string | null | undefined): string {
-  return (value ?? '').replace(/[\s,\u00a0\u202f]/g, '');
-}
-
 describe('TokenUsageDisplay', () => {
   afterEach(() => {
     document.body.innerHTML = '';
@@ -93,8 +89,9 @@ describe('TokenUsageDisplay', () => {
     });
 
     const popover = document.querySelector('[role="tooltip"]');
+    const expectedTotalTokens = new Intl.NumberFormat().format(2250);
     expect(popover).toBeTruthy();
-    expect(withoutNumberGroupSeparators(popover?.textContent)).toContain('2250');
+    expect(popover?.textContent).toContain(expectedTotalTokens);
     expect(popover?.textContent).toContain('500 (25.0% of prompt input)');
     expect(popover?.textContent).not.toContain('of context');
 


### PR DESCRIPTION
Follow-up for the tmux decoupling review after PR #89 was already merged.\n\nWhat changed:\n- strengthens the legacy process marker test to assert no tmux PID lookup is used\n- makes the token usage expectation locale-aware via Intl.NumberFormat\n\nLocal verification:\n- pnpm exec vitest run --maxWorkers 1 --minWorkers 1 test/main/services/team/runtimeTeammateMode.test.ts test/main/services/team/TeamProvisioningService.test.ts test/renderer/components/team/dialogs/teammateRuntimeCompatibility.test.ts test/renderer/components/common/TokenUsageDisplay.test.ts\n- pnpm test:ci\n- pnpm typecheck\n- pnpm build\n- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded team provisioning test coverage to verify additional operations are properly skipped under specific conditions.
  * Enhanced token usage display test to validate locale-specific number formatting in tooltips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->