### PR TITLE
fix(landing): point docs links to render docs site

### DIFF
--- a/landing/README.md
+++ b/landing/README.md
@@ -21,7 +21,7 @@ Landing and docs are deployed as separate Render Static Sites from the `main` br
 Landing:
 
 ```bash
-corepack enable && pnpm install --frozen-lockfile --ignore-scripts && NUXT_PUBLIC_SITE_URL=$RENDER_EXTERNAL_URL NUXT_PUBLIC_ROBOTS="index, follow" pnpm --filter agent-teams-landing generate
+corepack enable && pnpm install --frozen-lockfile --ignore-scripts && NUXT_PUBLIC_SITE_URL=$RENDER_EXTERNAL_URL NUXT_PUBLIC_DOCS_SITE_URL=https://agent-teams-ai-docs.onrender.com NUXT_PUBLIC_ROBOTS="index, follow" pnpm --filter agent-teams-landing generate
 ```
 
 Publish path: `landing/.output/public`
@@ -45,3 +45,4 @@ When a custom landing domain is attached, update `VITEPRESS_LANDING_SITE_URL` on
 - Theme auto-detection: localStorage -> system preference -> fallback `light`.
 - Hero video uses the Mux Player embed. Set `NUXT_PUBLIC_MUX_PLAYBACK_ID` to override the default playback id without changing the code.
 - Hero background can use a separate Mux asset via `NUXT_PUBLIC_MUX_BACKGROUND_PLAYBACK_ID`; otherwise it reuses `NUXT_PUBLIC_MUX_PLAYBACK_ID`.
+- Set `NUXT_PUBLIC_DOCS_SITE_URL` when the docs are deployed as a separate static site.

--- a/landing/components/layout/AppFooter.vue
+++ b/landing/components/layout/AppFooter.vue
@@ -1,15 +1,18 @@
 <script setup lang="ts">
 import robotLeadLounge from "~/assets/images/footer/robot-lead-lounge-v1.webp";
+import { buildDocsHref } from "~/utils/docsUrl";
 
 const { t, locale } = useI18n();
 const { repoUrl } = useGithubRepo();
-const { baseURL } = useRuntimeConfig().app;
+const runtimeConfig = useRuntimeConfig();
+const { baseURL } = runtimeConfig.app;
 const year = new Date().getFullYear();
 const authorLabel = computed(() => locale.value === 'ru' ? 'Автор' : 'Author');
-const docsHref = computed(() => {
-  const base = baseURL.replace(/\/?$/, '/');
-  return `${base}${locale.value === 'ru' ? 'docs/ru/' : 'docs/'}`;
-});
+const docsHref = computed(() => buildDocsHref({
+  locale: locale.value,
+  docsSiteUrl: runtimeConfig.public.docsSiteUrl,
+  embeddedBaseURL: baseURL,
+}));
 </script>
 
 <template>

--- a/landing/components/layout/AppHeader.vue
+++ b/landing/components/layout/AppHeader.vue
@@ -1,13 +1,18 @@
 <script setup lang="ts">
 import { mdiMenu, mdiClose, mdiGithub } from '@mdi/js';
+import { buildDocsHref } from '~/utils/docsUrl';
 
 const { t, locale } = useI18n();
 const { repoUrl } = useGithubRepo();
-const { baseURL } = useRuntimeConfig().app;
+const runtimeConfig = useRuntimeConfig();
+const { baseURL } = runtimeConfig.app;
 const menuOpen = ref(false);
 
-const withBase = (path: string) => `${baseURL.replace(/\/?$/, '/')}${path.replace(/^\/+/, '')}`;
-const docsHref = computed(() => withBase(locale.value === 'ru' ? 'docs/ru/' : 'docs/'));
+const docsHref = computed(() => buildDocsHref({
+  locale: locale.value,
+  docsSiteUrl: runtimeConfig.public.docsSiteUrl,
+  embeddedBaseURL: baseURL,
+}));
 const isRu = computed(() => locale.value === 'ru');
 const openMenuLabel = computed(() => (isRu.value ? 'Открыть меню' : 'Open menu'));
 const closeMenuLabel = computed(() => (isRu.value ? 'Закрыть меню' : 'Close menu'));

