### PR TITLE
fix(team): speed up provider runtime preflight

### DIFF
--- a/src/main/services/team/TeamProvisioningService.ts
+++ b/src/main/services/team/TeamProvisioningService.ts
@@ -1392,6 +1392,8 @@ interface RuntimeStatusCommandResponse {
 }
 
 interface AuthStatusCommandResponse {
+  provider?: string;
+  status?: Partial<CliProviderStatus>;
   loggedIn?: boolean;
   authMethod?: string | null;
   providers?: Record<string, Partial<CliProviderStatus>>;
@@ -4410,7 +4412,7 @@ export class TeamProvisioningService {
             {
               cwd: params.cwd,
               env: params.env,
-              timeout: 8_000,
+              timeout: PROVIDER_RUNTIME_STATUS_TIMEOUT_MS,
             }
           )
         : null;
@@ -36614,7 +36616,10 @@ export class TeamProvisioningService {
     authenticated: boolean | null;
     providerStatus: Partial<CliProviderStatus> | null;
   } {
-    const providerStatus = parsed.providers?.[providerId] ?? null;
+    const providerStatus =
+      parsed.providers?.[providerId] ??
+      (parsed.provider === providerId || !parsed.provider ? parsed.status : null) ??
+      null;
     if (typeof providerStatus?.authenticated === 'boolean') {
       return {
         authenticated: providerStatus.authenticated,
@@ -36656,13 +36661,14 @@ export class TeamProvisioningService {
           'runtime',
           'status',
           '--json',
+          '--summary',
           '--provider',
           providerId,
         ]),
         {
           cwd,
           env,
-          timeout: 8_000,
+          timeout: PROVIDER_RUNTIME_STATUS_TIMEOUT_MS,
         }
       );
       const parsed = extractJsonObjectFromCli<RuntimeStatusCommandResponse>(runtimeStatus.stdout);

--- a/test/main/services/team/TeamProvisioningServicePrepare.test.ts
+++ b/test/main/services/team/TeamProvisioningServicePrepare.test.ts
@@ -2288,7 +2288,7 @@ describe('TeamProvisioningService prepare/auth behavior', () => {
     expect(result.ready).toBe(true);
     expect(execCliMock).toHaveBeenCalledWith(
       '/fake/claude',
-      ['runtime', 'status', '--json', '--provider', 'codex'],
+      ['runtime', 'status', '--json', '--summary', '--provider', 'codex'],
       expect.objectContaining({ cwd: tempRoot })
     );
     expect(spawnProbe).toHaveBeenCalledTimes(1);
@@ -2332,11 +2332,53 @@ describe('TeamProvisioningService prepare/auth behavior', () => {
         'runtime',
         'status',
         '--json',
+        '--summary',
         '--provider',
         'codex',
       ],
       expect.objectContaining({ cwd: tempRoot })
     );
+  });
+
+  it('accepts provider-specific auth status fallback payloads', async () => {
+    execCliMock.mockImplementation(async (_binaryPath: string | null, args: string[]) => {
+      if (args.includes('runtime')) {
+        throw new Error(
+          'Timeout running: orchestrator-cli runtime status --json --summary --provider anthropic'
+        );
+      }
+      if (args.includes('auth')) {
+        return {
+          stdout: JSON.stringify({
+            schemaVersion: 1,
+            provider: 'anthropic',
+            status: {
+              supported: true,
+              authenticated: true,
+              capabilities: { teamLaunch: true, oneShot: true },
+            },
+          }),
+          stderr: '',
+          exitCode: 0,
+        };
+      }
+      return { stdout: '', stderr: '', exitCode: 0 };
+    });
+
+    const svc = new TeamProvisioningService();
+    const result = await (svc as any).probeProviderRuntimeControlPlane({
+      claudePath: '/fake/claude',
+      cwd: tempRoot,
+      env: {
+        PATH: '/usr/bin',
+        SHELL: '/bin/zsh',
+      },
+      providerId: 'anthropic',
+      providerArgs: [],
+    });
+
+    expect(result.warning).toContain('runtime status was unavailable, but auth status passed');
+    expect(result.warning).not.toContain('auth status did not report Anthropic authentication');
   });
 
   it('falls back from runtime status timeout to auth status and still checks selected models', async () => {


### PR DESCRIPTION
## Summary
- Use `runtime status --summary` for provider readiness preflight to avoid slow full Anthropic catalog checks on Windows prod.
- Accept provider-specific `auth status --provider anthropic` payloads with `status.authenticated` during fallback.
- Reuse the existing 20s runtime status timeout for launch fact status reads.

## Checks
- `pnpm exec vitest run --maxWorkers 1 --minWorkers 1 test/main/services/team/TeamProvisioningServicePrepare.test.ts -t "uses runtime status for codex primary preflight|passes provider launch args before codex runtime status subcommands|accepts provider-specific auth status fallback payloads|falls back from runtime status timeout"`
- `pnpm --config.engine-strict=false typecheck` because local Node is v24.15.0, repo requires >=24.16.0 <25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider runtime status checks with fallback authentication status parsing when timeouts occur.

* **Configuration**
  * Provider runtime status operations now use configurable timeout settings instead of fixed values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/777genius/agent-teams-ai/pull/185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->