### PR TITLE
fix: centralize absolute path detection

### DIFF
--- a/src/renderer/components/team/editor/EditorFileTree.tsx
+++ b/src/renderer/components/team/editor/EditorFileTree.tsx
@@ -32,6 +32,7 @@ import {
   isPathPrefix,
   joinPath,
   lastSeparatorIndex,
+  normalizePathForComparison,
   splitPath,
 } from '@shared/utils/platformPath';
 import { useVirtualizer } from '@tanstack/react-virtual';
@@ -80,6 +81,17 @@ const ITEM_HEIGHT = 28;
 const INDENT_PX = 12;
 const MAX_DEPTH = 12;
 const AUTO_EXPAND_DELAY_MS = 500;
+
+function treePathsEqual(
+  left: string | null | undefined,
+  right: string | null | undefined
+): boolean {
+  return (
+    typeof left === 'string' &&
+    typeof right === 'string' &&
+    normalizePathForComparison(left) === normalizePathForComparison(right)
+  );
+}
 
 // =============================================================================
 // Component
@@ -204,7 +216,7 @@ export const EditorFileTree = ({
   // Scroll to file when selectedFilePath changes (e.g. from revealFileInEditor)
   useEffect(() => {
     if (!selectedFilePath) return;
-    const idx = flatItems.findIndex((fi) => fi.node.fullPath === selectedFilePath);
+    const idx = flatItems.findIndex((fi) => treePathsEqual(fi.node.fullPath, selectedFilePath));
     if (idx >= 0) {
       virtualizer.scrollToIndex(idx, { align: 'center' });
     }
@@ -633,7 +645,7 @@ const DraggableTreeItem = React.memo(
     onRenameCancel,
   }: DraggableTreeItemProps): React.ReactElement => {
     const { node, depth, isExpanded } = item;
-    const isSelected = activeNodePath === node.fullPath;
+    const isSelected = treePathsEqual(activeNodePath, node.fullPath);
     const visualDepth = Math.min(depth, MAX_DEPTH);
     const isSensitive = node.data?.isSensitive;
 

--- a/src/renderer/store/slices/editorSlice.ts
+++ b/src/renderer/store/slices/editorSlice.ts
@@ -19,6 +19,7 @@ import {
   isWindowsishPath,
   joinPath,
   lastSeparatorIndex,
+  normalizePathForComparison,
   splitPath,
   stripTrailingSeparators,
 } from '@shared/utils/platformPath';
@@ -40,6 +41,29 @@ function omitKey<V>(record: Record<string, V>, key: string): Record<string, V> {
   const result = { ...record };
   delete result[key];
   return result;
+}
+
+function editorPathsEqual(left: string, right: string): boolean {
+  return normalizePathForComparison(left) === normalizePathForComparison(right);
+}
+
+function findMatchingPathKey<V>(record: Record<string, V>, filePath: string): string | null {
+  if (filePath in record) return filePath;
+  return Object.keys(record).find((key) => editorPathsEqual(key, filePath)) ?? null;
+}
+
+function getMatchingPathMapValue<V>(map: Map<string, V>, filePath: string): V | undefined {
+  const exact = map.get(filePath);
+  if (exact !== undefined) return exact;
+  for (const [key, value] of map) {
+    if (editorPathsEqual(key, filePath)) return value;
+  }
+  return undefined;
+}
+
+function omitMatchingPathKey<V>(record: Record<string, V>, filePath: string): Record<string, V> {
+  const key = findMatchingPathKey(record, filePath);
+  return key ? omitKey(record, key) : record;
 }
 
 /**
@@ -617,7 +641,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
     const { editorOpenTabs } = get();
 
     // Dedup: if file already open, just activate it
-    const existing = editorOpenTabs.find((t) => t.filePath === filePath);
+    const existing = editorOpenTabs.find((t) => editorPathsEqual(t.filePath, filePath));
     if (existing) {
       set({ editorActiveTabId: existing.id });
       return;
@@ -1216,26 +1240,27 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       }, 2000);
     }
     const { editorOpenTabs, editorProjectPath, editorSaving } = get();
+    const openTab = editorOpenTabs.find((tab) => editorPathsEqual(tab.filePath, event.path));
+    const canonicalEventPath = openTab?.filePath ?? event.path;
 
     // Ignore watcher events for files we are currently saving (our own write)
-    if (editorSaving[event.path]) return;
+    if (findMatchingPathKey(editorSaving, event.path)) return;
 
     // Ignore watcher events within cooldown after save
     // (covers race: save completes → editorSaving cleared → watcher fires late)
-    const lastSaveTime = recentSaveTimestamps.get(event.path);
+    const lastSaveTime = getMatchingPathMapValue(recentSaveTimestamps, event.path);
     if (lastSaveTime && Date.now() - lastSaveTime < SAVE_COOLDOWN_MS) return;
 
     // Ignore watcher events within cooldown after move
-    const lastMoveTime = recentMoveTimestamps.get(event.path);
+    const lastMoveTime = getMatchingPathMapValue(recentMoveTimestamps, event.path);
     if (lastMoveTime && Date.now() - lastMoveTime < MOVE_COOLDOWN_MS) return;
 
     // Track changes for open files
-    const isOpenFile = editorOpenTabs.some((t) => t.filePath === event.path);
-    if (isOpenFile || event.type === 'delete') {
+    if (openTab || event.type === 'delete') {
       set((s) => ({
         editorExternalChanges: {
           ...s.editorExternalChanges,
-          [event.path]: event.type,
+          [canonicalEventPath]: event.type,
         },
       }));
     }
@@ -1267,7 +1292,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
 
   clearExternalChange: (filePath: string) => {
     set((s) => ({
-      editorExternalChanges: omitKey(s.editorExternalChanges, filePath),
+      editorExternalChanges: omitMatchingPathKey(s.editorExternalChanges, filePath),
     }));
   },
 

--- a/src/renderer/store/utils/pathResolution.ts
+++ b/src/renderer/store/utils/pathResolution.ts
@@ -2,7 +2,7 @@
  * Path resolution utilities for the store.
  */
 
-import { stripTrailingSeparators } from '@shared/utils/platformPath';
+import { isAbsoluteOrHomePath, stripTrailingSeparators } from '@shared/utils/platformPath';
 
 /**
  * Resolves a relative path against a base path, handling various path formats.
@@ -15,7 +15,7 @@ import { stripTrailingSeparators } from '@shared/utils/platformPath';
  */
 export function resolveFilePath(base: string, relativePath: string): string {
   // If already absolute, return as-is
-  if (isAbsolutePath(relativePath)) {
+  if (isAbsoluteOrHomePath(relativePath)) {
     return relativePath;
   }
 
@@ -27,13 +27,7 @@ export function resolveFilePath(base: string, relativePath: string): string {
     cleanRelative = cleanRelative.slice(1);
   }
 
-  if (isAbsolutePath(cleanRelative)) {
-    return cleanRelative;
-  }
-
-  // Tilde paths (~/) are home-relative absolute paths - pass through as-is
-  // The main process will expand ~ to the actual home directory
-  if (cleanRelative.startsWith('~/') || cleanRelative.startsWith('~\\') || cleanRelative === '~') {
+  if (isAbsoluteOrHomePath(cleanRelative)) {
     return cleanRelative;
   }
 
@@ -67,10 +61,6 @@ export function resolveFilePath(base: string, relativePath: string): string {
     normalizedBase = `${separator}${separator}${normalizedBase}`;
   }
   return remainingRelative ? `${normalizedBase}${separator}${remainingRelative}` : normalizedBase;
-}
-
-function isAbsolutePath(input: string): boolean {
-  return input.startsWith('/') || input.startsWith('\\\\') || /^[a-zA-Z]:[\\/]/.test(input);
 }
 
 function normalizeSeparators(input: string, separator: '/' | '\\'): string {

--- a/src/renderer/utils/claudeMdTracker.ts
+++ b/src/renderer/utils/claudeMdTracker.ts
@@ -8,6 +8,7 @@
  */
 
 import {
+  isAbsoluteOrHomePath,
   isPathPrefix,
   lastSeparatorIndex,
   normalizePathForComparison,
@@ -64,20 +65,6 @@ export function getDisplayName(path: string, _source: ClaudeMdSource): string {
 }
 
 /**
- * Check if a path is absolute (starts with /).
- */
-function isAbsolutePath(path: string): boolean {
-  return (
-    path.startsWith('/') ||
-    path.startsWith('~/') ||
-    path.startsWith('~\\') ||
-    path === '~' ||
-    path.startsWith('\\\\') ||
-    /^[a-zA-Z]:[\\/]/.test(path)
-  );
-}
-
-/**
  * Join paths, handling various path formats properly.
  * Handles:
  * - Absolute paths: /full/path/file.tsx (returned as-is)
@@ -87,7 +74,7 @@ function isAbsolutePath(path: string): boolean {
  * - Paths with @ prefix: @apps/foo/bar.tsx (strips @ then joins)
  */
 function joinPaths(base: string, relative: string): string {
-  if (isAbsolutePath(relative)) {
+  if (isAbsoluteOrHomePath(relative)) {
     return relative;
   }
 
@@ -99,7 +86,7 @@ function joinPaths(base: string, relative: string): string {
   if (cleanRelative.startsWith('@')) {
     cleanRelative = cleanRelative.slice(1);
   }
-  if (isAbsolutePath(cleanRelative)) {
+  if (isAbsoluteOrHomePath(cleanRelative)) {
     return cleanRelative;
   }
 
@@ -239,7 +226,9 @@ export function extractUserMentionPaths(
   for (const ref of fileReferences) {
     if (ref.path) {
       // Convert to absolute if relative
-      const absolutePath = isAbsolutePath(ref.path) ? ref.path : joinPaths(projectRoot, ref.path);
+      const absolutePath = isAbsoluteOrHomePath(ref.path)
+        ? ref.path
+        : joinPaths(projectRoot, ref.path);
       paths.push(absolutePath);
     }
   }
@@ -525,7 +514,7 @@ function computeClaudeMdStats(params: ComputeClaudeMdStatsParams): ClaudeMdStats
   const responseRefs = extractFileRefsFromResponses(aiGroup.responses);
   for (const ref of responseRefs) {
     if (ref.path) {
-      const absPath = isAbsolutePath(ref.path) ? ref.path : joinPaths(projectRoot, ref.path);
+      const absPath = isAbsoluteOrHomePath(ref.path) ? ref.path : joinPaths(projectRoot, ref.path);
       allFilePaths.push(absPath);
     }
   }

--- a/src/renderer/utils/contextTracker.ts
+++ b/src/renderer/utils/contextTracker.ts
@@ -9,7 +9,11 @@
  * This builds on claudeMdTracker.ts and extends it to track all context sources.
  */
 
-import { normalizePathForComparison, stripTrailingSeparators } from '@shared/utils/platformPath';
+import {
+  isAbsoluteOrHomePath,
+  normalizePathForComparison,
+  stripTrailingSeparators,
+} from '@shared/utils/platformPath';
 import { estimateTokens } from '@shared/utils/tokenFormatting';
 
 import { MAX_MENTIONED_FILE_TOKENS } from '../types/contextInjection';
@@ -448,20 +452,6 @@ interface ComputeContextStatsParams {
 }
 
 /**
- * Helper to check if a path is absolute.
- */
-function isAbsolutePath(path: string): boolean {
-  return (
-    path.startsWith('/') ||
-    path.startsWith('~/') ||
-    path.startsWith('~\\') ||
-    path === '~' ||
-    path.startsWith('\\\\') ||
-    /^[a-zA-Z]:[\\/]/.test(path)
-  );
-}
-
-/**
  * Helper to join paths, handling various path formats properly.
  * Handles:
  * - Absolute paths: /full/path/file.tsx (returned as-is)
@@ -471,7 +461,7 @@ function isAbsolutePath(path: string): boolean {
  * - Paths with @ prefix: @apps/foo/bar.tsx (strips @ then joins)
  */
 function joinPaths(base: string, relative: string): string {
-  if (isAbsolutePath(relative)) {
+  if (isAbsoluteOrHomePath(relative)) {
     return relative;
   }
 
@@ -482,7 +472,7 @@ function joinPaths(base: string, relative: string): string {
   if (cleanRelative.startsWith('@')) {
     cleanRelative = cleanRelative.slice(1);
   }
-  if (isAbsolutePath(cleanRelative)) {
+  if (isAbsoluteOrHomePath(cleanRelative)) {
     return cleanRelative;
   }
 
@@ -679,7 +669,7 @@ function computeContextStats(params: ComputeContextStatsParams): ContextStats {
   const responseRefs = extractFileRefsFromResponses(aiGroup.responses);
   for (const ref of responseRefs) {
     if (ref.path) {
-      const absPath = isAbsolutePath(ref.path) ? ref.path : joinPaths(projectRoot, ref.path);
+      const absPath = isAbsoluteOrHomePath(ref.path) ? ref.path : joinPaths(projectRoot, ref.path);
       allFilePaths.push(absPath);
     }
   }
@@ -735,7 +725,7 @@ function computeContextStats(params: ComputeContextStatsParams): ContextStats {
       if (!fileRef.path) continue;
 
       // Convert to absolute path if needed
-      const absolutePath = isAbsolutePath(fileRef.path)
+      const absolutePath = isAbsoluteOrHomePath(fileRef.path)
         ? fileRef.path
         : joinPaths(projectRoot, fileRef.path);
 
@@ -768,7 +758,7 @@ function computeContextStats(params: ComputeContextStatsParams): ContextStats {
   for (const fileRef of responseRefs) {
     if (!fileRef.path) continue;
 
-    const absolutePath = isAbsolutePath(fileRef.path)
+    const absolutePath = isAbsoluteOrHomePath(fileRef.path)
       ? fileRef.path
       : joinPaths(projectRoot, fileRef.path);
 

--- a/src/shared/utils/platformPath.ts
+++ b/src/shared/utils/platformPath.ts
@@ -22,6 +22,18 @@ export function isWindowsishPath(filePath: string): boolean {
   return /^[A-Za-z]:\//.test(p) || p.startsWith('//');
 }
 
+/** True for filesystem-absolute paths and home-relative `~` paths. */
+export function isAbsoluteOrHomePath(filePath: string): boolean {
+  return (
+    filePath.startsWith('/') ||
+    filePath.startsWith('~/') ||
+    filePath.startsWith('~\\') ||
+    filePath === '~' ||
+    filePath.startsWith('\\\\') ||
+    /^[A-Za-z]:[\\/]/.test(filePath)
+  );
+}
+
 /**
  * Normalize for comparisons:
  * - Convert `\` → `/`

--- a/test/renderer/store/editorSlice.test.ts
+++ b/test/renderer/store/editorSlice.test.ts
@@ -295,6 +295,16 @@ describe('editorSlice', () => {
       expect(state.editorActiveTabId).toBe('/project/src/index.ts');
     });
 
+    it('deduplicates Windows tabs across drive case and separator differences', () => {
+      store.getState().openFile('C:\\Repo\\src\\index.ts');
+      store.getState().openFile('c:/repo/src/index.ts');
+
+      const state = store.getState();
+      expect(state.editorOpenTabs).toHaveLength(1);
+      expect(state.editorOpenTabs[0].filePath).toBe('C:\\Repo\\src\\index.ts');
+      expect(state.editorActiveTabId).toBe('C:\\Repo\\src\\index.ts');
+    });
+
     it('detects language from file extension', () => {
       store.getState().openFile('/project/data.json');
 
@@ -528,6 +538,31 @@ describe('editorSlice', () => {
 
       expect(store.getState().editorModifiedFiles).toEqual({ '/project/b.ts': true });
       expect(store.getState().editorSaveError).toEqual({});
+    });
+  });
+
+  describe('handleExternalFileChange', () => {
+    it('keys Windows watcher changes to the open tab path across separator differences', () => {
+      vi.useFakeTimers();
+      try {
+        store.getState().openFile('C:\\Repo\\src\\index.ts');
+
+        store.getState().handleExternalFileChange({
+          type: 'change',
+          path: 'c:/repo/src/index.ts',
+        });
+
+        expect(store.getState().editorExternalChanges).toEqual({
+          'C:\\Repo\\src\\index.ts': 'change',
+        });
+
+        store.getState().clearExternalChange('c:/repo/src/index.ts');
+
+        expect(store.getState().editorExternalChanges).toEqual({});
+      } finally {
+        vi.runOnlyPendingTimers();
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/test/shared/utils/platformPath.test.ts
+++ b/test/shared/utils/platformPath.test.ts
@@ -44,7 +44,9 @@ describe('platformPath Windows containment', () => {
     expect(isAbsoluteOrHomePath('/Users/Alice/Repo')).toBe(true);
     expect(isAbsoluteOrHomePath('C:\\Users\\Alice\\Repo')).toBe(true);
     expect(isAbsoluteOrHomePath('\\\\server\\share\\Repo')).toBe(true);
+    expect(isAbsoluteOrHomePath('~')).toBe(true);
     expect(isAbsoluteOrHomePath('~/Repo')).toBe(true);
+    expect(isAbsoluteOrHomePath('~\\Repo')).toBe(true);
     expect(isAbsoluteOrHomePath('src/app.ts')).toBe(false);
   });
 });

--- a/test/shared/utils/platformPath.test.ts
+++ b/test/shared/utils/platformPath.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { getRelativePathWithinPrefix, isPathPrefix } from '../../../src/shared/utils/platformPath';
+import {
+  getRelativePathWithinPrefix,
+  isAbsoluteOrHomePath,
+  isPathPrefix,
+} from '../../../src/shared/utils/platformPath';
 
 describe('platformPath Windows containment', () => {
   it('matches Windows drive paths case-insensitively and preserves child path style', () => {
@@ -34,5 +38,13 @@ describe('platformPath Windows containment', () => {
   it('does not treat an empty prefix as the root of absolute paths', () => {
     expect(isPathPrefix('', '/Users/Alice/Repo/src/app.ts')).toBe(false);
     expect(getRelativePathWithinPrefix('', '/Users/Alice/Repo/src/app.ts')).toBe(null);
+  });
+
+  it('detects absolute and home-relative paths across platforms', () => {
+    expect(isAbsoluteOrHomePath('/Users/Alice/Repo')).toBe(true);
+    expect(isAbsoluteOrHomePath('C:\\Users\\Alice\\Repo')).toBe(true);
+    expect(isAbsoluteOrHomePath('\\\\server\\share\\Repo')).toBe(true);
+    expect(isAbsoluteOrHomePath('~/Repo')).toBe(true);
+    expect(isAbsoluteOrHomePath('src/app.ts')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- centralize absolute/home path detection in shared platform path utilities
- remove duplicated local absolute-path helpers from Windows path handling code
- keep @-prefixed absolute, Windows drive, UNC and home paths passing through unchanged

## Tests
- corepack pnpm exec vitest run test/shared/utils/platformPath.test.ts test/renderer/store/pathResolution.test.ts test/renderer/utils/claudeMdTracker.test.ts test/renderer/utils/contextTracker.test.ts --maxWorkers 1 --minWorkers 1
- corepack pnpm exec eslint src/shared/utils/platformPath.ts src/renderer/store/utils/pathResolution.ts src/renderer/utils/claudeMdTracker.ts src/renderer/utils/contextTracker.ts test/shared/utils/platformPath.test.ts test/renderer/store/pathResolution.test.ts test/renderer/utils/claudeMdTracker.test.ts
- corepack pnpm typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Home-relative paths (e.g., ~/file) are preserved as rooted and no longer joined to project root.
  * Editor tabs and file selection now normalize equivalent paths (casing/separators) to avoid duplicate tabs and ensure correct selection/highlight and scroll-to-file behavior.
  * File-watcher external changes are matched by normalized paths so external edits/moves are correctly detected and cleared.

* **Tests**
  * Added tests covering absolute, home-relative, and normalization-based watcher/editor behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/777genius/agent-teams-ai/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->