### PR TITLE
ci: update ReviewRouter Codex action ref

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth review
         id: run_codex
-        uses: 777genius/review-router@eee881985b5675e073e263778d7092caa4383738
+        uses: 777genius/review-router@610885e08ed96b50d8250f491d62167ad47aaed0
         with:
           mode: codex-oauth-rotating
           api-url: "https://api.reviewrouter.site"


### PR DESCRIPTION
Update ReviewRouter Codex OAuth workflow to the latest pinned runtime SHA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow automation configuration to use the latest action version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/777genius/agent-teams-ai/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->