### PR TITLE
fix(opencode): recover empty bridge output sends

### DIFF
--- a/src/main/services/team/opencode/bridge/OpenCodeBridgeCommandClient.ts
+++ b/src/main/services/team/opencode/bridge/OpenCodeBridgeCommandClient.ts
@@ -89,6 +89,22 @@ export function resolveOpenCodeBridgeProcessCwd(
   return launcherDirectory && launcherDirectory !== '.' ? launcherDirectory : requestedCwd;
 }
 
+function shouldPreferShellForOpenCodeBridgeCommand(
+  binaryPath: string,
+  args: string[],
+  platform: NodeJS.Platform = process.platform
+): boolean {
+  if (platform !== 'win32') {
+    return false;
+  }
+  const extension = path.win32.extname(binaryPath).toLowerCase();
+  return (
+    WINDOWS_BATCH_EXTENSIONS.has(extension) &&
+    args[0] === 'runtime' &&
+    args[1] === 'opencode-command'
+  );
+}
+
 export class ExecCliOpenCodeBridgeProcessRunner implements OpenCodeBridgeProcessRunner {
   async run(input: OpenCodeBridgeProcessRunInput): Promise<OpenCodeBridgeProcessRunResult> {
     try {
@@ -97,6 +113,10 @@ export class ExecCliOpenCodeBridgeProcessRunner implements OpenCodeBridgeProcess
         timeout: input.timeoutMs,
         maxBuffer: input.stdoutLimitBytes + input.stderrLimitBytes,
         env: input.env,
+        preferShellForWindowsBatch: shouldPreferShellForOpenCodeBridgeCommand(
+          input.binaryPath,
+          input.args
+        ),
       });
       return {
         stdout: result.stdout,

--- a/src/main/services/team/opencode/bridge/OpenCodeBridgeCommandClient.ts
+++ b/src/main/services/team/opencode/bridge/OpenCodeBridgeCommandClient.ts
@@ -66,9 +66,9 @@ export interface OpenCodeBridgeCommandClientOptions {
 const DEFAULT_STDOUT_LIMIT_BYTES = 1_000_000;
 const DEFAULT_STDERR_LIMIT_BYTES = 256_000;
 const WINDOWS_BATCH_EXTENSIONS = new Set(['.cmd', '.bat']);
-const EMPTY_STDOUT_READINESS_MAX_ATTEMPTS = 2;
-const EMPTY_STDOUT_READINESS_STDOUT_FALLBACK_ATTEMPTS = 1;
-const EMPTY_STDOUT_READINESS_RETRY_DELAY_MS = 250;
+const EMPTY_STDOUT_READ_ONLY_MAX_ATTEMPTS = 2;
+const EMPTY_STDOUT_READ_ONLY_STDOUT_FALLBACK_ATTEMPTS = 1;
+const EMPTY_STDOUT_READ_ONLY_RETRY_DELAY_MS = 250;
 const SAFE_BRIDGE_INPUT_FILE_REQUEST_ID = /^[A-Za-z0-9._-]{1,120}$/;
 
 export function resolveOpenCodeBridgeProcessCwd(
@@ -175,12 +175,11 @@ export class OpenCodeBridgeCommandClient {
     const outputPath = `${inputPath}.output.json`;
 
     try {
-      const maxAttempts =
-        command === 'opencode.readiness'
-          ? EMPTY_STDOUT_READINESS_MAX_ATTEMPTS + EMPTY_STDOUT_READINESS_STDOUT_FALLBACK_ATTEMPTS
-          : 1;
+      const maxAttempts = isReadOnlyRetryableBridgeCommand(command)
+        ? EMPTY_STDOUT_READ_ONLY_MAX_ATTEMPTS + EMPTY_STDOUT_READ_ONLY_STDOUT_FALLBACK_ATTEMPTS
+        : 1;
       for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-        const useStdoutOnlyFallback = shouldUseReadinessStdoutOnlyFallback(
+        const useStdoutOnlyFallback = shouldUseReadOnlyStdoutOnlyFallback(
           command,
           attempt,
           maxAttempts
@@ -239,8 +238,8 @@ export class OpenCodeBridgeCommandClient {
 
         const parsed = parseSingleBridgeJsonResult<TData>(bridgeOutput.content);
         if (!parsed.ok) {
-          if (shouldRetryEmptyReadinessStdout(command, parsed.error, attempt, maxAttempts)) {
-            await sleep(EMPTY_STDOUT_READINESS_RETRY_DELAY_MS);
+          if (shouldRetryEmptyReadOnlyStdout(command, parsed.error, attempt, maxAttempts)) {
+            await sleep(EMPTY_STDOUT_READ_ONLY_RETRY_DELAY_MS);
             continue;
           }
 
@@ -406,23 +405,33 @@ export function redactBridgeDiagnosticText(value: string): string {
     .replace(/((?:api[_-]?key|token|password|secret)\s*[=:]\s*)[^\s"'`]+/gi, '$1[redacted]');
 }
 
-function shouldRetryEmptyReadinessStdout(
+function shouldRetryEmptyReadOnlyStdout(
   command: OpenCodeBridgeCommandName,
   error: string,
   attempt: number,
   maxAttempts: number
 ): boolean {
   return (
-    command === 'opencode.readiness' && error === 'Bridge stdout was empty' && attempt < maxAttempts
+    isReadOnlyRetryableBridgeCommand(command) &&
+    error === 'Bridge stdout was empty' &&
+    attempt < maxAttempts
   );
 }
 
-function shouldUseReadinessStdoutOnlyFallback(
+function shouldUseReadOnlyStdoutOnlyFallback(
   command: OpenCodeBridgeCommandName,
   attempt: number,
   maxAttempts: number
 ): boolean {
-  return command === 'opencode.readiness' && attempt === maxAttempts && maxAttempts > 1;
+  return isReadOnlyRetryableBridgeCommand(command) && attempt === maxAttempts && maxAttempts > 1;
+}
+
+function isReadOnlyRetryableBridgeCommand(command: OpenCodeBridgeCommandName): boolean {
+  return (
+    command === 'opencode.handshake' ||
+    command === 'opencode.commandStatus' ||
+    command === 'opencode.readiness'
+  );
 }
 
 function sleep(ms: number): Promise<void> {

--- a/src/main/services/team/opencode/bridge/OpenCodeBridgeCommandClient.ts
+++ b/src/main/services/team/opencode/bridge/OpenCodeBridgeCommandClient.ts
@@ -67,6 +67,7 @@ const DEFAULT_STDOUT_LIMIT_BYTES = 1_000_000;
 const DEFAULT_STDERR_LIMIT_BYTES = 256_000;
 const WINDOWS_BATCH_EXTENSIONS = new Set(['.cmd', '.bat']);
 const EMPTY_STDOUT_READINESS_MAX_ATTEMPTS = 2;
+const EMPTY_STDOUT_READINESS_STDOUT_FALLBACK_ATTEMPTS = 1;
 const EMPTY_STDOUT_READINESS_RETRY_DELAY_MS = 250;
 const SAFE_BRIDGE_INPUT_FILE_REQUEST_ID = /^[A-Za-z0-9._-]{1,120}$/;
 
@@ -175,19 +176,22 @@ export class OpenCodeBridgeCommandClient {
 
     try {
       const maxAttempts =
-        command === 'opencode.readiness' ? EMPTY_STDOUT_READINESS_MAX_ATTEMPTS : 1;
+        command === 'opencode.readiness'
+          ? EMPTY_STDOUT_READINESS_MAX_ATTEMPTS + EMPTY_STDOUT_READINESS_STDOUT_FALLBACK_ATTEMPTS
+          : 1;
       for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+        const useStdoutOnlyFallback = shouldUseReadinessStdoutOnlyFallback(
+          command,
+          attempt,
+          maxAttempts
+        );
+        const bridgeArgs = ['runtime', 'opencode-command', '--json', '--input', inputPath];
+        if (!useStdoutOnlyFallback) {
+          bridgeArgs.push('--output', outputPath);
+        }
         const processResult = await this.processRunner.run({
           binaryPath: this.binaryPath,
-          args: [
-            'runtime',
-            'opencode-command',
-            '--json',
-            '--input',
-            inputPath,
-            '--output',
-            outputPath,
-          ],
+          args: bridgeArgs,
           cwd: resolveOpenCodeBridgeProcessCwd(this.binaryPath, options.cwd),
           timeoutMs: options.timeoutMs,
           stdoutLimitBytes: options.stdoutLimitBytes ?? DEFAULT_STDOUT_LIMIT_BYTES,
@@ -411,6 +415,14 @@ function shouldRetryEmptyReadinessStdout(
   return (
     command === 'opencode.readiness' && error === 'Bridge stdout was empty' && attempt < maxAttempts
   );
+}
+
+function shouldUseReadinessStdoutOnlyFallback(
+  command: OpenCodeBridgeCommandName,
+  attempt: number,
+  maxAttempts: number
+): boolean {
+  return command === 'opencode.readiness' && attempt === maxAttempts && maxAttempts > 1;
 }
 
 function sleep(ms: number): Promise<void> {

--- a/src/main/services/team/opencode/bridge/OpenCodeReadinessBridge.ts
+++ b/src/main/services/team/opencode/bridge/OpenCodeReadinessBridge.ts
@@ -96,6 +96,15 @@ function buildSendPayloadHash(input: OpenCodeSendMessageCommandBody): string {
   return stableHash(hashable);
 }
 
+function isOpenCodeBridgeEmptyOutputFailure(result: OpenCodeBridgeResult<unknown>): boolean {
+  return (
+    !result.ok &&
+    result.error.kind === 'contract_violation' &&
+    (result.error.message === 'Bridge stdout was empty' ||
+      result.error.message === 'Bridge stdout was empty after retry')
+  );
+}
+
 export class OpenCodeReadinessBridge implements OpenCodeTeamRuntimeBridgePort {
   private readonly lastRuntimeSnapshotsByProjectPath = new Map<
     string,
@@ -384,12 +393,17 @@ export class OpenCodeReadinessBridge implements OpenCodeTeamRuntimeBridgePort {
         ? withOpenCodeObservedFallbackDiagnostic(result.data)
         : result.data;
     }
-    if (result.error.kind === 'timeout') {
+    if (result.error.kind === 'timeout' || isOpenCodeBridgeEmptyOutputFailure(result)) {
+      const recoveredAfterEmptyOutput = isOpenCodeBridgeEmptyOutputFailure(result);
       const recovered = await this.recoverSendMessageOutcome({
         originalRequestId: activeRequestId,
         body: activeBody,
-        diagnosticCode: 'opencode_send_recovered_after_bridge_timeout',
-        diagnosticMessage: 'OpenCode bridge outcome recovered after timeout.',
+        diagnosticCode: recoveredAfterEmptyOutput
+          ? 'opencode_send_recovered_after_bridge_empty_output'
+          : 'opencode_send_recovered_after_bridge_timeout',
+        diagnosticMessage: recoveredAfterEmptyOutput
+          ? 'OpenCode bridge outcome recovered after empty bridge output.'
+          : 'OpenCode bridge outcome recovered after timeout.',
       });
       if (recovered) {
         return usedObservedFallback ? withOpenCodeObservedFallbackDiagnostic(recovered) : recovered;

--- a/src/main/services/team/opencode/bridge/OpenCodeStateChangingBridgeCommandService.ts
+++ b/src/main/services/team/opencode/bridge/OpenCodeStateChangingBridgeCommandService.ts
@@ -209,7 +209,7 @@ export class OpenCodeStateChangingBridgeCommandService {
       );
 
       if (!result.ok) {
-        if (result.error.kind === 'timeout') {
+        if (isOpenCodeBridgeUnknownOutcomeFailure(result)) {
           await this.ledger.markUnknownAfterTimeout({
             idempotencyKey,
             error: result.error.message,
@@ -331,7 +331,9 @@ export class OpenCodeStateChangingBridgeCommandService {
           }),
       runId: input.runId ?? extractRunId(input.result) ?? undefined,
       severity: 'warning',
-      message: 'OpenCode bridge command timed out; outcome must be reconciled before retry',
+      message: isOpenCodeBridgeEmptyOutputFailure(input.result)
+        ? 'OpenCode bridge command exited without output; outcome must be reconciled before retry'
+        : 'OpenCode bridge command timed out; outcome must be reconciled before retry',
       createdAt: completedAt,
     });
   }
@@ -391,6 +393,21 @@ function stringifyError(error: unknown): string {
 
 function isActiveOpenCodeBridgeCommandLeaseError(error: OpenCodeBridgeCommandLeaseError): boolean {
   return error.message.startsWith('OpenCode bridge command lease already active:');
+}
+
+function isOpenCodeBridgeUnknownOutcomeFailure(result: OpenCodeBridgeResult<unknown>): boolean {
+  return (
+    !result.ok && (result.error.kind === 'timeout' || isOpenCodeBridgeEmptyOutputFailure(result))
+  );
+}
+
+function isOpenCodeBridgeEmptyOutputFailure(result: OpenCodeBridgeResult<unknown>): boolean {
+  return (
+    !result.ok &&
+    result.error.kind === 'contract_violation' &&
+    (result.error.message === 'Bridge stdout was empty' ||
+      result.error.message === 'Bridge stdout was empty after retry')
+  );
 }
 
 function sleep(delayMs: number): Promise<void> {

--- a/src/main/utils/childProcess.ts
+++ b/src/main/utils/childProcess.ts
@@ -355,10 +355,18 @@ function withCliProcessDefaults<
  * The return value matches the shape of Node's `execFile` promise: an
  * object with `stdout` and `stderr` strings.
  */
+export interface ExecCliOptions extends ExecFileOptions {
+  /**
+   * Some generated Windows launchers are safe to run directly, but callers can
+   * force the .cmd/.bat path when they need the launcher environment exactly.
+   */
+  preferShellForWindowsBatch?: boolean;
+}
+
 export async function execCli(
   binaryPath: string | null,
   args: string[],
-  options: ExecFileOptions = {}
+  options: ExecCliOptions = {}
 ): Promise<{ stdout: string; stderr: string }> {
   if (!binaryPath) {
     throw new Error(
@@ -366,8 +374,12 @@ export async function execCli(
     );
   }
   const target = binaryPath;
-  const opts = withCliProcessDefaults(options);
-  const directLauncher = resolveDirectWindowsLauncher(target);
+  const { preferShellForWindowsBatch = false, ...execOptions } = options;
+  const opts = withCliProcessDefaults(execOptions);
+  const directLauncher =
+    preferShellForWindowsBatch && isWindowsBatchLauncher(target)
+      ? null
+      : resolveDirectWindowsLauncher(target);
   if (directLauncher) {
     const result = await execFileAsync(
       directLauncher.command,

--- a/test/main/services/team/OpenCodeBridgeCommandClient.test.ts
+++ b/test/main/services/team/OpenCodeBridgeCommandClient.test.ts
@@ -346,10 +346,66 @@ describe('OpenCodeBridgeCommandClient', () => {
       command: 'opencode.readiness',
     });
     expect(runner.calls).toHaveLength(2);
+    expect(runner.calls[0].args).toContain('--output');
+    expect(runner.calls[1].args).toContain('--output');
+  });
+
+  it('falls back to stdout-only readiness when the output file contract returns no data', async () => {
+    runner.nextResults = [
+      {
+        stdout: '',
+        stderr: '',
+        exitCode: 0,
+        timedOut: false,
+      },
+      {
+        stdout: '',
+        stderr: '',
+        exitCode: 0,
+        timedOut: false,
+      },
+      {
+        stdout: `${JSON.stringify(
+          bridgeSuccess({
+            command: 'opencode.readiness',
+            data: { state: 'ready', launchAllowed: true },
+          })
+        )}\n`,
+        stderr: '',
+        exitCode: 0,
+        timedOut: false,
+      },
+    ];
+    const client = createClient();
+
+    const result = await client.execute(
+      'opencode.readiness',
+      { projectPath: '/tmp/project' },
+      {
+        cwd: '/tmp/project',
+        timeoutMs: 10_000,
+      }
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      requestId: 'req-1',
+      command: 'opencode.readiness',
+    });
+    expect(runner.calls).toHaveLength(3);
+    expect(runner.calls[0].args).toContain('--output');
+    expect(runner.calls[1].args).toContain('--output');
+    expect(runner.calls[2].args).not.toContain('--output');
   });
 
   it('keeps empty readiness stdout diagnostics after the retry is exhausted', async () => {
     runner.nextResults = [
+      {
+        stdout: '',
+        stderr: '',
+        exitCode: 0,
+        timedOut: false,
+      },
       {
         stdout: '',
         stderr: '',
@@ -380,7 +436,7 @@ describe('OpenCodeBridgeCommandClient', () => {
         kind: 'contract_violation',
         message: 'Bridge stdout was empty',
         details: {
-          attempts: 2,
+          attempts: 3,
           stdoutBytes: 0,
           stderrBytes: 0,
           outputSource: 'none',
@@ -389,7 +445,8 @@ describe('OpenCodeBridgeCommandClient', () => {
         },
       },
     });
-    expect(runner.calls).toHaveLength(2);
+    expect(runner.calls).toHaveLength(3);
+    expect(runner.calls[2].args).not.toContain('--output');
   });
 
   it('does not retry empty stdout for state-changing bridge commands', async () => {

--- a/test/main/services/team/OpenCodeBridgeCommandClient.test.ts
+++ b/test/main/services/team/OpenCodeBridgeCommandClient.test.ts
@@ -398,6 +398,54 @@ describe('OpenCodeBridgeCommandClient', () => {
     expect(runner.calls[2].args).not.toContain('--output');
   });
 
+  it('falls back to stdout-only handshake when the output file contract returns no data', async () => {
+    runner.nextResults = [
+      {
+        stdout: '',
+        stderr: '',
+        exitCode: 0,
+        timedOut: false,
+      },
+      {
+        stdout: '',
+        stderr: '',
+        exitCode: 0,
+        timedOut: false,
+      },
+      {
+        stdout: `${JSON.stringify(
+          bridgeSuccess({
+            command: 'opencode.handshake',
+            data: { acceptedCommands: ['opencode.launchTeam'] },
+          })
+        )}\n`,
+        stderr: '',
+        exitCode: 0,
+        timedOut: false,
+      },
+    ];
+    const client = createClient();
+
+    const result = await client.execute(
+      'opencode.handshake',
+      { requiredCommand: 'opencode.launchTeam' },
+      {
+        cwd: '/tmp/project',
+        timeoutMs: 10_000,
+      }
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      requestId: 'req-1',
+      command: 'opencode.handshake',
+    });
+    expect(runner.calls).toHaveLength(3);
+    expect(runner.calls[0].args).toContain('--output');
+    expect(runner.calls[1].args).toContain('--output');
+    expect(runner.calls[2].args).not.toContain('--output');
+  });
+
   it('keeps empty readiness stdout diagnostics after the retry is exhausted', async () => {
     runner.nextResults = [
       {

--- a/test/main/services/team/OpenCodeReadinessBridge.test.ts
+++ b/test/main/services/team/OpenCodeReadinessBridge.test.ts
@@ -585,6 +585,75 @@ describe('OpenCodeReadinessBridge', () => {
     ]);
   });
 
+  it('recovers accepted OpenCode sendMessage after empty bridge output through commandStatus', async () => {
+    const executor = fakeSequenceExecutor([
+      bridgeFailure('contract_violation', 'Bridge stdout was empty', [
+        {
+          id: 'diag-empty-output',
+          type: 'opencode_bridge_contract_violation',
+          providerId: 'opencode',
+          severity: 'error',
+          message: 'Bridge stdout was empty',
+          data: {
+            command: 'opencode.sendMessage',
+            outputSource: 'none',
+            outputReadError: 'ENOENT',
+          },
+          createdAt: '2026-04-21T12:00:00.000Z',
+        },
+      ]),
+      bridgeCommandSuccess({
+        command: 'opencode.commandStatus',
+        requestId: 'status-req-empty-output',
+        data: {
+          status: 'prompt_accepted',
+          safeToRetry: false,
+          accepted: true,
+          sessionId: 'session-bob',
+          runtimePromptMessageId: 'msg_prompt_1',
+          diagnostics: ['OpenCode prompt acceptance recovered from command status.'],
+        },
+      }),
+    ]);
+    const bridge = new OpenCodeReadinessBridge(executor);
+
+    await expect(
+      bridge.sendOpenCodeTeamMessage({
+        teamId: 'team-a',
+        teamName: 'team-a',
+        laneId: 'secondary:opencode:bob',
+        projectPath: '/repo',
+        memberName: 'bob',
+        text: 'hello',
+        messageId: 'message-1',
+        deliveryAttemptId: 'ledger-1:1:payload',
+      })
+    ).resolves.toMatchObject({
+      accepted: true,
+      sessionId: 'session-bob',
+      diagnostics: expect.arrayContaining([
+        expect.objectContaining({
+          code: 'opencode_send_recovered_after_bridge_empty_output',
+        }),
+      ]),
+    });
+
+    expect(executor.execute).toHaveBeenCalledTimes(2);
+    expect(executor.execute.mock.calls[1]).toEqual([
+      'opencode.commandStatus',
+      expect.objectContaining({
+        originalCommand: 'opencode.sendMessage',
+        originalRequestId: 'req-1',
+        deliveryAttemptId: 'ledger-1:1:payload',
+        payloadHash: expect.any(String),
+      }),
+      {
+        cwd: '/repo',
+        timeoutMs: 5_000,
+      },
+    ]);
+  });
+
   it('does not query commandStatus for non-timeout OpenCode sendMessage failures', async () => {
     const executor = fakeExecutor(bridgeFailure('provider_error', 'OpenCode send failed', []));
     const bridge = new OpenCodeReadinessBridge(executor);

--- a/test/main/services/team/OpenCodeStateChangingBridgeCommandService.test.ts
+++ b/test/main/services/team/OpenCodeStateChangingBridgeCommandService.test.ts
@@ -299,6 +299,50 @@ describe('OpenCodeStateChangingBridgeCommandService', () => {
     await expect(leaseStore.getActive('team-a')).resolves.toBeNull();
   });
 
+  it('records empty bridge output as unknown outcome and blocks duplicate retry', async () => {
+    bridge.resultFactory = ({ body, command, options }) => ({
+      ok: false,
+      schemaVersion: 1,
+      requestId: options.requestId,
+      command,
+      completedAt: '2026-04-21T12:00:10.000Z',
+      durationMs: 100,
+      error: {
+        kind: 'contract_violation',
+        message: 'Bridge stdout was empty',
+        retryable: false,
+      },
+      diagnostics: [],
+      data: body,
+    } as OpenCodeBridgeResult<unknown>);
+    const service = createService();
+
+    const first = await service.execute(buildLaunchInput());
+
+    expect(first).toMatchObject({
+      ok: false,
+      error: { kind: 'contract_violation' },
+    });
+    const idempotencyKey = bridge.calls[0].body.preconditions.idempotencyKey;
+    await expect(ledger.getByIdempotencyKey(idempotencyKey)).resolves.toMatchObject({
+      status: 'unknown_after_timeout',
+      retryable: false,
+      lastError: 'Bridge stdout was empty',
+    });
+    expect(diagnostics.append).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'opencode_bridge_unknown_outcome',
+        message: 'OpenCode bridge command exited without output; outcome must be reconciled before retry',
+      })
+    );
+
+    await expect(service.execute(buildLaunchInput())).rejects.toThrow(
+      'OpenCode bridge command outcome must be reconciled before retry'
+    );
+    expect(bridge.calls).toHaveLength(1);
+    await expect(leaseStore.getActive('team-a')).resolves.toBeNull();
+  });
+
   it('marks result precondition mismatch as failed and does not leave active lease', async () => {
     bridge.resultFactory = ({ body, options }) =>
       bridgeSuccess({

--- a/test/main/utils/childProcess.test.ts
+++ b/test/main/utils/childProcess.test.ts
@@ -425,6 +425,29 @@ describe('cli child process helpers', () => {
       }
     });
 
+    it('can force generated Bun cmd launchers through shell', async () => {
+      setPlatform('win32');
+      const execFileMock = child.execFile as unknown as Mock;
+      const execMock = child.exec as unknown as Mock;
+      execMock.mockImplementation((_cmd: string, _opts: unknown, cb: ExecCallback) => {
+        cb(null, 'ok', '');
+        return createMockProcess<ExecChild>();
+      });
+      const { dir, launcher } = createGeneratedBunLauncher();
+      try {
+        const result = await execCli(launcher, ['runtime', 'opencode-command'], {
+          preferShellForWindowsBatch: true,
+        });
+        expect(execFileMock).not.toHaveBeenCalled();
+        expect(execMock).toHaveBeenCalledTimes(1);
+        expect(execMock.mock.calls[0][0]).toContain('runtime');
+        expect(execMock.mock.calls[0][0]).toContain('opencode-command');
+        expect(result.stdout).toBe('ok');
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
     it('executes extensionless npm node cmd launchers directly', async () => {
       setPlatform('win32');
       const execFileMock = child.execFile as unknown as Mock;


### PR DESCRIPTION
## Summary
- Force OpenCode bridge `runtime opencode-command` Windows batch launchers through the launcher shell path
- Recover accepted `sendMessage` outcomes from `commandStatus` when bridge output is empty
- Treat empty output from guarded state-changing bridge commands as unknown outcome instead of terminal failure

## Tests
- `pnpm exec vitest run test/main/utils/childProcess.test.ts test/main/services/team/OpenCodeReadinessBridge.test.ts test/main/services/team/OpenCodeStateChangingBridgeCommandService.test.ts test/main/services/team/OpenCodeBridgeCommandClient.test.ts --maxWorkers 1 --minWorkers 1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows-specific shell execution preference for batch launcher binaries.
  * Implemented read-only stdout fallback handling when output files are unavailable.
  * Enhanced retry strategy with improved empty-output detection and recovery.

* **Bug Fixes**
  * Improved OpenCode bridge recovery from empty stdout and timeout failures.
  * Enhanced error diagnostics to differentiate between timeout and empty-output failures.

* **Tests**
  * Added comprehensive test coverage for bridge recovery and empty-output scenarios.
  * Extended tests for Windows batch execution and retry behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/777genius/agent-teams-ai/pull/155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->