### PR TITLE
fix: raise low heap options in mcp configs

### DIFF
--- a/scripts/dev-with-runtime.mjs
+++ b/scripts/dev-with-runtime.mjs
@@ -9,6 +9,7 @@ import { once } from 'node:events';
 import readline from 'node:readline';
 import { fileURLToPath } from 'node:url';
 
+import { ensureMinimumNodeOldSpaceEnv } from './lib/node-options.mjs';
 import { spawnSyncWithWindowsShell } from './lib/windows-shell-spawn.mjs';
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
@@ -662,6 +663,7 @@ async function main() {
     UV_THREADPOOL_SIZE: process.env.UV_THREADPOOL_SIZE?.trim() || '16',
     CLAUDE_AGENT_TEAMS_ORCHESTRATOR_CLI_PATH: resolvedRuntime.binaryPath,
   };
+  ensureMinimumNodeOldSpaceEnv(uiEnv);
   delete uiEnv.CLAUDE_CLI_PATH;
   const uiPackageManager = readPackageManagerCommand(uiRepoRoot);
   const resolvedElectronViteArgs = await resolveElectronViteArgs(electronViteArgs);

--- a/scripts/lib/node-options.mjs
+++ b/scripts/lib/node-options.mjs
@@ -1,0 +1,83 @@
+const DEFAULT_MIN_OLD_SPACE_MB = 2048;
+const OLD_SPACE_FLAG = '--max-old-space-size';
+const OLD_SPACE_FLAG_ALIAS = '--max_old_space_size';
+const OLD_SPACE_FLAGS = new Set([OLD_SPACE_FLAG, OLD_SPACE_FLAG_ALIAS]);
+const OLD_SPACE_VALUE_RE = /^\d+$/;
+
+function splitNodeOptions(value) {
+  return value
+    .trim()
+    .split(/\s+/)
+    .filter((part) => part.length > 0);
+}
+
+function joinNodeOptions(parts) {
+  return parts.length > 0 ? parts.join(' ') : undefined;
+}
+
+function parseOldSpaceMb(value) {
+  if (!value || !OLD_SPACE_VALUE_RE.test(value)) {
+    return NaN;
+  }
+  return Number.parseInt(value, 10);
+}
+
+function splitOldSpaceEquals(value) {
+  const separatorIndex = value.indexOf('=');
+  if (separatorIndex <= 0) {
+    return null;
+  }
+  const flag = value.slice(0, separatorIndex);
+  if (!OLD_SPACE_FLAGS.has(flag)) {
+    return null;
+  }
+  const mb = parseOldSpaceMb(value.slice(separatorIndex + 1));
+  return Number.isFinite(mb) ? { flag, mb } : null;
+}
+
+export function ensureMinimumNodeOldSpaceOptions(value, minMb = DEFAULT_MIN_OLD_SPACE_MB) {
+  if (!value?.trim()) {
+    return value;
+  }
+
+  const parts = splitNodeOptions(value);
+  const consumedIndexes = new Set();
+  let changed = false;
+  for (const [index, current] of parts.entries()) {
+    if (consumedIndexes.has(index)) {
+      continue;
+    }
+
+    const equalsMatch = splitOldSpaceEquals(current);
+    if (equalsMatch) {
+      if (equalsMatch.mb > 0 && equalsMatch.mb < minMb) {
+        parts[index] = `${equalsMatch.flag}=${minMb}`;
+        changed = true;
+      }
+      continue;
+    }
+
+    if (OLD_SPACE_FLAGS.has(current)) {
+      const next = parts[index + 1];
+      const mb = parseOldSpaceMb(next);
+      if (Number.isFinite(mb) && mb > 0 && mb < minMb) {
+        parts[index + 1] = String(minMb);
+        changed = true;
+      }
+      if (Number.isFinite(mb) && mb > 0) {
+        consumedIndexes.add(index + 1);
+      }
+    }
+  }
+
+  return changed ? joinNodeOptions(parts) : value;
+}
+
+export function ensureMinimumNodeOldSpaceEnv(env, minMb = DEFAULT_MIN_OLD_SPACE_MB) {
+  const normalized = ensureMinimumNodeOldSpaceOptions(env.NODE_OPTIONS, minMb);
+  if (normalized === undefined) {
+    delete env.NODE_OPTIONS;
+    return;
+  }
+  env.NODE_OPTIONS = normalized;
+}

