### PR TITLE
dev -> main

### DIFF
--- a/AGENT_CRITICAL_GUARDRAILS.md
+++ b/AGENT_CRITICAL_GUARDRAILS.md
@@ -1,0 +1,13 @@
+# Agent Critical Guardrails
+
+These are the hard rules to keep agent work predictable and safe in this repo.
+
+- Read `CLAUDE.md` first, then follow `docs/FEATURE_ARCHITECTURE_STANDARD.md` for new medium and large features.
+- Use `pnpm` for project commands. Do not switch to `npm` or `yarn`.
+- Do not run `pnpm lint:fix` unless the user explicitly asks for broad formatting changes.
+- Keep main, preload, renderer, and shared responsibilities separate.
+- Use `wrapAgentBlock(text)` instead of manually concatenating agent block markers.
+- Preserve task/subagent filtering, structured task refs, and message parsing semantics.
+- Validate IPC and other main-process inputs defensively and fail gracefully.
+- Treat `docs/team-management/debugging-agent-teams.md` as the first stop for team launch hangs, bootstrap issues, or missing teammate replies.
+- Do not revert unrelated user changes or other agents' edits.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ Always use pnpm (not npm/yarn) for this project.
 Workspace membership is canonical in `pnpm-workspace.yaml`; do not re-add root `package.json.workspaces`, because npm subproject installs in Codex Cloud must treat nested packages as standalone projects.
 Do NOT run `pnpm lint:fix` unless the user explicitly asks for it — it interferes with agents running in parallel.
 When running build/typecheck/test commands, pipe through `tail -20` to avoid flooding the context window (e.g. `pnpm typecheck 2>&1 | tail -20`).
+- Hard guardrails: [`AGENT_CRITICAL_GUARDRAILS.md`](AGENT_CRITICAL_GUARDRAILS.md)
 
 - `pnpm install` - Install dependencies
 - `pnpm dev` - Dev server with hot reload

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,72 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 
 ## [Unreleased]
 
-## [1.0.0] - 2026-03-19
+## [1.2.0] - 2026-03-31
+
+### Added
+
+- Agent Graph with real-time force-directed visualization, kanban task layout, animated message particles, member hexagons with avatars, and cross-team ghost nodes.
+- Per-team tool approval controls with readable permission prompts and interactive AskUserQuestion buttons.
+- Task comment notifications.
+
+### Changed
+
+- Team page performance with many tasks.
+- Team provisioning visibility on the team screen.
+- Default action mode switched to `delegate` so the lead coordinates instead of executing.
+- Skip pre-flight CLI check button in launch/create dialogs.
+- MCP config moved from `/tmp` to `userData` with cleanup on spawn failures.
+- Task change presence tracking overhaul.
+- Session label formatting and session item display improvements.
+- Update dialog layout cleanup.
+- Auto-approve banner softened from warning to info styling.
+- macOS title bar drag area improvements.
+
+### Fixed
+
+- Tool approval sheet hooks ordering crash.
+- Auto-approve reset when launching with manual approval.
+- `Allow all` and Settings panel targeting the wrong team.
+- AskUserQuestion Enter key bypass and edge cases.
+- Updater installing non-newer versions and showing updates for unavailable platforms.
+- Permission request deduplication across all entry paths.
+- Renderer IPC sends during crash recovery.
+- Standalone mode without Electron.
+- Sanitized inline HTML in markdown rendering.
+
+## [1.1.0] - 2026-03-25
+
+### Added
+
+- React 19 + Electron 40 migration.
+- User-initiated task starts from the kanban board.
+- Auth troubleshooting guide in the CLI status banner.
+- Syntax highlighting for R, Ruby, PHP, and SQL code blocks.
+- Collapsible output sections in tool results with markdown preview toggle.
+- Styled `@`-mentions in task comments with colored member badges.
+- Worktree-based projects detected on the dashboard.
+
+### Changed
+
+- 3x faster transcript search with optimized plain text matching.
+- Single-pass message processing replaces multiple filter passes.
+- Protocol noise filtering hides raw idle and teammate messages from lead thoughts.
+- Improved kanban column styling with colored headers and subtle body tints.
+- Teams sorted by last activity with alphabetical fallback.
+- Dynamic member colors in the Add Members dialog.
+
+### Fixed
+
+- Cost overcounting from duplicate request ID tracking.
+- WSL mount path translation and Windows drive letter normalization.
+- Sidebar repo and branch state not syncing when switching tabs.
+- CLI auth detection with non-default config paths.
+- XSS vulnerability via unsanitized inline HTML in markdown.
+- Standalone mode crash without Electron environment.
+- Stale sessions incorrectly shown as ongoing after 5 minutes of inactivity.
+- Incorrect error message when attaching files to offline team lead.
+
+## [1.0.0] - 2026-03-23
 
 Initial public release.
 

--- a/docs/FEATURE_ARCHITECTURE_STANDARD.md
+++ b/docs/FEATURE_ARCHITECTURE_STANDARD.md
@@ -16,18 +16,24 @@ This document defines the default architecture for medium and large features in 
 
 ```text
 src/features/<feature-name>/
+  index.ts
   contracts/
+    index.ts
   core/
     domain/
     application/
   main/
+    index.ts
     composition/
+    application/
     adapters/
       input/
       output/
     infrastructure/
   preload/
+    index.ts
   renderer/
+    index.ts
 ```
 
 Use this template by default when a feature:
@@ -37,7 +43,28 @@ Use this template by default when a feature:
 - needs its own transport bridge or integration surface
 - is expected to grow with new providers, sources, or presentation flows
 
+`index.ts` and `main/application/` are optional. Add them only when they have a
+clear public or runtime-orchestration role.
+
 ## Layer Responsibilities
+
+### `index.ts`
+
+Optional root public barrel for the feature.
+
+Use it for:
+
+- stable type re-exports from `contracts/`
+- small pure facades that are intentionally shared across layers
+- feature factories when the root barrel is intentionally main-owned and
+  imported only from main-process code
+
+Not allowed:
+
+- accidental wildcard exports from implementation folders
+- mixing browser-safe exports with main-only exports without making process
+  ownership obvious
+- replacing the layer entrypoints when callers need a process-specific surface
 
 ### `contracts/`
 
@@ -113,6 +140,24 @@ Responsibilities:
 - translate transport input into use case calls
 - keep transport concerns out of use cases
 
+### `main/application/`
+
+Optional main-process application services.
+
+Use this only when code is too runtime-aware for `core/application`, but is not a
+transport adapter or low-level infrastructure helper.
+
+Examples:
+
+- main-only readers that orchestrate runtime services
+- process-aware tracking or coordination helpers
+
+Not allowed:
+
+- IPC or HTTP handler registration
+- renderer or preload dependencies
+- pure domain policy that belongs in `core/domain`
+
 ### `main/adapters/output/`
 
 Driven adapters that implement application ports.
@@ -185,12 +230,16 @@ Responsibilities:
 
 Outside the feature, import only:
 
+- `@features/<feature>` when the feature owns a deliberate root public barrel
 - `@features/<feature>/contracts`
 - `@features/<feature>/main`
 - `@features/<feature>/preload`
 - `@features/<feature>/renderer`
 
 Do not deep-import feature internals from app shell or from other features.
+Layer entrypoints should be explicit `index.ts` files that export only supported
+surface area. Focused tests may import internals when they are testing that unit
+directly, but production integration code should not.
 
 ### Core isolation
 
@@ -207,8 +256,11 @@ Do not deep-import feature internals from app shell or from other features.
 
 `core/application` must not import:
 
-- `main/*`
-- `renderer/*`
+- `@features/<feature>/main/**`
+- `@features/<feature>/renderer/**`
+- `@main/*`
+- `@renderer/*`
+- `@preload/*`
 - Electron APIs
 - Fastify
 - child process modules
@@ -266,16 +318,35 @@ If the feature still owns meaningful pure semantics or projection rules, keep
 `core/` and skip only the process layers you do not need.
 
 Example:
+
 - `src/features/agent-graph` keeps `core/domain` and `renderer`, but does not add fake `main/` or `preload/` folders because the transport boundary lives elsewhere.
+
+## Current Feature Shape Examples
+
+Use these local examples before inventing a new variant:
+
+- `src/features/recent-projects` - full cross-process reference with
+  `contracts`, `core`, `main`, `preload`, and `renderer`.
+- `src/features/member-work-sync` - full cross-process feature with a root
+  public barrel and broader main-process infrastructure.
+- `src/features/member-log-stream` - full cross-process feature that uses
+  `main/application/` for main-only runtime orchestration.
+- `src/features/agent-graph` - thin renderer integration with `core/domain` and
+  `renderer`, no fake process layers.
+- `src/features/codex-model-catalog` and `src/features/team-runtime-lanes` -
+  process-limited features that omit renderer or preload layers when they do not
+  own that boundary.
+
 ## Definition Of Done For A Reference Feature
 
 A feature is reference-quality when:
 
-- structure matches the canonical template
+- structure matches the full or thin template chosen for the feature
 - core is side-effect free
 - app shell imports only public entrypoints
 - renderer UI is dumb and presentational
-- at least the main domain and application rules are tested
+- at least the main domain and application rules are tested when those layers
+  exist
 - architecture is enforced by lint rules
 - feature has a concise standard or plan doc if it introduces a new pattern
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -8,7 +8,7 @@ Agent Graph, per-team tool approval, interactive AskUserQuestion, task comment n
 
 Minor release: React 19 + Electron 40 migration, start-task-by-user, auth troubleshooting guide, syntax highlighting for R/Ruby/PHP/SQL, search performance improvements, cost tracking accuracy, WSL/Windows path fixes. Full list: [CHANGELOG.md](./CHANGELOG.md).
 
-## Published: v1.0.0 (2026-03-19)
+## Published: v1.0.0 (2026-03-23)
 
 Initial release: Agent Teams with reliable CLI detection in packaged builds (shell PATH/HOME, `CLAUDE_CONFIG_DIR`, auth output parsing), IPC status cache handling, concurrent binary resolution, capped NDJSON diagnostics. Full list: [CHANGELOG.md](./CHANGELOG.md).
 
@@ -37,23 +37,23 @@ First stable build: CLI/auth reliability in packaged apps, IPC hardening, and pl
 <table>
 <tr>
 <td align="center">
-  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v1.0.0/Claude.Agent.Teams.UI-1.0.0-arm64.dmg">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v1.0.0/Agent.Teams.AI-1.0.0-arm64.dmg">
     <img src="https://img.shields.io/badge/macOS_Apple_Silicon-.dmg-000000?style=for-the-badge&logo=apple&logoColor=white" alt="macOS Apple Silicon" />
   </a>
   <br />
-  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v1.0.0/Claude.Agent.Teams.UI-1.0.0.dmg">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v1.0.0/Agent.Teams.AI-1.0.0.dmg">
     <img src="https://img.shields.io/badge/macOS_Intel-.dmg-434343?style=for-the-badge&logo=apple&logoColor=white" alt="macOS Intel" />
   </a>
 </td>
 <td align="center">
-  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v1.0.0/Claude.Agent.Teams.UI.Setup.1.0.0.exe">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v1.0.0/Agent.Teams.AI.Setup.1.0.0.exe">
     <img src="https://img.shields.io/badge/Windows-Download_.exe-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Windows" />
   </a>
   <br />
   <sub>May trigger SmartScreen — click "More info" → "Run anyway"</sub>
 </td>
 <td align="center">
-  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v1.0.0/Claude.Agent.Teams.UI-1.0.0.AppImage">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v1.0.0/Agent.Teams.AI-1.0.0.AppImage">
     <img src="https://img.shields.io/badge/Linux-Download_.AppImage-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux AppImage" />
   </a>
   <br />

--- a/docs/claude-multimodel-integration-plan.md
+++ b/docs/claude-multimodel-integration-plan.md
@@ -384,38 +384,29 @@ Each row may show:
 ## Launch Flow Changes
 
 Current launch flow already supports a team-level `model`.
-Current UI also already has a provider affordance in [TeamModelSelector.tsx](../../src/renderer/components/team/dialogs/TeamModelSelector.tsx), but its logic is still placeholder/coming-soon. That placeholder currently uses `openai`; it should be normalized or mapped to the app-level provider id `codex` during implementation.
+Current UI already has a provider affordance in [TeamModelSelector.tsx](../src/renderer/components/team/dialogs/TeamModelSelector.tsx). The remaining work is to keep provider/model normalization consistent across all launch surfaces.
 
 Current code paths that must be kept in sync:
 
-- shared types in [team.ts](../../src/shared/types/team.ts)
-- HTTP launch parsing in [teams.ts](../../src/main/http/teams.ts)
-- IPC launch/create validation in [teams.ts](../../src/main/ipc/teams.ts)
-- persisted draft metadata in [TeamMetaStore.ts](../../src/main/services/team/TeamMetaStore.ts)
-- scheduled one-shot config in [schedule.ts](../../src/shared/types/schedule.ts)
-- scheduled execution in [ScheduledTaskExecutor.ts](../../src/main/services/schedule/ScheduledTaskExecutor.ts)
-- provider/model UI helpers in [TeamModelSelector.tsx](../../src/renderer/components/team/dialogs/TeamModelSelector.tsx)
-- model display parsing in [modelParser.ts](../../src/shared/utils/modelParser.ts)
-- launch dialog state persistence in [LaunchTeamDialog.tsx](../../src/renderer/components/team/dialogs/LaunchTeamDialog.tsx)
-- create dialog state persistence in [CreateTeamDialog.tsx](../../src/renderer/components/team/dialogs/CreateTeamDialog.tsx)
-- saved draft restore in [teams.ts](../../src/main/ipc/teams.ts)
+- shared types in [team.ts](../src/shared/types/team.ts)
+- HTTP launch parsing in [teams.ts](../src/main/http/teams.ts)
+- IPC launch/create validation in [teams.ts](../src/main/ipc/teams.ts)
+- persisted draft metadata in [TeamMetaStore.ts](../src/main/services/team/TeamMetaStore.ts)
+- scheduled one-shot config in [schedule.ts](../src/shared/types/schedule.ts)
+- scheduled execution in [ScheduledTaskExecutor.ts](../src/main/services/schedule/ScheduledTaskExecutor.ts)
+- provider/model UI helpers in [TeamModelSelector.tsx](../src/renderer/components/team/dialogs/TeamModelSelector.tsx)
+- model display parsing in [modelParser.ts](../src/shared/utils/modelParser.ts)
+- launch dialog state persistence in [LaunchTeamDialog.tsx](../src/renderer/components/team/dialogs/LaunchTeamDialog.tsx)
+- create dialog state persistence in [CreateTeamDialog.tsx](../src/renderer/components/team/dialogs/CreateTeamDialog.tsx)
+- saved draft restore in [teams.ts](../src/main/ipc/teams.ts)
 - launch param persistence in the renderer store
-- slash-command metadata in [slashCommands.ts](../../src/shared/utils/slashCommands.ts)
+- slash-command metadata in [slashCommands.ts](../src/shared/utils/slashCommands.ts)
 
