### PR TITLE
fix(token-usage): use shared Radix budget select

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@ For new features:
 - When running live smoke tests, keep cleanup narrow: stop only the smoke-owned team/run and launch-owned process teammates. Do not kill shared OpenCode hosts, unrelated tmux panes, or user teams while trying to clean stale smoke artifacts.
 - Verify new medium and large features follow `docs/FEATURE_ARCHITECTURE_STANDARD.md`, especially cross-process boundaries and public feature entrypoints.
 - Check that Electron main, preload, renderer, and shared code keep their responsibilities separate and use the documented path aliases.
+- Check that interactive UI controls use reusable Radix UI headless primitives from `src/renderer/components/ui` instead of one-off native or hand-rolled controls when a shared primitive exists.
 - Flag changes that manually concatenate agent block markers instead of using `wrapAgentBlock(text)`.
 - Flag changes that can break `isMeta` semantics, chunk generation, teammate message parsing, task/subagent filtering, or structured task references.
 - Ensure IPC and main-process handlers validate inputs, fail gracefully, and do not expose unsafe filesystem or process access.

--- a/AGENT_CRITICAL_GUARDRAILS.md
+++ b/AGENT_CRITICAL_GUARDRAILS.md
@@ -8,6 +8,7 @@ These are the hard rules to keep agent work predictable and safe in this repo.
 - Do not test agent teams, launch/provisioning, terminal runtime, task assignment, smoke-flow, or agent actions on real user projects. Use only new sandbox/test projects or explicitly test-only existing projects. Real projects such as `~/dev/projects/ai/claude-runtime` must not be used even for opening a runtime/terminal without fresh direct user permission.
 - Do not run `pnpm lint:fix` unless the user explicitly asks for broad formatting changes.
 - Keep main, preload, renderer, and shared responsibilities separate.
+- Build interactive UI controls from reusable Radix UI headless primitives under `src/renderer/components/ui` when a shared primitive exists. Do not add one-off native or hand-rolled controls for selects, dialogs, popovers, tabs, menus, tooltips, switches, or checkboxes.
 - Use `wrapAgentBlock(text)` instead of manually concatenating agent block markers.
 - Preserve task/subagent filtering, structured task refs, and message parsing semantics.
 - Validate IPC and other main-process inputs defensively and fail gracefully.

--- a/docs/FEATURE_ARCHITECTURE_STANDARD.md
+++ b/docs/FEATURE_ARCHITECTURE_STANDARD.md
@@ -224,6 +224,15 @@ Responsibilities:
 - `adapters/` transform DTOs into view models
 - `utils/` contain small pure renderer helpers
 
+### UI primitives
+
+Build interactive UI controls from reusable shared components backed by Radix UI
+headless primitives. Prefer existing components under `src/renderer/components/ui`
+for controls such as selects, dialogs, popovers, tabs, menus, tooltips, switches,
+and checkboxes. Avoid hand-rolled or native controls when a shared Radix-based
+primitive exists; add or extend the shared primitive instead of styling a one-off
+control inside a feature.
+
 ## Import Rules
 
 ### Public entrypoints only

--- a/src/features/token-usage/renderer/ui/TokenUsageDashboard.tsx
+++ b/src/features/token-usage/renderer/ui/TokenUsageDashboard.tsx
@@ -5,6 +5,13 @@ import { useAppTranslation } from '@features/localization/renderer';
 import { MemberBadge } from '@renderer/components/team/MemberBadge';
 import { Button } from '@renderer/components/ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@renderer/components/ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@renderer/components/ui/tabs';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@renderer/components/ui/tooltip';
 import { cn } from '@renderer/lib/utils';
@@ -932,17 +939,22 @@ const BudgetAlertsPanel = ({
               {budgetScopeLabel(target.scope, t)}
             </span>
           </div>
-          <select
-            value={budgetTargetKey}
-            onChange={(event) => onBudgetTargetKeyChange(event.target.value)}
-            className="mb-2 h-8 w-full rounded-sm border border-[var(--color-border-emphasis)] bg-surface px-2 text-xs text-text outline-none focus:border-fuchsia-500/60"
-          >
-            {budgetTargetOptions.map((option) => (
-              <option key={budgetOptionKey(option)} value={budgetOptionKey(option)}>
-                {budgetScopeLabel(option.scope, t)} / {option.label}
-              </option>
-            ))}
-          </select>
+          <Select value={budgetTargetKey} onValueChange={onBudgetTargetKeyChange}>
+            <SelectTrigger className="mb-2 h-8 rounded-sm border-[var(--color-border-emphasis)] bg-surface px-2 text-xs text-text shadow-none focus:border-fuchsia-500/60 focus:ring-0">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {budgetTargetOptions.map((option) => (
+                <SelectItem
+                  key={budgetOptionKey(option)}
+                  value={budgetOptionKey(option)}
+                  className="text-xs"
+                >
+                  {budgetScopeLabel(option.scope, t)} / {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
           <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-1 2xl:grid-cols-2">
             <BudgetLimitInput
               label={t('tokenUsage.budgets.tokenLimit')}


### PR DESCRIPTION
## Summary
- replace the token usage budget target native select with the shared Radix Select primitive
- document the Radix/headless UI primitive rule in project guardrails and architecture guidance

## Verification
- pnpm lint:fast:files -- src/features/token-usage/renderer/ui/TokenUsageDashboard.tsx
- pnpm typecheck

Note: PR #235 was already merged before this follow-up commit was pushed, so this is a small follow-up PR against fresh dev.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the budget target selector to use a more consistent, reusable dropdown control in the token usage dashboard.
  * Improved interactive UI behavior across the app by standardizing common controls on shared components.

* **Documentation**
  * Added guidance to promote reusable UI primitives for feature development and discourage one-off controls when a shared option exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->