### PR TITLE
Add Windows runner child-process preflight

### DIFF
--- a/src/main/services/runtime/agentChildProcessPreflight.test.ts
+++ b/src/main/services/runtime/agentChildProcessPreflight.test.ts
@@ -2,25 +2,14 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('child_process', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('child_process')>();
-  return {
-    ...actual,
-    spawnSync: vi.fn(),
-  };
-});
-
-import * as childProcess from 'child_process';
 import {
   applyAgentChildProcessWritableEnv,
-  assertAgentChildProcessPreflight,
+  prepareAgentChildProcessWritableEnv,
 } from './agentChildProcessPreflight';
 
 const originalPlatform = process.platform;
-const spawnSyncMock = vi.mocked(childProcess.spawnSync);
 
 function setPlatform(value: string): void {
   Object.defineProperty(process, 'platform', {
@@ -30,44 +19,48 @@ function setPlatform(value: string): void {
   });
 }
 
-function successfulSpawn(stdout = '1.0.0\n'): childProcess.SpawnSyncReturns<string> {
-  return {
-    output: [],
-    pid: 123,
-    signal: null,
-    status: 0,
-    stderr: '',
-    stdout,
-  };
-}
-
-describe('agent child-process preflight', () => {
+describe('agent child-process writable env', () => {
   let tmpRoot: string;
 
   beforeEach(() => {
     setPlatform('win32');
-    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-child-preflight-'));
-    spawnSyncMock.mockReset();
-    spawnSyncMock.mockReturnValue(successfulSpawn());
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-child-env-'));
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     setPlatform(originalPlatform);
     fs.rmSync(tmpRoot, { recursive: true, force: true });
   });
 
-  it('injects stable writable cache and temp env for Windows agents', () => {
+  it('does not mutate env on non-Windows platforms', async () => {
+    setPlatform('darwin');
+    const env: NodeJS.ProcessEnv = {
+      TEMP: path.join(tmpRoot, 'existing-temp'),
+    };
+
+    const result = await prepareAgentChildProcessWritableEnv(env, { home: tmpRoot });
+
+    expect(result).toEqual({ applied: false });
+    expect(env).toEqual({
+      TEMP: path.join(tmpRoot, 'existing-temp'),
+    });
+  });
+
+  it('prepares stable writable cache and temp env for Windows agents', async () => {
     const home = path.join(tmpRoot, 'home');
     const env: NodeJS.ProcessEnv = {
       COMSPEC: 'cmd.exe',
       LOCALAPPDATA: path.join(home, 'AppData', 'Local'),
     };
 
-    applyAgentChildProcessWritableEnv(env, { home });
+    const result = await prepareAgentChildProcessWritableEnv(env, { home });
 
     const expectedBase = path.join(home, 'AppData', 'Local', 'AgentStudio', 'runner-cache');
+    expect(result).toEqual({ applied: true, cacheBase: expectedBase });
     expect(env.TEMP).toBe(path.join(expectedBase, 'tmp'));
     expect(env.TMP).toBe(path.join(expectedBase, 'tmp'));
+    expect(env.TMPDIR).toBe(path.join(expectedBase, 'tmp'));
     expect(env.npm_config_cache).toBe(path.join(expectedBase, 'npm-cache'));
     expect(env.NPM_CONFIG_CACHE).toBe(path.join(expectedBase, 'npm-cache'));
     expect(env.GRADLE_USER_HOME).toBe(path.join(expectedBase, 'gradle-home'));
@@ -78,66 +71,54 @@ describe('agent child-process preflight', () => {
     expect(env.AGENT_STUDIO_NPX_CMD).toBe('npx.cmd');
     expect(env.GRADLE_OPTS).toContain('-Djava.io.tmpdir=');
     expect(env.JAVA_TOOL_OPTIONS).toContain('-Djava.io.tmpdir=');
-  });
 
-  it('checks writable roots and .cmd shims before the agent starts', async () => {
-    const env: NodeJS.ProcessEnv = {
-      COMSPEC: 'cmd.exe',
-      TEMP: path.join(tmpRoot, 'tmp'),
-      TMP: path.join(tmpRoot, 'tmp'),
-      npm_config_cache: path.join(tmpRoot, 'npm-cache'),
-      GRADLE_USER_HOME: path.join(tmpRoot, 'gradle-home'),
-      ANDROID_USER_HOME: path.join(tmpRoot, 'android-home'),
-      ANDROID_SDK_HOME: path.join(tmpRoot, 'android-home'),
-    };
-    const cwd = path.join(tmpRoot, 'workspace');
-
-    await assertAgentChildProcessPreflight({ cwd, env, timeoutMs: 1_000 });
-
-    expect(spawnSyncMock).toHaveBeenCalledTimes(3);
-    expect(spawnSyncMock).toHaveBeenNthCalledWith(
-      1,
-      'node.exe',
-      expect.any(Array),
-      expect.objectContaining({ cwd, env, timeout: 1_000, windowsHide: true })
-    );
-    expect(spawnSyncMock).toHaveBeenNthCalledWith(
-      2,
-      'cmd.exe',
-      ['/d', '/s', '/c', 'npm.cmd --version'],
-      expect.objectContaining({ cwd, env, timeout: 1_000, windowsHide: true })
-    );
-    expect(spawnSyncMock).toHaveBeenNthCalledWith(
-      3,
-      'cmd.exe',
-      ['/d', '/s', '/c', 'npx.cmd --version'],
-      expect.objectContaining({ cwd, env, timeout: 1_000, windowsHide: true })
-    );
-  });
-
-  it('fails with a runner-level error when child process spawn is blocked', async () => {
-    const env: NodeJS.ProcessEnv = {
-      COMSPEC: 'cmd.exe',
-      TEMP: path.join(tmpRoot, 'tmp'),
-      npm_config_cache: path.join(tmpRoot, 'npm-cache'),
-      GRADLE_USER_HOME: path.join(tmpRoot, 'gradle-home'),
-      ANDROID_USER_HOME: path.join(tmpRoot, 'android-home'),
-      ANDROID_SDK_HOME: path.join(tmpRoot, 'android-home'),
-    };
-    spawnSyncMock
-      .mockReturnValueOnce({
-        ...successfulSpawn(''),
-        error: new Error('spawnSync node.exe EPERM'),
-        status: null,
-      })
-      .mockReturnValue(successfulSpawn());
-
+    await expect(fs.promises.access(path.join(expectedBase, 'tmp'))).resolves.toBeUndefined();
+    await expect(fs.promises.access(path.join(expectedBase, 'npm-cache'))).resolves.toBeUndefined();
     await expect(
-      assertAgentChildProcessPreflight({
-        cwd: path.join(tmpRoot, 'workspace-failure'),
-        env,
-        timeoutMs: 1_000,
-      })
-    ).rejects.toThrow(/Agent child-process preflight failed/);
+      fs.promises.access(path.join(expectedBase, 'gradle-home'))
+    ).resolves.toBeUndefined();
+    await expect(
+      fs.promises.access(path.join(expectedBase, 'android-home'))
+    ).resolves.toBeUndefined();
+  });
+
+  it('fails open and leaves existing env untouched when cache dirs cannot be created', async () => {
+    const home = path.join(tmpRoot, 'home');
+    const originalTemp = path.join(tmpRoot, 'existing-temp');
+    const env: NodeJS.ProcessEnv = {
+      COMSPEC: 'cmd.exe',
+      LOCALAPPDATA: path.join(home, 'AppData', 'Local'),
+      TEMP: originalTemp,
+      TMP: originalTemp,
+    };
+    vi.spyOn(fs.promises, 'mkdir').mockRejectedValueOnce(new Error('EACCES'));
+
+    const result = await prepareAgentChildProcessWritableEnv(env, { home });
+
+    expect(result.applied).toBe(false);
+    expect(result.cacheBase).toBe(
+      path.join(home, 'AppData', 'Local', 'AgentStudio', 'runner-cache')
+    );
+    expect(result.warning).toContain('keeping existing temp/cache env');
+    expect(env).toEqual({
+      COMSPEC: 'cmd.exe',
+      LOCALAPPDATA: path.join(home, 'AppData', 'Local'),
+      TEMP: originalTemp,
+      TMP: originalTemp,
+    });
+  });
+
+  it('keeps the synchronous env applicator available for prepared directories', () => {
+    const home = path.join(tmpRoot, 'home');
+    const env: NodeJS.ProcessEnv = {
+      COMSPEC: 'cmd.exe',
+      LOCALAPPDATA: path.join(home, 'AppData', 'Local'),
+    };
+
+    applyAgentChildProcessWritableEnv(env, { home });
+
+    const expectedBase = path.join(home, 'AppData', 'Local', 'AgentStudio', 'runner-cache');
+    expect(env.TEMP).toBe(path.join(expectedBase, 'tmp'));
+    expect(env.TMPDIR).toBe(path.join(expectedBase, 'tmp'));
   });
 });

--- a/src/main/services/runtime/agentChildProcessPreflight.test.ts
+++ b/src/main/services/runtime/agentChildProcessPreflight.test.ts
@@ -1,13 +1,12 @@
 // @vitest-environment node
+import {
+  applyAgentChildProcessWritableEnv,
+  prepareAgentChildProcessWritableEnv,
+} from '@main/services/runtime/agentChildProcessPreflight';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-
-import {
-  applyAgentChildProcessWritableEnv,
-  prepareAgentChildProcessWritableEnv,
-} from './agentChildProcessPreflight';
 
 const originalPlatform = process.platform;
 
@@ -80,6 +79,14 @@ describe('agent child-process writable env', () => {
     await expect(
       fs.promises.access(path.join(expectedBase, 'android-home'))
     ).resolves.toBeUndefined();
+
+    for (const dirName of ['tmp', 'npm-cache', 'gradle-home', 'android-home']) {
+      const entries = await fs.promises.readdir(path.join(expectedBase, dirName));
+      const probeEntries = entries.filter((entry) =>
+        entry.startsWith('.agent-studio-write-probe-')
+      );
+      expect(probeEntries).toEqual([]);
+    }
   });
 
   it('fails open and leaves existing env untouched when cache dirs cannot be created', async () => {
@@ -108,6 +115,33 @@ describe('agent child-process writable env', () => {
     });
   });
 
+  it('fails open and leaves existing env untouched when cache dirs are not writable', async () => {
+    const home = path.join(tmpRoot, 'home');
+    const originalTemp = path.join(tmpRoot, 'existing-temp');
+    const env: NodeJS.ProcessEnv = {
+      COMSPEC: 'cmd.exe',
+      LOCALAPPDATA: path.join(home, 'AppData', 'Local'),
+      TEMP: originalTemp,
+      TMP: originalTemp,
+    };
+    vi.spyOn(fs.promises, 'writeFile').mockRejectedValueOnce(new Error('EPERM'));
+
+    const result = await prepareAgentChildProcessWritableEnv(env, { home });
+
+    expect(result.applied).toBe(false);
+    expect(result.cacheBase).toBe(
+      path.join(home, 'AppData', 'Local', 'AgentStudio', 'runner-cache')
+    );
+    expect(result.warning).toContain('failed writable check');
+    expect(result.warning).toContain('EPERM');
+    expect(env).toEqual({
+      COMSPEC: 'cmd.exe',
+      LOCALAPPDATA: path.join(home, 'AppData', 'Local'),
+      TEMP: originalTemp,
+      TMP: originalTemp,
+    });
+  });
+
   it('keeps the synchronous env applicator available for prepared directories', () => {
     const home = path.join(tmpRoot, 'home');
     const env: NodeJS.ProcessEnv = {
@@ -119,6 +153,7 @@ describe('agent child-process writable env', () => {
 
     const expectedBase = path.join(home, 'AppData', 'Local', 'AgentStudio', 'runner-cache');
     expect(env.TEMP).toBe(path.join(expectedBase, 'tmp'));
+    expect(env.TMP).toBe(path.join(expectedBase, 'tmp'));
     expect(env.TMPDIR).toBe(path.join(expectedBase, 'tmp'));
   });
 });

--- a/src/main/services/runtime/agentChildProcessPreflight.test.ts
+++ b/src/main/services/runtime/agentChildProcessPreflight.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment node
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return {
+    ...actual,
+    spawnSync: vi.fn(),
+  };
+});
+
+import * as childProcess from 'child_process';
+import {
+  applyAgentChildProcessWritableEnv,
+  assertAgentChildProcessPreflight,
+} from './agentChildProcessPreflight';
+
+const originalPlatform = process.platform;
+const spawnSyncMock = vi.mocked(childProcess.spawnSync);
+
+function setPlatform(value: string): void {
+  Object.defineProperty(process, 'platform', {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+function successfulSpawn(stdout = '1.0.0\n'): childProcess.SpawnSyncReturns<string> {
+  return {
+    output: [],
+    pid: 123,
+    signal: null,
+    status: 0,
+    stderr: '',
+    stdout,
+  };
+}
+
+describe('agent child-process preflight', () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    setPlatform('win32');
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-child-preflight-'));
+    spawnSyncMock.mockReset();
+    spawnSyncMock.mockReturnValue(successfulSpawn());
+  });
+
+  afterEach(() => {
+    setPlatform(originalPlatform);
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('injects stable writable cache and temp env for Windows agents', () => {
+    const home = path.join(tmpRoot, 'home');
+    const env: NodeJS.ProcessEnv = {
+      COMSPEC: 'cmd.exe',
+      LOCALAPPDATA: path.join(home, 'AppData', 'Local'),
+    };
+
+    applyAgentChildProcessWritableEnv(env, { home });
+
+    const expectedBase = path.join(home, 'AppData', 'Local', 'AgentStudio', 'runner-cache');
+    expect(env.TEMP).toBe(path.join(expectedBase, 'tmp'));
+    expect(env.TMP).toBe(path.join(expectedBase, 'tmp'));
+    expect(env.npm_config_cache).toBe(path.join(expectedBase, 'npm-cache'));
+    expect(env.NPM_CONFIG_CACHE).toBe(path.join(expectedBase, 'npm-cache'));
+    expect(env.GRADLE_USER_HOME).toBe(path.join(expectedBase, 'gradle-home'));
+    expect(env.ANDROID_USER_HOME).toBe(path.join(expectedBase, 'android-home'));
+    expect(env.ANDROID_SDK_HOME).toBe(path.join(expectedBase, 'android-home'));
+    expect(env.npm_config_script_shell).toBe('cmd.exe');
+    expect(env.AGENT_STUDIO_NPM_CMD).toBe('npm.cmd');
+    expect(env.AGENT_STUDIO_NPX_CMD).toBe('npx.cmd');
+    expect(env.GRADLE_OPTS).toContain('-Djava.io.tmpdir=');
+    expect(env.JAVA_TOOL_OPTIONS).toContain('-Djava.io.tmpdir=');
+  });
+
+  it('checks writable roots and .cmd shims before the agent starts', async () => {
+    const env: NodeJS.ProcessEnv = {
+      COMSPEC: 'cmd.exe',
+      TEMP: path.join(tmpRoot, 'tmp'),
+      TMP: path.join(tmpRoot, 'tmp'),
+      npm_config_cache: path.join(tmpRoot, 'npm-cache'),
+      GRADLE_USER_HOME: path.join(tmpRoot, 'gradle-home'),
+      ANDROID_USER_HOME: path.join(tmpRoot, 'android-home'),
+      ANDROID_SDK_HOME: path.join(tmpRoot, 'android-home'),
+    };
+    const cwd = path.join(tmpRoot, 'workspace');
+
+    await assertAgentChildProcessPreflight({ cwd, env, timeoutMs: 1_000 });
+
+    expect(spawnSyncMock).toHaveBeenCalledTimes(3);
+    expect(spawnSyncMock).toHaveBeenNthCalledWith(
+      1,
+      'node.exe',
+      expect.any(Array),
+      expect.objectContaining({ cwd, env, timeout: 1_000, windowsHide: true })
+    );
+    expect(spawnSyncMock).toHaveBeenNthCalledWith(
+      2,
+      'cmd.exe',
+      ['/d', '/s', '/c', 'npm.cmd --version'],
+      expect.objectContaining({ cwd, env, timeout: 1_000, windowsHide: true })
+    );
+    expect(spawnSyncMock).toHaveBeenNthCalledWith(
+      3,
+      'cmd.exe',
+      ['/d', '/s', '/c', 'npx.cmd --version'],
+      expect.objectContaining({ cwd, env, timeout: 1_000, windowsHide: true })
+    );
+  });
+
+  it('fails with a runner-level error when child process spawn is blocked', async () => {
+    const env: NodeJS.ProcessEnv = {
+      COMSPEC: 'cmd.exe',
+      TEMP: path.join(tmpRoot, 'tmp'),
+      npm_config_cache: path.join(tmpRoot, 'npm-cache'),
+      GRADLE_USER_HOME: path.join(tmpRoot, 'gradle-home'),
+      ANDROID_USER_HOME: path.join(tmpRoot, 'android-home'),
+      ANDROID_SDK_HOME: path.join(tmpRoot, 'android-home'),
+    };
+    spawnSyncMock
+      .mockReturnValueOnce({
+        ...successfulSpawn(''),
+        error: new Error('spawnSync node.exe EPERM'),
+        status: null,
+      })
+      .mockReturnValue(successfulSpawn());
+
+    await expect(
+      assertAgentChildProcessPreflight({
+        cwd: path.join(tmpRoot, 'workspace-failure'),
+        env,
+        timeoutMs: 1_000,
+      })
+    ).rejects.toThrow(/Agent child-process preflight failed/);
+  });
+});

--- a/src/main/services/runtime/agentChildProcessPreflight.ts
+++ b/src/main/services/runtime/agentChildProcessPreflight.ts
@@ -21,6 +21,11 @@ interface AgentChildProcessWritableEnvPaths {
   commandShell: string;
 }
 
+interface AgentChildProcessWritableDirectory {
+  label: string;
+  dir: string;
+}
+
 function firstNonEmpty(...values: (string | undefined | null)[]): string | undefined {
   for (const value of values) {
     const trimmed = value?.trim();
@@ -29,6 +34,10 @@ function firstNonEmpty(...values: (string | undefined | null)[]): string | undef
     }
   }
   return undefined;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function setPathEnv(env: NodeJS.ProcessEnv, key: string, value: string): string {
@@ -97,6 +106,45 @@ function applyResolvedWritableEnv(
   return env;
 }
 
+async function ensureWritableDirectory(root: AgentChildProcessWritableDirectory): Promise<void> {
+  try {
+    await fs.promises.mkdir(root.dir, { recursive: true });
+
+    const probePath = path.join(
+      root.dir,
+      `.agent-studio-write-probe-${process.pid}-${Date.now()}-${Math.random()
+        .toString(36)
+        .slice(2)}.tmp`
+    );
+    let probeCreated = false;
+    let cleanupError: unknown;
+
+    try {
+      await fs.promises.writeFile(probePath, 'ok', 'utf8');
+      probeCreated = true;
+
+      const written = await fs.promises.readFile(probePath, 'utf8');
+      if (written !== 'ok') {
+        throw new Error('write probe read back unexpected content');
+      }
+    } finally {
+      if (probeCreated) {
+        try {
+          await fs.promises.unlink(probePath);
+        } catch (error) {
+          cleanupError = error;
+        }
+      }
+    }
+
+    if (cleanupError) {
+      throw new Error(`write probe cleanup failed: ${errorMessage(cleanupError)}`);
+    }
+  } catch (error) {
+    throw new Error(`${root.label} at ${root.dir} failed writable check: ${errorMessage(error)}`);
+  }
+}
+
 export function applyAgentChildProcessWritableEnv(
   env: NodeJS.ProcessEnv,
   options: AgentChildProcessEnvOptions = {}
@@ -117,9 +165,19 @@ export async function prepareAgentChildProcessWritableEnv(
   }
 
   const paths = resolveWritableEnvPaths(env, options);
-  const dirs = [paths.tempRoot, paths.npmCache, paths.gradleHome, paths.androidHome];
+  const dirs: AgentChildProcessWritableDirectory[] = [
+    { label: 'TEMP/TMP/TMPDIR', dir: paths.tempRoot },
+    { label: 'npm cache', dir: paths.npmCache },
+    { label: 'Gradle home', dir: paths.gradleHome },
+    { label: 'Android home', dir: paths.androidHome },
+  ];
   try {
-    await Promise.all(dirs.map((dir) => fs.promises.mkdir(dir, { recursive: true })));
+    const checks = await Promise.allSettled(dirs.map((dir) => ensureWritableDirectory(dir)));
+    const failed = checks.find((check) => check.status === 'rejected');
+    if (failed?.status === 'rejected') {
+      throw failed.reason;
+    }
+
     applyResolvedWritableEnv(env, paths);
     return { applied: true, cacheBase: paths.cacheBase };
   } catch (error) {
@@ -128,9 +186,7 @@ export async function prepareAgentChildProcessWritableEnv(
       cacheBase: paths.cacheBase,
       warning:
         `Windows agent writable cache setup skipped for ${paths.cacheBase}; ` +
-        `keeping existing temp/cache env. Details: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
+        `keeping existing temp/cache env. Details: ${errorMessage(error)}`,
     };
   }
 }

--- a/src/main/services/runtime/agentChildProcessPreflight.ts
+++ b/src/main/services/runtime/agentChildProcessPreflight.ts
@@ -1,4 +1,3 @@
-import { spawnSync, type SpawnSyncReturns } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -7,21 +6,22 @@ export interface AgentChildProcessEnvOptions {
   home?: string;
 }
 
-export interface AgentChildProcessPreflightOptions {
-  cwd?: string;
-  env: NodeJS.ProcessEnv;
-  timeoutMs?: number;
+export interface AgentChildProcessWritableEnvResult {
+  applied: boolean;
+  cacheBase?: string;
+  warning?: string;
 }
 
-interface WritableRoot {
-  label: string;
-  dir: string;
+interface AgentChildProcessWritableEnvPaths {
+  cacheBase: string;
+  tempRoot: string;
+  npmCache: string;
+  gradleHome: string;
+  androidHome: string;
+  commandShell: string;
 }
 
-const DEFAULT_TIMEOUT_MS = 15_000;
-const PREFLIGHT_CACHE = new Set<string>();
-
-function firstNonEmpty(...values: Array<string | undefined | null>): string | undefined {
+function firstNonEmpty(...values: (string | undefined | null)[]): string | undefined {
   for (const value of values) {
     const trimmed = value?.trim();
     if (trimmed) {
@@ -41,7 +41,8 @@ function appendJavaTmpDirOption(current: string | undefined, tempRoot: string): 
     return current;
   }
   const escapedTempRoot = tempRoot.replace(/"/g, '\\"');
-  return `${current?.trim() ? `${current.trim()} ` : ''}-Djava.io.tmpdir="${escapedTempRoot}"`;
+  const prefix = current?.trim() ? `${current.trim()} ` : '';
+  return `${prefix}-Djava.io.tmpdir="${escapedTempRoot}"`;
 }
 
 function getRuntimeCacheBase(env: NodeJS.ProcessEnv, home: string): string {
@@ -50,170 +51,86 @@ function getRuntimeCacheBase(env: NodeJS.ProcessEnv, home: string): string {
     return path.resolve(explicit);
   }
 
-  const localAppData = firstNonEmpty(env.LOCALAPPDATA, path.join(home, 'AppData', 'Local'));
+  const localAppData = firstNonEmpty(env.LOCALAPPDATA) ?? path.join(home, 'AppData', 'Local');
   return path.join(localAppData, 'AgentStudio', 'runner-cache');
+}
+
+function resolveWritableEnvPaths(
+  env: NodeJS.ProcessEnv,
+  options: AgentChildProcessEnvOptions
+): AgentChildProcessWritableEnvPaths {
+  const home = firstNonEmpty(options.home, env.USERPROFILE, env.HOME, os.homedir()) ?? os.tmpdir();
+  const cacheBase = getRuntimeCacheBase(env, home);
+  const tempRoot = path.join(cacheBase, 'tmp');
+  const commandShell =
+    firstNonEmpty(env.ComSpec, env.COMSPEC, process.env.ComSpec, process.env.COMSPEC) ?? 'cmd.exe';
+
+  return {
+    cacheBase,
+    tempRoot,
+    npmCache: path.join(cacheBase, 'npm-cache'),
+    gradleHome: path.join(cacheBase, 'gradle-home'),
+    androidHome: path.join(cacheBase, 'android-home'),
+    commandShell,
+  };
+}
+
+function applyResolvedWritableEnv(
+  env: NodeJS.ProcessEnv,
+  paths: AgentChildProcessWritableEnvPaths
+): NodeJS.ProcessEnv {
+  setPathEnv(env, 'TEMP', paths.tempRoot);
+  setPathEnv(env, 'TMP', paths.tempRoot);
+  setPathEnv(env, 'TMPDIR', paths.tempRoot);
+  setPathEnv(env, 'npm_config_cache', paths.npmCache);
+  setPathEnv(env, 'NPM_CONFIG_CACHE', paths.npmCache);
+  setPathEnv(env, 'GRADLE_USER_HOME', paths.gradleHome);
+  setPathEnv(env, 'ANDROID_USER_HOME', paths.androidHome);
+  setPathEnv(env, 'ANDROID_SDK_HOME', paths.androidHome);
+  setPathEnv(env, 'npm_config_script_shell', paths.commandShell);
+  setPathEnv(env, 'AGENT_STUDIO_NPM_CMD', 'npm.cmd');
+  setPathEnv(env, 'AGENT_STUDIO_NPX_CMD', 'npx.cmd');
+
+  env.GRADLE_OPTS = appendJavaTmpDirOption(env.GRADLE_OPTS, paths.tempRoot);
+  env.JAVA_TOOL_OPTIONS = appendJavaTmpDirOption(env.JAVA_TOOL_OPTIONS, paths.tempRoot);
+
+  return env;
 }
 
 export function applyAgentChildProcessWritableEnv(
   env: NodeJS.ProcessEnv,
-  options: AgentChildProcessEnvOptions = {},
+  options: AgentChildProcessEnvOptions = {}
 ): NodeJS.ProcessEnv {
   if (process.platform !== 'win32') {
     return env;
   }
 
-  const home = firstNonEmpty(options.home, env.USERPROFILE, env.HOME, os.homedir(), os.tmpdir())!;
-  const cacheBase = getRuntimeCacheBase(env, home);
-  const tempRoot = path.join(cacheBase, 'tmp');
-  const npmCache = path.join(cacheBase, 'npm-cache');
-  const gradleHome = path.join(cacheBase, 'gradle-home');
-  const androidHome = path.join(cacheBase, 'android-home');
-  const commandShell = firstNonEmpty(env.ComSpec, env.COMSPEC, process.env.ComSpec, process.env.COMSPEC, 'cmd.exe')!;
-
-  setPathEnv(env, 'TEMP', tempRoot);
-  setPathEnv(env, 'TMP', tempRoot);
-  setPathEnv(env, 'TMPDIR', tempRoot);
-  setPathEnv(env, 'npm_config_cache', npmCache);
-  setPathEnv(env, 'NPM_CONFIG_CACHE', npmCache);
-  setPathEnv(env, 'GRADLE_USER_HOME', gradleHome);
-  setPathEnv(env, 'ANDROID_USER_HOME', androidHome);
-  setPathEnv(env, 'ANDROID_SDK_HOME', androidHome);
-  setPathEnv(env, 'npm_config_script_shell', commandShell);
-  setPathEnv(env, 'AGENT_STUDIO_NPM_CMD', 'npm.cmd');
-  setPathEnv(env, 'AGENT_STUDIO_NPX_CMD', 'npx.cmd');
-
-  env.GRADLE_OPTS = appendJavaTmpDirOption(env.GRADLE_OPTS, tempRoot);
-  env.JAVA_TOOL_OPTIONS = appendJavaTmpDirOption(env.JAVA_TOOL_OPTIONS, tempRoot);
-
-  return env;
+  return applyResolvedWritableEnv(env, resolveWritableEnvPaths(env, options));
 }
 
-function pushWritableRoot(
-  roots: WritableRoot[],
-  seen: Set<string>,
-  label: string,
-  dir: string | undefined,
-): void {
-  if (!dir?.trim()) {
-    return;
-  }
-  const resolved = path.resolve(dir);
-  const key = resolved.toLowerCase();
-  if (seen.has(key)) {
-    return;
-  }
-  seen.add(key);
-  roots.push({ label, dir: resolved });
-}
-
-function getWritableRoots(env: NodeJS.ProcessEnv, cwd?: string): WritableRoot[] {
-  const roots: WritableRoot[] = [];
-  const seen = new Set<string>();
-
-  pushWritableRoot(roots, seen, 'TEMP', env.TEMP);
-  pushWritableRoot(roots, seen, 'TMP', env.TMP);
-  pushWritableRoot(roots, seen, 'npm_config_cache', firstNonEmpty(env.npm_config_cache, env.NPM_CONFIG_CACHE));
-  pushWritableRoot(roots, seen, 'GRADLE_USER_HOME', env.GRADLE_USER_HOME);
-  pushWritableRoot(roots, seen, 'ANDROID_USER_HOME', env.ANDROID_USER_HOME);
-  pushWritableRoot(roots, seen, 'ANDROID_SDK_HOME', env.ANDROID_SDK_HOME);
-  pushWritableRoot(roots, seen, 'cwd', cwd);
-
-  return roots;
-}
-
-async function verifyWritableRoot(root: WritableRoot): Promise<void> {
-  await fs.promises.mkdir(root.dir, { recursive: true });
-  const probePath = path.join(root.dir, `.agent-studio-write-probe-${process.pid}-${Date.now()}.tmp`);
-  await fs.promises.writeFile(probePath, 'ok', 'utf8');
-  const written = await fs.promises.readFile(probePath, 'utf8');
-  if (written !== 'ok') {
-    throw new Error(`${root.label} write probe read back unexpected content`);
-  }
-  await fs.promises.unlink(probePath);
-}
-
-function summarizeSpawnFailure(label: string, result: SpawnSyncReturns<string>): string | null {
-  if (result.error) {
-    return `${label}: ${result.error.message}`;
-  }
-  if (result.signal) {
-    return `${label}: terminated by ${result.signal}`;
-  }
-  if (result.status && result.status !== 0) {
-    const output = `${result.stderr ?? ''}${result.stdout ?? ''}`.trim();
-    return `${label}: exited ${result.status}${output ? ` (${output.slice(0, 240)})` : ''}`;
-  }
-  return null;
-}
-
-function runNodeChildSpawnProbe(env: NodeJS.ProcessEnv, cwd: string | undefined, timeoutMs: number): string | null {
-  const script =
-    "const r=require('child_process').spawnSync(process.execPath,['-v'],{encoding:'utf8'});" +
-    "if(r.error){console.error(r.error.message);process.exit(1)}" +
-    "if(r.status!==0){process.stderr.write((r.stderr||'')+(r.stdout||''));process.exit(r.status||1)}" +
-    "process.stdout.write((r.stdout||'').trim())";
-  const result = spawnSync('node.exe', ['-e', script], {
-    cwd,
-    encoding: 'utf8',
-    env,
-    timeout: timeoutMs,
-    windowsHide: true,
-  });
-  return summarizeSpawnFailure('node child_process spawnSync probe', result);
-}
-
-function runCmdShimVersion(
-  command: 'npm.cmd' | 'npx.cmd',
+export async function prepareAgentChildProcessWritableEnv(
   env: NodeJS.ProcessEnv,
-  cwd: string | undefined,
-  timeoutMs: number,
-): string | null {
-  const comspec = firstNonEmpty(env.ComSpec, env.COMSPEC, process.env.ComSpec, process.env.COMSPEC, 'cmd.exe')!;
-  const result = spawnSync(comspec, ['/d', '/s', '/c', `${command} --version`], {
-    cwd,
-    encoding: 'utf8',
-    env,
-    timeout: timeoutMs,
-    windowsHide: true,
-  });
-  return summarizeSpawnFailure(`${command} --version`, result);
-}
-
-export async function assertAgentChildProcessPreflight(
-  options: AgentChildProcessPreflightOptions,
-): Promise<void> {
-  if (process.platform !== 'win32' || options.env.AGENT_STUDIO_SKIP_CHILD_PROCESS_PREFLIGHT === '1') {
-    return;
+  options: AgentChildProcessEnvOptions = {}
+): Promise<AgentChildProcessWritableEnvResult> {
+  if (process.platform !== 'win32') {
+    return { applied: false };
   }
 
-  const cwd = options.cwd ? path.resolve(options.cwd) : undefined;
-  const roots = getWritableRoots(options.env, cwd);
-  const cacheKey = roots.map((root) => root.dir.toLowerCase()).sort().join('|');
-  if (PREFLIGHT_CACHE.has(cacheKey)) {
-    return;
+  const paths = resolveWritableEnvPaths(env, options);
+  const dirs = [paths.tempRoot, paths.npmCache, paths.gradleHome, paths.androidHome];
+  try {
+    await Promise.all(dirs.map((dir) => fs.promises.mkdir(dir, { recursive: true })));
+    applyResolvedWritableEnv(env, paths);
+    return { applied: true, cacheBase: paths.cacheBase };
+  } catch (error) {
+    return {
+      applied: false,
+      cacheBase: paths.cacheBase,
+      warning:
+        `Windows agent writable cache setup skipped for ${paths.cacheBase}; ` +
+        `keeping existing temp/cache env. Details: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+    };
   }
-
-  const failures: string[] = [];
-  for (const root of roots) {
-    try {
-      await verifyWritableRoot(root);
-    } catch (error) {
-      failures.push(`${root.label} (${root.dir}): ${error instanceof Error ? error.message : String(error)}`);
-    }
-  }
-
-  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const commandFailures = [
-    runNodeChildSpawnProbe(options.env, cwd, timeoutMs),
-    runCmdShimVersion('npm.cmd', options.env, cwd, timeoutMs),
-    runCmdShimVersion('npx.cmd', options.env, cwd, timeoutMs),
-  ].filter((failure): failure is string => Boolean(failure));
-
-  failures.push(...commandFailures);
-
-  if (failures.length) {
-    throw new Error(`Agent child-process preflight failed:\n- ${failures.join('\n- ')}`);
-  }
-
-  PREFLIGHT_CACHE.add(cacheKey);
 }

--- a/src/main/services/runtime/agentChildProcessPreflight.ts
+++ b/src/main/services/runtime/agentChildProcessPreflight.ts
@@ -1,0 +1,219 @@
+import { spawnSync, type SpawnSyncReturns } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+export interface AgentChildProcessEnvOptions {
+  home?: string;
+}
+
+export interface AgentChildProcessPreflightOptions {
+  cwd?: string;
+  env: NodeJS.ProcessEnv;
+  timeoutMs?: number;
+}
+
+interface WritableRoot {
+  label: string;
+  dir: string;
+}
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const PREFLIGHT_CACHE = new Set<string>();
+
+function firstNonEmpty(...values: Array<string | undefined | null>): string | undefined {
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  return undefined;
+}
+
+function setPathEnv(env: NodeJS.ProcessEnv, key: string, value: string): string {
+  env[key] = value;
+  return value;
+}
+
+function appendJavaTmpDirOption(current: string | undefined, tempRoot: string): string {
+  if (current?.includes('-Djava.io.tmpdir=')) {
+    return current;
+  }
+  const escapedTempRoot = tempRoot.replace(/"/g, '\\"');
+  return `${current?.trim() ? `${current.trim()} ` : ''}-Djava.io.tmpdir="${escapedTempRoot}"`;
+}
+
+function getRuntimeCacheBase(env: NodeJS.ProcessEnv, home: string): string {
+  const explicit = firstNonEmpty(env.AGENT_STUDIO_RUNNER_CACHE_ROOT, env.STUDIO_AGENT_CACHE_ROOT);
+  if (explicit) {
+    return path.resolve(explicit);
+  }
+
+  const localAppData = firstNonEmpty(env.LOCALAPPDATA, path.join(home, 'AppData', 'Local'));
+  return path.join(localAppData, 'AgentStudio', 'runner-cache');
+}
+
+export function applyAgentChildProcessWritableEnv(
+  env: NodeJS.ProcessEnv,
+  options: AgentChildProcessEnvOptions = {},
+): NodeJS.ProcessEnv {
+  if (process.platform !== 'win32') {
+    return env;
+  }
+
+  const home = firstNonEmpty(options.home, env.USERPROFILE, env.HOME, os.homedir(), os.tmpdir())!;
+  const cacheBase = getRuntimeCacheBase(env, home);
+  const tempRoot = path.join(cacheBase, 'tmp');
+  const npmCache = path.join(cacheBase, 'npm-cache');
+  const gradleHome = path.join(cacheBase, 'gradle-home');
+  const androidHome = path.join(cacheBase, 'android-home');
+  const commandShell = firstNonEmpty(env.ComSpec, env.COMSPEC, process.env.ComSpec, process.env.COMSPEC, 'cmd.exe')!;
+
+  setPathEnv(env, 'TEMP', tempRoot);
+  setPathEnv(env, 'TMP', tempRoot);
+  setPathEnv(env, 'TMPDIR', tempRoot);
+  setPathEnv(env, 'npm_config_cache', npmCache);
+  setPathEnv(env, 'NPM_CONFIG_CACHE', npmCache);
+  setPathEnv(env, 'GRADLE_USER_HOME', gradleHome);
+  setPathEnv(env, 'ANDROID_USER_HOME', androidHome);
+  setPathEnv(env, 'ANDROID_SDK_HOME', androidHome);
+  setPathEnv(env, 'npm_config_script_shell', commandShell);
+  setPathEnv(env, 'AGENT_STUDIO_NPM_CMD', 'npm.cmd');
+  setPathEnv(env, 'AGENT_STUDIO_NPX_CMD', 'npx.cmd');
+
+  env.GRADLE_OPTS = appendJavaTmpDirOption(env.GRADLE_OPTS, tempRoot);
+  env.JAVA_TOOL_OPTIONS = appendJavaTmpDirOption(env.JAVA_TOOL_OPTIONS, tempRoot);
+
+  return env;
+}
+
+function pushWritableRoot(
+  roots: WritableRoot[],
+  seen: Set<string>,
+  label: string,
+  dir: string | undefined,
+): void {
+  if (!dir?.trim()) {
+    return;
+  }
+  const resolved = path.resolve(dir);
+  const key = resolved.toLowerCase();
+  if (seen.has(key)) {
+    return;
+  }
+  seen.add(key);
+  roots.push({ label, dir: resolved });
+}
+
+function getWritableRoots(env: NodeJS.ProcessEnv, cwd?: string): WritableRoot[] {
+  const roots: WritableRoot[] = [];
+  const seen = new Set<string>();
+
+  pushWritableRoot(roots, seen, 'TEMP', env.TEMP);
+  pushWritableRoot(roots, seen, 'TMP', env.TMP);
+  pushWritableRoot(roots, seen, 'npm_config_cache', firstNonEmpty(env.npm_config_cache, env.NPM_CONFIG_CACHE));
+  pushWritableRoot(roots, seen, 'GRADLE_USER_HOME', env.GRADLE_USER_HOME);
+  pushWritableRoot(roots, seen, 'ANDROID_USER_HOME', env.ANDROID_USER_HOME);
+  pushWritableRoot(roots, seen, 'ANDROID_SDK_HOME', env.ANDROID_SDK_HOME);
+  pushWritableRoot(roots, seen, 'cwd', cwd);
+
+  return roots;
+}
+
+async function verifyWritableRoot(root: WritableRoot): Promise<void> {
+  await fs.promises.mkdir(root.dir, { recursive: true });
+  const probePath = path.join(root.dir, `.agent-studio-write-probe-${process.pid}-${Date.now()}.tmp`);
+  await fs.promises.writeFile(probePath, 'ok', 'utf8');
+  const written = await fs.promises.readFile(probePath, 'utf8');
+  if (written !== 'ok') {
+    throw new Error(`${root.label} write probe read back unexpected content`);
+  }
+  await fs.promises.unlink(probePath);
+}
+
+function summarizeSpawnFailure(label: string, result: SpawnSyncReturns<string>): string | null {
+  if (result.error) {
+    return `${label}: ${result.error.message}`;
+  }
+  if (result.signal) {
+    return `${label}: terminated by ${result.signal}`;
+  }
+  if (result.status && result.status !== 0) {
+    const output = `${result.stderr ?? ''}${result.stdout ?? ''}`.trim();
+    return `${label}: exited ${result.status}${output ? ` (${output.slice(0, 240)})` : ''}`;
+  }
+  return null;
+}
+
+function runNodeChildSpawnProbe(env: NodeJS.ProcessEnv, cwd: string | undefined, timeoutMs: number): string | null {
+  const script =
+    "const r=require('child_process').spawnSync(process.execPath,['-v'],{encoding:'utf8'});" +
+    "if(r.error){console.error(r.error.message);process.exit(1)}" +
+    "if(r.status!==0){process.stderr.write((r.stderr||'')+(r.stdout||''));process.exit(r.status||1)}" +
+    "process.stdout.write((r.stdout||'').trim())";
+  const result = spawnSync('node.exe', ['-e', script], {
+    cwd,
+    encoding: 'utf8',
+    env,
+    timeout: timeoutMs,
+    windowsHide: true,
+  });
+  return summarizeSpawnFailure('node child_process spawnSync probe', result);
+}
+
+function runCmdShimVersion(
+  command: 'npm.cmd' | 'npx.cmd',
+  env: NodeJS.ProcessEnv,
+  cwd: string | undefined,
+  timeoutMs: number,
+): string | null {
+  const comspec = firstNonEmpty(env.ComSpec, env.COMSPEC, process.env.ComSpec, process.env.COMSPEC, 'cmd.exe')!;
+  const result = spawnSync(comspec, ['/d', '/s', '/c', `${command} --version`], {
+    cwd,
+    encoding: 'utf8',
+    env,
+    timeout: timeoutMs,
+    windowsHide: true,
+  });
+  return summarizeSpawnFailure(`${command} --version`, result);
+}
+
+export async function assertAgentChildProcessPreflight(
+  options: AgentChildProcessPreflightOptions,
+): Promise<void> {
+  if (process.platform !== 'win32' || options.env.AGENT_STUDIO_SKIP_CHILD_PROCESS_PREFLIGHT === '1') {
+    return;
+  }
+
+  const cwd = options.cwd ? path.resolve(options.cwd) : undefined;
+  const roots = getWritableRoots(options.env, cwd);
+  const cacheKey = roots.map((root) => root.dir.toLowerCase()).sort().join('|');
+  if (PREFLIGHT_CACHE.has(cacheKey)) {
+    return;
+  }
+
+  const failures: string[] = [];
+  for (const root of roots) {
+    try {
+      await verifyWritableRoot(root);
+    } catch (error) {
+      failures.push(`${root.label} (${root.dir}): ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const commandFailures = [
+    runNodeChildSpawnProbe(options.env, cwd, timeoutMs),
+    runCmdShimVersion('npm.cmd', options.env, cwd, timeoutMs),
+    runCmdShimVersion('npx.cmd', options.env, cwd, timeoutMs),
+  ].filter((failure): failure is string => Boolean(failure));
+
+  failures.push(...commandFailures);
+
+  if (failures.length) {
+    throw new Error(`Agent child-process preflight failed:\n- ${failures.join('\n- ')}`);
+  }
+
+  PREFLIGHT_CACHE.add(cacheKey);
+}

--- a/src/main/services/team/TeamProvisioningService.ts
+++ b/src/main/services/team/TeamProvisioningService.ts
@@ -152,6 +152,10 @@ import pidusage from 'pidusage';
 import * as readline from 'readline';
 
 import {
+  applyAgentChildProcessWritableEnv,
+  assertAgentChildProcessPreflight,
+} from '../runtime/agentChildProcessPreflight';
+import {
   ANTHROPIC_HELPER_MODE_COMPETING_AUTH_ENV_KEYS,
   type AnthropicTeamApiKeyHelperMaterial,
   CLAUDE_TEAM_ANTHROPIC_API_KEY_HELPER_SETTINGS_PATH_ENV,
@@ -19553,6 +19557,10 @@ export class TeamProvisioningService {
     // Respawn with saved context — CLI handles its own auth refresh.
     let child: ReturnType<typeof spawn>;
     try {
+      await assertAgentChildProcessPreflight({
+        cwd: ctx.cwd,
+        env: ctx.env,
+      });
       if (mcpFlagIdx !== -1 && mcpFlagIdx + 1 < ctx.args.length) {
         await this.validateAgentTeamsMcpRuntime(
           ctx.claudePath,
@@ -20253,6 +20261,15 @@ export class TeamProvisioningService {
         emitProvisioningCheckpoint(run, 'Writing MCP config file');
         mcpConfigPath = await this.mcpConfigBuilder.writeConfigFile(request.cwd);
         run.mcpConfigPath = mcpConfigPath;
+        emitProvisioningCheckpoint(
+          run,
+          'Running child-process preflight',
+          `cwd=${request.cwd}`
+        );
+        await assertAgentChildProcessPreflight({
+          cwd: request.cwd,
+          env: shellEnv,
+        });
         emitProvisioningCheckpoint(run, 'Validating agent-teams MCP runtime');
         await this.validateAgentTeamsMcpRuntime(claudePath, request.cwd, shellEnv, mcpConfigPath, {
           isCancelled: () =>
@@ -21512,6 +21529,15 @@ export class TeamProvisioningService {
         emitProvisioningCheckpoint(run, 'Writing MCP config file');
         mcpConfigPath = await this.mcpConfigBuilder.writeConfigFile(request.cwd);
         run.mcpConfigPath = mcpConfigPath;
+        emitProvisioningCheckpoint(
+          run,
+          'Running child-process preflight',
+          `cwd=${request.cwd}`
+        );
+        await assertAgentChildProcessPreflight({
+          cwd: request.cwd,
+          env: shellEnv,
+        });
         emitProvisioningCheckpoint(run, 'Validating agent-teams MCP runtime');
         await this.validateAgentTeamsMcpRuntime(claudePath, request.cwd, shellEnv, mcpConfigPath, {
           isCancelled: () =>
@@ -33350,6 +33376,7 @@ export class TeamProvisioningService {
     });
     const providerConnectionIssue = providerEnvResult.connectionIssues[resolvedProviderId];
     const providerEnv = providerEnvResult.env;
+    applyAgentChildProcessWritableEnv(providerEnv, { home });
     if (options?.includeCodexTeammateAuth && resolvedProviderId !== 'codex') {
       await this.providerConnectionService.augmentConfiguredConnectionEnv(
         providerEnv,

--- a/src/main/services/team/TeamProvisioningService.ts
+++ b/src/main/services/team/TeamProvisioningService.ts
@@ -51,6 +51,7 @@ import {
 } from '@features/workspace-trust/main';
 import { ConfigManager } from '@main/services/infrastructure/ConfigManager';
 import { NotificationManager } from '@main/services/infrastructure/NotificationManager';
+import { prepareAgentChildProcessWritableEnv } from '@main/services/runtime/agentChildProcessPreflight';
 import { getAppIconPath } from '@main/utils/appIcon';
 import {
   execCli,
@@ -151,10 +152,6 @@ import * as path from 'path';
 import pidusage from 'pidusage';
 import * as readline from 'readline';
 
-import {
-  applyAgentChildProcessWritableEnv,
-  assertAgentChildProcessPreflight,
-} from '../runtime/agentChildProcessPreflight';
 import {
   ANTHROPIC_HELPER_MODE_COMPETING_AUTH_ENV_KEYS,
   type AnthropicTeamApiKeyHelperMaterial,
@@ -19557,10 +19554,6 @@ export class TeamProvisioningService {
     // Respawn with saved context — CLI handles its own auth refresh.
     let child: ReturnType<typeof spawn>;
     try {
-      await assertAgentChildProcessPreflight({
-        cwd: ctx.cwd,
-        env: ctx.env,
-      });
       if (mcpFlagIdx !== -1 && mcpFlagIdx + 1 < ctx.args.length) {
         await this.validateAgentTeamsMcpRuntime(
           ctx.claudePath,
@@ -20261,15 +20254,6 @@ export class TeamProvisioningService {
         emitProvisioningCheckpoint(run, 'Writing MCP config file');
         mcpConfigPath = await this.mcpConfigBuilder.writeConfigFile(request.cwd);
         run.mcpConfigPath = mcpConfigPath;
-        emitProvisioningCheckpoint(
-          run,
-          'Running child-process preflight',
-          `cwd=${request.cwd}`
-        );
-        await assertAgentChildProcessPreflight({
-          cwd: request.cwd,
-          env: shellEnv,
-        });
         emitProvisioningCheckpoint(run, 'Validating agent-teams MCP runtime');
         await this.validateAgentTeamsMcpRuntime(claudePath, request.cwd, shellEnv, mcpConfigPath, {
           isCancelled: () =>
@@ -21529,15 +21513,6 @@ export class TeamProvisioningService {
         emitProvisioningCheckpoint(run, 'Writing MCP config file');
         mcpConfigPath = await this.mcpConfigBuilder.writeConfigFile(request.cwd);
         run.mcpConfigPath = mcpConfigPath;
-        emitProvisioningCheckpoint(
-          run,
-          'Running child-process preflight',
-          `cwd=${request.cwd}`
-        );
-        await assertAgentChildProcessPreflight({
-          cwd: request.cwd,
-          env: shellEnv,
-        });
         emitProvisioningCheckpoint(run, 'Validating agent-teams MCP runtime');
         await this.validateAgentTeamsMcpRuntime(claudePath, request.cwd, shellEnv, mcpConfigPath, {
           isCancelled: () =>
@@ -33376,7 +33351,10 @@ export class TeamProvisioningService {
     });
     const providerConnectionIssue = providerEnvResult.connectionIssues[resolvedProviderId];
     const providerEnv = providerEnvResult.env;
-    applyAgentChildProcessWritableEnv(providerEnv, { home });
+    const writableEnvResult = await prepareAgentChildProcessWritableEnv(providerEnv, { home });
+    if (writableEnvResult.warning) {
+      logger.warn(`[TeamProvisioningService] ${writableEnvResult.warning}`);
+    }
     if (options?.includeCodexTeammateAuth && resolvedProviderId !== 'codex') {
       await this.providerConnectionService.augmentConfiguredConnectionEnv(
         providerEnv,


### PR DESCRIPTION
## Summary

- inject stable Windows cache/temp env roots for agent child processes
- add a fail-fast preflight for writable roots, nested Node spawn, npm.cmd, and npx.cmd
- run the preflight before agent create/launch/respawn paths so Android/Gradle failures surface as runner errors

## Verification

- Local smoke preflight in the current Agent Studio runner wrote the configured roots, then failed on `child_process.spawnSync('node.exe', ...)` with `EPERM`, matching the runner blocker this PR is meant to surface early.
- Full Vitest run could not complete in this sandbox: loading Vitest from the founder checkout failed with `EPERM` on the child process reading `D:\\Wiki\\AgentTools\\agent-teams-ui\\node_modules\\...\\vitest.mjs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windows-only agent child-process environment setup: ensures temp/cache dirs and tool home vars are set consistently and JVM tmp option is appended; provisioning now applies this and surfaces warnings when issues occur.

* **Tests**
  * Added tests validating writable-env preparation and application on Windows, including failure handling that preserves existing environment values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/777genius/agent-teams-ai/pull/98)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->