### PR TITLE
fix(opencode): extend summary status timeout

### DIFF
--- a/src/main/services/runtime/ClaudeMultimodelBridgeService.ts
+++ b/src/main/services/runtime/ClaudeMultimodelBridgeService.ts
@@ -26,6 +26,7 @@ const logger = createLogger('ClaudeMultimodelBridgeService');
 const PROVIDER_STATUS_TIMEOUT_MS = 90_000;
 const PROVIDER_STATUS_SUMMARY_TIMEOUT_MS = 30_000;
 const LEGACY_FALLBACK_PROVIDER_STATUS_SUMMARY_TIMEOUT_MS = 5_000;
+const OPENCODE_FALLBACK_PROVIDER_STATUS_SUMMARY_TIMEOUT_MS = 12_000;
 const LEGACY_PROVIDER_AUTH_TIMEOUT_MS = 15_000;
 const PROVIDER_MODELS_TIMEOUT_MS = 25_000;
 const PROVIDER_STATUS_MAX_BUFFER_BYTES = 8 * 1024 * 1024;
@@ -891,10 +892,11 @@ export class ClaudeMultimodelBridgeService {
     options: { summary?: boolean; timeoutMs?: number }
   ): number {
     if (options.summary && this.shouldUseLegacyProviderTimeoutFallback(providerId)) {
-      return Math.min(
-        options.timeoutMs ?? PROVIDER_STATUS_SUMMARY_TIMEOUT_MS,
-        LEGACY_FALLBACK_PROVIDER_STATUS_SUMMARY_TIMEOUT_MS
-      );
+      const fallbackTimeout =
+        providerId === 'opencode'
+          ? OPENCODE_FALLBACK_PROVIDER_STATUS_SUMMARY_TIMEOUT_MS
+          : LEGACY_FALLBACK_PROVIDER_STATUS_SUMMARY_TIMEOUT_MS;
+      return Math.min(options.timeoutMs ?? PROVIDER_STATUS_SUMMARY_TIMEOUT_MS, fallbackTimeout);
     }
     return (
       options.timeoutMs ??

--- a/test/main/services/runtime/ClaudeMultimodelBridgeService.test.ts
+++ b/test/main/services/runtime/ClaudeMultimodelBridgeService.test.ts
@@ -467,7 +467,7 @@ describe('ClaudeMultimodelBridgeService', () => {
       'runtime status --json --provider opencode --summary',
       'model list --json --provider opencode',
     ]);
-    expect(execCliMock.mock.calls[0][2]?.timeout).toBe(5000);
+    expect(execCliMock.mock.calls[0][2]?.timeout).toBe(12000);
     vi.mocked(console.warn).mockClear();
   });
 
@@ -642,7 +642,7 @@ describe('ClaudeMultimodelBridgeService', () => {
     expect(execCliMock).toHaveBeenCalledTimes(8);
     expect(
       execCliMock.mock.calls.map((call) => call[2]?.timeout as number).sort((a, b) => a - b)
-    ).toEqual([5000, 5000, 5000, 15000, 15000, 25000, 25000, 25000]);
+    ).toEqual([5000, 5000, 12000, 15000, 15000, 25000, 25000, 25000]);
     expect(calls).toEqual(
       expect.arrayContaining([
         'runtime status --json --provider anthropic --summary',


### PR DESCRIPTION
## Summary
- raise only the OpenCode provider-scoped summary runtime status fallback timeout from 5s to 12s
- keep Anthropic/Codex on the existing 5s fallback budget
- update runtime bridge tests for the OpenCode-specific budget

## Verification
- pnpm --config.engine-strict=false exec vitest run --maxWorkers 1 --minWorkers 1 test/main/services/runtime/ClaudeMultimodelBridgeService.test.ts
- pnpm --config.engine-strict=false exec vitest run --maxWorkers 1 --minWorkers 1 test/renderer/components/cli/CliStatusVisibility.test.ts -t "OpenCode inventory fallback"
- pnpm --config.engine-strict=false exec vitest run --maxWorkers 1 --minWorkers 1 test/renderer/components/team/TeamModelSelectorDisabledState.test.ts -t "allows selecting unauthenticated OpenCode when free models are available|points missing OpenCode runtime users"
- pnpm --config.engine-strict=false typecheck
- local dev with CLAUDE_DEV_RUNTIME_ROOT=C:\Users\User\PROJECT_IT\сlaude_team\agent_teams_orchestrator built runtime 0.0.49-dev.20260527.t213238.sha73c1f62a
- cli-dev.cmd runtime status --json --summary --provider opencode: exit 0, 6015ms, supported=true, verification=verified
- cli-dev.cmd runtime status --json --provider opencode: exit 0, 10247ms, authMethod=opencode_builtin_free, teamLaunch=true, models=25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout handling for provider status operations. Refined configuration of timeout values for fallback scenarios to enhance system stability and responsiveness when monitoring provider status summary requests. These adjustments improve overall performance when handling edge cases and timeout-related scenarios in provider status checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/777genius/agent-teams-ai/pull/186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->