### PR TITLE
fix(ci): resolve two test failures introduced in dev branch

### DIFF
--- a/src/main/http/teams.ts
+++ b/src/main/http/teams.ts
@@ -1,4 +1,5 @@
 import { validateTeammateName, validateTeamName } from '@main/ipc/guards';
+import { TeamConfigReader } from '@main/services/team/TeamConfigReader';
 import { getTeamsBasePath } from '@main/utils/pathDecoder';
 import { extractUserFlags, PROTECTED_CLI_FLAGS } from '@shared/utils/cliArgsParser';
 import {
@@ -551,6 +552,7 @@ export function registerTeamRoutes(app: FastifyInstance, services: HttpServices)
               parseLaunchRequest(teamName, request.body),
               () => undefined
             );
+        TeamConfigReader.invalidateListTeamsCache();
         return reply.send(response);
       } catch (error) {
         const statusCode = getStatusCode(error);

--- a/src/main/services/team/TeamProvisioningService.ts
+++ b/src/main/services/team/TeamProvisioningService.ts
@@ -24809,7 +24809,9 @@ export class TeamProvisioningService {
       }
     }
     // Remove from runs Map to free memory (stdoutBuffer, stderrBuffer, claudeLogLines)
-    this.retainProvisioningProgress(run.runId, run.progress);
+    if (run.progress) {
+      this.retainProvisioningProgress(run.runId, run.progress);
+    }
     this.runs.delete(run.runId);
   }
 


### PR DESCRIPTION
## Summary

Two CI failures that appeared after recent \`dev\` branch changes:

- **4 failures** in \`TeamProvisioningServiceLiveMessages.test.ts\` — \`Cannot read properties of undefined (reading 'warnings')\` because \`cleanupRun\` now calls \`retainProvisioningProgress(run.runId, run.progress)\` but test mocks don't include a \`progress\` field. Fixed with a null guard before the call.

- **1 failure** in \`teamMcpControl.integration.test.ts\` — \`expect(launchedListItem).not.toHaveProperty('pendingCreate')\` after \`team_launch\`. The \`TeamConfigReader\` has a 5-second LRU cache on \`listTeams()\`; after launch writes \`config.json\`, the next \`GET /api/teams\` hits the stale cache that still carries \`pendingCreate: true\`. Fixed by calling \`TeamConfigReader.invalidateListTeamsCache()\` in the launch HTTP handler right after the provisioning call succeeds.

## Test plan

- [x] \`TeamProvisioningServiceLiveMessages.test.ts\` — 32/32 pass
- [x] \`teamMcpControl.integration.test.ts\` — 1/1 pass
- [x] Full suite: 5565 passed, only pre-existing \`GlobalTaskList.test.ts\` failure remains (unrelated, predates this branch)
- [x] \`pnpm typecheck\` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Team list cache now properly refreshes when teams are created or launched, ensuring users always see the most current team information without manual intervention
  * Provisioning progress tracking improved to only retain valid progress data during team provisioning, reducing edge case issues and enhancing team creation workflow reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->