### PR TITLE
fix: pin ReviewRouter node24 action

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth review
         id: run_codex
-        uses: 777genius/review-router@51a487bbb7d2afaf335336a74b81bdee8d6aed5c
+        uses: 777genius/review-router@00b1e337751b9ab8e4ebe01ee9068570e9b5acec
         with:
           mode: codex-oauth-rotating
           api-url: "https://api.reviewrouter.site"

--- a/.github/workflows/reviewrouter-interaction.yml
+++ b/.github/workflows/reviewrouter-interaction.yml
@@ -21,7 +21,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || ((github.event_name != 'issue_comment' || github.event.issue.pull_request) && github.event.comment.user.type != 'Bot') }}
     env:
       REVIEWROUTER_API_URL: "https://api.reviewrouter.site"
-      REVIEWROUTER_ACTION_VERSION: "51a487bbb7d2afaf335336a74b81bdee8d6aed5c"
+      REVIEWROUTER_ACTION_VERSION: "00b1e337751b9ab8e4ebe01ee9068570e9b5acec"
       REVIEWROUTER_OIDC_AUDIENCE: "reviewrouter"
       REVIEWROUTER_RUNTIME_CONFIG_MODE: "oidc"
       REVIEWROUTER_STATIC_CONFIG_FALLBACK: "true"
@@ -42,7 +42,7 @@ jobs:
 
       - name: Preflight ReviewRouter interaction
         id: preflight
-        uses: 777genius/review-router@51a487bbb7d2afaf335336a74b81bdee8d6aed5c
+        uses: 777genius/review-router@00b1e337751b9ab8e4ebe01ee9068570e9b5acec
         env:
           GITHUB_TOKEN: ${{ github.token }}
           REVIEW_ROUTER_MODE: "interaction-preflight"
@@ -78,7 +78,7 @@ jobs:
 
       - name: Run ReviewRouter interaction
         if: ${{ steps.preflight.outputs.should_run == 'true' }}
-        uses: 777genius/review-router@51a487bbb7d2afaf335336a74b81bdee8d6aed5c
+        uses: 777genius/review-router@00b1e337751b9ab8e4ebe01ee9068570e9b5acec
         env:
           GITHUB_TOKEN: ${{ github.token }}
           REVIEW_ROUTER_MODE: "interaction"


### PR DESCRIPTION
Updates the ReviewRouter workflows to the production action SHA that declares the JavaScript runtime as Node 24.\n\nThis keeps the repository aligned with the current ReviewRouter SaaS production action ref.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal review workflow automation tooling to a newer pinned version across review workflows; applied consistently to preflight and interaction steps. No runtime behavior, triggers, or environment changes were introduced.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/777genius/agent-teams-ai/pull/164?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-router-summary:start -->
## Summary

- updates a GitHub Actions workflow
- touch 2 files (2 modified) with +4/-4 lines


<details>
<summary>📒 Files selected for processing (2)</summary>

* `.github/workflows/reviewrouter-codex.yml`
* `.github/workflows/reviewrouter-interaction.yml`

</details>

<details>
<summary>📝 Walkthrough</summary>

## Walkthrough

This PR updates 2 files across 2 CI workflow. The generated summary is based on the GitHub pull request file list and diff metadata, and the author's description above is preserved.

## Changes

| Cohort / File(s) | Summary |
|---|---|
| **CI workflow** <br> `.github/workflows/reviewrouter-codex.yml`<br>`.github/workflows/reviewrouter-interaction.yml` | Updates a GitHub Actions workflow.<br>Line stats: 2 modified; +4/-4. |

</details>
<!-- review-router-summary:end -->