### PR TITLE
fix: preserve absolute mention paths

### DIFF
--- a/src/renderer/store/utils/pathResolution.ts
+++ b/src/renderer/store/utils/pathResolution.ts
@@ -27,6 +27,10 @@ export function resolveFilePath(base: string, relativePath: string): string {
     cleanRelative = cleanRelative.slice(1);
   }
 
+  if (isAbsolutePath(cleanRelative)) {
+    return cleanRelative;
+  }
+
   // Tilde paths (~/) are home-relative absolute paths - pass through as-is
   // The main process will expand ~ to the actual home directory
   if (cleanRelative.startsWith('~/') || cleanRelative.startsWith('~\\') || cleanRelative === '~') {

--- a/src/renderer/utils/claudeMdTracker.ts
+++ b/src/renderer/utils/claudeMdTracker.ts
@@ -99,6 +99,9 @@ function joinPaths(base: string, relative: string): string {
   if (cleanRelative.startsWith('@')) {
     cleanRelative = cleanRelative.slice(1);
   }
+  if (isAbsolutePath(cleanRelative)) {
+    return cleanRelative;
+  }
 
   // Handle ./ prefix (current directory)
   if (cleanRelative.startsWith('./') || cleanRelative.startsWith('.\\')) {

--- a/src/renderer/utils/contextTracker.ts
+++ b/src/renderer/utils/contextTracker.ts
@@ -482,6 +482,9 @@ function joinPaths(base: string, relative: string): string {
   if (cleanRelative.startsWith('@')) {
     cleanRelative = cleanRelative.slice(1);
   }
+  if (isAbsolutePath(cleanRelative)) {
+    return cleanRelative;
+  }
 
   // Handle ./ prefix (current directory)
   if (cleanRelative.startsWith('./') || cleanRelative.startsWith('.\\')) {

--- a/test/renderer/store/pathResolution.test.ts
+++ b/test/renderer/store/pathResolution.test.ts
@@ -41,6 +41,14 @@ describe('resolveFilePath', () => {
     expect(resolveFilePath('/repo', '@~/some/file.ts')).toBe('~/some/file.ts');
   });
 
+  it('passes through @-prefixed absolute paths after stripping the mention marker', () => {
+    expect(resolveFilePath('/repo', '@/outside/file.ts')).toBe('/outside/file.ts');
+    expect(resolveFilePath('C:\\repo', '@C:\\outside\\file.ts')).toBe('C:\\outside\\file.ts');
+    expect(resolveFilePath('C:\\repo', '@\\\\server\\share\\file.ts')).toBe(
+      '\\\\server\\share\\file.ts'
+    );
+  });
+
   it('passes through bare tilde as-is', () => {
     expect(resolveFilePath('/repo', '~')).toBe('~');
   });

--- a/test/renderer/utils/claudeMdTracker.test.ts
+++ b/test/renderer/utils/claudeMdTracker.test.ts
@@ -195,4 +195,13 @@ describe('extractUserMentionPaths Windows paths', () => {
       ['~\\.claude\\CLAUDE.md']
     );
   });
+
+  it('strips mention markers before preserving absolute mention paths', () => {
+    expect(extractUserMentionPaths(userGroupWithPath('@C:\\Other\\file.ts'), 'C:\\Repo')).toEqual([
+      'C:\\Other\\file.ts',
+    ]);
+    expect(
+      extractUserMentionPaths(userGroupWithPath('@\\\\server\\share\\file.ts'), 'C:\\Repo')
+    ).toEqual(['\\\\server\\share\\file.ts']);
+  });
 });


### PR DESCRIPTION
## Summary
- preserve @-prefixed absolute, Windows drive and UNC paths after stripping the mention marker
- cover path resolution and CLAUDE.md mention extraction regressions

## Tests
- corepack pnpm exec vitest run test/renderer/store/pathResolution.test.ts test/renderer/utils/claudeMdTracker.test.ts --maxWorkers 1 --minWorkers 1
- corepack pnpm exec eslint src/renderer/store/utils/pathResolution.ts src/renderer/utils/claudeMdTracker.ts src/renderer/utils/contextTracker.ts test/renderer/store/pathResolution.test.ts test/renderer/utils/claudeMdTracker.test.ts
- corepack pnpm typecheck

<!-- review-router-summary:start -->
## Summary

- update 2 test files
- updates resolveFilePath: changes return value handling
- updates joinPaths: changes return value handling
- touch 5 files (5 modified) with +27/-0 lines

## Tests

- changed test file: `test/renderer/store/pathResolution.test.ts`
- changed test file: `test/renderer/utils/claudeMdTracker.test.ts`

<details>
<summary>📒 Files selected for processing (5)</summary>

* `src/renderer/store/utils/pathResolution.ts`
* `src/renderer/utils/claudeMdTracker.ts`
* `src/renderer/utils/contextTracker.ts`
* `test/renderer/store/pathResolution.test.ts`
* `test/renderer/utils/claudeMdTracker.test.ts`

</details>

<details>
<summary>📝 Walkthrough</summary>

## Walkthrough

This PR updates 5 files across 3 source, 2 tests. The generated summary is based on the GitHub pull request file list and diff metadata, and the author's description above is preserved.

## Changes

| Cohort / File(s) | Summary |
|---|---|
| **Source** <br> `src/renderer/store/utils/pathResolution.ts`<br>`src/renderer/utils/claudeMdTracker.ts`<br>`src/renderer/utils/contextTracker.ts` | Updates resolveFilePath: changes return value handling.<br>Updates joinPaths: changes return value handling.<br>Line stats: 3 modified; +10/-0. |
| **Tests** <br> `test/renderer/store/pathResolution.test.ts`<br>`test/renderer/utils/claudeMdTracker.test.ts` | Updates test coverage for passes through @-prefixed absolute paths after stripping th....<br>Updates test coverage for strips mention markers before preserving absolute mention p....<br>Line stats: 2 modified; +17/-0. |

</details>
<!-- review-router-summary:end -->