-Next step is to extend launch requests to include provider selection:
-
-```ts
-interface TeamLaunchRequest {
-  providerId?: 'anthropic' | 'codex';
-  model?: string;
-}
-```
-
-Future-compatible extension for providers with internal backend preference:
+Launch requests already carry provider selection. The remaining work is to keep request parsing, persistence, and runtime selection consistent. Future-compatible provider options can look like this:
 
 ```ts
 interface TeamLaunchRequest {
-  providerId?: 'anthropic' | 'codex' | 'gemini';
+  providerId?: TeamProviderId;
   model?: string;
   providerOptions?: {
     geminiBackendPreference?: 'auto' | 'api' | 'cli';
@@ -444,9 +435,9 @@ Future-compatible shape:
 
 ```ts
 interface TeamLaunchRequest {
-  providerId?: 'anthropic' | 'codex';
+  providerId?: TeamProviderId;
   model?: string;
-  memberProviders?: Record<string, 'anthropic' | 'codex'>;
+  memberProviders?: Record<string, TeamProviderId>;
   memberModels?: Record<string, string>;
 }
 ```
@@ -793,7 +784,7 @@ This phase must explicitly define the child-process env mapping for provider sel
 It must also persist launch-time `providerId` alongside `model` in team/run metadata so existing runs remain inspectable after refresh.
 It must update both the interactive team runtime path and the scheduler one-shot path.
 
-Phase 4 should also explicitly hide or keep disabled unsupported placeholder providers in `TeamModelSelector` until their runtime support actually exists. In Phase 1/2/3, only `Anthropic` and `Codex` should move out of placeholder behavior.
+Phase 4 should also explicitly hide or keep disabled unsupported providers in `TeamModelSelector` until their runtime support actually exists. In Phase 1/2/3, only `Anthropic` and `Codex` should move out of disabled state.
 
 ### Phase 5. Future teammate-level routing
 

--- a/docs/team-management/README.md
+++ b/docs/team-management/README.md
@@ -28,6 +28,8 @@
 
 ⚠️ `docs/iterations/*` - это исторические planning notes. Они полезны для контекста, но не являются source-of-truth для текущего поведения продукта. Актуальный контракт review flow описан в этом файле и в [kanban-design.md](./kanban-design.md).
 
+⚠️ `agent-attachments-*.md` (architecture plan + phase 1-5 plans) - это исторические дизайн-документы для feature attachments. Фактическая реализация в `src/features/agent-attachments/` может отличаться от описанной архитектуры. Для актуального состояния см. код в `src/features/agent-attachments/core/domain/` и тесты.
+
 ### 1. Messaging: Inbox-файлы
 
 Единственный способ общаться с **запущенными** тиммейтами. SDK и CLI создают новые сессии, а не подключаются к существующим. Подробности: [research-messaging.md](./research-messaging.md)
@@ -106,7 +108,7 @@ Kanban-позиция (REVIEW, APPROVED) хранится в `kanban-state.json`
 
 ## Открытые вопросы
 
-- **FileWatcher расширение**: FileWatcher.ts уже 900+ строк — добавление teams/tasks watchers нетривиально, требует отдельного спайка
+- **FileWatcher расширение**: FileWatcher.ts уже 1243 строк — добавление teams/tasks watchers нетривиально, требует отдельного спайка
 - **Windows atomic rename**: `fs.renameSync` на Windows бросает `EXDEV`/`EBUSY` при кросс-устройственном rename — нужна обёртка
 - **leadSessionId интеграция**: config.json содержит `leadSessionId`, но интеграция с session viewer (переход к сессии лида) — открытый вопрос
 - **Hard Interrupt**: сообщения доставляются между turns (1-30с задержка). В будущем нужен способ прервать mid-turn

--- a/docs/team-management/agent-attachments-architecture-plan.md
+++ b/docs/team-management/agent-attachments-architecture-plan.md
@@ -1,5 +1,7 @@
 # Agent attachments architecture plan
 
+⚠️ **Историческая документация**: Этот файл содержит дизайн-документацию и план реализации. Фактическая реализация в `src/features/agent-attachments/` может отличаться от описанной архитектуры. Для актуального состояния см. код в `src/features/agent-attachments/core/domain/` (budgets.ts, errors.ts, capabilities.ts, types.ts и т.д.).
+
 ## Summary
 
 Goal: support screenshots/images and later documents across Claude, Codex, and OpenCode teammates without treating base64 as a universal transport and without destabilizing team launch/runtime delivery.

--- a/docs/team-management/agent-attachments-phase-1-normalization-and-budgets-plan.md
+++ b/docs/team-management/agent-attachments-phase-1-normalization-and-budgets-plan.md
@@ -1,5 +1,7 @@
 # Phase 1 - Attachment normalization, image optimization, budgets, and UI warnings
 
+⚠️ **Историческая документация**: Этот файл содержит дизайн-документацию для Phase 1. Фактическая реализация в `src/features/agent-attachments/` может отличаться от описанной архитектуры. Для актуального состояния см. код в `src/features/agent-attachments/core/domain/` (budgets.ts, errors.ts, capabilities.ts, types.ts и т.д.).
+
 ## Summary
 
 Goal: make attachment intake safe before changing provider delivery paths.

--- a/docs/team-management/agent-attachments-phase-2-claude-stream-json-plan.md
+++ b/docs/team-management/agent-attachments-phase-2-claude-stream-json-plan.md
@@ -1,4 +1,5 @@
 # Phase 2 - Claude stream-json attachment delivery adapter
+⚠️ **Историческая документация**: Этот файл содержит дизайн-документацию. Фактическая реализация в `src/features/agent-attachments/` может отличаться от описанной архитектуры.
 
 ## Summary
 

--- a/docs/team-management/agent-attachments-phase-3-codex-native-plan.md
+++ b/docs/team-management/agent-attachments-phase-3-codex-native-plan.md
@@ -1,4 +1,5 @@
 # Phase 3 - Codex native image attachment delivery
+⚠️ **Историческая документация**: Этот файл содержит дизайн-документацию. Фактическая реализация в `src/features/agent-attachments/` может отличаться от описанной архитектуры.
 
 ## Summary
 

--- a/docs/team-management/agent-attachments-phase-4-opencode-vision-plan.md
+++ b/docs/team-management/agent-attachments-phase-4-opencode-vision-plan.md
@@ -1,4 +1,5 @@
 # Phase 4 - OpenCode file parts and model vision capability gate
+⚠️ **Историческая документация**: Этот файл содержит дизайн-документацию. Фактическая реализация в `src/features/agent-attachments/` может отличаться от описанной архитектуры.
 
 ## Summary
 

--- a/docs/team-management/agent-attachments-phase-5-e2e-and-polish-plan.md
+++ b/docs/team-management/agent-attachments-phase-5-e2e-and-polish-plan.md
@@ -1,4 +1,5 @@
 # Phase 5 - Cross-runtime attachment E2E, diagnostics, docs, and polish
+⚠️ **Историческая документация**: Этот файл содержит дизайн-документацию. Фактическая реализация в `src/features/agent-attachments/` может отличаться от описанной архитектуры.
 
 ## Summary
 

--- a/docs/team-management/agent-attachments.md
+++ b/docs/team-management/agent-attachments.md
@@ -1,4 +1,5 @@
 # Agent attachments
+⚠️ **Историческая документация**: Этот файл содержит дизайн-документацию. Фактическая реализация в `src/features/agent-attachments/` может отличаться от описанной архитектуры.
 
 This document describes the v1 attachment path for Agent Teams.
 

--- a/landing/product-docs/.vitepress/theme/custom.css
+++ b/landing/product-docs/.vitepress/theme/custom.css
@@ -180,25 +180,11 @@ body {
   z-index: 2;
   max-width: 780px !important;
   padding: 30px 32px 32px;
-  border: 1px solid color-mix(in srgb, var(--vp-c-border) 72%, transparent);
-  border-radius: 28px;
-  background:
-    linear-gradient(180deg, color-mix(in srgb, var(--vp-c-bg-elv) 74%, transparent), color-mix(in srgb, var(--vp-c-bg-soft) 56%, transparent)),
-    color-mix(in srgb, var(--vp-c-bg-elv) 70%, transparent);
-  box-shadow: var(--at-shadow-cyan-lg);
-  backdrop-filter: blur(var(--at-blur-lg));
+  text-shadow: 0 2px 22px color-mix(in srgb, var(--vp-c-bg) 82%, transparent);
 }
 
 .VPHero.has-image .main::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  pointer-events: none;
-  background:
-    radial-gradient(circle at 20% 0%, rgba(0, 240, 255, 0.14), transparent 42%),
-    radial-gradient(circle at 82% 12%, rgba(255, 0, 255, 0.08), transparent 30%);
-  opacity: 0.9;
+  display: none;
 }
 
 .VPHero.has-image .main > * {

--- a/landing/product-docs/.vitepress/theme/custom.css
+++ b/landing/product-docs/.vitepress/theme/custom.css
@@ -5,8 +5,8 @@
   --vp-c-brand-2: #009fb0;
   --vp-c-brand-3: #005c66;
   --vp-c-brand-soft: rgba(0, 128, 144, 0.12);
-  --vp-c-bg: var(--at-c-light-2);
-  --vp-c-bg-alt: var(--at-c-light-1);
+  --vp-c-bg: #f7f9fc;
+  --vp-c-bg-alt: #fbfcfe;
   --vp-c-bg-elv: var(--at-c-light-0);
   --vp-c-bg-soft: rgba(255, 255, 255, 0.74);
   --vp-c-text-1: var(--at-c-text-light-1);
@@ -24,7 +24,14 @@
   --vp-button-alt-hover-bg: rgba(255, 255, 255, 0.92);
   --vp-code-bg: rgba(8, 145, 178, 0.08);
   --vp-code-color: var(--at-c-cyan-deep);
-  --vp-code-block-bg: #0a0a0f;
+  --vp-code-block-bg: #ffffff;
+  --vp-code-block-color: var(--at-c-text-light-1);
+  --vp-code-block-divider-color: rgba(8, 145, 178, 0.12);
+  --vp-code-lang-color: var(--at-c-text-light-3);
+  --vp-code-line-highlight-color: rgba(8, 145, 178, 0.08);
+  --vp-code-copy-code-border-color: rgba(8, 145, 178, 0.18);
+  --vp-code-copy-code-bg: rgba(255, 255, 255, 0.78);
+  --vp-code-copy-code-hover-bg: #ffffff;
 }
 
 .dark {
@@ -48,6 +55,14 @@
   --vp-button-brand-bg: var(--at-c-cyan);
   --vp-code-bg: rgba(0, 240, 255, 0.1);
   --vp-code-color: var(--at-c-cyan);
+  --vp-code-block-bg: #0a0a0f;
+  --vp-code-block-color: var(--at-c-text-dark-2);
+  --vp-code-block-divider-color: rgba(0, 240, 255, 0.1);
+  --vp-code-lang-color: var(--at-c-text-dark-muted);
+  --vp-code-line-highlight-color: rgba(0, 240, 255, 0.08);
+  --vp-code-copy-code-border-color: rgba(0, 240, 255, 0.14);
+  --vp-code-copy-code-bg: rgba(10, 10, 15, 0.72);
+  --vp-code-copy-code-hover-bg: rgba(18, 18, 26, 0.96);
 }
 
 html {
@@ -69,8 +84,9 @@ body {
 
 .Layout::before {
   content: "";
-  position: fixed;
-  inset: 0;
+  position: absolute;
+  inset: 0 0 auto;
+  height: 560px;
   z-index: -2;
   pointer-events: none;
   background:
@@ -83,14 +99,12 @@ body {
 
 .Layout::after {
   content: "";
-  position: fixed;
-  inset: 0;
+  position: absolute;
+  inset: 0 0 auto;
+  height: 560px;
   z-index: -1;
   pointer-events: none;
-  background:
-    linear-gradient(180deg, transparent 0%, color-mix(in srgb, var(--vp-c-bg) 72%, transparent) 58%, var(--vp-c-bg) 100%),
-    linear-gradient(90deg, transparent 0, transparent calc(100% - 1px), var(--vp-c-divider) calc(100% - 1px), var(--vp-c-divider) 100%);
-  background-size: auto, 72px 72px;
+  background: linear-gradient(180deg, transparent 0%, color-mix(in srgb, var(--vp-c-bg) 72%, transparent) 58%, var(--vp-c-bg) 100%);
   opacity: 0.6;
 }
 
@@ -260,6 +274,39 @@ body {
 .VPButton.brand:hover,
 .VPButton.alt:hover {
   border-color: var(--at-c-border-strong) !important;
+}
+
+.markdown-copy-buttons-inner {
+  gap: 6px;
+  margin: 10px 0 12px;
+}
+
+.markdown-copy-buttons .dropdown-trigger {
+  border-radius: var(--at-radius-sm);
+  font-size: 13px;
+}
+
+.markdown-copy-buttons .copy-page {
+  gap: 6px;
+  padding: 6px 12px;
+}
+
+.markdown-copy-buttons .chevron-wrapper {
+  padding: 0 9px;
+}
+
+.markdown-copy-buttons .download-btn {
+  padding: 6px 9px;
+  border-radius: var(--at-radius-sm);
+}
+
+.markdown-copy-buttons .divider {
+  height: 20px;
+}
+
+.markdown-copy-buttons .icon {
+  width: 16px;
+  height: 16px;
 }
 
 .VPFeature {

--- a/landing/product-docs/index.md
+++ b/landing/product-docs/index.md
@@ -24,7 +24,7 @@ features:
     linkText: Create a team
   - icon: "02"
     title: Live kanban board
-    details: Watch tasks move through todo, progress, review, blocked, and done as agents work.
+    details: Watch tasks move through todo, in progress, review, done, and approved as agents work.
     link: /guide/agent-workflow
     linkText: Understand workflow
   - icon: "03"

--- a/landing/product-docs/ru/index.md
+++ b/landing/product-docs/ru/index.md
@@ -24,7 +24,7 @@ features:
     linkText: Создать команду
   - icon: "02"
     title: Живая канбан-доска
-    details: Видно, как задачи проходят todo, progress, review, blocked и done во время работы агентов.
+    details: Видно, как задачи проходят todo, in progress, review, done и approved во время работы агентов.
     link: /ru/guide/agent-workflow
     linkText: Разобрать workflow
   - icon: "03"

--- a/runtime.lock.json
+++ b/runtime.lock.json
@@ -1,27 +1,27 @@
 {
-  "version": "0.0.27",
-  "sourceRef": "v0.0.27",
+  "version": "0.0.28",
+  "sourceRef": "v0.0.28",
   "sourceRepository": "777genius/agent_teams_orchestrator",
   "releaseRepository": "777genius/agent-teams-ai",
   "releaseTag": "v1.2.0",
   "assets": {
     "darwin-arm64": {
-      "file": "agent-teams-runtime-darwin-arm64-v0.0.27.tar.gz",
+      "file": "agent-teams-runtime-darwin-arm64-v0.0.28.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel"
     },
     "darwin-x64": {
-      "file": "agent-teams-runtime-darwin-x64-v0.0.27.tar.gz",
+      "file": "agent-teams-runtime-darwin-x64-v0.0.28.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel"
     },
     "linux-x64": {
-      "file": "agent-teams-runtime-linux-x64-v0.0.27.tar.gz",
+      "file": "agent-teams-runtime-linux-x64-v0.0.28.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel"
     },
     "win32-x64": {
-      "file": "agent-teams-runtime-win32-x64-v0.0.27.zip",
+      "file": "agent-teams-runtime-win32-x64-v0.0.28.zip",
       "archiveKind": "zip",
       "binaryName": "claude-multimodel.exe"
     }

--- a/src/features/CLAUDE.md
+++ b/src/features/CLAUDE.md
@@ -1,0 +1,31 @@
+# Feature-Local Guidance
+
+This file is a navigation layer for feature slices under `src/features/`.
+
+Before changing a feature slice, read:
+
+- [Project instructions](../../CLAUDE.md)
+- [Feature Architecture Standard](../../docs/FEATURE_ARCHITECTURE_STANDARD.md)
+- [Feature root guide](./README.md)
+
+Use local references:
+
+- `src/features/recent-projects` - full cross-process reference
+- `src/features/member-work-sync` - full feature with a root public barrel
+- `src/features/member-log-stream` - full feature with `main/application/`
+- `src/features/agent-graph` - thin `core/domain` plus `renderer` reference
+
+Default location for new feature work:
+
+- `src/features/<feature-name>/`
+
+Before adding or moving code:
+
+- decide whether the feature is full, thin, or process-limited
+- add only the layers the feature actually owns
+- expose production callers through public entrypoints only
+- keep tests close to the layer they verify under `test/features/<feature>/` or
+  feature-local `__tests__` when that is the established local pattern
+
+Do not duplicate architecture rules here. Keep architecture rules centralized in
+[../../docs/FEATURE_ARCHITECTURE_STANDARD.md](../../docs/FEATURE_ARCHITECTURE_STANDARD.md).

--- a/src/main/ipc/teams.ts
+++ b/src/main/ipc/teams.ts
@@ -48,6 +48,7 @@ import {
   TEAM_INITIALIZE_GIT_REPOSITORY,
   TEAM_KILL_PROCESS,
   TEAM_LAUNCH,
+  TEAM_LAUNCH_FAILURE_DIAGNOSTICS,
   TEAM_LEAD_ACTIVITY,
   TEAM_LEAD_CONTEXT,
   TEAM_LIST,
@@ -143,6 +144,7 @@ import {
 import { mergeLiveLeadProcessMessages } from '../services/team/mergeLiveLeadProcessMessages';
 import { TeamAttachmentStore } from '../services/team/TeamAttachmentStore';
 import { TeamConfigReader } from '../services/team/TeamConfigReader';
+import { readTeamLaunchFailureDiagnosticsBundle } from '../services/team/TeamLaunchFailureArtifactPack';
 import { TeamMembersMetaStore } from '../services/team/TeamMembersMetaStore';
 import { TeamMetaStore } from '../services/team/TeamMetaStore';
 import { buildAddMemberSpawnMessage } from '../services/team/TeamProvisioningService';
@@ -215,6 +217,7 @@ import type {
   TeamGetDataOptions,
   TeamLaunchRequest,
   TeamLaunchResponse,
+  TeamLaunchFailureDiagnosticsBundle,
   TeamMemberActivityMeta,
   TeamMessageNotificationData,
   TeamProviderBackendId,
@@ -702,6 +705,7 @@ export function registerTeamHandlers(ipcMain: IpcMain): void {
   ipcMain.handle(TEAM_CREATE, handleCreateTeam);
   ipcMain.handle(TEAM_LAUNCH, handleLaunchTeam);
   ipcMain.handle(TEAM_PROVISIONING_STATUS, handleProvisioningStatus);
+  ipcMain.handle(TEAM_LAUNCH_FAILURE_DIAGNOSTICS, handleLaunchFailureDiagnostics);
   ipcMain.handle(TEAM_CANCEL_PROVISIONING, handleCancelProvisioning);
   ipcMain.handle(TEAM_SEND_MESSAGE, handleSendMessage);
   ipcMain.handle(TEAM_GET_OPENCODE_RUNTIME_DELIVERY_STATUS, handleGetOpenCodeRuntimeDeliveryStatus);
@@ -788,6 +792,7 @@ export function removeTeamHandlers(ipcMain: IpcMain): void {
   ipcMain.removeHandler(TEAM_CREATE);
   ipcMain.removeHandler(TEAM_LAUNCH);
   ipcMain.removeHandler(TEAM_PROVISIONING_STATUS);
+  ipcMain.removeHandler(TEAM_LAUNCH_FAILURE_DIAGNOSTICS);
   ipcMain.removeHandler(TEAM_CANCEL_PROVISIONING);
   ipcMain.removeHandler(TEAM_SEND_MESSAGE);
   ipcMain.removeHandler(TEAM_GET_OPENCODE_RUNTIME_DELIVERY_STATUS);
@@ -2378,6 +2383,21 @@ async function handleProvisioningStatus(
   }
   return wrapTeamHandler('provisioningStatus', () =>
     getTeamProvisioningService().getProvisioningStatus(runId.trim())
+  );
+}
+
+async function handleLaunchFailureDiagnostics(
+  _event: IpcMainInvokeEvent,
+  teamName: unknown,
+  runId: unknown
+): Promise<IpcResult<TeamLaunchFailureDiagnosticsBundle>> {
+  const validatedTeamName = validateTeamName(teamName);
+  if (!validatedTeamName.valid) {
+    return { success: false, error: validatedTeamName.error ?? 'Invalid teamName' };
+  }
+  const validatedRunId = typeof runId === 'string' && runId.trim() ? runId.trim() : undefined;
+  return wrapTeamHandler('launchFailureDiagnostics', () =>
+    readTeamLaunchFailureDiagnosticsBundle(validatedTeamName.value!, validatedRunId)
   );
 }
 

--- a/src/main/services/team/TeamLaunchFailureArtifactPack.ts
+++ b/src/main/services/team/TeamLaunchFailureArtifactPack.ts
@@ -11,6 +11,7 @@ import type {
   MemberSpawnStatusEntry,
   PersistedTeamLaunchSnapshot,
   TeamLaunchDiagnosticItem,
+  TeamLaunchFailureDiagnosticsBundle,
   TeamMember,
   TeamProviderBackendId,
   TeamProviderId,
@@ -24,6 +25,7 @@ const LATEST_ARTIFACT_FILE = 'latest.json';
 const MAX_CLI_LOG_CHARS = 256_000;
 const MAX_TRACE_CHARS = 128_000;
 const MAX_COPIED_FILE_BYTES = 256 * 1024;
+const MAX_DIAGNOSTICS_COPY_FILE_BYTES = 128 * 1024;
 
 type JsonRecord = Record<string, unknown>;
 
@@ -330,6 +332,181 @@ async function readBoundedTextFile(sourcePath: string): Promise<{ text?: string;
     const code = (error as NodeJS.ErrnoException).code;
     return { issue: code === 'ENOENT' ? 'missing' : 'unreadable' };
   }
+}
+
+async function readDiagnosticsCopyFile(
+  label: string,
+  sourcePath: string
+): Promise<TeamLaunchFailureDiagnosticsBundle['files'][number]> {
+  const read = await readBoundedTextFile(sourcePath);
+  if (read.text === undefined) {
+    return {
+      label,
+      path: sourcePath,
+      issue: read.issue ?? 'unreadable',
+    };
+  }
+
+  const text =
+    read.text.length > MAX_DIAGNOSTICS_COPY_FILE_BYTES
+      ? `[truncated to last ${MAX_DIAGNOSTICS_COPY_FILE_BYTES} chars]\n${read.text.slice(
+          read.text.length - MAX_DIAGNOSTICS_COPY_FILE_BYTES
+        )}`
+      : read.text;
+
+  return {
+    label,
+    path: sourcePath,
+    content: redactLaunchFailureArtifactText(text).trimEnd(),
+  };
+}
+
+function parseJsonObject(text: string | undefined): JsonRecord | null {
+  if (!text) return null;
+  try {
+    const parsed = JSON.parse(text);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as JsonRecord)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function getString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
+function getRecord(value: unknown): JsonRecord | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as JsonRecord) : null;
+}
+
+function resolveArtifactManifestPath(
+  teamDir: string,
+  latestJson: JsonRecord | null,
+  runId?: string
+): { path?: string; issue?: string } {
+  if (!latestJson) {
+    return { issue: 'latest_json_unavailable' };
+  }
+  const latestRunId = getString(latestJson.runId);
+  if (runId && latestRunId && latestRunId !== runId) {
+    return { issue: `latest_run_mismatch:${latestRunId}` };
+  }
+
+  const manifestPath = getString(latestJson.manifestPath);
+  if (!manifestPath) {
+    return { issue: 'manifest_path_missing' };
+  }
+
+  try {
+    assertPathWithin(path.join(teamDir, ARTIFACTS_DIR_NAME), manifestPath);
+  } catch {
+    return { issue: 'manifest_path_outside_artifacts_dir' };
+  }
+  return { path: manifestPath };
+}
+
+export async function readTeamLaunchFailureDiagnosticsBundle(
+  teamName: string,
+  runId?: string
+): Promise<TeamLaunchFailureDiagnosticsBundle> {
+  const teamDir = path.join(getTeamsBasePath(), teamName);
+  const latestPath = path.join(teamDir, ARTIFACTS_DIR_NAME, LATEST_ARTIFACT_FILE);
+  const latestFile = await readDiagnosticsCopyFile(
+    'launch-failure-artifacts/latest.json',
+    latestPath
+  );
+  const latestJson = parseJsonObject(latestFile.content);
+  const resolvedManifest = resolveArtifactManifestPath(teamDir, latestJson, runId);
+  const files: TeamLaunchFailureDiagnosticsBundle['files'] = [latestFile];
+
+  let manifestJson: JsonRecord | null = null;
+  if (resolvedManifest.path) {
+    const manifestFile = await readDiagnosticsCopyFile(
+      'launch-failure-artifacts/manifest.json',
+      resolvedManifest.path
+    );
+    files.push(manifestFile);
+    manifestJson = parseJsonObject(manifestFile.content);
+  } else {
+    files.push({
+      label: 'launch-failure-artifacts/manifest.json',
+      path:
+        getString(latestJson?.manifestPath) ??
+        path.join(teamDir, ARTIFACTS_DIR_NAME, 'manifest.json'),
+      issue: resolvedManifest.issue ?? 'manifest_unavailable',
+    });
+  }
+
+  files.push(
+    await readDiagnosticsCopyFile(
+      'bootstrap-journal.jsonl',
+      path.join(teamDir, 'bootstrap-journal.jsonl')
+    ),
+    await readDiagnosticsCopyFile('launch-state.json', getTeamLaunchStatePath(teamName))
+  );
+
+  const classification = getRecord(manifestJson?.classification);
+  const bootstrapTransportBreadcrumb = getRecord(manifestJson?.bootstrapTransportBreadcrumb);
+
+  return {
+    teamName,
+    ...(runId
+      ? { runId }
+      : getString(latestJson?.runId)
+        ? { runId: getString(latestJson?.runId) }
+        : {}),
+    latestPath,
+    ...(getString(latestJson?.directory)
+      ? { artifactDirectory: getString(latestJson?.directory) }
+      : {}),
+    ...(resolvedManifest.path ? { manifestPath: resolvedManifest.path } : {}),
+    classification: classification
+      ? {
+          code: getString(classification.code),
+          confidence:
+            typeof classification.confidence === 'number' ? classification.confidence : undefined,
+          evidence: Array.isArray(classification.evidence)
+            ? classification.evidence.filter((item): item is string => typeof item === 'string')
+            : undefined,
+        }
+      : null,
+    bootstrapTransportBreadcrumb: bootstrapTransportBreadcrumb
+      ? {
+          lastTransportStage:
+            typeof bootstrapTransportBreadcrumb.lastTransportStage === 'string'
+              ? bootstrapTransportBreadcrumb.lastTransportStage
+              : bootstrapTransportBreadcrumb.lastTransportStage === null
+                ? null
+                : undefined,
+          submitRejected:
+            typeof bootstrapTransportBreadcrumb.submitRejected === 'boolean'
+              ? bootstrapTransportBreadcrumb.submitRejected
+              : undefined,
+          retryable:
+            typeof bootstrapTransportBreadcrumb.retryable === 'boolean'
+              ? bootstrapTransportBreadcrumb.retryable
+              : bootstrapTransportBreadcrumb.retryable === null
+                ? null
+                : undefined,
+          noStdinWarning:
+            typeof bootstrapTransportBreadcrumb.noStdinWarning === 'boolean'
+              ? bootstrapTransportBreadcrumb.noStdinWarning
+              : undefined,
+          bootstrapSubmitted:
+            typeof bootstrapTransportBreadcrumb.bootstrapSubmitted === 'boolean'
+              ? bootstrapTransportBreadcrumb.bootstrapSubmitted
+              : undefined,
+          evidence: Array.isArray(bootstrapTransportBreadcrumb.evidence)
+            ? bootstrapTransportBreadcrumb.evidence.filter(
+                (item): item is string => typeof item === 'string'
+              )
+            : undefined,
+        }
+      : null,
+    files,
+  };
 }
 
 function getKnownLaunchArtifactSourceFiles(teamName: string): CopiedArtifactFile[] {

--- a/src/main/services/team/TeamLogSourceTracker.ts
+++ b/src/main/services/team/TeamLogSourceTracker.ts
@@ -1,4 +1,5 @@
 import { createLogger } from '@shared/utils/logger';
+import { getTeamsBasePath } from '@main/utils/pathDecoder';
 import { watch } from 'chokidar';
 import { createHash } from 'crypto';
 import * as fs from 'fs/promises';
@@ -13,6 +14,7 @@ import {
   BOARD_TASK_CHANGES_DIRNAME,
   BOARD_TASK_LOG_FRESHNESS_DIRNAME,
   BOARD_TASK_LOG_FRESHNESS_FILE_SUFFIX,
+  TEAM_TASK_LOG_FRESHNESS_DIRNAME,
   classifyLogSourceWatcherEvent,
   getRelativeLogSourceParts,
   isAgentTranscriptFileName,
@@ -84,6 +86,23 @@ function pushUniqueNormalizedPath(paths: string[], candidate: string | undefined
   if (!paths.some((existing) => path.normalize(existing) === normalized)) {
     paths.push(normalized);
   }
+}
+
+function getTeamTaskLogFreshnessDir(teamName: string): string {
+  return path.join(getTeamsBasePath(), teamName, TEAM_TASK_LOG_FRESHNESS_DIRNAME);
+}
+
+function pathsOverlap(left: string, right: string): boolean {
+  const normalizedLeft = path.normalize(left);
+  const normalizedRight = path.normalize(right);
+  const leftToRight = path.relative(normalizedLeft, normalizedRight);
+  const rightToLeft = path.relative(normalizedRight, normalizedLeft);
+  return (
+    !leftToRight ||
+    (!leftToRight.startsWith('..') && !path.isAbsolute(leftToRight)) ||
+    !rightToLeft ||
+    (!rightToLeft.startsWith('..') && !path.isAbsolute(rightToLeft))
+  );
 }
 
 export function shouldIgnoreLogSourceWatcherPath(
@@ -382,19 +401,23 @@ export class TeamLogSourceTracker {
     }
 
     const taskFreshnessRootDirs = this.getTaskFreshnessRootDirs(context);
-    const taskFreshnessWatchRootDirs = await this.ensureLogSourceFreshnessDirs(
+    const taskFreshnessDirs = await this.ensureLogSourceFreshnessDirs(
+      teamName,
       context.projectDir,
       taskFreshnessRootDirs
     ).catch((error) => {
       logger.debug(`Failed to ensure log-source freshness dirs for ${teamName}: ${String(error)}`);
-      return [path.normalize(context.projectDir)];
+      return {
+        legacyRootDirs: [path.normalize(context.projectDir)],
+        logSignalDirs: [getTeamTaskLogFreshnessDir(teamName)],
+      };
     });
 
     const { targets, scopedSessionIds } = await this.buildScopedWatchTargets(
       context.projectDir,
       context.watchSessionIds,
       this.getPendingUnknownSessionIds(state),
-      taskFreshnessWatchRootDirs
+      taskFreshnessDirs
     );
     if (!this.isTrackingCurrent(teamName, expectedVersion)) {
       return;
@@ -406,11 +429,19 @@ export class TeamLogSourceTracker {
       ignorePermissionErrors: true,
       followSymlinks: false,
       depth: 0,
-      ignored: (watchedPath) =>
-        shouldIgnoreLogSourceWatcherPath(context.projectDir, watchedPath, {
+      ignored: (watchedPath) => {
+        if (
+          taskFreshnessDirs.logSignalDirs.some((logSignalDir) =>
+            pathsOverlap(watchedPath, logSignalDir)
+          )
+        ) {
+          return false;
+        }
+        return shouldIgnoreLogSourceWatcherPath(context.projectDir, watchedPath, {
           scopedSessionIds,
           pendingRootSessionIds: new Set(this.getPendingUnknownSessionIds(state)),
-        }),
+        });
+      },
       awaitWriteFinish: {
         stabilityThreshold: 250,
         pollInterval: 50,
@@ -431,13 +462,13 @@ export class TeamLogSourceTracker {
         return;
       }
       const eventTaskFreshnessRootDirs = this.getTaskFreshnessRootDirs(current.activeContext);
-      pushUniqueNormalizedPath(eventTaskFreshnessRootDirs, current.projectDir);
+      const eventTaskFreshnessDirs = this.getTaskFreshnessDirsForContext(
+        teamName,
+        current.projectDir,
+        eventTaskFreshnessRootDirs
+      );
       if (
-        this.handleTaskFreshnessSignalChangeForRoots(
-          teamName,
-          changedPath,
-          eventTaskFreshnessRootDirs
-        )
+        this.handleTaskFreshnessSignalChangeForDirs(teamName, changedPath, eventTaskFreshnessDirs)
       ) {
         return;
       }
@@ -485,17 +516,19 @@ export class TeamLogSourceTracker {
   }
 
   private async ensureLogSourceFreshnessDirs(
+    teamName: string,
     transcriptProjectDir: string,
     projectDirs: readonly string[]
-  ): Promise<string[]> {
-    const watchRootDirs: string[] = [];
+  ): Promise<{ legacyRootDirs: string[]; logSignalDirs: string[] }> {
+    const legacyRootDirs: string[] = [];
+    const logSignalDirs: string[] = [];
     const normalizedTranscriptProjectDir = path.normalize(transcriptProjectDir);
-    pushUniqueNormalizedPath(watchRootDirs, normalizedTranscriptProjectDir);
+    const teamLogFreshnessDir = getTeamTaskLogFreshnessDir(teamName);
+    pushUniqueNormalizedPath(legacyRootDirs, normalizedTranscriptProjectDir);
+    pushUniqueNormalizedPath(logSignalDirs, teamLogFreshnessDir);
 
     await Promise.all([
-      fs.mkdir(path.join(normalizedTranscriptProjectDir, BOARD_TASK_LOG_FRESHNESS_DIRNAME), {
-        recursive: true,
-      }),
+      fs.mkdir(teamLogFreshnessDir, { recursive: true }),
       fs.mkdir(path.join(normalizedTranscriptProjectDir, BOARD_TASK_CHANGE_FRESHNESS_DIRNAME), {
         recursive: true,
       }),
@@ -511,34 +544,35 @@ export class TeamLogSourceTracker {
           if (!(await this.isDirectory(normalizedProjectDir))) {
             return;
           }
-          await Promise.all([
-            fs.mkdir(path.join(normalizedProjectDir, BOARD_TASK_LOG_FRESHNESS_DIRNAME), {
-              recursive: true,
-            }),
-            fs.mkdir(path.join(normalizedProjectDir, BOARD_TASK_CHANGE_FRESHNESS_DIRNAME), {
-              recursive: true,
-            }),
-          ]);
-          pushUniqueNormalizedPath(watchRootDirs, normalizedProjectDir);
+          await fs.mkdir(path.join(normalizedProjectDir, BOARD_TASK_CHANGE_FRESHNESS_DIRNAME), {
+            recursive: true,
+          });
+          pushUniqueNormalizedPath(legacyRootDirs, normalizedProjectDir);
         } catch (error) {
           logger.debug(`Failed to ensure task freshness dirs in ${projectDir}: ${String(error)}`);
         }
       })
     );
-    return watchRootDirs;
+    return { legacyRootDirs, logSignalDirs };
   }
 
   private async buildScopedWatchTargets(
     projectDir: string,
     confirmedSessionIds: readonly string[],
     pendingRootSessionIds: readonly string[],
-    taskFreshnessRootDirs: readonly string[] = [projectDir]
+    taskFreshnessDirs: {
+      legacyRootDirs: readonly string[];
+      logSignalDirs: readonly string[];
+    } = { legacyRootDirs: [projectDir], logSignalDirs: [] }
   ): Promise<{ targets: string[]; scopedSessionIds: Set<string> }> {
     const targets = new Set<string>();
     const scopedSessionIds = new Set<string>();
 
     targets.add(projectDir);
-    for (const freshnessRootDir of taskFreshnessRootDirs) {
+    for (const logSignalDir of taskFreshnessDirs.logSignalDirs) {
+      targets.add(logSignalDir);
+    }
+    for (const freshnessRootDir of taskFreshnessDirs.legacyRootDirs) {
       targets.add(path.join(freshnessRootDir, BOARD_TASK_LOG_FRESHNESS_DIRNAME));
       targets.add(path.join(freshnessRootDir, BOARD_TASK_CHANGE_FRESHNESS_DIRNAME));
     }
@@ -841,6 +875,36 @@ export class TeamLogSourceTracker {
       }
     }
     return false;
+  }
+
+  private getTaskFreshnessDirsForContext(
+    teamName: string,
+    projectDir: string,
+    taskFreshnessRootDirs: readonly string[]
+  ): { legacyRootDirs: string[]; logSignalDirs: string[] } {
+    const legacyRootDirs = [...taskFreshnessRootDirs];
+    pushUniqueNormalizedPath(legacyRootDirs, projectDir);
+    return {
+      legacyRootDirs,
+      logSignalDirs: [getTeamTaskLogFreshnessDir(teamName)],
+    };
+  }
+
+  private handleTaskFreshnessSignalChangeForDirs(
+    teamName: string,
+    changedPath: string,
+    taskFreshnessDirs: { legacyRootDirs: readonly string[]; logSignalDirs: readonly string[] }
+  ): boolean {
+    for (const logSignalDir of taskFreshnessDirs.logSignalDirs) {
+      if (this.handleTaskFreshnessSignalChange(teamName, changedPath, logSignalDir, 'log')) {
+        return true;
+      }
+    }
+    return this.handleTaskFreshnessSignalChangeForRoots(
+      teamName,
+      changedPath,
+      taskFreshnessDirs.legacyRootDirs
+    );
   }
 
   private async recompute(teamName: string): Promise<TeamLogSourceSnapshot> {

--- a/src/main/services/team/TeamProvisioningService.ts
+++ b/src/main/services/team/TeamProvisioningService.ts
@@ -3488,68 +3488,6 @@ function buildEffectiveTeamMemberSpecs(
   return members.map((member) => buildEffectiveTeamMemberSpec(member, defaults));
 }
 
-function shouldSkipResumeForProviderRuntimeChange(
-  request: Pick<TeamLaunchRequest, 'providerId' | 'providerBackendId' | 'model'>,
-  config: Record<string, unknown>,
-  persistedProviderBackendId?: string | null
-): { skip: boolean; reason?: string } {
-  const providerId = normalizeTeamMemberProviderId(request.providerId);
-  if (providerId !== 'gemini' && providerId !== 'codex') {
-    return { skip: false };
-  }
-
-  const requestedBackendId =
-    migrateProviderBackendId(providerId, request.providerBackendId?.trim()) || null;
-  const previousBackendId =
-    migrateProviderBackendId(providerId, persistedProviderBackendId?.trim()) || null;
-  if (requestedBackendId && previousBackendId && requestedBackendId !== previousBackendId) {
-    return {
-      skip: true,
-      reason: `runtime backend changed (${previousBackendId} -> ${requestedBackendId})`,
-    };
-  }
-
-  const members = Array.isArray(config.members)
-    ? (config.members as Record<string, unknown>[])
-    : [];
-  const lead =
-    members.find((member) => isLeadMember(member)) ??
-    members.find((member) => {
-      const name = typeof member?.name === 'string' ? member.name.trim().toLowerCase() : '';
-      return name === 'team-lead';
-    });
-  if (!lead) {
-    return { skip: false };
-  }
-
-  const currentLeadProviderId =
-    normalizeTeamMemberProviderId(
-      typeof lead.providerId === 'string'
-        ? lead.providerId
-        : typeof lead.provider === 'string'
-          ? lead.provider
-          : providerId
-    ) ?? providerId;
-  const requestedModel = request.model?.trim() || '';
-  const currentLeadModel = typeof lead.model === 'string' ? lead.model.trim() : '';
-
-  if (currentLeadProviderId !== providerId) {
-    return {
-      skip: true,
-      reason: `provider changed (${currentLeadProviderId} -> ${providerId})`,
-    };
-  }
-
-  if (requestedModel && currentLeadModel && requestedModel !== currentLeadModel) {
-    return {
-      skip: true,
-      reason: `model changed (${currentLeadModel} -> ${requestedModel})`,
-    };
-  }
-
-  return { skip: false };
-}
-
 function buildMembersPrompt(members: TeamCreateRequest['members']): string {
   return members
     .map((member) => {
@@ -4637,8 +4575,10 @@ function buildDeterministicLaunchHydrationPrompt(
   const isSolo = members.length === 0;
   const projectName = path.basename(request.cwd);
   const startLabel = isResume ? 'Team Start (resume)' : 'Team Start';
+  const startupLabel = isResume ? 'resume/bootstrap' : 'launch/bootstrap';
+  const headerModeLabel = isResume ? 'Deterministic resume' : 'Deterministic launch';
   const userPromptBlock = request.prompt?.trim()
-    ? `\nOriginal user instructions to apply after reconnect is stable:\n${request.prompt.trim()}\n`
+    ? `\nOriginal user instructions to apply after ${isResume ? 'resume' : 'startup'} is stable:\n${request.prompt.trim()}\n`
     : '';
   const hasOriginalUserPrompt = Boolean(request.prompt?.trim());
   const taskBoardSnapshot = buildTaskBoardSnapshot(tasks);
@@ -4649,7 +4589,7 @@ function buildDeterministicLaunchHydrationPrompt(
     members,
   });
   const nextSteps = isSolo
-    ? `This reconnect/bootstrap step has already been completed deterministically by the runtime.
+    ? `This ${startupLabel} step has already been completed deterministically by the runtime.
 Do NOT call TeamCreate.
 Do NOT use Agent to spawn or restore teammates.
 Do NOT start implementation in this turn.
@@ -4659,7 +4599,7 @@ ${
     ? 'Do NOT create or update any new task in this turn - wait for the next normal operating turn before translating those instructions into board work.'
     : 'Do NOT create, assign, or delegate any new task in this turn. If the board is empty, stay silent and wait for a fresh user instruction.'
 }`
-    : `This reconnect/bootstrap step has already been completed deterministically by the runtime.
+    : `This ${startupLabel} step has already been completed deterministically by the runtime.
 Do NOT call TeamCreate.
 Do NOT use Agent to spawn or restore teammates.
 Do NOT repeat the launch summary.
@@ -4671,7 +4611,7 @@ ${
 }
 Treat teammates whose bootstrap is still pending as not-yet-available for blocking assignments.`;
 
-  return `${startLabel} [Deterministic reconnect | Team: "${request.teamName}" | Project: "${projectName}" | Lead: "${leadName}"]
+  return `${startLabel} [${headerModeLabel} | Team: "${request.teamName}" | Project: "${projectName}" | Lead: "${leadName}"]
 
 You are running headless in a non-interactive CLI session. Do not ask questions.
 You are "${leadName}", the team lead.
@@ -18419,8 +18359,8 @@ export class TeamProvisioningService {
         run,
         'configuring',
         run.deterministicBootstrap
-          ? 'CLI running — deterministic reconnect in progress'
-          : 'CLI running — reconnecting with teammates'
+          ? 'CLI running - deterministic launch in progress'
+          : 'CLI running - reconnecting with teammates'
       );
       run.onProgress(run.progress);
     }
@@ -19789,135 +19729,19 @@ export class TeamProvisioningService {
         providerId: request.providerId,
         members: expectedMemberSpecs,
       });
-      // Extract leadSessionId for session resume on reconnect.
-      // If a valid JSONL file exists for the previous session, we can resume it
-      // so the lead retains full context of prior work.
-      // When clearContext is true, skip resume entirely to start a fresh session.
-      let previousSessionId: string | undefined;
-      let skipResume = false;
+      // Deterministic launch always sends --team-bootstrap-spec. The orchestrator
+      // rejects combining that startup mode with --resume, so relaunch starts a
+      // fresh lead runtime session and restores operational context from durable
+      // team state instead of the previous transcript.
       if (request.clearContext) {
-        skipResume = true;
         logger.info(
-          `[${request.teamName}] clearContext requested — skipping session resume, starting fresh`
+          `[${request.teamName}] clearContext requested - starting fresh deterministic bootstrap session`
         );
       } else {
-        // Check persisted launch state: if the previous launch ended with no teammates
-        // ever spawned (all in 'starting' state), resuming would reconnect the lead but
-        // the CLI's deterministic bootstrap won't re-spawn dead teammates in reconnect
-        // mode. Skip resume so the CLI creates a fresh session that fully bootstraps.
-        const persistedLaunchState = await this.launchStateStore.read(request.teamName);
-        if (persistedLaunchState) {
-          const {
-            expectedMembers: prevExpected,
-            members: prevMembers,
-            launchPhase,
-          } = persistedLaunchState;
-          const teammateWasNeverSpawned = (
-            member:
-              | {
-                  agentToolAccepted?: boolean;
-                  firstSpawnAcceptedAt?: string;
-                  runtimeAlive?: boolean;
-                  bootstrapConfirmed?: boolean;
-                }
-              | undefined
-          ): boolean => {
-            if (!member) return true;
-            const hasAcceptedSpawn =
-              member.agentToolAccepted === true ||
-              (typeof member.firstSpawnAcceptedAt === 'string' &&
-                member.firstSpawnAcceptedAt.trim().length > 0);
-            return (
-              !hasAcceptedSpawn &&
-              member.runtimeAlive !== true &&
-              member.bootstrapConfirmed !== true
-            );
-          };
-          const updatedAtMs = Date.parse(persistedLaunchState.updatedAt);
-          const activeLaunchLooksStale =
-            launchPhase === 'active' &&
-            (!Number.isFinite(updatedAtMs) || Date.now() - updatedAtMs >= MEMBER_LAUNCH_GRACE_MS);
-          const launchOutcomeIsSettledOrStale = launchPhase !== 'active' || activeLaunchLooksStale;
-          const hasPreviousExpectedTeammates = prevExpected.length > 0;
-          const previousTeammates = prevExpected.map((name) => prevMembers[name]);
-          const staleActiveLaunchHasNoLiveTeammates =
-            activeLaunchLooksStale &&
-            hasPreviousExpectedTeammates &&
-            !previousTeammates.some(
-              (member) => member?.runtimeAlive === true || member?.bootstrapConfirmed === true
-            );
-          const allTeammatesNeverSpawned =
-            launchOutcomeIsSettledOrStale &&
-            hasPreviousExpectedTeammates &&
-            previousTeammates.every(teammateWasNeverSpawned);
-          if (allTeammatesNeverSpawned || staleActiveLaunchHasNoLiveTeammates) {
-            skipResume = true;
-            logger.info(
-              `[${request.teamName}] Previous launch cannot be resumed safely - ` +
-                `skipping session resume to allow full bootstrap`
-            );
-          }
-        }
-      }
-      if (!skipResume) {
-        try {
-          const configParsed = JSON.parse(configRaw) as Record<string, unknown>;
-          const persistedTeamMeta = await this.teamMetaStore
-            .getMeta(request.teamName)
-            .catch(() => null);
-          const resumeGuard = shouldSkipResumeForProviderRuntimeChange(
-            request,
-            configParsed,
-            persistedTeamMeta?.providerBackendId ?? null
-          );
-          if (resumeGuard.skip) {
-            logger.info(
-              `[${request.teamName}] Skipping session resume — ${resumeGuard.reason ?? 'runtime changed'}`
-            );
-          } else if (
-            typeof configParsed.leadSessionId === 'string' &&
-            configParsed.leadSessionId.trim().length > 0
-          ) {
-            const candidateId = configParsed.leadSessionId.trim();
-            const storedProjectPath =
-              typeof configParsed.projectPath === 'string' &&
-              configParsed.projectPath.trim().length > 0
-                ? configParsed.projectPath.trim()
-                : null;
-
-            // Sessions are stored per-project (~/.claude/projects/{encodePath(cwd)}/).
-            // If the project path changed, the old session JSONL won't be found by the CLI
-            // at the new project directory. Skip resume to avoid passing an invalid --resume arg.
-            if (
-              storedProjectPath &&
-              path.resolve(storedProjectPath) !== path.resolve(request.cwd)
-            ) {
-              logger.info(
-                `[${request.teamName}] Project path changed: ${storedProjectPath} → ${request.cwd}. ` +
-                  `Skipping session resume — sessions are per-project.`
-              );
-            } else {
-              const resumeProjectPath = storedProjectPath ?? request.cwd;
-              const projectId = encodePath(resumeProjectPath);
-              const baseDir = extractBaseDir(projectId);
-              const jsonlPath = path.join(getProjectsBasePath(), baseDir, `${candidateId}.jsonl`);
-              if (await this.pathExists(jsonlPath)) {
-                previousSessionId = candidateId;
-                logger.info(
-                  `[${request.teamName}] Found previous session JSONL for resume: ${candidateId}`
-                );
-              } else {
-                logger.info(
-                  `[${request.teamName}] Previous session JSONL not found at ${jsonlPath}, starting fresh`
-                );
-              }
-            }
-          }
-        } catch {
-          logger.debug(
-            `[${request.teamName}] Failed to extract leadSessionId from config for resume`
-          );
-        }
+        logger.info(
+          `[${request.teamName}] Starting fresh deterministic bootstrap session because ` +
+            `--team-bootstrap-spec cannot be combined with --resume`
+        );
       }
 
       // IMPORTANT: The CLI auto-suffixes teammate names when they already exist in config.json.
@@ -20117,7 +19941,7 @@ export class TeamProvisioningService {
         provisioningTraceLines: [],
         lastProvisioningTraceKey: null,
         provisioningOutputIndexByMessageId: new Map(),
-        detectedSessionId: previousSessionId ?? null,
+        detectedSessionId: null,
         leadActivityState: 'active',
         leadContextUsage: null,
         authFailureRetried: false,
@@ -20188,7 +20012,7 @@ export class TeamProvisioningService {
         request,
         effectiveMemberSpecs,
         existingTasks,
-        Boolean(previousSessionId)
+        false
       );
       const promptSize = getPromptSizeSummary(prompt);
       let child: ReturnType<typeof spawn>;
@@ -20289,12 +20113,6 @@ export class TeamProvisioningService {
           ? ['--dangerously-skip-permissions', '--permission-mode', 'bypassPermissions']
           : ['--permission-prompt-tool', 'stdio', '--permission-mode', 'default']),
       ];
-      if (previousSessionId) {
-        launchArgs.push('--resume', previousSessionId);
-        logger.info(
-          `[${request.teamName}] Launching with --resume ${previousSessionId} for session continuity`
-        );
-      }
       const launchModelArg = getLaunchModelArg(
         resolveTeamProviderId(request.providerId),
         request.model,
@@ -20344,8 +20162,8 @@ export class TeamProvisioningService {
         expectedMembersCount: effectiveMemberSpecs.length,
         launchIdentity,
       });
-      // --resume is added above when a valid previous session JSONL exists.
-      // Without it, CLI creates a fresh session ID automatically.
+      // Deterministic bootstrap launches fresh because --team-bootstrap-spec and
+      // --resume are not a supported orchestrator combination.
       emitProvisioningCheckpoint(run, 'Persisting team metadata before spawn');
       await this.teamMetaStore.writeMeta(request.teamName, {
         displayName: syntheticRequest.displayName,
@@ -20417,8 +20235,7 @@ export class TeamProvisioningService {
         throw error;
       }
 
-      const resumeHint = previousSessionId ? ' (resuming previous session)' : '';
-      updateProgress(run, 'spawning', `Starting Claude CLI process for team launch${resumeHint}`, {
+      updateProgress(run, 'spawning', 'Starting Claude CLI process for team launch', {
         pid: child.pid ?? undefined,
         warnings: mergeProvisioningWarnings(run.progress.warnings, runtimeWarning),
       });
@@ -20444,7 +20261,7 @@ export class TeamProvisioningService {
       // For launch, skip the filesystem monitor — files (config, inboxes, tasks)
       // already exist from the previous run and would trigger immediate false
       // completion on the first poll. Rely on stream-json result.success instead.
-      updateProgress(run, 'configuring', 'CLI running — deterministic reconnect in progress');
+      updateProgress(run, 'configuring', 'CLI running - deterministic launch in progress');
       run.onProgress(run.progress);
 
       run.timeoutHandle = setTimeout(() => {

--- a/src/main/services/team/stallMonitor/TeamTaskLogFreshnessReader.ts
+++ b/src/main/services/team/stallMonitor/TeamTaskLogFreshnessReader.ts
@@ -1,3 +1,4 @@
+import { getTeamsBasePath } from '@main/utils/pathDecoder';
 import { createHash } from 'crypto';
 import * as fs from 'fs/promises';
 import * as path from 'path';
@@ -7,6 +8,7 @@ import { BoardTaskActivityParseCache } from '../taskLogs/activity/BoardTaskActiv
 import type { TaskLogFreshnessSignal } from './TeamTaskStallTypes';
 
 const BOARD_TASK_LOG_FRESHNESS_DIRNAME = '.board-task-log-freshness';
+const TEAM_TASK_LOG_FRESHNESS_DIRNAME = 'task-log-freshness';
 const BOARD_TASK_LOG_FRESHNESS_FILE_SUFFIX = '.json';
 const MAX_TASK_ID_ARTIFACT_SEGMENT_LENGTH = 120;
 
@@ -43,12 +45,14 @@ function taskIdArtifactSegments(taskId: string): string[] {
   return safe === legacy ? [safe] : [safe, legacy];
 }
 
-function taskSignalPathCandidates(projectDir: string, taskId: string): string[] {
-  return taskIdArtifactSegments(taskId).map((segment) =>
-    path.join(
-      projectDir,
-      BOARD_TASK_LOG_FRESHNESS_DIRNAME,
-      `${segment}${BOARD_TASK_LOG_FRESHNESS_FILE_SUFFIX}`
+function taskSignalPathCandidates(projectDir: string, taskId: string, teamName?: string): string[] {
+  const dirs = [
+    ...(teamName ? [path.join(getTeamsBasePath(), teamName, TEAM_TASK_LOG_FRESHNESS_DIRNAME)] : []),
+    path.join(projectDir, BOARD_TASK_LOG_FRESHNESS_DIRNAME),
+  ];
+  return dirs.flatMap((dir) =>
+    taskIdArtifactSegments(taskId).map((segment) =>
+      path.join(dir, `${segment}${BOARD_TASK_LOG_FRESHNESS_FILE_SUFFIX}`)
     )
   );
 }
@@ -62,11 +66,12 @@ export class TeamTaskLogFreshnessReader {
 
   async readSignals(
     projectDir: string,
-    taskIds: string[]
+    taskIds: string[],
+    options?: { teamName?: string }
   ): Promise<Map<string, TaskLogFreshnessSignal>> {
     const uniqueTaskIds = [...new Set(taskIds)].filter((taskId) => taskId.trim().length > 0).sort();
     const signalFilePathCandidates = uniqueTaskIds.map((taskId) =>
-      taskSignalPathCandidates(projectDir, taskId)
+      taskSignalPathCandidates(projectDir, taskId, options?.teamName)
     );
     this.cache.retainOnly(new Set(signalFilePathCandidates.flat()));
 

--- a/src/main/services/team/stallMonitor/TeamTaskStallSnapshotSource.ts
+++ b/src/main/services/team/stallMonitor/TeamTaskStallSnapshotSource.ts
@@ -159,7 +159,8 @@ export class TeamTaskStallSnapshotSource {
     const [freshnessByTaskId, exactRowsByFilePath, openCodeEvidence] = await Promise.all([
       this.freshnessReader.readSignals(
         transcriptContext.projectDir,
-        relevantMonitorTasks.map((task) => task.id)
+        relevantMonitorTasks.map((task) => task.id),
+        { teamName }
       ),
       exactReadsEnabled
         ? this.exactRowReader.parseFiles(relevantExactFiles)

--- a/src/main/services/team/teamLogSourceWatchScope.ts
+++ b/src/main/services/team/teamLogSourceWatchScope.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import type { PersistedTeamLaunchMemberState, PersistedTeamLaunchSnapshot } from '@shared/types';
 
 export const BOARD_TASK_LOG_FRESHNESS_DIRNAME = '.board-task-log-freshness';
+export const TEAM_TASK_LOG_FRESHNESS_DIRNAME = 'task-log-freshness';
 export const BOARD_TASK_CHANGE_FRESHNESS_DIRNAME = '.board-task-change-freshness';
 export const BOARD_TASK_CHANGES_DIRNAME = '.board-task-changes';
 export const BOARD_TASK_LOG_FRESHNESS_FILE_SUFFIX = '.json';

--- a/src/preload/constants/ipcChannels.ts
+++ b/src/preload/constants/ipcChannels.ts
@@ -276,6 +276,9 @@ export const TEAM_CREATE_INITIAL_GIT_COMMIT = 'team:createInitialGitCommit';
 /** Get provisioning status by runId */
 export const TEAM_PROVISIONING_STATUS = 'team:provisioningStatus';
 
