### PR TITLE
fix(opencode): retry read-only bridge no-output

### DIFF
--- a/src/main/services/team/opencode/bridge/OpenCodeBridgeCommandClient.ts
+++ b/src/main/services/team/opencode/bridge/OpenCodeBridgeCommandClient.ts
@@ -66,9 +66,9 @@ export interface OpenCodeBridgeCommandClientOptions {
 const DEFAULT_STDOUT_LIMIT_BYTES = 1_000_000;
 const DEFAULT_STDERR_LIMIT_BYTES = 256_000;
 const WINDOWS_BATCH_EXTENSIONS = new Set(['.cmd', '.bat']);
-const EMPTY_STDOUT_READINESS_MAX_ATTEMPTS = 2;
-const EMPTY_STDOUT_READINESS_STDOUT_FALLBACK_ATTEMPTS = 1;
-const EMPTY_STDOUT_READINESS_RETRY_DELAY_MS = 250;
+const EMPTY_STDOUT_READ_ONLY_MAX_ATTEMPTS = 2;
+const EMPTY_STDOUT_READ_ONLY_STDOUT_FALLBACK_ATTEMPTS = 1;
+const EMPTY_STDOUT_READ_ONLY_RETRY_DELAY_MS = 250;
 const SAFE_BRIDGE_INPUT_FILE_REQUEST_ID = /^[A-Za-z0-9._-]{1,120}$/;
 
 export function resolveOpenCodeBridgeProcessCwd(
@@ -175,12 +175,11 @@ export class OpenCodeBridgeCommandClient {
     const outputPath = `${inputPath}.output.json`;
 
     try {
-      const maxAttempts =
-        command === 'opencode.readiness'
-          ? EMPTY_STDOUT_READINESS_MAX_ATTEMPTS + EMPTY_STDOUT_READINESS_STDOUT_FALLBACK_ATTEMPTS
-          : 1;
+      const maxAttempts = isReadOnlyRetryableBridgeCommand(command)
+        ? EMPTY_STDOUT_READ_ONLY_MAX_ATTEMPTS + EMPTY_STDOUT_READ_ONLY_STDOUT_FALLBACK_ATTEMPTS
+        : 1;
       for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-        const useStdoutOnlyFallback = shouldUseReadinessStdoutOnlyFallback(
+        const useStdoutOnlyFallback = shouldUseReadOnlyStdoutOnlyFallback(
           command,
           attempt,
           maxAttempts
@@ -239,8 +238,8 @@ export class OpenCodeBridgeCommandClient {
 
         const parsed = parseSingleBridgeJsonResult<TData>(bridgeOutput.content);
         if (!parsed.ok) {
-          if (shouldRetryEmptyReadinessStdout(command, parsed.error, attempt, maxAttempts)) {
-            await sleep(EMPTY_STDOUT_READINESS_RETRY_DELAY_MS);
+          if (shouldRetryEmptyReadOnlyStdout(command, parsed.error, attempt, maxAttempts)) {
+            await sleep(EMPTY_STDOUT_READ_ONLY_RETRY_DELAY_MS);
             continue;
           }
 
@@ -406,23 +405,33 @@ export function redactBridgeDiagnosticText(value: string): string {
     .replace(/((?:api[_-]?key|token|password|secret)\s*[=:]\s*)[^\s"'`]+/gi, '$1[redacted]');
 }
 
-function shouldRetryEmptyReadinessStdout(
+function shouldRetryEmptyReadOnlyStdout(
   command: OpenCodeBridgeCommandName,
   error: string,
   attempt: number,
   maxAttempts: number
 ): boolean {
   return (
-    command === 'opencode.readiness' && error === 'Bridge stdout was empty' && attempt < maxAttempts
+    isReadOnlyRetryableBridgeCommand(command) &&
+    error === 'Bridge stdout was empty' &&
+    attempt < maxAttempts
   );
 }
 
-function shouldUseReadinessStdoutOnlyFallback(
+function shouldUseReadOnlyStdoutOnlyFallback(
   command: OpenCodeBridgeCommandName,
   attempt: number,
   maxAttempts: number
 ): boolean {
-  return command === 'opencode.readiness' && attempt === maxAttempts && maxAttempts > 1;
+  return isReadOnlyRetryableBridgeCommand(command) && attempt === maxAttempts && maxAttempts > 1;
+}
+
+function isReadOnlyRetryableBridgeCommand(command: OpenCodeBridgeCommandName): boolean {
+  return (
+    command === 'opencode.handshake' ||
+    command === 'opencode.commandStatus' ||
+    command === 'opencode.readiness'
+  );
 }
 
 function sleep(ms: number): Promise<void> {

--- a/src/main/services/team/opencode/bridge/OpenCodeBridgeCommandClient.ts
+++ b/src/main/services/team/opencode/bridge/OpenCodeBridgeCommandClient.ts
@@ -67,6 +67,7 @@ const DEFAULT_STDOUT_LIMIT_BYTES = 1_000_000;
 const DEFAULT_STDERR_LIMIT_BYTES = 256_000;
 const WINDOWS_BATCH_EXTENSIONS = new Set(['.cmd', '.bat']);
 const EMPTY_STDOUT_READINESS_MAX_ATTEMPTS = 2;
+const EMPTY_STDOUT_READINESS_STDOUT_FALLBACK_ATTEMPTS = 1;
 const EMPTY_STDOUT_READINESS_RETRY_DELAY_MS = 250;
 const SAFE_BRIDGE_INPUT_FILE_REQUEST_ID = /^[A-Za-z0-9._-]{1,120}$/;
 
@@ -175,19 +176,22 @@ export class OpenCodeBridgeCommandClient {
 
     try {
       const maxAttempts =
-        command === 'opencode.readiness' ? EMPTY_STDOUT_READINESS_MAX_ATTEMPTS : 1;
+        command === 'opencode.readiness'
+          ? EMPTY_STDOUT_READINESS_MAX_ATTEMPTS + EMPTY_STDOUT_READINESS_STDOUT_FALLBACK_ATTEMPTS
+          : 1;
       for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+        const useStdoutOnlyFallback = shouldUseReadinessStdoutOnlyFallback(
+          command,
+          attempt,
+          maxAttempts
+        );
+        const bridgeArgs = ['runtime', 'opencode-command', '--json', '--input', inputPath];
+        if (!useStdoutOnlyFallback) {
+          bridgeArgs.push('--output', outputPath);
+        }
         const processResult = await this.processRunner.run({
           binaryPath: this.binaryPath,
-          args: [
-            'runtime',
-            'opencode-command',
-            '--json',
-            '--input',
-            inputPath,
-            '--output',
-            outputPath,
-          ],
+          args: bridgeArgs,
           cwd: resolveOpenCodeBridgeProcessCwd(this.binaryPath, options.cwd),
           timeoutMs: options.timeoutMs,
           stdoutLimitBytes: options.stdoutLimitBytes ?? DEFAULT_STDOUT_LIMIT_BYTES,
@@ -411,6 +415,14 @@ function shouldRetryEmptyReadinessStdout(
   return (
     command === 'opencode.readiness' && error === 'Bridge stdout was empty' && attempt < maxAttempts
   );
+}
+
+function shouldUseReadinessStdoutOnlyFallback(
+  command: OpenCodeBridgeCommandName,
+  attempt: number,
+  maxAttempts: number
+): boolean {
+  return command === 'opencode.readiness' && attempt === maxAttempts && maxAttempts > 1;
 }
 
 function sleep(ms: number): Promise<void> {

--- a/test/main/services/team/OpenCodeBridgeCommandClient.test.ts
+++ b/test/main/services/team/OpenCodeBridgeCommandClient.test.ts
@@ -346,10 +346,66 @@ describe('OpenCodeBridgeCommandClient', () => {
       command: 'opencode.readiness',
     });
     expect(runner.calls).toHaveLength(2);
+    expect(runner.calls[0].args).toContain('--output');
+    expect(runner.calls[1].args).toContain('--output');
+  });
+
+  it('falls back to stdout-only readiness when the output file contract returns no data', async () => {
+    runner.nextResults = [
+      {
+        stdout: '',
+        stderr: '',
+        exitCode: 0,
+        timedOut: false,
+      },
+      {
+        stdout: '',
+        stderr: '',
+        exitCode: 0,
+        timedOut: false,
+      },
+      {
+        stdout: `${JSON.stringify(
+          bridgeSuccess({
+            command: 'opencode.readiness',
+            data: { state: 'ready', launchAllowed: true },
+          })
+        )}\n`,
+        stderr: '',
+        exitCode: 0,
+        timedOut: false,
+      },
+    ];
+    const client = createClient();
+
+    const result = await client.execute(
+      'opencode.readiness',
+      { projectPath: '/tmp/project' },
+      {
+        cwd: '/tmp/project',
+        timeoutMs: 10_000,
+      }
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      requestId: 'req-1',
+      command: 'opencode.readiness',
+    });
+    expect(runner.calls).toHaveLength(3);
+    expect(runner.calls[0].args).toContain('--output');
+    expect(runner.calls[1].args).toContain('--output');
+    expect(runner.calls[2].args).not.toContain('--output');
   });
 
   it('keeps empty readiness stdout diagnostics after the retry is exhausted', async () => {
     runner.nextResults = [
+      {
+        stdout: '',
+        stderr: '',
+        exitCode: 0,
+        timedOut: false,
+      },
       {
         stdout: '',
         stderr: '',
@@ -380,7 +436,7 @@ describe('OpenCodeBridgeCommandClient', () => {
         kind: 'contract_violation',
         message: 'Bridge stdout was empty',
         details: {
-          attempts: 2,
+          attempts: 3,
           stdoutBytes: 0,
           stderrBytes: 0,
           outputSource: 'none',
@@ -389,7 +445,8 @@ describe('OpenCodeBridgeCommandClient', () => {
         },
       },
     });
-    expect(runner.calls).toHaveLength(2);
+    expect(runner.calls).toHaveLength(3);
+    expect(runner.calls[2].args).not.toContain('--output');
   });
 
   it('does not retry empty stdout for state-changing bridge commands', async () => {

--- a/test/main/services/team/OpenCodeBridgeCommandClient.test.ts
+++ b/test/main/services/team/OpenCodeBridgeCommandClient.test.ts
@@ -398,6 +398,54 @@ describe('OpenCodeBridgeCommandClient', () => {
     expect(runner.calls[2].args).not.toContain('--output');
   });
 
+  it('falls back to stdout-only handshake when the output file contract returns no data', async () => {
+    runner.nextResults = [
+      {
+        stdout: '',
+        stderr: '',
+        exitCode: 0,
+        timedOut: false,
+      },
+      {
+        stdout: '',
+        stderr: '',
+        exitCode: 0,
+        timedOut: false,
+      },
+      {
+        stdout: `${JSON.stringify(
+          bridgeSuccess({
+            command: 'opencode.handshake',
+            data: { acceptedCommands: ['opencode.launchTeam'] },
+          })
+        )}\n`,
+        stderr: '',
+        exitCode: 0,
+        timedOut: false,
+      },
+    ];
+    const client = createClient();
+
+    const result = await client.execute(
+      'opencode.handshake',
+      { requiredCommand: 'opencode.launchTeam' },
+      {
+        cwd: '/tmp/project',
+        timeoutMs: 10_000,
+      }
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      requestId: 'req-1',
+      command: 'opencode.handshake',
+    });
+    expect(runner.calls).toHaveLength(3);
+    expect(runner.calls[0].args).toContain('--output');
+    expect(runner.calls[1].args).toContain('--output');
+    expect(runner.calls[2].args).not.toContain('--output');
+  });
+
   it('keeps empty readiness stdout diagnostics after the retry is exhausted', async () => {
     runner.nextResults = [
       {


### PR DESCRIPTION
## Summary
- add read-only bridge no-output retries for `opencode.handshake`, `opencode.readiness`, and `opencode.commandStatus`
- keep the final retry stdout-only when the output-file bridge contract returns no data
- keep state-changing commands fail-closed without retry to avoid duplicate launch/message side effects

## Tests
- `pnpm test -- test/main/services/team/OpenCodeBridgeCommandClient.test.ts`
- `pnpm lint:fast:files -- src/main/services/team/opencode/bridge/OpenCodeBridgeCommandClient.ts test/main/services/team/OpenCodeBridgeCommandClient.test.ts`
- `pnpm typecheck`
- manual `OpenCodeBridgeCommandClient` readiness check with app-managed OpenCode `1.14.48`: `ok:true`, `state:"ready"`, `launchAllowed:true`
- manual `OpenCodeBridgeCommandClient` handshake check with `opencode.launchTeam`: `ok:true`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Generalized and strengthened retry behavior for bridge read-only commands: added an extra fallback attempt that relies on stdout-only when standard output retrieval fails, increasing robustness and reducing intermittent failures during command communication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/777genius/agent-teams-ai/pull/154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->