--- a/src/main/services/team/TeamMcpConfigBuilder.ts
+++ b/src/main/services/team/TeamMcpConfigBuilder.ts
@@ -1,5 +1,6 @@
 import { execCli } from '@main/utils/childProcess';
 import { buildMergedCliPath } from '@main/utils/cliPathMerge';
+import { ensureMinimumNodeOldSpaceOptions } from '@main/utils/nodeOptions';
 import {
   getClaudeBasePath,
   getMcpConfigsBasePath,
@@ -78,6 +79,31 @@ function isPackagedApp(): boolean {
   } catch {
     return false;
   }
+}
+
+function normalizeMcpServerNodeOptions(config: McpServerConfig): McpServerConfig {
+  const env = config.env;
+  if (!env || typeof env !== 'object' || Array.isArray(env)) {
+    return config;
+  }
+
+  const nodeOptions = (env as Record<string, unknown>).NODE_OPTIONS;
+  if (typeof nodeOptions !== 'string') {
+    return config;
+  }
+
+  const normalizedNodeOptions = ensureMinimumNodeOldSpaceOptions(nodeOptions);
+  if (!normalizedNodeOptions || normalizedNodeOptions === nodeOptions) {
+    return config;
+  }
+
+  return {
+    ...config,
+    env: {
+      ...(env as Record<string, unknown>),
+      NODE_OPTIONS: normalizedNodeOptions,
+    },
+  };
 }
 
 function getAppVersion(): string {
@@ -659,7 +685,7 @@ export class TeamMcpConfigBuilder {
     // into the generated --mcp-config. User/project/local MCP remain loaded
     // through Claude's native settings sources.
     const generatedServers: Record<string, McpServerConfig> = Object.create(null);
-    generatedServers[MCP_SERVER_NAME] = {
+    generatedServers[MCP_SERVER_NAME] = normalizeMcpServerNodeOptions({
       command: launchSpec.command,
       args: launchSpec.args,
       enabled: true,
@@ -668,7 +694,7 @@ export class TeamMcpConfigBuilder {
         [MCP_CLAUDE_DIR_ENV]: getClaudeBasePath(),
         ...(controlApiBaseUrl ? { [MCP_CONTROL_URL_ENV]: controlApiBaseUrl } : {}),
       },
-    };
+    });
     if (mcpPolicy?.mode === 'strictAllowlist') {
       for (const [name, config] of Object.entries(
         await this.readAllowlistedServers(projectPath, mcpPolicy)
@@ -726,7 +752,7 @@ export class TeamMcpConfigBuilder {
           continue;
         }
         if (allowlist.has(entry.name.toLowerCase())) {
-          selected[entry.name] = entry.config;
+          selected[entry.name] = normalizeMcpServerNodeOptions(entry.config);
         }
       }
     }

--- a/src/main/utils/nodeOptions.ts
+++ b/src/main/utils/nodeOptions.ts
@@ -1,6 +1,7 @@
 const DEFAULT_MIN_OLD_SPACE_MB = 2048;
-const OLD_SPACE_EQUALS_RE = /^--max-old-space-size=(\d+)$/;
 const OLD_SPACE_FLAG = '--max-old-space-size';
+const OLD_SPACE_FLAG_ALIAS = '--max_old_space_size';
+const OLD_SPACE_FLAGS = new Set([OLD_SPACE_FLAG, OLD_SPACE_FLAG_ALIAS]);
 const OLD_SPACE_VALUE_RE = /^\d+$/;
 
 function splitNodeOptions(value: string): string[] {
@@ -21,6 +22,19 @@ function parseOldSpaceMb(value: string | undefined): number {
   return Number.parseInt(value, 10);
 }
 
+function splitOldSpaceEquals(value: string): { flag: string; mb: number } | null {
+  const separatorIndex = value.indexOf('=');
+  if (separatorIndex <= 0) {
+    return null;
+  }
+  const flag = value.slice(0, separatorIndex);
+  if (!OLD_SPACE_FLAGS.has(flag)) {
+    return null;
+  }
+  const mb = parseOldSpaceMb(value.slice(separatorIndex + 1));
+  return Number.isFinite(mb) ? { flag, mb } : null;
+}
+
 export function ensureMinimumNodeOldSpaceOptions(
   value: string | undefined,
   minMb = DEFAULT_MIN_OLD_SPACE_MB
@@ -37,17 +51,16 @@ export function ensureMinimumNodeOldSpaceOptions(
       continue;
     }
 
-    const equalsMatch = OLD_SPACE_EQUALS_RE.exec(current);
+    const equalsMatch = splitOldSpaceEquals(current);
     if (equalsMatch) {
-      const mb = parseOldSpaceMb(equalsMatch[1]);
-      if (Number.isFinite(mb) && mb > 0 && mb < minMb) {
-        parts[index] = `${OLD_SPACE_FLAG}=${minMb}`;
+      if (equalsMatch.mb > 0 && equalsMatch.mb < minMb) {
+        parts[index] = `${equalsMatch.flag}=${minMb}`;
         changed = true;
       }
       continue;
     }
 
-    if (current === OLD_SPACE_FLAG) {
+    if (OLD_SPACE_FLAGS.has(current)) {
       const next = parts[index + 1];
       const mb = parseOldSpaceMb(next);
       if (Number.isFinite(mb) && mb > 0 && mb < minMb) {

--- a/test/main/services/team/TeamMcpConfigBuilder.test.ts
+++ b/test/main/services/team/TeamMcpConfigBuilder.test.ts
@@ -864,6 +864,49 @@ describe('TeamMcpConfigBuilder', () => {
     expect(parsed.mcpServers.sentry).toBeUndefined();
   });
 
+  it('raises low NODE_OPTIONS heap in allowlisted MCP server env', async () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'team-mcp-home-'));
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'team-mcp-project-'));
+    createdDirs.push(homeDir, projectDir);
+    mockHomeDir = homeDir;
+
+    fs.writeFileSync(
+      path.join(projectDir, '.mcp.json'),
+      JSON.stringify(
+        {
+          mcpServers: {
+            memoryHeavy: {
+              command: 'node',
+              args: ['memory-heavy-mcp.js'],
+              env: {
+                NODE_OPTIONS: '--max_old_space_size=64 --trace-warnings',
+                MCP_TOKEN: 'secret',
+              },
+            },
+          },
+        },
+        null,
+        2
+      )
+    );
+
+    const builder = new TeamMcpConfigBuilder();
+    const configPath = await builder.writeConfigFile(projectDir, {
+      mode: 'strictAllowlist',
+      serverNames: ['memoryHeavy'],
+    });
+    createdPaths.push(configPath);
+
+    const parsed = JSON.parse(fs.readFileSync(configPath, 'utf8')) as {
+      mcpServers: Record<string, { env?: Record<string, string> }>;
+    };
+
+    expect(parsed.mcpServers.memoryHeavy?.env).toEqual({
+      NODE_OPTIONS: '--max_old_space_size=2048 --trace-warnings',
+      MCP_TOKEN: 'secret',
+    });
+  });
+
   it('generated agent-teams server ignores same-named user MCP entry', async () => {
     const { sourceEntry, tsxCli } = mockSourceWorkspaceEntryAvailable();
     const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'team-mcp-home-'));

--- a/test/main/utils/nodeOptions.test.ts
+++ b/test/main/utils/nodeOptions.test.ts
@@ -17,6 +17,18 @@ describe('nodeOptions', () => {
     );
   });
 
+  it('raises a low equals-form underscore max old space alias', () => {
+    expect(ensureMinimumNodeOldSpaceOptions('--max_old_space_size=64 --trace-warnings')).toBe(
+      '--max_old_space_size=2048 --trace-warnings'
+    );
+  });
+
+  it('raises a low split-form underscore max old space alias', () => {
+    expect(ensureMinimumNodeOldSpaceOptions('--trace-warnings --max_old_space_size 128')).toBe(
+      '--trace-warnings --max_old_space_size 2048'
+    );
+  });
+
   it('does not skip a later valid old-space flag after a malformed split flag', () => {
     expect(
       ensureMinimumNodeOldSpaceOptions('--max-old-space-size --max-old-space-size=128')

--- a/test/scripts/nodeOptions.test.ts
+++ b/test/scripts/nodeOptions.test.ts
@@ -1,0 +1,42 @@
+// @vitest-environment node
+
+import * as path from 'path';
+import { pathToFileURL } from 'url';
+import { describe, expect, it } from 'vitest';
+
+interface NodeOptionsModule {
+  ensureMinimumNodeOldSpaceEnv(env: NodeJS.ProcessEnv, minMb?: number): void;
+  ensureMinimumNodeOldSpaceOptions(value: string | undefined, minMb?: number): string | undefined;
+}
+
+describe('script node options helpers', () => {
+  it('raises low hyphen old-space values', async () => {
+    const { ensureMinimumNodeOldSpaceOptions } = await loadModule();
+
+    expect(ensureMinimumNodeOldSpaceOptions('--max-old-space-size=64 --trace-warnings')).toBe(
+      '--max-old-space-size=2048 --trace-warnings'
+    );
+  });
+
+  it('raises low underscore old-space values', async () => {
+    const { ensureMinimumNodeOldSpaceOptions } = await loadModule();
+
+    expect(ensureMinimumNodeOldSpaceOptions('--trace-warnings --max_old_space_size 64')).toBe(
+      '--trace-warnings --max_old_space_size 2048'
+    );
+  });
+
+  it('mutates env without adding NODE_OPTIONS when unset', async () => {
+    const { ensureMinimumNodeOldSpaceEnv } = await loadModule();
+    const env: NodeJS.ProcessEnv = {};
+
+    ensureMinimumNodeOldSpaceEnv(env);
+
+    expect(env.NODE_OPTIONS).toBeUndefined();
+  });
+});
+
+async function loadModule(): Promise<NodeOptionsModule> {
+  const moduleUrl = pathToFileURL(path.join(process.cwd(), 'scripts/lib/node-options.mjs')).href;
+  return (await import(`${moduleUrl}?t=${Date.now()}`)) as NodeOptionsModule;
+}


### PR DESCRIPTION
## Summary
- support the V8/Node underscore alias `--max_old_space_size` when raising low `NODE_OPTIONS` heap limits
- raise low `NODE_OPTIONS` heap limits in generated MCP configs, including strict allowlisted user MCP server env
- raise inherited low `NODE_OPTIONS` before `scripts/dev-with-runtime.mjs` launches `electron-vite dev`
- preserve other MCP/dev env values unchanged

## Cause
Issue #214 still shows an OOM around a ~64 MB old-space limit after the prior fix. That strongly points to a low heap flag still reaching a Node/Electron process. The remaining gaps were:

1. `--max_old_space_size` was accepted by Node/V8 but not recognized by our normalizer.
2. strict allowlisted MCP server configs copied explicit `env.NODE_OPTIONS` unchanged.
3. the dev launcher forwarded inherited `NODE_OPTIONS` into `electron-vite dev` unchanged, so changing package.json Node flags could still leave the Electron main process capped.

This matches the report: the crash happens with a smaller team doing complex work over multiple MCP instances, and the last app log is a MemberWorkSync runtime snapshot timeout. The snapshot is likely the pressure point/last symptom, while the low heap cap is the condition that makes it fatal.

## Tests
- `pnpm exec vitest run test/scripts/nodeOptions.test.ts test/main/utils/nodeOptions.test.ts test/main/services/team/TeamMcpConfigBuilder.test.ts -t "script node options helpers|nodeOptions|raises low NODE_OPTIONS heap in allowlisted MCP server env"`
- `pnpm typecheck`

## Note
Full `TeamMcpConfigBuilder.test.ts` still has one existing failure unrelated to this change: `prefers strict shell env lookup over fast Node lookup from a minimal GUI PATH`. The same focused test fails on the pre-existing main worktree before this patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automatic Node.js heap memory enforcement during development and external service configuration to improve runtime stability.

* **Tests**
  * Added test coverage for Node.js memory configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->