+/** Read bounded redacted launch failure diagnostics for support copy */
+export const TEAM_LAUNCH_FAILURE_DIAGNOSTICS = 'team:launchFailureDiagnostics';
+
 /** Cancel running provisioning by runId */
 export const TEAM_CANCEL_PROVISIONING = 'team:cancelProvisioning';
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -155,6 +155,7 @@ import {
   TEAM_INITIALIZE_GIT_REPOSITORY,
   TEAM_KILL_PROCESS,
   TEAM_LAUNCH,
+  TEAM_LAUNCH_FAILURE_DIAGNOSTICS,
   TEAM_LEAD_ACTIVITY,
   TEAM_LEAD_CONTEXT,
   TEAM_LIST,
@@ -320,6 +321,7 @@ import type {
   TeamGetDataOptions,
   TeamLaunchRequest,
   TeamLaunchResponse,
+  TeamLaunchFailureDiagnosticsBundle,
   TeamMemberActivityMeta,
   TeamMessageNotificationData,
   TeamProvisioningModelVerificationMode,
@@ -950,6 +952,13 @@ const electronAPI: ElectronAPI = {
     },
     getProvisioningStatus: async (runId: string) => {
       return invokeIpcWithResult<TeamProvisioningProgress>(TEAM_PROVISIONING_STATUS, runId);
+    },
+    getLaunchFailureDiagnostics: async (teamName: string, runId?: string) => {
+      return invokeIpcWithResult<TeamLaunchFailureDiagnosticsBundle>(
+        TEAM_LAUNCH_FAILURE_DIAGNOSTICS,
+        teamName,
+        runId
+      );
     },
     cancelProvisioning: async (runId: string) => {
       return invokeIpcWithResult<void>(TEAM_CANCEL_PROVISIONING, runId);

--- a/src/renderer/api/httpClient.ts
+++ b/src/renderer/api/httpClient.ts
@@ -74,6 +74,7 @@ import type {
   TeamCreateRequest,
   TeamCreateResponse,
   TeamGetDataOptions,
+  TeamLaunchFailureDiagnosticsBundle,
   TeamLaunchRequest,
   TeamLaunchResponse,
   TeamMemberActivityMeta,
@@ -818,6 +819,12 @@ export class HttpAPIClient implements ElectronAPI {
     },
     getProvisioningStatus: async (_runId: string): Promise<TeamProvisioningProgress> => {
       throw new Error('Team provisioning is not available in browser mode');
+    },
+    getLaunchFailureDiagnostics: async (
+      _teamName: string,
+      _runId?: string
+    ): Promise<TeamLaunchFailureDiagnosticsBundle> => {
+      throw new Error('Launch failure diagnostics are not available in browser mode');
     },
     cancelProvisioning: async (_runId: string): Promise<void> => {
       throw new Error('Team provisioning is not available in browser mode');

--- a/src/renderer/components/layout/MoreMenu.tsx
+++ b/src/renderer/components/layout/MoreMenu.tsx
@@ -1,18 +1,20 @@
 /**
  * MoreMenu - Dropdown menu behind a "..." icon for less-frequent toolbar actions.
  *
- * Groups: Teams, Settings, Extensions, Search, Schedules, Export (session-only), Analyze (session-only).
+ * Groups: Teams, Settings, Extensions, Search, Schedules, Docs, Export (session-only), Analyze (session-only).
  * Closes on outside click or Escape.
  */
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
+import { isElectronMode } from '@renderer/api';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@renderer/components/ui/tooltip';
 import { useStore } from '@renderer/store';
 import { triggerDownload } from '@renderer/utils/sessionExporter';
 import { formatShortcut } from '@renderer/utils/stringUtils';
 import {
   Activity,
+  BookOpen,
   Braces,
   Calendar,
   FileText,
@@ -28,6 +30,8 @@ import { useShallow } from 'zustand/react/shallow';
 import type { SessionDetail } from '@renderer/types/data';
 import type { Tab } from '@renderer/types/tabs';
 import type { ExportFormat } from '@renderer/utils/sessionExporter';
+
+const DOCS_URL = 'https://777genius.github.io/agent-teams-ai/docs/';
 
 interface MoreMenuProps {
   activeTab: Tab | undefined;
@@ -109,6 +113,15 @@ export const MoreMenu = ({
     [activeTabSessionDetail]
   );
 
+  const handleOpenDocs = useCallback(async () => {
+    if (isElectronMode()) {
+      await window.electronAPI.openExternal(DOCS_URL);
+    } else {
+      window.open(DOCS_URL, '_blank', 'noopener,noreferrer');
+    }
+    setIsOpen(false);
+  }, []);
+
   const isSessionWithData = activeTab?.type === 'session' && activeTabSessionDetail != null;
 
   // Build menu sections
@@ -157,6 +170,14 @@ export const MoreMenu = ({
       onClick: () => {
         openSchedulesTab();
         setIsOpen(false);
+      },
+    },
+    {
+      id: 'docs',
+      label: 'Docs',
+      icon: BookOpen,
+      onClick: () => {
+        void handleOpenDocs();
       },
     },
   ];

--- a/src/renderer/components/layout/TabBarActions.tsx
+++ b/src/renderer/components/layout/TabBarActions.tsx
@@ -174,7 +174,7 @@ export const TabBarActions = (): React.JSX.Element => {
         <TooltipContent side="bottom">Discord</TooltipContent>
       </Tooltip>
 
-      {/* More menu (Teams, Settings, Extensions, Search, Export, Analyze, Schedules) */}
+      {/* More menu (Teams, Settings, Extensions, Search, Schedules, Docs, Export, Analyze) */}
       <MoreMenu
         activeTab={activeTab}
         activeTabSessionDetail={activeTabSessionDetail}

--- a/src/renderer/components/team/ProvisioningProgressBlock.tsx
+++ b/src/renderer/components/team/ProvisioningProgressBlock.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
+import { api } from '@renderer/api';
 import { Button } from '@renderer/components/ui/button';
 import { cn } from '@renderer/lib/utils';
 import { renderLinkifiedText } from '@renderer/utils/linkifiedText';
@@ -23,7 +24,7 @@ import { StepProgressBar } from './StepProgressBar';
 
 import type { StepProgressBarStep } from './StepProgressBar';
 import type { MemberLaunchDiagnosticsPayload } from '@renderer/utils/memberLaunchDiagnostics';
-import type { TeamLaunchDiagnosticItem } from '@shared/types';
+import type { TeamLaunchDiagnosticItem, TeamLaunchFailureDiagnosticsBundle } from '@shared/types';
 
 /** Pre-built step definitions for the provisioning stepper. */
 const PROVISIONING_STEPS: StepProgressBarStep[] = DISPLAY_STEPS.map((s) => ({
@@ -69,6 +70,9 @@ export interface ProvisioningProgressBlockProps {
   onDismiss?: (() => void) | null;
   /** ISO timestamp when provisioning started */
   startedAt?: string;
+  /** Team/run identity used to enrich copied launch diagnostics with artifact pack data. */
+  teamName?: string;
+  runId?: string;
   /** PID of the CLI process */
   pid?: number;
   /** CLI logs captured during launch */
@@ -202,6 +206,49 @@ function formatMemberDiagnosticsCopy(
   return JSON.stringify(items, null, 2);
 }
 
+function formatLaunchFailureArtifactCopy(
+  bundle: TeamLaunchFailureDiagnosticsBundle | null | undefined,
+  error?: string | null
+): string {
+  if (error) {
+    return `Failed to read launch failure artifact bundle: ${error}`;
+  }
+  if (!bundle) {
+    return '(none)';
+  }
+
+  const parts = [
+    `teamName: ${bundle.teamName}`,
+    `runId: ${formatOptionalValue(bundle.runId)}`,
+    `latestPath: ${bundle.latestPath}`,
+    `artifactDirectory: ${formatOptionalValue(bundle.artifactDirectory)}`,
+    `manifestPath: ${formatOptionalValue(bundle.manifestPath)}`,
+    '',
+    'classification:',
+    bundle.classification ? JSON.stringify(bundle.classification, null, 2) : '(none)',
+    '',
+    'bootstrapTransportBreadcrumb:',
+    bundle.bootstrapTransportBreadcrumb
+      ? JSON.stringify(bundle.bootstrapTransportBreadcrumb, null, 2)
+      : '(none)',
+    '',
+    'files:',
+  ];
+
+  for (const file of bundle.files) {
+    parts.push(
+      '',
+      `--- ${file.label}`,
+      `path: ${file.path}`,
+      file.issue ? `issue: ${file.issue}` : 'issue: (none)',
+      'content:',
+      file.content?.trim() || '(empty)'
+    );
+  }
+
+  return parts.join('\n');
+}
+
 function buildProvisioningDiagnosticsCopy(input: {
   title: string;
   message?: string | null;
@@ -216,6 +263,8 @@ function buildProvisioningDiagnosticsCopy(input: {
   cliLogsTail?: string;
   launchDiagnostics?: TeamLaunchDiagnosticItem[];
   memberDiagnostics?: MemberLaunchDiagnosticsPayload[];
+  launchFailureArtifact?: TeamLaunchFailureDiagnosticsBundle | null;
+  launchFailureArtifactError?: string | null;
 }): string {
   const payload = [
     '# Team provisioning diagnostics',
@@ -236,6 +285,9 @@ function buildProvisioningDiagnosticsCopy(input: {
     '',
     '## Member launch snapshots',
     formatMemberDiagnosticsCopy(input.memberDiagnostics),
+    '',
+    '## Launch failure artifact bundle',
+    formatLaunchFailureArtifactCopy(input.launchFailureArtifact, input.launchFailureArtifactError),
     '',
     '## Live output',
     input.liveOutput?.trim() || '(empty)',
@@ -262,6 +314,8 @@ export const ProvisioningProgressBlock = ({
   successMessageSeverity = 'success',
   onDismiss,
   startedAt,
+  teamName,
+  runId,
   pid,
   cliLogsTail,
   assistantOutput,
@@ -279,39 +333,6 @@ export const ProvisioningProgressBlock = ({
   const copyResetTimerRef = useRef<number | null>(null);
   const isError = tone === 'error';
   const displayAssistantOutput = sanitizeAssistantOutput(assistantOutput, isError);
-  const diagnosticsCopyText = useMemo(
-    () =>
-      buildProvisioningDiagnosticsCopy({
-        title,
-        message,
-        messageSeverity,
-        tone,
-        startedAt,
-        elapsed,
-        pid,
-        currentStepIndex,
-        errorStepIndex,
-        liveOutput: displayAssistantOutput,
-        cliLogsTail,
-        launchDiagnostics,
-        memberDiagnostics,
-      }),
-    [
-      title,
-      message,
-      messageSeverity,
-      tone,
-      startedAt,
-      elapsed,
-      pid,
-      currentStepIndex,
-      errorStepIndex,
-      displayAssistantOutput,
-      cliLogsTail,
-      launchDiagnostics,
-      memberDiagnostics,
-    ]
-  );
   const visibleLaunchDiagnostics =
     launchDiagnostics?.filter((item) => item.severity === 'warning' || item.severity === 'error') ??
     [];
@@ -357,6 +378,32 @@ export const ProvisioningProgressBlock = ({
       setDiagnosticsCopied(false);
       return;
     }
+    let launchFailureArtifact: TeamLaunchFailureDiagnosticsBundle | null = null;
+    let launchFailureArtifactError: string | null = null;
+    if (teamName) {
+      try {
+        launchFailureArtifact = await api.teams.getLaunchFailureDiagnostics(teamName, runId);
+      } catch (error) {
+        launchFailureArtifactError = error instanceof Error ? error.message : String(error);
+      }
+    }
+    const diagnosticsCopyText = buildProvisioningDiagnosticsCopy({
+      title,
+      message,
+      messageSeverity,
+      tone,
+      startedAt,
+      elapsed,
+      pid,
+      currentStepIndex,
+      errorStepIndex,
+      liveOutput: displayAssistantOutput,
+      cliLogsTail,
+      launchDiagnostics,
+      memberDiagnostics,
+      launchFailureArtifact,
+      launchFailureArtifactError,
+    });
     try {
       await navigator.clipboard.writeText(diagnosticsCopyText);
     } catch {

--- a/src/renderer/components/team/TeamChangesSection.tsx
+++ b/src/renderer/components/team/TeamChangesSection.tsx
@@ -7,6 +7,7 @@ import { AlertTriangle, FileDiff, GitCompareArrows, Info, Loader2, RefreshCw } f
 
 import { FileIcon } from './editor/FileIcon';
 import { CollapsibleTeamSection } from './CollapsibleTeamSection';
+import { MemberBadge } from './MemberBadge';
 import {
   getTeamChangeTaskTimeMs,
   TEAM_CHANGES_MAX_RENDERED_FILE_ROWS,
@@ -18,6 +19,8 @@ import type { FileChangeSummary, TaskChangeSetV2, TeamTaskWithKanban } from '@sh
 interface TeamChangesSectionProps {
   teamName: string;
   tasks: TeamTaskWithKanban[];
+  memberColorMap?: ReadonlyMap<string, string>;
+  onOpenTask: (task: TeamTaskWithKanban) => void;
   onViewChanges: (taskId: string, filePath?: string) => void;
 }
 
@@ -27,6 +30,8 @@ interface RenderedTeamChangeSummary {
   visibleFiles: FileChangeSummary[];
   fileBudget: number;
 }
+
+const EMPTY_MEMBER_COLOR_MAP = new Map<string, string>();
 
 function getChangeSetFiles(changeSet: TaskChangeSetV2 | null): FileChangeSummary[] {
   if (!Array.isArray(changeSet?.files)) {
@@ -121,16 +126,17 @@ function getTaskChangeDiagnosticMessages(changeSet: TaskChangeSetV2): string[] {
 export const TeamChangesSection = memo(function TeamChangesSection({
   teamName,
   tasks,
+  memberColorMap = EMPTY_MEMBER_COLOR_MAP,
+  onOpenTask,
   onViewChanges,
 }: TeamChangesSectionProps): React.JSX.Element {
   const [sectionOpen, setSectionOpen] = useState(false);
-  const { summariesByTaskId, stats, loading, refreshing, error, refresh } = useTeamChangesSummaries(
-    {
+  const { summariesByTaskId, badgeCount, stats, loading, refreshing, error, refresh } =
+    useTeamChangesSummaries({
       teamName,
       tasks,
       sectionOpen,
-    }
-  );
+    });
   const taskMap = useMemo(() => new Map(tasks.map((task) => [task.id, task])), [tasks]);
 
   const visibleSummaries = useMemo(() => {
@@ -153,7 +159,7 @@ export const TeamChangesSection = memo(function TeamChangesSection({
     0
   );
   const hiddenFileRows = Math.max(0, totalFiles - TEAM_CHANGES_MAX_RENDERED_FILE_ROWS);
-  const badge = totalFiles > 0 ? totalFiles : visibleSummaries.length || undefined;
+  const badge = badgeCount ?? undefined;
   const renderedSummaries = useMemo(() => {
     const entries: RenderedTeamChangeSummary[] = [];
     let remainingFileRows = TEAM_CHANGES_MAX_RENDERED_FILE_ROWS;
@@ -233,30 +239,64 @@ export const TeamChangesSection = memo(function TeamChangesSection({
                   key={summary.taskId}
                   className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-secondary)]"
                 >
-                  <button
-                    type="button"
-                    className="flex w-full min-w-0 items-center gap-2 rounded-t-md px-2 py-1.5 text-left transition-colors hover:bg-[var(--color-surface-raised)]"
-                    onClick={() => onViewChanges(task.id)}
-                  >
-                    <span className="shrink-0 font-mono text-[10px] text-[var(--color-text-muted)]">
-                      #{deriveTaskDisplayId(task.id)}
-                    </span>
-                    <span className="min-w-0 flex-1 truncate text-xs font-medium text-[var(--color-text)]">
-                      {task.subject}
-                    </span>
-                    <span
-                      className="hidden max-w-[180px] shrink-0 truncate text-[10px] text-[var(--color-text-muted)] sm:inline"
-                      title={contributors.join(', ')}
+                  <div className="flex min-w-0 items-center gap-1 rounded-t-md px-2 py-1.5 transition-colors hover:bg-[var(--color-surface-raised)]">
+                    <button
+                      type="button"
+                      className="flex min-w-0 flex-1 items-center gap-2 text-left"
+                      onClick={() => onOpenTask(task)}
+                      aria-label={`Open task ${task.subject}`}
                     >
-                      {contributorLabel}
-                      {extraContributors > 0 ? ` +${extraContributors}` : ''}
-                    </span>
-                    {badgeText ? (
-                      <span className="shrink-0 rounded bg-[var(--color-bg-tertiary)] px-1.5 py-0.5 text-[10px] text-[var(--color-text-muted)]">
-                        {badgeText}
+                      <span className="shrink-0 font-mono text-[10px] text-[var(--color-text-muted)]">
+                        #{deriveTaskDisplayId(task.id)}
                       </span>
-                    ) : null}
-                  </button>
+                      <span className="min-w-0 flex-1 truncate text-xs font-medium text-[var(--color-text)]">
+                        {task.subject}
+                      </span>
+                      {contributors[0] ? (
+                        <span className="hidden min-w-0 max-w-[220px] shrink-0 items-center gap-1 sm:inline-flex">
+                          <MemberBadge
+                            name={contributors[0]}
+                            color={memberColorMap.get(contributors[0])}
+                            size="xs"
+                            disableHoverCard
+                          />
+                          {extraContributors > 0 ? (
+                            <span
+                              className="shrink-0 text-[10px] text-[var(--color-text-muted)]"
+                              title={contributors.join(', ')}
+                            >
+                              +{extraContributors}
+                            </span>
+                          ) : null}
+                        </span>
+                      ) : (
+                        <span
+                          className="hidden max-w-[180px] shrink-0 truncate text-[10px] text-[var(--color-text-muted)] sm:inline"
+                          title={contributors.join(', ')}
+                        >
+                          {contributorLabel}
+                        </span>
+                      )}
+                      {badgeText ? (
+                        <span className="shrink-0 rounded bg-[var(--color-bg-tertiary)] px-1.5 py-0.5 text-[10px] text-[var(--color-text-muted)]">
+                          {badgeText}
+                        </span>
+                      ) : null}
+                    </button>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          className="shrink-0 rounded p-1 text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-border-emphasis)] hover:text-[var(--color-text)]"
+                          onClick={() => onViewChanges(task.id)}
+                          aria-label="Review task diff"
+                        >
+                          <GitCompareArrows size={13} />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="top">Review diff</TooltipContent>
+                    </Tooltip>
+                  </div>
 
                   {summary.error ? (
                     <div className="flex items-center gap-2 border-t border-[var(--color-border)] px-2 py-1.5 text-xs text-red-400">

--- a/src/renderer/components/team/TeamDetailView.tsx
+++ b/src/renderer/components/team/TeamDetailView.tsx
@@ -2719,6 +2719,8 @@ export const TeamDetailView = memo(function TeamDetailView({
               <TeamChangesSection
                 teamName={teamName}
                 tasks={data.tasks}
+                memberColorMap={resolvedMemberColorMap}
+                onOpenTask={(task) => setSelectedTask(task)}
                 onViewChanges={handleViewChangesForFile}
               />
 

--- a/src/renderer/components/team/TeamProvisioningPanel.tsx
+++ b/src/renderer/components/team/TeamProvisioningPanel.tsx
@@ -135,6 +135,8 @@ export const TeamProvisioningPanel = memo(function TeamProvisioningPanel({
       }
       loading={showRunningState}
       startedAt={presentation.progress.startedAt}
+      teamName={teamName}
+      runId={presentation.progress.runId}
       pid={presentation.progress.pid}
       cliLogsTail={presentation.progress.cliLogsTail}
       assistantOutput={presentation.progress.assistantOutput}

--- a/src/renderer/components/team/__tests__/useTeamChangesSummaries.test.tsx
+++ b/src/renderer/components/team/__tests__/useTeamChangesSummaries.test.tsx
@@ -15,6 +15,7 @@ import type {
 } from '@shared/types';
 
 const hoisted = vi.hoisted(() => ({
+  fetchConfig: vi.fn(),
   getTeamTaskChangeSummaries: vi.fn(),
   recordTaskChangePresence: vi.fn(),
   setSelectedTeamTaskChangePresence: vi.fn(),
@@ -31,8 +32,15 @@ vi.mock('@renderer/api', () => ({
 vi.mock('@renderer/store', () => ({
   useStore: (selector: (state: Record<string, unknown>) => unknown) =>
     selector({
+      appConfig: { general: { theme: 'dark' } },
+      configLoading: false,
+      fetchConfig: hoisted.fetchConfig,
+      memberActivityMetaByTeam: {},
       recordTaskChangePresence: hoisted.recordTaskChangePresence,
       setSelectedTeamTaskChangePresence: hoisted.setSelectedTeamTaskChangePresence,
+      selectedTeamData: null,
+      selectedTeamName: undefined,
+      teamDataCacheByName: {},
     }),
 }));
 
@@ -187,6 +195,7 @@ interface HookSnapshot {
   loading: boolean;
   refreshing: boolean;
   error: string | null;
+  badgeCount: number | null;
   summariesByTaskId: Record<string, TeamChangeSummaryState>;
 }
 
@@ -207,9 +216,17 @@ const HookHarness = ({
       loading: state.loading,
       refreshing: state.refreshing,
       error: state.error,
+      badgeCount: state.badgeCount,
       summariesByTaskId: state.summariesByTaskId,
     });
-  }, [onSnapshot, state.error, state.loading, state.refreshing, state.summariesByTaskId]);
+  }, [
+    onSnapshot,
+    state.badgeCount,
+    state.error,
+    state.loading,
+    state.refreshing,
+    state.summariesByTaskId,
+  ]);
   return null;
 };
 
@@ -585,6 +602,7 @@ describe('useTeamChangesSummaries', () => {
             React.createElement(TeamChangesSection, {
               teamName: 'team-a',
               tasks: [task()],
+              onOpenTask: vi.fn(),
               onViewChanges: vi.fn(),
             })
           )
@@ -607,6 +625,281 @@ describe('useTeamChangesSummaries', () => {
         'The change summary reported one file without safe review details.'
       );
       expect(hoisted.recordTaskChangePresence).not.toHaveBeenCalled();
+    } finally {
+      if (scrollIntoViewDescriptor) {
+        Object.defineProperty(Element.prototype, 'scrollIntoView', scrollIntoViewDescriptor);
+      } else {
+        delete (Element.prototype as { scrollIntoView?: Element['scrollIntoView'] }).scrollIntoView;
+      }
+    }
+  });
+
+  it('shows the closed-section counter only after the background count load resolves', async () => {
+    const deferred = createDeferred<TeamTaskChangeSummariesResponse>();
+    hoisted.getTeamTaskChangeSummaries.mockReturnValue(deferred.promise);
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(
+        React.createElement(
+          TooltipProvider,
+          null,
+          React.createElement(TeamChangesSection, {
+            teamName: 'team-a',
+            tasks: [task()],
+            onOpenTask: vi.fn(),
+            onViewChanges: vi.fn(),
+          })
+        )
+      );
+    });
+
+    expect(container.textContent).toContain('Changes');
+    expect(container.textContent).not.toContain('0');
+    expect(hoisted.getTeamTaskChangeSummaries).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      deferred.resolve(response());
+      await deferred.promise;
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain('0');
+  });
+
+  it('loads the closed-section counter without rendering full change rows', async () => {
+    hoisted.getTeamTaskChangeSummaries.mockResolvedValue(lowConfidenceFileResponse());
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(
+        React.createElement(
+          TooltipProvider,
+          null,
+          React.createElement(TeamChangesSection, {
+            teamName: 'team-a',
+            tasks: [task()],
+            onOpenTask: vi.fn(),
+            onViewChanges: vi.fn(),
+          })
+        )
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(hoisted.getTeamTaskChangeSummaries).toHaveBeenCalledTimes(1);
+    expect(container.textContent).toContain('1');
+    expect(container.textContent).not.toContain('src/app.ts');
+  });
+
+  it('runs a queued closed counter refresh when tasks change during an active count load', async () => {
+    const first = createDeferred<TeamTaskChangeSummariesResponse>();
+    const second = createDeferred<TeamTaskChangeSummariesResponse>();
+    hoisted.getTeamTaskChangeSummaries
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(
+        React.createElement(
+          TooltipProvider,
+          null,
+          React.createElement(TeamChangesSection, {
+            teamName: 'team-a',
+            tasks: [task()],
+            onOpenTask: vi.fn(),
+            onViewChanges: vi.fn(),
+          })
+        )
+      );
+    });
+
+    expect(hoisted.getTeamTaskChangeSummaries).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      root?.render(
+        React.createElement(
+          TooltipProvider,
+          null,
+          React.createElement(TeamChangesSection, {
+            teamName: 'team-a',
+            tasks: [task({ updatedAt: '2026-05-10T10:00:02.000Z' })],
+            onOpenTask: vi.fn(),
+            onViewChanges: vi.fn(),
+          })
+        )
+      );
+    });
+
+    await act(async () => {
+      first.resolve(lowConfidenceFileResponse());
+      await first.promise;
+      await Promise.resolve();
+    });
+
+    expect(hoisted.getTeamTaskChangeSummaries).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      second.resolve(response());
+      await second.promise;
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain('0');
+  });
+
+  it('does not lose the full load queued by opening the section during a failed count load', async () => {
+    const first = createDeferred<TeamTaskChangeSummariesResponse>();
+    const second = createDeferred<TeamTaskChangeSummariesResponse>();
+    hoisted.getTeamTaskChangeSummaries
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+
+    const scrollIntoViewDescriptor = Object.getOwnPropertyDescriptor(
+      Element.prototype,
+      'scrollIntoView'
+    );
+    Object.defineProperty(Element.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    try {
+      container = document.createElement('div');
+      document.body.appendChild(container);
+      root = createRoot(container);
+
+      await act(async () => {
+        root?.render(
+          React.createElement(
+            TooltipProvider,
+            null,
+            React.createElement(TeamChangesSection, {
+              teamName: 'team-a',
+              tasks: [task()],
+              onOpenTask: vi.fn(),
+              onViewChanges: vi.fn(),
+            })
+          )
+        );
+      });
+
+      const expandButton = container.querySelector<HTMLButtonElement>(
+        'button[aria-label="Expand section"]'
+      );
+      expect(expandButton).not.toBeNull();
+
+      await act(async () => {
+        expandButton?.click();
+      });
+
+      expect(container.textContent).toContain('Loading changes...');
+
+      await act(async () => {
+        first.reject(new Error('silent count failed'));
+        await first.promise.catch(() => undefined);
+        await Promise.resolve();
+      });
+
+      expect(hoisted.getTeamTaskChangeSummaries).toHaveBeenCalledTimes(2);
+
+      await act(async () => {
+        second.resolve(lowConfidenceFileResponse());
+        await second.promise;
+        await Promise.resolve();
+      });
+
+      expect(container.textContent).toContain('src/app.ts');
+      expect(container.textContent).not.toContain('silent count failed');
+    } finally {
+      if (scrollIntoViewDescriptor) {
+        Object.defineProperty(Element.prototype, 'scrollIntoView', scrollIntoViewDescriptor);
+      } else {
+        delete (Element.prototype as { scrollIntoView?: Element['scrollIntoView'] }).scrollIntoView;
+      }
+    }
+  });
+
+  it('opens the task popup from summary header and keeps diff on the review action', async () => {
+    const taskItem = task({ changePresence: 'has_changes' });
+    const onOpenTask = vi.fn();
+    const onViewChanges = vi.fn();
+    hoisted.getTeamTaskChangeSummaries.mockResolvedValue(lowConfidenceFileResponse());
+
+    const scrollIntoViewDescriptor = Object.getOwnPropertyDescriptor(
+      Element.prototype,
+      'scrollIntoView'
+    );
+    Object.defineProperty(Element.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    try {
+      container = document.createElement('div');
+      document.body.appendChild(container);
+      root = createRoot(container);
+
+      await act(async () => {
+        root?.render(
+          React.createElement(
+            TooltipProvider,
+            null,
+            React.createElement(TeamChangesSection, {
+              teamName: 'team-a',
+              tasks: [taskItem],
+              memberColorMap: new Map([['alice', 'blue']]),
+              onOpenTask,
+              onViewChanges,
+            })
+          )
+        );
+      });
+
+      const expandButton = container.querySelector<HTMLButtonElement>(
+        'button[aria-label="Expand section"]'
+      );
+      expect(expandButton).not.toBeNull();
+
+      await act(async () => {
+        expandButton?.click();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(container.querySelector('img')).not.toBeNull();
+
+      const openTaskButton = container.querySelector<HTMLButtonElement>(
+        'button[aria-label="Open task Task 1"]'
+      );
+      expect(openTaskButton).not.toBeNull();
+
+      await act(async () => {
+        openTaskButton?.click();
+      });
+
+      expect(onOpenTask).toHaveBeenCalledWith(taskItem);
+      expect(onViewChanges).not.toHaveBeenCalled();
+
+      const reviewTaskDiffButton = container.querySelector<HTMLButtonElement>(
+        'button[aria-label="Review task diff"]'
+      );
+      expect(reviewTaskDiffButton).not.toBeNull();
+
+      await act(async () => {
+        reviewTaskDiffButton?.click();
+      });
+
+      expect(onViewChanges).toHaveBeenCalledWith('task-1');
     } finally {
       if (scrollIntoViewDescriptor) {
         Object.defineProperty(Element.prototype, 'scrollIntoView', scrollIntoViewDescriptor);

--- a/src/renderer/components/team/dialogs/LaunchTeamDialog.tsx
+++ b/src/renderer/components/team/dialogs/LaunchTeamDialog.tsx
@@ -31,7 +31,6 @@ import {
 } from '@renderer/components/team/members/MembersEditorSection';
 import { TeamRosterEditorSection } from '@renderer/components/team/members/TeamRosterEditorSection';
 import { Button } from '@renderer/components/ui/button';
-import { Checkbox } from '@renderer/components/ui/checkbox';
 import { Combobox } from '@renderer/components/ui/combobox';
 import {
   Dialog,
@@ -82,7 +81,6 @@ import {
   ChevronRight,
   Info,
   Loader2,
-  RotateCcw,
   X,
 } from 'lucide-react';
 import { useShallow } from 'zustand/react/shallow';
@@ -452,7 +450,6 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
   const [limitContext, setLimitContextRaw] = useState(
     () => localStorage.getItem('team:lastLimitContext') === 'true'
   );
-  const [clearContext, setClearContext] = useState(false);
   const [conflictDismissed, setConflictDismissed] = useState(false);
   const [prepareState, setPrepareState] = useState<'idle' | 'loading' | 'ready' | 'failed'>('idle');
   const [prepareMessage, setPrepareMessage] = useState<string | null>(null);
@@ -715,7 +712,6 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
     setCwdMode('project');
     setSelectedProjectPath('');
     setCustomCwd('');
-    setClearContext(false);
     setConflictDismissed(false);
     setMembersDrafts([]);
     setSyncModelsWithLead(false);
@@ -1811,7 +1807,6 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
     } else if (selectedProviderId === 'codex') {
       args.push(...buildCodexFastModeArgs(codexFastModeResolution?.resolvedFastMode));
     }
-    if (!clearContext) args.push('--resume', '<previous>');
     return args;
   }, [
     anthropicFastModeResolution?.resolvedFastMode,
@@ -1823,7 +1818,6 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
     effectiveAnthropicRuntimeLimitContext,
     selectedEffort,
     selectedProviderId,
-    clearContext,
     runtimeProviderStatusById,
   ]);
 
@@ -1854,7 +1848,7 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
       summary.push('Anthropic limited to 200K context');
     }
     if (skipPermissions) summary.push('Auto-approve tools');
-    if (clearContext) summary.push('Fresh session');
+    summary.push('Fresh lead session');
     if (worktreeEnabled && worktreeName.trim()) summary.push(`Worktree: ${worktreeName.trim()}`);
     if (customArgs.trim()) summary.push('Custom CLI args');
     return summary;
@@ -1869,7 +1863,6 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
     anthropicProviderFastModeDefault,
     effectiveAnthropicRuntimeLimitContext,
     skipPermissions,
-    clearContext,
     worktreeEnabled,
     worktreeName,
     customArgs,
@@ -2117,7 +2110,6 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
                 ? selectedFastMode
                 : undefined,
             limitContext: effectiveAnthropicRuntimeLimitContext,
-            clearContext: clearContext || undefined,
             skipPermissions,
             worktree: worktreeEnabled && worktreeName.trim() ? worktreeName.trim() : undefined,
             extraCliArgs: customArgs.trim() || undefined,
@@ -2680,39 +2672,22 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
                       </div>
                     </div>
                   ) : null}
-                  <div className="flex items-center gap-2">
-                    <Checkbox
-                      id="clear-context"
-                      checked={clearContext}
-                      onCheckedChange={(checked) => setClearContext(checked === true)}
-                    />
-                    <Label
-                      htmlFor="clear-context"
-                      className="flex cursor-pointer items-center gap-1.5 text-xs font-normal text-text-secondary"
-                    >
-                      <RotateCcw className="size-3 shrink-0" />
-                      Clear context (fresh session)
-                    </Label>
-                  </div>
-                  {clearContext && (
-                    <div
-                      className="rounded-md border px-3 py-2 text-xs"
-                      style={{
-                        backgroundColor: 'var(--warning-bg)',
-                        borderColor: 'var(--warning-border)',
-                        color: 'var(--warning-text)',
-                      }}
-                    >
-                      <div className="flex items-start gap-2">
-                        <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
-                        <p>
-                          The team lead will start a new session without resuming previous context.
-                          All accumulated session memory and conversation history will not be
-                          available.
-                        </p>
-                      </div>
+                  <div
+                    className="rounded-md border px-3 py-2 text-xs"
+                    style={{
+                      backgroundColor: 'var(--warning-bg)',
+                      borderColor: 'var(--warning-border)',
+                      color: 'var(--warning-text)',
+                    }}
+                  >
+                    <div className="flex items-start gap-2">
+                      <Info className="mt-0.5 size-3.5 shrink-0" />
+                      <p>
+                        Team relaunch starts a fresh lead session. Durable team state, task board,
+                        and member configuration are rehydrated into the launch prompt.
+                      </p>
                     </div>
-                  )}
+                  </div>
                 </div>
 
                 <AdvancedCliSection

--- a/src/renderer/components/team/useTeamChangesSummaries.ts
+++ b/src/renderer/components/team/useTeamChangesSummaries.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { api } from '@renderer/api';
 import { useStore } from '@renderer/store';
 import { resolveTaskChangePresenceFromResult } from '@renderer/utils/taskChangePresence';
+import { classifyTaskChangeReviewability } from '@shared/utils/taskChangeReviewability';
 
 import { withTeamChangesLoadTimeout } from './teamChangesLoadTimeout';
 import {
@@ -18,6 +19,7 @@ import type {
 } from '@shared/types';
 
 const TEAM_CHANGES_AUTO_REFRESH_MS = 30_000;
+const TEAM_CHANGES_COUNTER_AUTO_REFRESH_MS = 60_000;
 const TEAM_CHANGES_ERROR_AUTO_RETRY_COOLDOWN_MS = 120_000;
 
 export interface TeamChangeSummaryState {
@@ -36,6 +38,9 @@ interface TeamChangesLoadOptions {
   forceFresh?: boolean;
   showSpinner?: boolean;
   preserveOnError?: boolean;
+  storeSummaries?: boolean;
+  reportError?: boolean;
+  blockAutoRetryOnError?: boolean;
 }
 
 interface UseTeamChangesSummariesInput {
@@ -46,6 +51,7 @@ interface UseTeamChangesSummariesInput {
 
 interface UseTeamChangesSummariesResult {
   summariesByTaskId: Record<string, TeamChangeSummaryState>;
+  badgeCount: number | null;
   stats: TeamChangeStats;
   loading: boolean;
   refreshing: boolean;
@@ -101,6 +107,19 @@ function hasSafeFileSummaries(changeSet: TaskChangeSetV2): boolean {
   );
 }
 
+function hasDisplayableFileSummaries(changeSet: TaskChangeSetV2): boolean {
+  return (
+    Array.isArray(changeSet.files) &&
+    changeSet.files.some(
+      (file) =>
+        file &&
+        typeof file === 'object' &&
+        typeof file.filePath === 'string' &&
+        file.filePath.trim().length > 0
+    )
+  );
+}
+
 function isMinimalPresenceChangeSet(changeSet: TaskChangeSetV2): boolean {
   return Boolean(
     Array.isArray(changeSet.files) &&
@@ -136,6 +155,31 @@ function resolveCacheablePresenceFromChangeSet(
   return null;
 }
 
+function isCountableTeamChangeSummary(item: TeamTaskChangeSummaryItem): boolean {
+  if (item.error) {
+    return true;
+  }
+
+  const changeSet = item.changeSet;
+  if (!changeSet) {
+    return false;
+  }
+  if (hasDisplayableFileSummaries(changeSet)) {
+    return true;
+  }
+
+  const reviewability = classifyTaskChangeReviewability(changeSet).reviewability;
+  return reviewability === 'attention_required' || reviewability === 'diagnostic_only';
+}
+
+function countChangedTasks(changeCountByTaskId: Record<string, boolean>): number {
+  return Object.values(changeCountByTaskId).filter(Boolean).length;
+}
+
+function isDocumentHidden(): boolean {
+  return typeof document !== 'undefined' && document.visibilityState === 'hidden';
+}
+
 export function useTeamChangesSummaries({
   teamName,
   tasks,
@@ -146,6 +190,8 @@ export function useTeamChangesSummaries({
   const [summariesByTaskId, setSummariesByTaskId] = useState<
     Record<string, TeamChangeSummaryState>
   >({});
+  const [changeCountByTaskId, setChangeCountByTaskId] = useState<Record<string, boolean>>({});
+  const [counterLoaded, setCounterLoaded] = useState(false);
   const [stats, setStats] = useState<TeamChangeStats>({
     eligibleCount: 0,
     requestedCount: 0,
@@ -161,14 +207,10 @@ export function useTeamChangesSummaries({
   const activeRequestSeqRef = useRef<number | null>(null);
   const queuedRefreshOptionsRef = useRef<TeamChangesLoadOptions | null>(null);
   const autoRefreshBlockedUntilRef = useRef(0);
-  const sectionOpenRef = useRef(sectionOpen);
   const unknownScanCursorRef = useRef(0);
   const lastRequestedTasksFingerprintRef = useRef<string | null>(null);
-  const tasksFingerprint = useMemo(
-    () => (sectionOpen ? buildTeamChangesTasksFingerprint(tasks) : ''),
-    [sectionOpen, tasks]
-  );
-  sectionOpenRef.current = sectionOpen;
+  const lastCounterTasksFingerprintRef = useRef<string | null>(null);
+  const tasksFingerprint = useMemo(() => buildTeamChangesTasksFingerprint(tasks), [tasks]);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -181,6 +223,7 @@ export function useTeamChangesSummaries({
       hasLoadedRef.current = false;
       unknownScanCursorRef.current = 0;
       lastRequestedTasksFingerprintRef.current = null;
+      lastCounterTasksFingerprintRef.current = null;
     };
   }, []);
 
@@ -189,6 +232,9 @@ export function useTeamChangesSummaries({
       forceFresh = false,
       showSpinner = false,
       preserveOnError = true,
+      storeSummaries = true,
+      reportError = true,
+      blockAutoRetryOnError = true,
     }: TeamChangesLoadOptions = {}): Promise<void> => {
       if (forceFresh) {
         autoRefreshBlockedUntilRef.current = 0;
@@ -204,8 +250,18 @@ export function useTeamChangesSummaries({
           preserveOnError: previous
             ? Boolean(previous.preserveOnError && preserveOnError)
             : preserveOnError,
+          storeSummaries: Boolean(previous?.storeSummaries || storeSummaries),
+          reportError: previous ? Boolean(previous.reportError || reportError) : reportError,
+          blockAutoRetryOnError: previous
+            ? Boolean(previous.blockAutoRetryOnError || blockAutoRetryOnError)
+            : blockAutoRetryOnError,
         };
-        if (activeRequestSeqRef.current === null && sectionOpenRef.current) {
+        if (showSpinner) {
+          setLoading(true);
+        } else if (storeSummaries) {
+          setRefreshing(true);
+        }
+        if (activeRequestSeqRef.current === null) {
           setQueuedRefreshTick((value) => value + 1);
         }
         return;
@@ -223,7 +279,11 @@ export function useTeamChangesSummaries({
       setError(null);
 
       if (plan.requests.length === 0) {
-        setSummariesByTaskId({});
+        if (storeSummaries) {
+          setSummariesByTaskId({});
+        }
+        setChangeCountByTaskId({});
+        setCounterLoaded(true);
         autoRefreshBlockedUntilRef.current = 0;
         setLoading(false);
         setRefreshing(false);
@@ -232,7 +292,7 @@ export function useTeamChangesSummaries({
 
       if (showSpinner) {
         setLoading(true);
-      } else {
+      } else if (storeSummaries) {
         setRefreshing(true);
       }
       activeRequestSeqRef.current = requestSeq;
@@ -250,6 +310,22 @@ export function useTeamChangesSummaries({
         autoRefreshBlockedUntilRef.current = 0;
         const responseItems = getSafeResponseItems(response);
 
+        setChangeCountByTaskId((previous) => {
+          const next: Record<string, boolean> = {};
+          const currentTaskIds = new Set(tasks.map((task) => task.id));
+          for (const [taskId, countable] of Object.entries(previous)) {
+            if (currentTaskIds.has(taskId) && plan.eligibleTaskIds.has(taskId)) {
+              next[taskId] = countable;
+            }
+          }
+          for (const item of responseItems) {
+            if (!plan.requestOptionsByTaskId.has(item.taskId)) continue;
+            next[item.taskId] = isCountableTeamChangeSummary(item);
+          }
+          return next;
+        });
+        setCounterLoaded(true);
+
         const currentTaskIds = new Set(tasks.map((task) => task.id));
         for (const item of responseItems) {
           const changeSet = item.changeSet;
@@ -262,41 +338,55 @@ export function useTeamChangesSummaries({
           setSelectedTeamTaskChangePresence(teamName, item.taskId, nextPresence);
         }
 
-        setSummariesByTaskId((previous) => {
-          const next: Record<string, TeamChangeSummaryState> = {};
-          for (const [taskId, summary] of Object.entries(previous)) {
-            if (currentTaskIds.has(taskId) && plan.eligibleTaskIds.has(taskId)) {
-              next[taskId] = summary;
+        if (storeSummaries) {
+          setSummariesByTaskId((previous) => {
+            const next: Record<string, TeamChangeSummaryState> = {};
+            for (const [taskId, summary] of Object.entries(previous)) {
+              if (currentTaskIds.has(taskId) && plan.eligibleTaskIds.has(taskId)) {
+                next[taskId] = summary;
+              }
             }
-          }
-          for (const item of responseItems) {
-            const options = plan.requestOptionsByTaskId.get(item.taskId);
-            if (!options) continue;
-            next[item.taskId] = {
-              taskId: item.taskId,
-              changeSet: item.changeSet,
-              error: item.error,
-            };
-          }
-          return next;
-        });
+            for (const item of responseItems) {
+              const options = plan.requestOptionsByTaskId.get(item.taskId);
+              if (!options) continue;
+              next[item.taskId] = {
+                taskId: item.taskId,
+                changeSet: item.changeSet,
+                error: item.error,
+              };
+            }
+            return next;
+          });
+        }
       } catch (err) {
         if (!mountedRef.current || requestSeqRef.current !== requestSeq) {
           return;
         }
-        queuedRefreshOptionsRef.current = null;
-        autoRefreshBlockedUntilRef.current = Date.now() + TEAM_CHANGES_ERROR_AUTO_RETRY_COOLDOWN_MS;
+        const queuedOptions = queuedRefreshOptionsRef.current as TeamChangesLoadOptions | null;
+        const shouldRunVisibleQueuedRefreshAfterSilentFailure =
+          !storeSummaries &&
+          !reportError &&
+          Boolean(queuedOptions?.showSpinner || queuedOptions?.storeSummaries);
+        if (!shouldRunVisibleQueuedRefreshAfterSilentFailure) {
+          queuedRefreshOptionsRef.current = null;
+        }
+        if (blockAutoRetryOnError) {
+          autoRefreshBlockedUntilRef.current =
+            Date.now() + TEAM_CHANGES_ERROR_AUTO_RETRY_COOLDOWN_MS;
+        }
         if (!preserveOnError) {
           setSummariesByTaskId({});
         }
-        setError(err instanceof Error ? err.message : 'Failed to load team changes');
+        if (reportError) {
+          setError(err instanceof Error ? err.message : 'Failed to load team changes');
+        }
       } finally {
         if (mountedRef.current) {
           const hasQueuedRefresh = queuedRefreshOptionsRef.current !== null;
           if (activeRequestSeqRef.current === requestSeq) {
             activeRequestSeqRef.current = null;
           }
-          if (hasQueuedRefresh && activeRequestSeqRef.current === null && sectionOpenRef.current) {
+          if (hasQueuedRefresh && activeRequestSeqRef.current === null) {
             setQueuedRefreshTick((value) => value + 1);
           }
           const shouldStopIndicators =
@@ -320,7 +410,10 @@ export function useTeamChangesSummaries({
     autoRefreshBlockedUntilRef.current = 0;
     unknownScanCursorRef.current = 0;
     lastRequestedTasksFingerprintRef.current = null;
+    lastCounterTasksFingerprintRef.current = null;
     setSummariesByTaskId({});
+    setChangeCountByTaskId({});
+    setCounterLoaded(false);
     setError(null);
     setStats({ eligibleCount: 0, requestedCount: 0, deferredCount: 0 });
   }, [teamName]);
@@ -340,6 +433,23 @@ export function useTeamChangesSummaries({
       setRefreshing(false);
     }
   }, [sectionOpen]);
+
+  useEffect(() => {
+    if (sectionOpen) {
+      return;
+    }
+    if (lastCounterTasksFingerprintRef.current === tasksFingerprint && counterLoaded) {
+      return;
+    }
+    lastCounterTasksFingerprintRef.current = tasksFingerprint;
+    void loadSummaries({
+      showSpinner: false,
+      preserveOnError: true,
+      storeSummaries: false,
+      reportError: false,
+      blockAutoRetryOnError: false,
+    });
+  }, [counterLoaded, loadSummaries, sectionOpen, tasksFingerprint]);
 
   useEffect(() => {
     if (!sectionOpen || hasLoadedRef.current) {
@@ -362,7 +472,7 @@ export function useTeamChangesSummaries({
   }, [loadSummaries, sectionOpen, tasksFingerprint]);
 
   useEffect(() => {
-    if (!sectionOpen || activeRequestSeqRef.current !== null) {
+    if (activeRequestSeqRef.current !== null) {
       return;
     }
     const options = queuedRefreshOptionsRef.current;
@@ -371,7 +481,7 @@ export function useTeamChangesSummaries({
     }
     queuedRefreshOptionsRef.current = null;
     void loadSummaries(options);
-  }, [loadSummaries, queuedRefreshTick, sectionOpen]);
+  }, [loadSummaries, queuedRefreshTick]);
 
   useEffect(() => {
     if (!sectionOpen) {
@@ -390,12 +500,39 @@ export function useTeamChangesSummaries({
     };
   }, [loadSummaries, sectionOpen]);
 
+  useEffect(() => {
+    if (sectionOpen) {
+      return;
+    }
+
+    const timer = window.setInterval(() => {
+      if (isDocumentHidden()) {
+        return;
+      }
+      if (activeRequestSeqRef.current !== null || queuedRefreshOptionsRef.current !== null) {
+        return;
+      }
+      void loadSummaries({
+        showSpinner: false,
+        preserveOnError: true,
+        storeSummaries: false,
+        reportError: false,
+        blockAutoRetryOnError: false,
+      });
+    }, TEAM_CHANGES_COUNTER_AUTO_REFRESH_MS);
+
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [loadSummaries, sectionOpen]);
+
   const refresh = useCallback(() => {
     void loadSummaries({ forceFresh: true, showSpinner: true, preserveOnError: false });
   }, [loadSummaries]);
 
   return {
     summariesByTaskId,
+    badgeCount: counterLoaded ? countChangedTasks(changeCountByTaskId) : null,
     stats,
     loading,
     refreshing,

--- a/src/renderer/features/CLAUDE.md
+++ b/src/renderer/features/CLAUDE.md
@@ -3,17 +3,21 @@
 This directory contains older renderer-local slices and integrations.
 
 For new medium and large features, use the canonical standard instead:
-- [Feature Architecture Standard](../../docs/FEATURE_ARCHITECTURE_STANDARD.md)
-- [Canonical feature root](../README.md)
-- [Feature-local guidance](../CLAUDE.md)
+
+- [Feature Architecture Standard](../../../docs/FEATURE_ARCHITECTURE_STANDARD.md)
+- [Canonical feature root](../../features/README.md)
+- [Feature-local guidance](../../features/CLAUDE.md)
 
 Default location for new feature work:
+
 - `src/features/<feature-name>/`
 
 Reference implementation:
+
 - `src/features/recent-projects`
 
 Keep `src/renderer/features/*` for:
+
 - existing legacy slices
 - renderer-only thin integrations
 - work that does not introduce a new use case, transport boundary, or cross-process architecture

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -81,6 +81,7 @@ import type {
   TeamGetDataOptions,
   TeamLaunchRequest,
   TeamLaunchResponse,
+  TeamLaunchFailureDiagnosticsBundle,
   TeamMemberActivityMeta,
   TeamMessageNotificationData,
   TeamProvisioningModelVerificationMode,
@@ -499,6 +500,10 @@ export interface TeamsAPI {
   createInitialGitCommit: (projectPath: string) => Promise<TeamWorktreeGitStatus>;
   createTeam: (request: TeamCreateRequest) => Promise<TeamCreateResponse>;
   getProvisioningStatus: (runId: string) => Promise<TeamProvisioningProgress>;
+  getLaunchFailureDiagnostics: (
+    teamName: string,
+    runId?: string
+  ) => Promise<TeamLaunchFailureDiagnosticsBundle>;
   cancelProvisioning: (runId: string) => Promise<void>;
   sendMessage: (teamName: string, request: SendMessageRequest) => Promise<SendMessageResult>;
   getOpenCodeRuntimeDeliveryStatus: (

--- a/src/shared/types/team.ts
+++ b/src/shared/types/team.ts
@@ -991,7 +991,7 @@ export interface TeamLaunchRequest {
   fastMode?: TeamFastMode;
   /** When true, context window is limited to 200K tokens instead of the default. */
   limitContext?: boolean;
-  /** When true, skip --resume and start a fresh session (clears context memory). */
+  /** Legacy flag retained for compatibility. Deterministic bootstrap launches fresh today. */
   clearContext?: boolean;
   /** When false, run WITHOUT --dangerously-skip-permissions (manual tool approval). Default: true. */
   skipPermissions?: boolean;
@@ -1477,6 +1477,35 @@ export interface TeamLaunchDiagnosticItem {
   label: string;
   detail?: string;
   observedAt: string;
+}
+
+export interface TeamLaunchFailureDiagnosticsFile {
+  label: string;
+  path: string;
+  content?: string;
+  issue?: string;
+}
+
+export interface TeamLaunchFailureDiagnosticsBundle {
+  teamName: string;
+  runId?: string;
+  latestPath: string;
+  artifactDirectory?: string;
+  manifestPath?: string;
+  classification?: {
+    code?: string;
+    confidence?: number;
+    evidence?: string[];
+  } | null;
+  bootstrapTransportBreadcrumb?: {
+    lastTransportStage?: string | null;
+    submitRejected?: boolean;
+    retryable?: boolean | null;
+    noStdinWarning?: boolean;
+    bootstrapSubmitted?: boolean;
+    evidence?: string[];
+  } | null;
+  files: TeamLaunchFailureDiagnosticsFile[];
 }
 
 export interface TeamRuntimeState {

--- a/test/main/services/team/TeamLaunchFailureArtifactPack.test.ts
+++ b/test/main/services/team/TeamLaunchFailureArtifactPack.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   classifyLaunchFailureArtifact,
   extractLaunchBootstrapTransportBreadcrumb,
+  readTeamLaunchFailureDiagnosticsBundle,
   redactLaunchFailureArtifactText,
   writeTeamLaunchFailureArtifactPack,
 } from '../../../../src/main/services/team/TeamLaunchFailureArtifactPack';
@@ -103,7 +104,10 @@ describe('TeamLaunchFailureArtifactPack', () => {
     expect(manifest.artifactFiles).toContain('launch-state.json');
     expect(manifest.progress.error).toContain('[REDACTED]');
 
-    const copiedLaunchState = await fs.readFile(path.join(result.directory, 'launch-state.json'), 'utf8');
+    const copiedLaunchState = await fs.readFile(
+      path.join(result.directory, 'launch-state.json'),
+      'utf8'
+    );
     expect(copiedLaunchState).toContain('[REDACTED_ANTHROPIC_API_KEY]');
     expect(() => JSON.parse(copiedLaunchState)).not.toThrow();
     expect(copiedLaunchState).toContain('"token":"[REDACTED]"');
@@ -117,6 +121,29 @@ describe('TeamLaunchFailureArtifactPack', () => {
       await fs.readFile(path.join(teamDir, 'launch-failure-artifacts', 'latest.json'), 'utf8')
     ) as { manifestPath: string };
     expect(latest.manifestPath).toBe(result.manifestPath);
+
+    const bundle = await readTeamLaunchFailureDiagnosticsBundle(teamName, runId);
+    expect(bundle).toMatchObject({
+      teamName,
+      runId,
+      manifestPath: result.manifestPath,
+      classification: { code: 'provider_auth' },
+      bootstrapTransportBreadcrumb: { submitRejected: false },
+    });
+    expect(bundle.files.map((file) => file.label)).toEqual([
+      'launch-failure-artifacts/latest.json',
+      'launch-failure-artifacts/manifest.json',
+      'bootstrap-journal.jsonl',
+      'launch-state.json',
+    ]);
+    expect(
+      bundle.files.find((file) => file.label === 'bootstrap-journal.jsonl')?.content
+    ).toContain('"event":"started"');
+    const launchStateContent = bundle.files.find(
+      (file) => file.label === 'launch-state.json'
+    )?.content;
+    expect(launchStateContent).toContain('[REDACTED_ANTHROPIC_API_KEY]');
+    expect(launchStateContent).not.toContain('sk-ant-');
   });
 
   it('redacts common bearer and token-shaped secrets', () => {
@@ -140,7 +167,8 @@ describe('TeamLaunchFailureArtifactPack', () => {
 
     expect(classifyLaunchFailureArtifact(input).code).toBe('transport_rejected');
     expect(extractLaunchBootstrapTransportBreadcrumb(input)).toMatchObject({
-      lastTransportStage: 'bootstrap_submit_rejected: submit rejected by local prompt handler retryable=true',
+      lastTransportStage:
+        'bootstrap_submit_rejected: submit rejected by local prompt handler retryable=true',
       submitRejected: true,
       retryable: true,
       noStdinWarning: true,

--- a/test/main/services/team/TeamLogSourceTracker.test.ts
+++ b/test/main/services/team/TeamLogSourceTracker.test.ts
@@ -5,6 +5,10 @@ import * as path from 'path';
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import {
+  getTeamsBasePath,
+  setClaudeBasePathOverride,
+} from '../../../../src/main/utils/pathDecoder';
+import {
   shouldIgnoreLogSourceWatcherPath,
   TeamLogSourceTracker,
 } from '../../../../src/main/services/team/TeamLogSourceTracker';
@@ -19,6 +23,10 @@ function safeTaskIdSegment(taskId: string): string {
   return `task-id-${createHash('sha256').update(taskId).digest('hex').slice(0, 32)}`;
 }
 
+function teamLogFreshnessDir(teamName = 'demo'): string {
+  return path.join(getTeamsBasePath(), teamName, 'task-log-freshness');
+}
+
 describe('TeamLogSourceTracker', () => {
   let tempDir: string | null = null;
 
@@ -28,6 +36,7 @@ describe('TeamLogSourceTracker', () => {
   });
 
   afterEach(async () => {
+    setClaudeBasePathOverride(null);
     if (tempDir) {
       await rm(tempDir, { recursive: true, force: true });
       tempDir = null;
@@ -49,6 +58,7 @@ describe('TeamLogSourceTracker', () => {
 
   it('emits task-log-change for matching runtime freshness signals without broad log-source-change', async () => {
     tempDir = await mkdtemp(path.join(tmpdir(), 'team-log-source-tracker-'));
+    setClaudeBasePathOverride(path.join(tempDir, '.claude'));
 
     const logsFinder = {
       getLiveLogSourceWatchContext: vi.fn(async () => ({
@@ -64,10 +74,10 @@ describe('TeamLogSourceTracker', () => {
 
     await tracker.enableTracking('demo', 'change_presence');
     emitter.mockClear();
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await new Promise((resolve) => setTimeout(resolve, 350));
 
     const taskId = '123e4567-e89b-12d3-a456-426614174999';
-    const signalDir = path.join(tempDir, '.board-task-log-freshness');
+    const signalDir = teamLogFreshnessDir();
     await mkdir(signalDir, { recursive: true });
     await writeFile(path.join(signalDir, `${encodeURIComponent(taskId)}.json`), '{"ok":true}');
 
@@ -87,6 +97,7 @@ describe('TeamLogSourceTracker', () => {
 
   it('keeps task-log tracking alive until the last consumer unsubscribes', async () => {
     tempDir = await mkdtemp(path.join(tmpdir(), 'team-log-source-tracker-refcount-'));
+    setClaudeBasePathOverride(path.join(tempDir, '.claude'));
 
     const logsFinder = {
       getLiveLogSourceWatchContext: vi.fn(async () => ({
@@ -103,12 +114,12 @@ describe('TeamLogSourceTracker', () => {
     await tracker.enableTracking('demo', 'task_log_stream');
     await tracker.enableTracking('demo', 'task_log_stream');
     emitter.mockClear();
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await new Promise((resolve) => setTimeout(resolve, 350));
 
     await tracker.disableTracking('demo', 'task_log_stream');
 
     const taskId = '223e4567-e89b-12d3-a456-426614174999';
-    const signalDir = path.join(tempDir, '.board-task-log-freshness');
+    const signalDir = teamLogFreshnessDir();
     await mkdir(signalDir, { recursive: true });
     await writeFile(path.join(signalDir, `${encodeURIComponent(taskId)}.json`), '{"ok":true}');
 
@@ -129,8 +140,9 @@ describe('TeamLogSourceTracker', () => {
     expect(emitter).not.toHaveBeenCalled();
   });
 
-  it('creates transcript freshness dirs without creating missing live cwd roots', async () => {
+  it('creates team log freshness dir without creating missing live cwd roots', async () => {
     tempDir = await mkdtemp(path.join(tmpdir(), 'team-log-source-tracker-missing-root-'));
+    setClaudeBasePathOverride(path.join(tempDir, '.claude'));
     const transcriptProjectDir = path.join(tempDir, 'transcript-project');
     const missingWorkspaceDir = path.join(tempDir, 'missing-workspace');
 
@@ -152,17 +164,12 @@ describe('TeamLogSourceTracker', () => {
     emitter.mockClear();
     await new Promise((resolve) => setTimeout(resolve, 100));
 
-    expect((await stat(path.join(transcriptProjectDir, '.board-task-log-freshness'))).isDirectory())
-      .toBe(true);
+    expect((await stat(teamLogFreshnessDir())).isDirectory()).toBe(true);
     await expect(stat(missingWorkspaceDir)).rejects.toThrow();
 
     const taskId = 'transcript-root-task';
     await writeFile(
-      path.join(
-        transcriptProjectDir,
-        '.board-task-log-freshness',
-        `${encodeURIComponent(taskId)}.json`
-      ),
+      path.join(teamLogFreshnessDir(), `${encodeURIComponent(taskId)}.json`),
       JSON.stringify({ taskId }),
       'utf8'
     );
@@ -181,6 +188,7 @@ describe('TeamLogSourceTracker', () => {
 
   it('emits log freshness kind from Windows-safe hashed task-log freshness files', async () => {
     tempDir = await mkdtemp(path.join(tmpdir(), 'team-log-source-tracker-safe-log-'));
+    setClaudeBasePathOverride(path.join(tempDir, '.claude'));
 
     const logsFinder = {
       getLiveLogSourceWatchContext: vi.fn(async () => ({
@@ -199,7 +207,7 @@ describe('TeamLogSourceTracker', () => {
     await new Promise((resolve) => setTimeout(resolve, 100));
 
     const taskId = 'AUX';
-    const signalDir = path.join(tempDir, '.board-task-log-freshness');
+    const signalDir = teamLogFreshnessDir();
     await mkdir(signalDir, { recursive: true });
     await writeFile(
       path.join(signalDir, `${safeTaskIdSegment(taskId)}.json`),
@@ -219,8 +227,9 @@ describe('TeamLogSourceTracker', () => {
     await tracker.disableTracking('demo', 'task_log_stream');
   });
 
-  it('watches live cwd freshness roots used by Codex Native traces', async () => {
+  it('watches team-scoped log freshness and live cwd task-change freshness roots', async () => {
     tempDir = await mkdtemp(path.join(tmpdir(), 'team-log-source-tracker-codex-root-'));
+    setClaudeBasePathOverride(path.join(tempDir, '.claude'));
     const transcriptProjectDir = path.join(tempDir, 'transcripts');
     const workspaceProjectDir = path.join(tempDir, 'workspace');
     const memberProjectDir = path.join(tempDir, 'member-workspace');
@@ -244,30 +253,15 @@ describe('TeamLogSourceTracker', () => {
 
     await tracker.enableTracking('demo', 'task_log_stream');
     emitter.mockClear();
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await new Promise((resolve) => setTimeout(resolve, 350));
 
-    const logTaskId = 'codex-task-1';
-    await writeFile(
-      path.join(
-        memberProjectDir,
-        '.board-task-log-freshness',
-        `${encodeURIComponent(logTaskId)}.json`
-      ),
-      JSON.stringify({ taskId: logTaskId, source: 'codex-native-trace' }),
-      'utf8'
-    );
+    await expect(stat(path.join(memberProjectDir, '.board-task-log-freshness'))).rejects.toThrow();
+    await expect(stat(path.join(workspaceProjectDir, '.board-task-log-freshness'))).rejects.toThrow();
 
-    await vi.waitFor(() => {
-      expect(emitter).toHaveBeenCalledWith({
-        type: 'task-log-change',
-        teamName: 'demo',
-        taskId: logTaskId,
-        taskSignalKind: 'log',
-      });
-    });
-
-    emitter.mockClear();
     const changeTaskId = 'codex-task-2';
+    await mkdir(path.join(workspaceProjectDir, '.board-task-change-freshness'), {
+      recursive: true,
+    });
     await writeFile(
       path.join(
         workspaceProjectDir,
@@ -432,6 +426,7 @@ describe('TeamLogSourceTracker', () => {
 
   it('supports stall_monitor as an independent tracking consumer', async () => {
     tempDir = await mkdtemp(path.join(tmpdir(), 'team-log-source-tracker-stall-monitor-'));
+    setClaudeBasePathOverride(path.join(tempDir, '.claude'));
 
     const logsFinder = {
       getLiveLogSourceWatchContext: vi.fn(async () => ({
@@ -450,7 +445,7 @@ describe('TeamLogSourceTracker', () => {
     await new Promise((resolve) => setTimeout(resolve, 100));
 
     const taskId = '323e4567-e89b-12d3-a456-426614174999';
-    const signalDir = path.join(tempDir, '.board-task-log-freshness');
+    const signalDir = teamLogFreshnessDir();
     await mkdir(signalDir, { recursive: true });
     await writeFile(path.join(signalDir, `${encodeURIComponent(taskId)}.json`), '{"ok":true}');
 

--- a/test/main/services/team/TeamProvisioningService.test.ts
+++ b/test/main/services/team/TeamProvisioningService.test.ts
@@ -14062,7 +14062,7 @@ describe('TeamProvisioningService', () => {
     ).toBe('Questions (2): First question with extra spacing.');
   });
 
-  it('skips --resume when the persisted launch state shows no teammate ever spawned', async () => {
+  it('skips --resume for deterministic bootstrap when previous launch state has no spawned teammates', async () => {
     allowConsoleLogs();
     const teamName = 'resume-skip-team';
     const leadSessionId = 'lead-session-skip';
@@ -14114,7 +14114,7 @@ describe('TeamProvisioningService', () => {
     expect(launchArgs).not.toContain(leadSessionId);
   });
 
-  it('skips --resume when a stale active launch state shows no teammate ever spawned', async () => {
+  it('skips --resume for deterministic bootstrap when previous active launch is stale', async () => {
     allowConsoleLogs();
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-03T12:03:00.000Z'));
@@ -14178,7 +14178,7 @@ describe('TeamProvisioningService', () => {
     expect(launchArgs).not.toContain(leadSessionId);
   });
 
-  it('skips --resume when a stale active launch has accepted but no live teammates', async () => {
+  it('skips --resume for deterministic bootstrap when stale active launch has no live teammates', async () => {
     allowConsoleLogs();
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-03T12:03:00.000Z'));
@@ -14244,7 +14244,7 @@ describe('TeamProvisioningService', () => {
     expect(launchArgs).not.toContain(leadSessionId);
   });
 
-  it('keeps --resume when a teammate had an accepted spawn before failing bootstrap', async () => {
+  it('skips --resume with deterministic bootstrap even after an accepted failed spawn', async () => {
     allowConsoleLogs();
     const teamName = 'resume-keep-team';
     const leadSessionId = 'lead-session-keep';
@@ -14291,11 +14291,11 @@ describe('TeamProvisioningService', () => {
     );
 
     const launchArgs = vi.mocked(spawnCli).mock.calls[0]?.[1] as string[];
-    expect(launchArgs).toContain('--resume');
-    expect(launchArgs).toContain(leadSessionId);
+    expect(launchArgs).not.toContain('--resume');
+    expect(launchArgs).not.toContain(leadSessionId);
   });
 
-  it('keeps --resume when a persisted legacy Codex backend normalizes to codex-native', async () => {
+  it('skips --resume with deterministic bootstrap after Codex backend normalization', async () => {
     allowConsoleLogs();
     const teamName = 'resume-backend-change-team';
     const leadSessionId = 'lead-session-backend-change';
@@ -14348,11 +14348,11 @@ describe('TeamProvisioningService', () => {
 
     const launchArgs = vi.mocked(spawnCli).mock.calls.at(-1)?.[1] as string[];
     expect(launchArgs).toBeTruthy();
-    expect(launchArgs).toContain('--resume');
-    expect(launchArgs).toContain(leadSessionId);
+    expect(launchArgs).not.toContain('--resume');
+    expect(launchArgs).not.toContain(leadSessionId);
   });
 
-  it('seeds the current lead session id immediately when launch resumes an existing session', async () => {
+  it('does not seed the previous lead session id when deterministic bootstrap skips resume', async () => {
     allowConsoleLogs();
     const teamName = 'resume-seed-session-team';
     const leadSessionId = 'lead-session-seeded';
@@ -14388,7 +14388,10 @@ describe('TeamProvisioningService', () => {
 
     const { runId } = await svc.launchTeam({ teamName, cwd: tempClaudeRoot }, () => {});
 
-    expect(svc.getCurrentLeadSessionId(teamName)).toBe(leadSessionId);
+    const launchArgs = vi.mocked(spawnCli).mock.calls.at(-1)?.[1] as string[];
+    expect(launchArgs).not.toContain('--resume');
+    expect((svc as any).pathExists).not.toHaveBeenCalled();
+    expect(svc.getCurrentLeadSessionId(teamName)).toBeNull();
 
     await svc.cancelProvisioning(runId);
   });

--- a/test/main/services/team/TeamProvisioningServicePrompts.test.ts
+++ b/test/main/services/team/TeamProvisioningServicePrompts.test.ts
@@ -215,7 +215,7 @@ describe('TeamProvisioningService prompt content (solo mode discipline)', () => 
     await svc.cancelProvisioning(runId);
   });
 
-  it('launchTeam prompt (solo) uses deterministic refresh-only reconnect instructions', async () => {
+  it('launchTeam prompt (solo) uses deterministic refresh-only launch instructions', async () => {
     // Seed config.json so launchTeam can validate team existence.
     const teamName = 'solo-team-launch';
     const teamDir = path.join(tempTeamsBase, teamName);
@@ -265,7 +265,7 @@ describe('TeamProvisioningService prompt content (solo mode discipline)', () => 
     expect(writeSpy).not.toHaveBeenCalled();
     const prompt = extractPromptFromBootstrapFile();
     expect(prompt).toContain('SOLO MODE: This team CURRENTLY has ZERO teammates.');
-    expect(prompt).toContain('This reconnect/bootstrap step has already been completed deterministically by the runtime.');
+    expect(prompt).toContain('This launch/bootstrap step has already been completed deterministically by the runtime.');
     expect(prompt).toContain('Do NOT start implementation in this turn.');
     expect(prompt).toContain('Use this turn only to refresh context, review the current board snapshot, and confirm you are ready.');
     expect(prompt).toContain(
@@ -738,7 +738,7 @@ describe('TeamProvisioningService prompt content (solo mode discipline)', () => 
     await svc.cancelProvisioning(runId);
   });
 
-  it('launchTeam reconnect prompt for teammates includes explicit hidden-instruction block rules', async () => {
+  it('launchTeam bootstrap prompt for teammates includes explicit hidden-instruction block rules', async () => {
     const teamName = 'multi-team-launch';
     const teamDir = path.join(tempTeamsBase, teamName);
     fs.mkdirSync(teamDir, { recursive: true });
@@ -790,7 +790,7 @@ describe('TeamProvisioningService prompt content (solo mode discipline)', () => 
 
     expect(writeSpy).not.toHaveBeenCalled();
     const prompt = extractPromptFromBootstrapFile();
-    expect(prompt).toContain('This reconnect/bootstrap step has already been completed deterministically by the runtime.');
+    expect(prompt).toContain('This launch/bootstrap step has already been completed deterministically by the runtime.');
     expect(prompt).toContain('Do NOT use Agent to spawn or restore teammates.');
     expect(prompt).toContain('Use this turn only to refresh context and review the current board snapshot.');
     expect(prompt).toContain(

--- a/test/main/services/team/stallMonitor/TeamTaskLogFreshnessReader.test.ts
+++ b/test/main/services/team/stallMonitor/TeamTaskLogFreshnessReader.test.ts
@@ -4,6 +4,10 @@ import * as os from 'os';
 import * as path from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
 
+import {
+  getTeamsBasePath,
+  setClaudeBasePathOverride,
+} from '../../../../../src/main/utils/pathDecoder';
 import { TeamTaskLogFreshnessReader } from '../../../../../src/main/services/team/stallMonitor/TeamTaskLogFreshnessReader';
 
 const tempDirs: string[] = [];
@@ -13,12 +17,17 @@ function safeTaskIdSegment(taskId: string): string {
 }
 
 afterEach(async () => {
+  setClaudeBasePathOverride(null);
   await Promise.all(
     tempDirs.splice(0).map(async (dirPath) => {
       await fs.rm(dirPath, { recursive: true, force: true });
     })
   );
 });
+
+function teamSignalDir(teamName: string): string {
+  return path.join(getTeamsBasePath(), teamName, 'task-log-freshness');
+}
 
 describe('TeamTaskLogFreshnessReader', () => {
   it('reads valid freshness signals and normalizes transcript basename', async () => {
@@ -82,6 +91,31 @@ describe('TeamTaskLogFreshnessReader', () => {
       path.join(signalDir, `${safeTaskIdSegment('CON')}.json`)
     );
     expect(signals.get('CON')?.transcriptFileBasename).toBe('session-con.jsonl');
+  });
+
+  it('prefers team-scoped freshness signals', async () => {
+    const projectDir = await fs.mkdtemp(path.join(os.tmpdir(), 'stall-freshness-'));
+    tempDirs.push(projectDir);
+    setClaudeBasePathOverride(path.join(projectDir, '.claude'));
+    const signalDir = teamSignalDir('demo');
+    await fs.mkdir(signalDir, { recursive: true });
+
+    await fs.writeFile(
+      path.join(signalDir, `${encodeURIComponent('task-a')}.json`),
+      JSON.stringify({
+        taskId: 'task-a',
+        updatedAt: '2026-04-19T12:00:00.000Z',
+      }),
+      'utf8'
+    );
+
+    const signals = await new TeamTaskLogFreshnessReader().readSignals(projectDir, ['task-a'], {
+      teamName: 'demo',
+    });
+
+    expect(signals.get('task-a')?.filePath).toBe(
+      path.join(signalDir, `${encodeURIComponent('task-a')}.json`)
+    );
   });
 
   it('reads hashed freshness files for very long task ids', async () => {

--- a/test/main/services/team/stallMonitor/TeamTaskStallSnapshotSource.test.ts
+++ b/test/main/services/team/stallMonitor/TeamTaskStallSnapshotSource.test.ts
@@ -155,7 +155,9 @@ describe('TeamTaskStallSnapshotSource', () => {
       tasks: [...expectedWorkflowActiveTasks, ...deletedTasks],
       messages: rawMessages,
     });
-    expect(freshnessReader.readSignals).toHaveBeenCalledWith('/tmp/project', ['task-a', 'task-b']);
+    expect(freshnessReader.readSignals).toHaveBeenCalledWith('/tmp/project', ['task-a', 'task-b'], {
+      teamName: 'demo',
+    });
     expect(exactRowReader.parseFiles).toHaveBeenCalledWith(['/tmp/project/session-a.jsonl', '/tmp/project/session-b.jsonl']);
     expect(openCodeEvidenceSource.readEvidence).toHaveBeenCalledWith({
       teamName: 'demo',


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added launch failure diagnostics for troubleshooting team provisioning issues
  * Added "Docs" menu item to access project documentation
  * Implemented team-scoped task freshness signal tracking

* **Bug Fixes**
  * Improved team launch monitoring and diagnostics artifact collection
  * Refined task change tracking for closed-section counter behavior

* **Documentation**
  * Updated release notes for versions 1.1.0 and 1.2.0
  * Enhanced feature architecture standards and guardrails
  * Added historical design documentation disclaimers

* **Style**
  * Refined landing page CSS styling and hero image overlay

* **Chores**
  * Updated runtime to version 0.0.28
  * Reorganized team provisioning launch flow messaging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-router-summary:start -->
## Summary

- update 7 test files
- updates source implementation in custom
- updates registerTeamHandlers, removeTeamHandlers: changes return value handling
- updates readBoundedTextFile, getKnownLaunchArtifactSourceFiles: changes fallback/null handling, return value handling, error handling
- touch 47 files (2 added, 45 modified) with +1451/-514 lines

## Tests

- changed test file: `src/renderer/components/team/__tests__/useTeamChangesSummaries.test.tsx`
- changed test file: `test/main/services/team/TeamLaunchFailureArtifactPack.test.ts`
- changed test file: `test/main/services/team/TeamLogSourceTracker.test.ts`
- changed test file: `test/main/services/team/TeamProvisioningService.test.ts`
- changed test file: `test/main/services/team/TeamProvisioningServicePrompts.test.ts`
- changed test file: `test/main/services/team/stallMonitor/TeamTaskLogFreshnessReader.test.ts`
- changed test file: `test/main/services/team/stallMonitor/TeamTaskStallSnapshotSource.test.ts`

<details>
<summary>📒 Files selected for processing (47)</summary>

* `AGENT_CRITICAL_GUARDRAILS.md`
* `CLAUDE.md`
* `docs/CHANGELOG.md`
* `docs/FEATURE_ARCHITECTURE_STANDARD.md`
* `docs/RELEASE.md`
* `docs/claude-multimodel-integration-plan.md`
* `docs/team-management/README.md`
* `docs/team-management/agent-attachments-architecture-plan.md`
* `docs/team-management/agent-attachments-phase-1-normalization-and-budgets-plan.md`
* `docs/team-management/agent-attachments-phase-2-claude-stream-json-plan.md`
* `docs/team-management/agent-attachments-phase-3-codex-native-plan.md`
* `docs/team-management/agent-attachments-phase-4-opencode-vision-plan.md`
* `docs/team-management/agent-attachments-phase-5-e2e-and-polish-plan.md`
* `docs/team-management/agent-attachments.md`
* `landing/product-docs/.vitepress/theme/custom.css`
* `landing/product-docs/index.md`
* `landing/product-docs/ru/index.md`
* `runtime.lock.json`
* `src/features/CLAUDE.md`
* `src/main/ipc/teams.ts`
* `src/main/services/team/TeamLaunchFailureArtifactPack.ts`
* `src/main/services/team/TeamLogSourceTracker.ts`
* `src/main/services/team/TeamProvisioningService.ts`
* `src/main/services/team/stallMonitor/TeamTaskLogFreshnessReader.ts`
* `src/main/services/team/stallMonitor/TeamTaskStallSnapshotSource.ts`
* `src/main/services/team/teamLogSourceWatchScope.ts`
* `src/preload/constants/ipcChannels.ts`
* `src/preload/index.ts`
* `src/renderer/api/httpClient.ts`
* `src/renderer/components/layout/MoreMenu.tsx`
* `src/renderer/components/layout/TabBarActions.tsx`
* `src/renderer/components/team/ProvisioningProgressBlock.tsx`
* `src/renderer/components/team/TeamChangesSection.tsx`
* `src/renderer/components/team/TeamDetailView.tsx`
* `src/renderer/components/team/TeamProvisioningPanel.tsx`
* `src/renderer/components/team/__tests__/useTeamChangesSummaries.test.tsx`
* `src/renderer/components/team/dialogs/LaunchTeamDialog.tsx`
* `src/renderer/components/team/useTeamChangesSummaries.ts`
* `src/renderer/features/CLAUDE.md`
* `src/shared/types/api.ts`
* `src/shared/types/team.ts`
* `test/main/services/team/TeamLaunchFailureArtifactPack.test.ts`
* `test/main/services/team/TeamLogSourceTracker.test.ts`
* `test/main/services/team/TeamProvisioningService.test.ts`
* `test/main/services/team/TeamProvisioningServicePrompts.test.ts`
* `test/main/services/team/stallMonitor/TeamTaskLogFreshnessReader.test.ts`
* `test/main/services/team/stallMonitor/TeamTaskStallSnapshotSource.test.ts`

</details>

<details>
<summary>📝 Walkthrough</summary>

## Walkthrough

This PR updates 47 files across 21 source, 18 documentation, 7 tests, 1 configuration. The generated summary is based on the GitHub pull request file list and diff metadata, and the author's description above is preserved.

## Changes

| Cohort / File(s) | Summary |
|---|---|
| **Source** <br> `landing/product-docs/.vitepress/theme/custom.css`<br>`src/main/ipc/teams.ts`<br>`src/main/services/team/TeamLaunchFailureArtifactPack.ts`<br>`src/main/services/team/TeamLogSourceTracker.ts`<br>`src/main/services/team/TeamProvisioningService.ts`<br>and 16 more | Updates source implementation in custom.<br>Updates registerTeamHandlers, removeTeamHandlers: changes return value handling.<br>Updates readBoundedTextFile, getKnownLaunchArtifactSourceFiles: changes fallback/null handling, return value handling, error handling.<br>Also updates 18 more files.<br>Line stats: 21 modified; +805/-410. |
| **Documentation** <br> `AGENT_CRITICAL_GUARDRAILS.md`<br>`CLAUDE.md`<br>`docs/CHANGELOG.md`<br>`docs/FEATURE_ARCHITECTURE_STANDARD.md`<br>`docs/RELEASE.md`<br>and 13 more | Adds documentation for Agent Critical Guardrails.<br>Updates documentation content.<br>Updates documentation for [1.2.0] - 2026-03-31, Added.<br>Also updates 15 more files.<br>Line stats: 2 added, 16 modified; +230/-43. |
| **Tests** <br> `src/renderer/components/team/__tests__/useTeamChangesSummaries.test.tsx`<br>`test/main/services/team/TeamLaunchFailureArtifactPack.test.ts`<br>`test/main/services/team/TeamLogSourceTracker.test.ts`<br>`test/main/services/team/TeamProvisioningService.test.ts`<br>`test/main/services/team/TeamProvisioningServicePrompts.test.ts`<br>and 2 more | Updates test coverage for shows the closed-section counter only after the background ..., loads the closed-section counter without rendering full cha....<br>Updates test coverage for copiedLaunchState, bundle.<br>Updates test coverage for teamLogFreshnessDir, creates team log freshness dir without creating missing liv....<br>Also updates 4 more files.<br>Line stats: 7 modified; +410/-55. |
| **Configuration** <br> `runtime.lock.json` | Updates configuration for version, sourceRef, file.<br>Line stats: 1 modified; +6/-6. |

</details>
<!-- review-router-summary:end -->