--- a/landing/components/sections/HeroSection.vue
+++ b/landing/components/sections/HeroSection.vue
@@ -4,10 +4,12 @@ import {
   mdiDownload,
 } from "@mdi/js";
 import { getLocalizedHeroMessages, type HeroMessagePhase } from "~/data/heroScene";
+import { buildDocsHref } from "~/utils/docsUrl";
 
 const { content } = useLandingContent();
 const { t, locale } = useI18n();
-const { baseURL } = useRuntimeConfig().app;
+const runtimeConfig = useRuntimeConfig();
+const { baseURL } = runtimeConfig.app;
 const heroRef = ref<HTMLElement | null>(null);
 const activeHeroMessageIndex = ref(0);
 const heroMessagePhase = ref<HeroMessagePhase>("cooldown");
@@ -21,7 +23,6 @@ const downloadStore = useDownloadStore();
 const { resolve, data: releaseData } = useReleaseDownloads();
 const { latestReleaseUrl, releaseDownloadUrl } = useGithubRepo();
 const { selectedDownloadAsset } = useDownloadAssetPresentation();
-const withBase = (path: string) => `${baseURL.replace(/\/?$/, "/")}${path.replace(/^\/+/, "")}`;
 
 useCyberHeroParallax(heroRef);
 
@@ -71,7 +72,11 @@ const heroDownloadUrl = computed(() => {
   return resolve(asset.os, arch)?.url || releaseDownloadUrl(asset.fileName);
 });
 
