### PR TITLE
fix: count OpenCode inventory fallback as connected

### DIFF
--- a/src/renderer/components/dashboard/CliStatusBanner.tsx
+++ b/src/renderer/components/dashboard/CliStatusBanner.tsx
@@ -37,6 +37,7 @@ import {
   getProviderDisconnectAction,
   isConnectionManagedRuntimeProvider,
   isOpenCodeCatalogHydrating,
+  isProviderInventoryOnlyFallback,
   shouldShowProviderConnectAction,
   shouldShowProviderStatusSkeleton,
 } from '@renderer/components/runtime/providerConnectionUi';
@@ -527,6 +528,10 @@ function isPendingMultimodelProviderStatus(provider: CliProviderStatus): boolean
   );
 }
 
+function isProviderCountedAsConnected(provider: CliProviderStatus): boolean {
+  return provider.authenticated || isProviderInventoryOnlyFallback(provider);
+}
+
 function formatRuntimeAuthSummary(
   cliStatus: NonNullable<ReturnType<typeof useCliInstaller>['cliStatus']>,
   visibleProviders: readonly CliProviderStatus[],
@@ -541,7 +546,7 @@ function formatRuntimeAuthSummary(
       return t('cliStatus.provider.checkingProviders');
     }
     const denominator = visibleProviders.length;
-    const connected = visibleProviders.filter((provider) => provider.authenticated).length;
+    const connected = visibleProviders.filter(isProviderCountedAsConnected).length;
 
     return t('cliStatus.provider.connectedCount', { connected, denominator });
   }
@@ -571,7 +576,7 @@ function isCheckingMultimodelStatus(
 function hasVisibleAuthenticatedMultimodelProvider(
   visibleProviders: readonly CliProviderStatus[]
 ): boolean {
-  return visibleProviders.some((provider) => provider.authenticated);
+  return visibleProviders.some(isProviderCountedAsConnected);
 }
 
 function isOpenCodeProviderEffectivelyReady(provider: CliProviderStatus): boolean {

--- a/test/renderer/components/cli/CliStatusVisibility.test.ts
+++ b/test/renderer/components/cli/CliStatusVisibility.test.ts
@@ -718,9 +718,34 @@ describe('CLI status visibility during completed install state', () => {
       supportsSelfUpdate: false,
       showVersionDetails: false,
       showBinaryPath: false,
-      authLoggedIn: false,
+      authLoggedIn: true,
       authStatusChecking: false,
       providers: [
+        {
+          providerId: 'anthropic',
+          displayName: 'Anthropic',
+          supported: true,
+          authenticated: true,
+          authMethod: 'api_key',
+          verificationState: 'verified',
+          statusMessage: null,
+          models: ['claude-haiku-4-5'],
+          modelAvailability: [],
+          canLoginFromUi: true,
+          capabilities: {
+            teamLaunch: true,
+            oneShot: true,
+          },
+          backend: null,
+          modelCatalog: null,
+          modelCatalogRefreshState: 'idle',
+          runtimeCapabilities: null,
+        },
+        createCodexNativeRolloutProvider({
+          state: 'ready',
+          statusMessage: 'ChatGPT account ready',
+          models: ['gpt-5.4'],
+        }),
         {
           providerId: 'opencode',
           displayName: 'OpenCode (200+ models)',
@@ -755,6 +780,7 @@ describe('CLI status visibility during completed install state', () => {
     });
 
     expect(host.textContent).toContain('OpenCode');
+    expect(host.textContent).toContain('Providers: 3/3 connected');
     expect(host.textContent).toContain('Models available');
     expect(host.textContent).toContain('big-pickle');
     expect(host.textContent).not.toContain('Checking...');


### PR DESCRIPTION
## Summary
- Count OpenCode inventory fallback as connected in the dashboard provider summary
- Keep OpenCode auth semantics unchanged while treating discovered models as ready for the header count
- Cover the Anthropic + Codex + OpenCode fallback case so the dashboard shows 3/3 connected

## Verification
- pnpm exec vitest run test/renderer/components/cli/CliStatusVisibility.test.ts
- pnpm --config.engine-strict=false lint:fast:files -- src/renderer/components/dashboard/CliStatusBanner.tsx test/renderer/components/cli/CliStatusVisibility.test.ts
- pnpm --config.engine-strict=false typecheck

<!-- review-router-summary:start -->
## Summary

- update 1 test file
- updates isPendingMultimodelProviderStatus, formatRuntimeAuthSummary: changes return value handling
- updates CliStatusVisibility.test test coverage
- touch 2 files (2 modified) with +34/-3 lines

## Tests

- changed test file: `test/renderer/components/cli/CliStatusVisibility.test.ts`

<details>
<summary>📒 Files selected for processing (2)</summary>

* `src/renderer/components/dashboard/CliStatusBanner.tsx`
* `test/renderer/components/cli/CliStatusVisibility.test.ts`

</details>

<details>
<summary>📝 Walkthrough</summary>

## Walkthrough

This PR updates 2 files across 1 source, 1 tests. The generated summary is based on the GitHub pull request file list and diff metadata, and the author's description above is preserved.

## Changes

| Cohort / File(s) | Summary |
|---|---|
| **Source** <br> `src/renderer/components/dashboard/CliStatusBanner.tsx` | Updates isPendingMultimodelProviderStatus, formatRuntimeAuthSummary: changes return value handling.<br>Line stats: 1 modified; +7/-2. |
| **Tests** <br> `test/renderer/components/cli/CliStatusVisibility.test.ts` | Updates CliStatusVisibility.test test coverage.<br>Line stats: 1 modified; +27/-1. |

</details>
<!-- review-router-summary:end -->