### PR TITLE
fix(opencode): retry empty readiness bridge stdout

### DIFF
--- a/src/main/services/team/opencode/bridge/OpenCodeBridgeCommandClient.ts
+++ b/src/main/services/team/opencode/bridge/OpenCodeBridgeCommandClient.ts
@@ -58,6 +58,8 @@ export interface OpenCodeBridgeCommandClientOptions {
 const DEFAULT_STDOUT_LIMIT_BYTES = 1_000_000;
 const DEFAULT_STDERR_LIMIT_BYTES = 256_000;
 const WINDOWS_BATCH_EXTENSIONS = new Set(['.cmd', '.bat']);
+const EMPTY_STDOUT_READINESS_MAX_ATTEMPTS = 2;
+const EMPTY_STDOUT_READINESS_RETRY_DELAY_MS = 250;
 
 export function resolveOpenCodeBridgeProcessCwd(
   binaryPath: string,
@@ -162,54 +164,77 @@ export class OpenCodeBridgeCommandClient {
     const inputPath = await this.writeInputFile(envelope);
 
     try {
-      const processResult = await this.processRunner.run({
-        binaryPath: this.binaryPath,
-        args: ['runtime', 'opencode-command', '--json', '--input', inputPath],
-        cwd: resolveOpenCodeBridgeProcessCwd(this.binaryPath, options.cwd),
-        timeoutMs: options.timeoutMs,
-        stdoutLimitBytes: options.stdoutLimitBytes ?? DEFAULT_STDOUT_LIMIT_BYTES,
-        stderrLimitBytes: options.stderrLimitBytes ?? DEFAULT_STDERR_LIMIT_BYTES,
-        env: await this.resolveEnv(),
-      });
-
-      if (processResult.timedOut) {
-        return this.contractFailure(
-          envelope,
-          'timeout',
-          'OpenCode bridge command timed out',
-          true,
-          {
-            stderr: redactBridgeDiagnosticText(processResult.stderr),
-          }
-        );
-      }
-
-      if (processResult.exitCode !== 0) {
-        return this.contractFailure(
-          envelope,
-          'provider_error',
-          'OpenCode bridge command failed',
-          true,
-          {
-            exitCode: processResult.exitCode,
-            stderr: redactBridgeDiagnosticText(processResult.stderr),
-          }
-        );
-      }
-
-      const parsed = parseSingleBridgeJsonResult<TData>(processResult.stdout);
-      if (!parsed.ok) {
-        return this.contractFailure(envelope, 'contract_violation', parsed.error, false, {
-          stdoutPreview: redactBridgeDiagnosticText(processResult.stdout.slice(0, 2_000)),
+      const maxAttempts =
+        command === 'opencode.readiness' ? EMPTY_STDOUT_READINESS_MAX_ATTEMPTS : 1;
+      for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+        const processResult = await this.processRunner.run({
+          binaryPath: this.binaryPath,
+          args: ['runtime', 'opencode-command', '--json', '--input', inputPath],
+          cwd: resolveOpenCodeBridgeProcessCwd(this.binaryPath, options.cwd),
+          timeoutMs: options.timeoutMs,
+          stdoutLimitBytes: options.stdoutLimitBytes ?? DEFAULT_STDOUT_LIMIT_BYTES,
+          stderrLimitBytes: options.stderrLimitBytes ?? DEFAULT_STDERR_LIMIT_BYTES,
+          env: await this.resolveEnv(),
         });
+
+        if (processResult.timedOut) {
+          return this.contractFailure(
+            envelope,
+            'timeout',
+            'OpenCode bridge command timed out',
+            true,
+            {
+              stderr: redactBridgeDiagnosticText(processResult.stderr),
+              attempts: attempt,
+            }
+          );
+        }
+
+        if (processResult.exitCode !== 0) {
+          return this.contractFailure(
+            envelope,
+            'provider_error',
+            'OpenCode bridge command failed',
+            true,
+            {
+              exitCode: processResult.exitCode,
+              stderr: redactBridgeDiagnosticText(processResult.stderr),
+              attempts: attempt,
+            }
+          );
+        }
+
+        const parsed = parseSingleBridgeJsonResult<TData>(processResult.stdout);
+        if (!parsed.ok) {
+          if (shouldRetryEmptyReadinessStdout(command, parsed.error, attempt, maxAttempts)) {
+            await sleep(EMPTY_STDOUT_READINESS_RETRY_DELAY_MS);
+            continue;
+          }
+
+          return this.contractFailure(envelope, 'contract_violation', parsed.error, false, {
+            stdoutPreview: redactBridgeDiagnosticText(processResult.stdout.slice(0, 2_000)),
+            stderrPreview: redactBridgeDiagnosticText(processResult.stderr.slice(0, 2_000)),
+            attempts: attempt,
+          });
+        }
+
+        const validation = validateBridgeResultEnvelope(parsed.value, envelope);
+        if (!validation.ok) {
+          return this.contractFailure(envelope, 'contract_violation', validation.reason, false, {
+            attempts: attempt,
+          });
+        }
+
+        return parsed.value;
       }
 
-      const validation = validateBridgeResultEnvelope(parsed.value, envelope);
-      if (!validation.ok) {
-        return this.contractFailure(envelope, 'contract_violation', validation.reason, false, {});
-      }
-
-      return parsed.value;
+      return this.contractFailure(
+        envelope,
+        'contract_violation',
+        'Bridge stdout was empty after retry',
+        false,
+        { attempts: maxAttempts }
+      );
     } finally {
       if (!this.keepInputFile) {
         await fs.unlink(inputPath).catch(() => undefined);
@@ -283,6 +308,21 @@ export function redactBridgeDiagnosticText(value: string): string {
   return capped
     .replace(/(authorization:\s*bearer\s+)[^\s]+/gi, '$1[redacted]')
     .replace(/((?:api[_-]?key|token|password|secret)\s*[=:]\s*)[^\s"'`]+/gi, '$1[redacted]');
+}
+
+function shouldRetryEmptyReadinessStdout(
+  command: OpenCodeBridgeCommandName,
+  error: string,
+  attempt: number,
+  maxAttempts: number
+): boolean {
+  return (
+    command === 'opencode.readiness' && error === 'Bridge stdout was empty' && attempt < maxAttempts
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function bufferToString(value: string | Buffer | undefined): string {

--- a/test/main/services/team/OpenCodeBridgeCommandClient.test.ts
+++ b/test/main/services/team/OpenCodeBridgeCommandClient.test.ts
@@ -109,9 +109,9 @@ describe('OpenCodeBridgeCommandClient', () => {
         type: 'opencode_bridge_contract_violation',
         severity: 'error',
         runId: 'run-1',
-        data: {
+        data: expect.objectContaining({
           stdoutPreview: 'debug token=[redacted]\n{"ok":true}\n',
-        },
+        }),
       })
     );
   });
@@ -181,6 +181,81 @@ describe('OpenCodeBridgeCommandClient', () => {
         },
       },
     });
+  });
+
+  it('retries empty stdout once for readiness because it is read-only', async () => {
+    runner.nextResults = [
+      {
+        stdout: '',
+        stderr: '',
+        exitCode: 0,
+        timedOut: false,
+      },
+      {
+        stdout: `${JSON.stringify(
+          bridgeSuccess({
+            command: 'opencode.readiness',
+            data: { state: 'ready', launchAllowed: true },
+          })
+        )}\n`,
+        stderr: '',
+        exitCode: 0,
+        timedOut: false,
+      },
+    ];
+    const client = createClient();
+
+    const result = await client.execute(
+      'opencode.readiness',
+      { projectPath: '/tmp/project' },
+      {
+        cwd: '/tmp/project',
+        timeoutMs: 10_000,
+      }
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      requestId: 'req-1',
+      command: 'opencode.readiness',
+    });
+    expect(runner.calls).toHaveLength(2);
+  });
+
+  it('does not retry empty stdout for state-changing bridge commands', async () => {
+    runner.nextResults = [
+      {
+        stdout: '',
+        stderr: '',
+        exitCode: 0,
+        timedOut: false,
+      },
+      {
+        stdout: `${JSON.stringify(bridgeSuccess({ data: { runId: 'run-1' } }))}\n`,
+        stderr: '',
+        exitCode: 0,
+        timedOut: false,
+      },
+    ];
+    const client = createClient();
+
+    const result = await client.execute(
+      'opencode.launchTeam',
+      { runId: 'run-1' },
+      {
+        cwd: '/tmp/project',
+        timeoutMs: 10_000,
+      }
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        kind: 'contract_violation',
+        message: 'Bridge stdout was empty',
+      },
+    });
+    expect(runner.calls).toHaveLength(1);
   });
 
   it('rejects bridge result envelope mismatches before caller can mutate state', async () => {
@@ -373,6 +448,7 @@ function bridgeSuccess(
 class FakeBridgeProcessRunner implements OpenCodeBridgeProcessRunner {
   calls: OpenCodeBridgeProcessRunInput[] = [];
   inputEnvelopes: string[] = [];
+  nextResults: OpenCodeBridgeProcessRunResult[] = [];
   nextResult: OpenCodeBridgeProcessRunResult = {
     stdout: '',
     stderr: '',
@@ -383,7 +459,7 @@ class FakeBridgeProcessRunner implements OpenCodeBridgeProcessRunner {
   async run(input: OpenCodeBridgeProcessRunInput): Promise<OpenCodeBridgeProcessRunResult> {
     this.calls.push(input);
     this.inputEnvelopes.push(await fs.readFile(input.args[4], 'utf8'));
-    return this.nextResult;
+    return this.nextResults.shift() ?? this.nextResult;
   }
 
   async readInputEnvelope(index: number): Promise<string> {


### PR DESCRIPTION
## Summary
- retry `opencode.readiness` once when the bridge exits successfully with empty stdout
- keep state-changing OpenCode bridge commands single-shot
- include attempt count and stdout/stderr previews in bridge parse diagnostics
- add regression tests for read-only readiness retry and no retry for state-changing commands

## Companion
- Runtime fix: https://github.com/777genius/agent_teams_orchestrator/pull/13

## Verification
- `pnpm exec vitest run test/main/services/team/OpenCodeBridgeCommandClient.test.ts test/main/services/team/OpenCodeReadinessBridge.test.ts`
- `pnpm exec vitest run test/main/services/team/OpenCodeBridgeCommandClient.test.ts test/main/services/team/OpenCodeReadinessBridge.test.ts test/main/services/team/OpenCodeTeamLaunchReadiness.test.ts test/main/services/team/OpenCodeTeamRuntimeAdapter.test.ts test/main/services/team/OpenCodeStateChangingBridgeCommandService.test.ts test/main/services/team/OpenCodeBridgeCommandContract.test.ts`
- `pnpm exec prettier --check src/main/services/team/opencode/bridge/OpenCodeBridgeCommandClient.ts test/main/services/team/OpenCodeBridgeCommandClient.test.ts`
- `git diff --check`

## Notes
- `pnpm typecheck` still fails on the pre-existing unrelated missing `@radix-ui/react-presence` test dependency.
- The Windows compiled runtime E2E is covered by the companion runtime PR.

<!-- review-router-summary:start -->
## Summary

- update 1 test file
- updates resolveOpenCodeBridgeProcessCwd, OpenCodeBridgeCommandClient: changes fallback/null handling, return value handling
- updates test coverage for retries empty stdout once for readiness because it is read-..., does not retry empty stdout for state-changing bridge comma...
- touch 2 files (2 modified) with +160/-44 lines

## Tests

- changed test file: `test/main/services/team/OpenCodeBridgeCommandClient.test.ts`

<details>
<summary>📒 Files selected for processing (2)</summary>

* `src/main/services/team/opencode/bridge/OpenCodeBridgeCommandClient.ts`
* `test/main/services/team/OpenCodeBridgeCommandClient.test.ts`

</details>

<details>
<summary>📝 Walkthrough</summary>

## Walkthrough

This PR updates 2 files across 1 source, 1 tests. The generated summary is based on the GitHub pull request file list and diff metadata, and the author's description above is preserved.

## Changes

| Cohort / File(s) | Summary |
|---|---|
| **Source** <br> `src/main/services/team/opencode/bridge/OpenCodeBridgeCommandClient.ts` | Updates resolveOpenCodeBridgeProcessCwd, OpenCodeBridgeCommandClient: changes fallback/null handling, return value handling.<br>Line stats: 1 modified; +81/-41. |
| **Tests** <br> `test/main/services/team/OpenCodeBridgeCommandClient.test.ts` | Updates test coverage for retries empty stdout once for readiness because it is read-..., does not retry empty stdout for state-changing bridge comma....<br>Line stats: 1 modified; +79/-3. |

</details>
<!-- review-router-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bridge readiness commands now automatically retry once when output parsing encounters empty stdout errors.
  * Enhanced error messages to include retry attempt information for improved diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/777genius/agent-teams-ai/pull/131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->