-const docsHref = computed(() => withBase(locale.value === "ru" ? "docs/ru/" : "docs/"));
+const docsHref = computed(() => buildDocsHref({
+  locale: locale.value,
+  docsSiteUrl: runtimeConfig.public.docsSiteUrl,
+  embeddedBaseURL: baseURL,
+}));
 const downloadActionSubtitle = computed(() => {
   if (!selectedDownloadAsset.value) {
     return locale.value === "ru"

--- a/landing/nuxt.config.ts
+++ b/landing/nuxt.config.ts
@@ -12,6 +12,7 @@ const githubRepo = process.env.NUXT_PUBLIC_GITHUB_REPO || "777genius/agent-teams
 const githubReleasesUrl = `https://github.com/${githubRepo}/releases`;
 const muxPlaybackId = process.env.NUXT_PUBLIC_MUX_PLAYBACK_ID || "qyeNuDjFqoDALK8eB02jMTOWUz006BdIhiqiAip3U00x7I";
 const muxBackgroundPlaybackId = process.env.NUXT_PUBLIC_MUX_BACKGROUND_PLAYBACK_ID || muxPlaybackId;
+const docsSiteUrl = process.env.NUXT_PUBLIC_DOCS_SITE_URL || "";
 const baseURL = process.env.NUXT_APP_BASE_URL || "/";
 const basePrefixedDocsPath = `${baseURL.replace(/\/?$/, "/")}docs`;
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -144,6 +145,7 @@ export default defineNuxtConfig({
       siteUrl,
       githubRepo,
       githubReleasesUrl,
+      docsSiteUrl,
       muxPlaybackId,
       muxBackgroundPlaybackId
     }

--- a/landing/public/docs/index.html
+++ b/landing/public/docs/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://agent-teams-ai-docs.onrender.com/">
+    <link rel="canonical" href="https://agent-teams-ai-docs.onrender.com/">
+    <title>Redirecting to Agent Teams Docs</title>
+  </head>
+  <body>
+    <a href="https://agent-teams-ai-docs.onrender.com/">Agent Teams Docs</a>
+  </body>
+</html>

--- a/landing/public/docs/ru/index.html
+++ b/landing/public/docs/ru/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="ru">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://agent-teams-ai-docs.onrender.com/ru/">
+    <link rel="canonical" href="https://agent-teams-ai-docs.onrender.com/ru/">
+    <title>Redirecting to Agent Teams Docs</title>
+  </head>
+  <body>
+    <a href="https://agent-teams-ai-docs.onrender.com/ru/">Agent Teams Docs</a>
+  </body>
+</html>

--- a/landing/server/routes/llms.txt.ts
+++ b/landing/server/routes/llms.txt.ts
@@ -1,4 +1,5 @@
 import { defaultLocale, getLocalizedPagePath, sitemapPages, supportedLocales } from "~/data/i18n";
+import { normalizeDocsSiteUrl } from "~/utils/docsUrl";
 
 const trimTrailingSlash = (value: string) => value.replace(/\/+$/, "");
 
@@ -11,6 +12,7 @@ export default defineEventHandler((event) => {
   const githubUrl = `https://github.com/${githubRepo}`;
   const releasesUrl = `${githubUrl}/releases`;
   const toSiteUrl = (path: string) => `${siteUrl}${path === "/" ? "/" : `/${path.replace(/^\/+/, "")}`}`;
+  const docsSiteUrl = normalizeDocsSiteUrl(config.public.docsSiteUrl) || toSiteUrl("/docs/");
 
   setHeader(event, "content-type", "text/plain; charset=utf-8");
 
@@ -32,8 +34,8 @@ export default defineEventHandler((event) => {
 
 - Homepage (${defaultLocale}): ${toSiteUrl("/")}
 - Download: ${toSiteUrl("/download")}
-- Documentation: ${toSiteUrl("/docs/")}
-- Documentation llms.txt: ${toSiteUrl("/docs/llms.txt")}
+- Documentation: ${docsSiteUrl}
+- Documentation llms.txt: ${docsSiteUrl}llms.txt
 - GitHub repository: ${githubUrl}
 - Releases: ${releasesUrl}
 - Sitemap: ${toSiteUrl("/sitemap.xml")}

--- a/landing/server/routes/robots.txt.ts
+++ b/landing/server/routes/robots.txt.ts
@@ -1,12 +1,15 @@
+import { normalizeDocsSiteUrl } from "~/utils/docsUrl";
+
 export default defineEventHandler((event) => {
   const config = useRuntimeConfig();
   const siteUrl = ((config.public.siteUrl as string) || "https://777genius.github.io/agent-teams-ai").replace(/\/+$/, "");
+  const docsSiteUrl = normalizeDocsSiteUrl(config.public.docsSiteUrl) || `${siteUrl}/docs/`;
 
   setHeader(event, "content-type", "text/plain; charset=utf-8");
 
   return `User-agent: *
 Allow: /
 Sitemap: ${siteUrl}/sitemap.xml
-Sitemap: ${siteUrl}/docs/sitemap.xml
+Sitemap: ${docsSiteUrl}sitemap.xml
 `;
 });

--- a/landing/utils/docsUrl.ts
+++ b/landing/utils/docsUrl.ts
@@ -1,0 +1,29 @@
+type DocsLocale = string | undefined;
+
+const trimTrailingSlash = (value: string) => value.replace(/\/+$/, '');
+const withTrailingSlash = (value: string) => `${trimTrailingSlash(value)}/`;
+
+export function normalizeDocsSiteUrl(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  return withTrailingSlash(trimmed);
+}
+
+export function buildDocsHref(args: {
+  locale?: DocsLocale;
+  docsSiteUrl?: unknown;
+  embeddedBaseURL: string;
+}): string {
+  const localizedPath = args.locale === 'ru' ? 'ru/' : '';
+  const externalDocsUrl = normalizeDocsSiteUrl(args.docsSiteUrl);
+
+  if (externalDocsUrl) {
+    return `${externalDocsUrl}${localizedPath}`;
+  }
+
+  const base = args.embeddedBaseURL.replace(/\/?$/, '/');
+  return `${base}${args.locale === 'ru' ? 'docs/ru/' : 'docs/'}`;
+}


### PR DESCRIPTION
## Summary
- point landing docs CTAs to the separate Render docs site via NUXT_PUBLIC_DOCS_SITE_URL
- keep /docs/ and /docs/ru/ on the landing static site as redirect fallbacks
- update robots.txt and llms.txt docs references

## Verification
- pnpm --filter agent-teams-landing exec eslint nuxt.config.ts components/layout/AppHeader.vue components/layout/AppFooter.vue components/sections/HeroSection.vue server/routes/robots.txt.ts server/routes/llms.txt.ts utils/docsUrl.ts
- NUXT_PUBLIC_SITE_URL=https://agent-teams-ai-landing.onrender.com NUXT_PUBLIC_DOCS_SITE_URL=https://agent-teams-ai-docs.onrender.com NUXT_PUBLIC_ROBOTS='index, follow' pnpm --filter agent-teams-landing generate
- rg confirms generated landing output links to https://agent-teams-ai-docs.onrender.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for deploying documentation as an external, separately-hosted site with configurable URL via environment variable.

* **Chores**
  * Updated navigation links, footer, and site configuration to properly reference the external documentation location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->