### PR TITLE
fix(opencode): keep local MCP fallback with HTTP

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -69,7 +69,6 @@ import { CrossTeamService } from '@main/services/team/CrossTeamService';
 import { FileContentResolver } from '@main/services/team/FileContentResolver';
 import { GitDiffFallback } from '@main/services/team/GitDiffFallback';
 import {
-  clearOpenCodeLocalMcpLaunchEnv,
   copyOpenCodeLocalMcpLaunchEnv,
   hasOpenCodeLocalMcpLaunchEnv,
   isOpenCodeMcpHttpBridgeEnabled,
@@ -362,12 +361,7 @@ async function createOpenCodeRuntimeAdapterRegistry(
   bridgeEnv.AGENT_TEAMS_MCP_CLAUDE_DIR = getClaudeBasePath();
   const useHttpMcpBridge = isOpenCodeMcpHttpBridgeEnabled(bridgeEnv);
   const explicitLocalMcpLaunchEnv = snapshotOpenCodeLocalMcpLaunchEnv(bridgeEnv);
-  if (!useHttpMcpBridge) {
-    delete bridgeEnv.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL;
-  } else {
-    delete bridgeEnv.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL;
-    clearOpenCodeLocalMcpLaunchEnv(bridgeEnv);
-  }
+  delete bridgeEnv.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL;
   const applyMcpLaunchSpecEnv = async (
     targetEnv: NodeJS.ProcessEnv,
     options: { emitProgress?: boolean } = {}
@@ -447,7 +441,6 @@ async function createOpenCodeRuntimeAdapterRegistry(
       reportProgress('runtime-mcp-http', 'Starting Agent Teams MCP server...');
       const mcpHttpServer = await agentTeamsMcpHttpServer.ensureStarted();
       bridgeEnv.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL = mcpHttpServer.url;
-      clearOpenCodeLocalMcpLaunchEnv(bridgeEnv);
       reportProgress('runtime-mcp-http-ready', 'Agent Teams MCP server is ready...');
     } catch (error) {
       logger.warn(
@@ -457,7 +450,7 @@ async function createOpenCodeRuntimeAdapterRegistry(
       );
     }
   }
-  if (!bridgeEnv.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL) {
+  if (useHttpMcpBridge || !bridgeEnv.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL) {
     await ensureOpenCodeLocalMcpLaunchEnv(bridgeEnv, { emitProgress: true });
   }
 
@@ -471,12 +464,10 @@ async function createOpenCodeRuntimeAdapterRegistry(
       const mcpHttpServer = await agentTeamsMcpHttpServer.ensureStarted();
       bridgeEnv.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL = mcpHttpServer.url;
       nextEnv.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL = mcpHttpServer.url;
-      clearOpenCodeLocalMcpLaunchEnv(bridgeEnv);
-      clearOpenCodeLocalMcpLaunchEnv(nextEnv);
+      await ensureOpenCodeLocalMcpLaunchEnv(nextEnv);
     } catch (error) {
       delete bridgeEnv.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL;
       delete nextEnv.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL;
-      clearOpenCodeLocalMcpLaunchEnv(nextEnv);
       await ensureOpenCodeLocalMcpLaunchEnv(nextEnv);
       logger.warn(
         `[OpenCode] Runtime adapter bridge MCP HTTP server refresh failed: ${


### PR DESCRIPTION
## Summary
- keep resolving/passing local Agent Teams MCP command env while HTTP MCP is enabled
- pass URL and local fallback together so newer runtimes can prefer URL and runtime 0.0.33 still has COMMAND/ENTRY/ARGS_JSON for readiness
- stop clearing local MCP env after successful HTTP refresh

## Tests
- pnpm exec vitest run test/main/services/team/OpenCodeMcpBridgeEnv.test.ts test/main/services/team/OpenCodeBridgeCommandClient.test.ts test/main/services/team/AgentTeamsMcpHttpServer.test.ts --maxWorkers 1 --minWorkers 1
- pnpm exec eslint src/main/index.ts src/main/services/team/opencode/bridge/OpenCodeMcpBridgeEnv.ts src/main/services/team/opencode/bridge/OpenCodeBridgeCommandClient.ts test/main/services/team/OpenCodeMcpBridgeEnv.test.ts (passes with existing sonarjs/no-alphabetical-sort warnings in src/main/index.ts)

<!-- review-router-summary:start -->
## Summary

- updates createOpenCodeRuntimeAdapterRegistry: changes database query construction


<details>
<summary>📒 Files selected for processing (1)</summary>

* `src/main/index.ts`

</details>

<details>
<summary>📝 Walkthrough</summary>

## Walkthrough

This PR updates 1 file across 1 source. The generated summary is based on the GitHub pull request file list and diff metadata, and the author's description above is preserved.

## Changes

| Cohort / File(s) | Summary |
|---|---|
| **Source** <br> `src/main/index.ts` | Updates createOpenCodeRuntimeAdapterRegistry: changes database query construction.<br>Line stats: 1 modified; +3/-12. |

</details>
<!-- review-router-summary:end -->