### PR TITLE
chore(landing): configure render static deployments

### DIFF
--- a/landing/README.md
+++ b/landing/README.md
@@ -14,7 +14,32 @@ pnpm generate
 pnpm preview
 ```
 
+## Render static sites
+
+Landing and docs are deployed as separate Render Static Sites from the `main` branch.
+
+Landing:
+
+```bash
+corepack enable && pnpm install --frozen-lockfile --ignore-scripts && NUXT_PUBLIC_SITE_URL=$RENDER_EXTERNAL_URL NUXT_PUBLIC_ROBOTS="index, follow" pnpm --filter agent-teams-landing generate
+```
+
+Publish path: `landing/.output/public`
+
+Docs:
+
+```bash
+corepack enable && pnpm install --frozen-lockfile --ignore-scripts && VITEPRESS_BASE=/ VITEPRESS_SITE_URL=$RENDER_EXTERNAL_URL VITEPRESS_LANDING_SITE_URL=https://agent-teams-ai-landing.onrender.com pnpm --filter agent-teams-landing docs:build
+```
+
+Publish path: `landing/product-docs/.vitepress/dist`
+
+Both sites set `NODE_VERSION=24.16.0` and `SKIP_INSTALL_DEPS=true`; the build command runs the pnpm install step explicitly with `--ignore-scripts`.
+
+When a custom landing domain is attached, update `VITEPRESS_LANDING_SITE_URL` on the docs site. When a custom docs domain is attached, `VITEPRESS_SITE_URL=$RENDER_EXTERNAL_URL` can stay unchanged for the Render preview URL or be replaced with the custom domain for canonical SEO.
+
 ## Notes
+
 - Static-first (SSG) by design.
 - Locale auto-detection: cookie -> browser settings -> fallback `en`.
 - Theme auto-detection: localStorage -> system preference -> fallback `light`.

--- a/landing/nuxt.config.ts
+++ b/landing/nuxt.config.ts
@@ -18,6 +18,7 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const defaultSeoTitle = "Agent Teams - AI Agent Orchestration for Developers";
 const defaultSeoDescription = "Free, open-source desktop app for AI agent teams. Start with a free model with no auth, then connect Claude, Codex, or OpenCode when you need more models.";
 const defaultSeoImage = `${siteUrl.replace(/\/+$/, "")}/og-image-agent-teams-v6.png`;
+const robots = process.env.NUXT_PUBLIC_ROBOTS || "noindex, nofollow";
 
 export default defineNuxtConfig({
   compatibilityDate: "2026-01-19",
@@ -29,7 +30,7 @@ export default defineNuxtConfig({
       title: defaultSeoTitle,
       meta: [
         { name: "description", content: defaultSeoDescription },
-        { name: "robots", content: "noindex, nofollow" },
+        { name: "robots", content: robots },
         { property: "og:title", content: defaultSeoTitle },
         { property: "og:description", content: defaultSeoDescription },
         { property: "og:type", content: "website" },

--- a/landing/product-docs/.vitepress/config.ts
+++ b/landing/product-docs/.vitepress/config.ts
@@ -21,15 +21,20 @@ const normalizeBase = (value: string) => {
 const withTrailingSlash = (value: string) => `${trimTrailingSlash(value)}/`;
 
 const appBase = normalizeBase(process.env.NUXT_APP_BASE_URL || "/");
-const base = appBase === "/" ? "/docs/" : `${appBase}docs/`;
-const siteUrl = trimTrailingSlash(
-  process.env.NUXT_PUBLIC_SITE_URL || "https://777genius.github.io/agent-teams-ai"
+const embeddedDocsBase = appBase === "/" ? "/docs/" : `${appBase}docs/`;
+const base = process.env.VITEPRESS_BASE ? normalizeBase(process.env.VITEPRESS_BASE) : embeddedDocsBase;
+const landingSiteUrl = trimTrailingSlash(
+  process.env.VITEPRESS_LANDING_SITE_URL ||
+    process.env.NUXT_PUBLIC_SITE_URL ||
+    "https://777genius.github.io/agent-teams-ai"
 );
 const publicBaseUrl =
-  appBase === "/" || siteUrl.endsWith(trimTrailingSlash(appBase))
-    ? withTrailingSlash(siteUrl)
-    : `${withTrailingSlash(siteUrl)}${appBase.replace(/^\/+/, "")}`;
-const docsUrl = `${publicBaseUrl}docs/`;
+  appBase === "/" || landingSiteUrl.endsWith(trimTrailingSlash(appBase))
+    ? withTrailingSlash(landingSiteUrl)
+    : `${withTrailingSlash(landingSiteUrl)}${appBase.replace(/^\/+/, "")}`;
+const docsUrl = process.env.VITEPRESS_SITE_URL
+  ? withTrailingSlash(process.env.VITEPRESS_SITE_URL)
+  : `${publicBaseUrl}docs/`;
 const downloadUrl = `${publicBaseUrl}download/`;
 const ruDownloadUrl = `${publicBaseUrl}ru/download/`;
 const ogImageUrl = `${publicBaseUrl}og-image-agent-teams-v6.png`;
@@ -130,7 +135,11 @@ const ruGuide: DefaultTheme.SidebarItem[] = [
 ];
 
 const rootNav: DefaultTheme.NavItem[] = [
-  { text: "Guide", link: "/guide/beginner-workflow", activeMatch: "^/guide/(?!troubleshooting(?:/|$))" },
+  {
+    text: "Guide",
+    link: "/guide/beginner-workflow",
+    activeMatch: "^/guide/(?!troubleshooting(?:/|$))"
+  },
   { text: "Developers", link: "/developers/", activeMatch: "^/developers/" },
   { text: "Reference", link: "/reference/concepts", activeMatch: "^/reference/" },
   {


### PR DESCRIPTION
## Summary
- allow the landing robots meta to be controlled from Render env
- allow VitePress docs to build as a standalone root static site
- document the two Render Static Site build and publish settings

## Verification
- corepack enable && pnpm install --frozen-lockfile --ignore-scripts
- NUXT_PUBLIC_SITE_URL=https://agent-teams-ai-landing.onrender.com NUXT_PUBLIC_ROBOTS="index, follow" pnpm --filter agent-teams-landing generate
- VITEPRESS_BASE=/ VITEPRESS_SITE_URL=https://agent-teams-ai-docs.onrender.com VITEPRESS_LANDING_SITE_URL=https://agent-teams-ai-landing.onrender.com pnpm --filter agent-teams-landing docs:build
- pnpm exec eslint nuxt.config.ts product-docs/.vitepress/config.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Expanded build documentation with detailed deployment instructions, environment variables, and output paths for static site generation.

* **Configuration**
  * Added support for configurable robots meta tag via environment variable.
  * Enhanced URL and base path configuration for flexible deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->