### PR TITLE
feat(token-usage): add task usage breakdowns

### DIFF
--- a/src/features/localization/renderer/locales/ar/dashboard.json
+++ b/src/features/localization/renderer/locales/ar/dashboard.json
@@ -199,7 +199,8 @@
     "partialData": "بيانات جزئية",
     "actions": {
       "refresh": "تحديث",
-      "openTeam": "فتح {{team}}"
+      "openTeam": "فتح {{team}}",
+      "openTask": "Open task {{task}}"
     },
     "aria": {
       "modelUsageBySegment": "استخدام النماذج حسب المقطع"
@@ -264,7 +265,9 @@
       "tokensCost": "{{tokens}} رموز / {{cost}}",
       "total": "الإجمالي",
       "unassigned": "غير معين",
-      "unknownAgent": "وكيل غير معروف"
+      "unknownAgent": "وكيل غير معروف",
+      "eventCount": "{{count}} حدث",
+      "streakCount": "{{count}} يوم متتالية"
     },
     "metrics": {
       "apiEquivalent": "API-equivalent",
@@ -287,6 +290,7 @@
       "agents": "Agents",
       "commandPeriods": "Command periods",
       "commandSpend": "Command spend",
+      "taskSpend": "Task spend",
       "commands": "Commands",
       "expensiveRuns": "Expensive runs",
       "modelUsage": "Model usage",
@@ -294,7 +298,8 @@
       "recentRuns": "Recent runs",
       "runtimeMix": "Runtime mix",
       "sessions": "Sessions",
-      "sources": "Sources",
+      "sources": "أحداث المصدر",
+      "tasks": "Tasks",
       "teams": "Teams",
       "usageTrend": "Usage trend",
       "billingSplit": "Billing split",

--- a/src/features/localization/renderer/locales/bn/dashboard.json
+++ b/src/features/localization/renderer/locales/bn/dashboard.json
@@ -199,7 +199,8 @@
     "partialData": "আংশিক ডেটা",
     "actions": {
       "refresh": "রিফ্রেশ",
-      "openTeam": "{{team}} খুলুন"
+      "openTeam": "{{team}} খুলুন",
+      "openTask": "Open task {{task}}"
     },
     "aria": {
       "modelUsageBySegment": "সেগমেন্ট অনুযায়ী মডেল ব্যবহার"
@@ -264,7 +265,9 @@
       "tokensCost": "{{tokens}} টোকেন / {{cost}}",
       "total": "মোট",
       "unassigned": "অ্যাসাইন করা নেই",
-      "unknownAgent": "অজানা এজেন্ট"
+      "unknownAgent": "অজানা এজেন্ট",
+      "eventCount": "{{count}} ইভেন্ট",
+      "streakCount": "{{count}} দিনের স্ট্রিক"
     },
     "metrics": {
       "apiEquivalent": "API-equivalent",
@@ -287,6 +290,7 @@
       "agents": "Agents",
       "commandPeriods": "Command periods",
       "commandSpend": "Command spend",
+      "taskSpend": "Task spend",
       "commands": "Commands",
       "expensiveRuns": "Expensive runs",
       "modelUsage": "Model usage",
@@ -294,7 +298,8 @@
       "recentRuns": "Recent runs",
       "runtimeMix": "Runtime mix",
       "sessions": "Sessions",
-      "sources": "Sources",
+      "sources": "সোর্স ইভেন্ট",
+      "tasks": "Tasks",
       "teams": "Teams",
       "usageTrend": "Usage trend",
       "billingSplit": "Billing split",

--- a/src/features/localization/renderer/locales/de/dashboard.json
+++ b/src/features/localization/renderer/locales/de/dashboard.json
@@ -199,7 +199,8 @@
     "partialData": "Teilweise Daten",
     "actions": {
       "refresh": "Aktualisieren",
-      "openTeam": "{{team}} öffnen"
+      "openTeam": "{{team}} öffnen",
+      "openTask": "Open task {{task}}"
     },
     "aria": {
       "modelUsageBySegment": "Modellnutzung nach Segment"
@@ -264,7 +265,9 @@
       "tokensCost": "{{tokens}} Tokens / {{cost}}",
       "total": "Gesamt",
       "unassigned": "Nicht zugewiesen",
-      "unknownAgent": "Unbekannter Agent"
+      "unknownAgent": "Unbekannter Agent",
+      "eventCount": "{{count}} Ereignisse",
+      "streakCount": "{{count}} Tage Streak"
     },
     "metrics": {
       "apiEquivalent": "API-equivalent",
@@ -287,6 +290,7 @@
       "agents": "Agents",
       "commandPeriods": "Command periods",
       "commandSpend": "Command spend",
+      "taskSpend": "Task spend",
       "commands": "Commands",
       "expensiveRuns": "Expensive runs",
       "modelUsage": "Model usage",
@@ -294,7 +298,8 @@
       "recentRuns": "Recent runs",
       "runtimeMix": "Runtime mix",
       "sessions": "Sessions",
-      "sources": "Sources",
+      "sources": "Quellereignisse",
+      "tasks": "Tasks",
       "teams": "Teams",
       "usageTrend": "Usage trend",
       "billingSplit": "Billing split",

--- a/src/features/localization/renderer/locales/en/dashboard.json
+++ b/src/features/localization/renderer/locales/en/dashboard.json
@@ -199,7 +199,8 @@
     "partialData": "Partial data",
     "actions": {
       "refresh": "Refresh",
-      "openTeam": "Open {{team}}"
+      "openTeam": "Open {{team}}",
+      "openTask": "Open task {{task}}"
     },
     "aria": {
       "modelUsageBySegment": "Model usage by segment"
@@ -297,7 +298,9 @@
       "tokensCost": "{{tokens}} tokens / {{cost}}",
       "total": "Total",
       "unassigned": "Unassigned",
-      "unknownAgent": "Unknown agent"
+      "unknownAgent": "Unknown agent",
+      "eventCount": "{{count}} events",
+      "streakCount": "{{count}} day streak"
     },
     "metrics": {
       "apiEquivalent": "API-equivalent",
@@ -323,6 +326,7 @@
       "burnRate": "Burn rate",
       "commandPeriods": "Command periods",
       "commandSpend": "Command spend",
+      "taskSpend": "Task spend",
       "commands": "Commands",
       "expensiveRuns": "Expensive runs",
       "modelUsage": "Model usage",
@@ -330,7 +334,8 @@
       "recentRuns": "Recent runs",
       "runtimeMix": "Runtime mix",
       "sessions": "Sessions",
-      "sources": "Sources",
+      "sources": "Source events",
+      "tasks": "Tasks",
       "teams": "Teams",
       "usageTrend": "Usage trend"
     },

--- a/src/features/localization/renderer/locales/es/dashboard.json
+++ b/src/features/localization/renderer/locales/es/dashboard.json
@@ -199,7 +199,8 @@
     "partialData": "Datos parciales",
     "actions": {
       "refresh": "Actualizar",
-      "openTeam": "Abrir {{team}}"
+      "openTeam": "Abrir {{team}}",
+      "openTask": "Open task {{task}}"
     },
     "aria": {
       "modelUsageBySegment": "Uso de modelos por segmento"
@@ -264,7 +265,9 @@
       "tokensCost": "{{tokens}} tokens / {{cost}}",
       "total": "Total",
       "unassigned": "Sin asignar",
-      "unknownAgent": "Agente desconocido"
+      "unknownAgent": "Agente desconocido",
+      "eventCount": "{{count}} eventos",
+      "streakCount": "{{count}} días seguidos"
     },
     "metrics": {
       "apiEquivalent": "API-equivalent",
@@ -287,6 +290,7 @@
       "agents": "Agents",
       "commandPeriods": "Command periods",
       "commandSpend": "Command spend",
+      "taskSpend": "Task spend",
       "commands": "Commands",
       "expensiveRuns": "Expensive runs",
       "modelUsage": "Model usage",
@@ -294,7 +298,8 @@
       "recentRuns": "Recent runs",
       "runtimeMix": "Runtime mix",
       "sessions": "Sessions",
-      "sources": "Sources",
+      "sources": "Eventos de origen",
+      "tasks": "Tasks",
       "teams": "Teams",
       "usageTrend": "Usage trend",
       "billingSplit": "Billing split",

--- a/src/features/localization/renderer/locales/fa/dashboard.json
+++ b/src/features/localization/renderer/locales/fa/dashboard.json
@@ -199,7 +199,8 @@
     "partialData": "داده جزئی",
     "actions": {
       "refresh": "بازآوری",
-      "openTeam": "باز کردن {{team}}"
+      "openTeam": "باز کردن {{team}}",
+      "openTask": "Open task {{task}}"
     },
     "aria": {
       "modelUsageBySegment": "مصرف مدل بر اساس بخش"
@@ -264,7 +265,9 @@
       "tokensCost": "{{tokens}} توکن / {{cost}}",
       "total": "کل",
       "unassigned": "تخصیص‌نیافته",
-      "unknownAgent": "عامل ناشناس"
+      "unknownAgent": "عامل ناشناس",
+      "eventCount": "{{count}} رویداد",
+      "streakCount": "{{count}} روز پیاپی"
     },
     "metrics": {
       "apiEquivalent": "API-equivalent",
@@ -287,6 +290,7 @@
       "agents": "Agents",
       "commandPeriods": "Command periods",
       "commandSpend": "Command spend",
+      "taskSpend": "Task spend",
       "commands": "Commands",
       "expensiveRuns": "Expensive runs",
       "modelUsage": "Model usage",
@@ -294,7 +298,8 @@
       "recentRuns": "Recent runs",
       "runtimeMix": "Runtime mix",
       "sessions": "Sessions",
-      "sources": "Sources",
+      "sources": "رویدادهای منبع",
+      "tasks": "Tasks",
       "teams": "Teams",
       "usageTrend": "Usage trend",
       "billingSplit": "Billing split",

--- a/src/features/localization/renderer/locales/fil/dashboard.json
+++ b/src/features/localization/renderer/locales/fil/dashboard.json
@@ -199,7 +199,8 @@
     "partialData": "Bahagyang data",
     "actions": {
       "refresh": "I-refresh",
-      "openTeam": "Buksan {{team}}"
+      "openTeam": "Buksan {{team}}",
+      "openTask": "Open task {{task}}"
     },
     "aria": {
       "modelUsageBySegment": "Paggamit ng model bawat segment"
@@ -264,7 +265,9 @@
       "tokensCost": "{{tokens}} tokens / {{cost}}",
       "total": "Kabuuan",
       "unassigned": "Hindi naka-assign",
-      "unknownAgent": "Hindi kilalang agent"
+      "unknownAgent": "Hindi kilalang agent",
+      "eventCount": "{{count}} event",
+      "streakCount": "{{count}} araw na streak"
     },
     "metrics": {
       "apiEquivalent": "API-equivalent",
@@ -287,6 +290,7 @@
       "agents": "Agents",
       "commandPeriods": "Command periods",
       "commandSpend": "Command spend",
+      "taskSpend": "Task spend",
       "commands": "Commands",
       "expensiveRuns": "Expensive runs",
       "modelUsage": "Model usage",
@@ -294,7 +298,8 @@
       "recentRuns": "Recent runs",
       "runtimeMix": "Runtime mix",
       "sessions": "Sessions",
-      "sources": "Sources",
+      "sources": "Mga event ng source",
+      "tasks": "Tasks",
       "teams": "Teams",
       "usageTrend": "Usage trend",
       "billingSplit": "Billing split",

--- a/src/features/localization/renderer/locales/fr/dashboard.json
+++ b/src/features/localization/renderer/locales/fr/dashboard.json
@@ -199,7 +199,8 @@
     "partialData": "Données partielles",
     "actions": {
       "refresh": "Actualiser",
-      "openTeam": "Ouvrir {{team}}"
+      "openTeam": "Ouvrir {{team}}",
+      "openTask": "Open task {{task}}"
     },
     "aria": {
       "modelUsageBySegment": "Utilisation des modèles par segment"
@@ -264,7 +265,9 @@
       "tokensCost": "{{tokens}} tokens / {{cost}}",
       "total": "Total",
       "unassigned": "Non assigné",
-      "unknownAgent": "Agent inconnu"
+      "unknownAgent": "Agent inconnu",
+      "eventCount": "{{count}} événements",
+      "streakCount": "{{count}} jours de suite"
     },
     "metrics": {
       "apiEquivalent": "API-equivalent",
@@ -287,6 +290,7 @@
       "agents": "Agents",
       "commandPeriods": "Command periods",
       "commandSpend": "Command spend",
+      "taskSpend": "Task spend",
       "commands": "Commands",
       "expensiveRuns": "Expensive runs",
       "modelUsage": "Model usage",
@@ -294,7 +298,8 @@
       "recentRuns": "Recent runs",
       "runtimeMix": "Runtime mix",
       "sessions": "Sessions",
-      "sources": "Sources",
+      "sources": "Événements source",
+      "tasks": "Tasks",
       "teams": "Teams",
       "usageTrend": "Usage trend",
       "billingSplit": "Billing split",

--- a/src/features/localization/renderer/locales/hi/dashboard.json
+++ b/src/features/localization/renderer/locales/hi/dashboard.json
@@ -199,7 +199,8 @@
     "partialData": "आंशिक डेटा",
     "actions": {
       "refresh": "रीफ्रेश",
-      "openTeam": "{{team}} खोलें"
+      "openTeam": "{{team}} खोलें",
+      "openTask": "Open task {{task}}"
     },
     "aria": {
       "modelUsageBySegment": "सेगमेंट के अनुसार मॉडल उपयोग"
@@ -264,7 +265,9 @@
       "tokensCost": "{{tokens}} टोकन / {{cost}}",
       "total": "कुल",
       "unassigned": "अनअसाइन्ड",
-      "unknownAgent": "अज्ञात एजेंट"
+      "unknownAgent": "अज्ञात एजेंट",
+      "eventCount": "{{count}} इवेंट",
+      "streakCount": "{{count}} दिन की स्ट्रीक"
     },
     "metrics": {
       "apiEquivalent": "API-equivalent",
@@ -287,6 +290,7 @@
       "agents": "Agents",
       "commandPeriods": "Command periods",
       "commandSpend": "Command spend",
+      "taskSpend": "Task spend",
       "commands": "Commands",
       "expensiveRuns": "Expensive runs",
       "modelUsage": "Model usage",
@@ -294,7 +298,8 @@
       "recentRuns": "Recent runs",
       "runtimeMix": "Runtime mix",
       "sessions": "Sessions",
-      "sources": "Sources",
+      "sources": "स्रोत इवेंट",
+      "tasks": "Tasks",
       "teams": "Teams",
       "usageTrend": "Usage trend",
       "billingSplit": "Billing split",

--- a/src/features/localization/renderer/locales/id/dashboard.json
+++ b/src/features/localization/renderer/locales/id/dashboard.json
@@ -199,7 +199,8 @@
     "partialData": "Data sebagian",
     "actions": {
       "refresh": "Segarkan",
-      "openTeam": "Buka {{team}}"
+      "openTeam": "Buka {{team}}",
+      "openTask": "Open task {{task}}"
     },
     "aria": {
       "modelUsageBySegment": "Pemakaian model per segmen"
@@ -264,7 +265,9 @@
       "tokensCost": "{{tokens}} token / {{cost}}",
       "total": "Total",
       "unassigned": "Belum ditetapkan",
-      "unknownAgent": "Agen tidak dikenal"
+      "unknownAgent": "Agen tidak dikenal",
+      "eventCount": "{{count}} event",
+      "streakCount": "{{count}} hari beruntun"
     },
     "metrics": {
       "apiEquivalent": "API-equivalent",
@@ -287,6 +290,7 @@
       "agents": "Agents",
       "commandPeriods": "Command periods",
       "commandSpend": "Command spend",
+      "taskSpend": "Task spend",
       "commands": "Commands",
       "expensiveRuns": "Expensive runs",
       "modelUsage": "Model usage",
@@ -294,7 +298,8 @@
       "recentRuns": "Recent runs",
       "runtimeMix": "Runtime mix",
       "sessions": "Sessions",
-      "sources": "Sources",
+      "sources": "Event sumber",
+      "tasks": "Tasks",
       "teams": "Teams",
       "usageTrend": "Usage trend",
       "billingSplit": "Billing split",

--- a/src/features/localization/renderer/locales/it/dashboard.json
+++ b/src/features/localization/renderer/locales/it/dashboard.json
@@ -199,7 +199,8 @@
     "partialData": "Dati parziali",
     "actions": {
       "refresh": "Aggiorna",
-      "openTeam": "Apri {{team}}"
+      "openTeam": "Apri {{team}}",
+      "openTask": "Open task {{task}}"
     },
     "aria": {
       "modelUsageBySegment": "Uso modelli per segmento"
@@ -264,7 +265,9 @@
       "tokensCost": "{{tokens}} token / {{cost}}",
       "total": "Totale",
       "unassigned": "Non assegnato",
-      "unknownAgent": "Agente sconosciuto"
+      "unknownAgent": "Agente sconosciuto",
+      "eventCount": "{{count}} eventi",
+      "streakCount": "{{count}} giorni di streak"
     },
     "metrics": {
       "apiEquivalent": "API-equivalent",
@@ -287,6 +290,7 @@
       "agents": "Agents",
       "commandPeriods": "Command periods",
       "commandSpend": "Command spend",
+      "taskSpend": "Task spend",
       "commands": "Commands",
       "expensiveRuns": "Expensive runs",
       "modelUsage": "Model usage",
@@ -294,7 +298,8 @@
       "recentRuns": "Recent runs",
       "runtimeMix": "Runtime mix",
       "sessions": "Sessions",
-      "sources": "Sources",
+      "sources": "Eventi origine",
+      "tasks": "Tasks",
       "teams": "Teams",
       "usageTrend": "Usage trend",
       "billingSplit": "Billing split",

--- a/src/features/localization/renderer/locales/ja/dashboard.json
+++ b/src/features/localization/renderer/locales/ja/dashboard.json
@@ -199,7 +199,8 @@
     "partialData": "一部データ",
     "actions": {
       "refresh": "更新",
-      "openTeam": "{{team}} を開く"
+      "openTeam": "{{team}} を開く",
+      "openTask": "Open task {{task}}"
     },
     "aria": {
       "modelUsageBySegment": "セグメント別モデル使用量"
@@ -264,7 +265,9 @@
       "tokensCost": "{{tokens}} トークン / {{cost}}",
       "total": "合計",
       "unassigned": "未割り当て",
-      "unknownAgent": "不明なエージェント"
+      "unknownAgent": "不明なエージェント",
+      "eventCount": "{{count}} 件のイベント",
+      "streakCount": "{{count}}日連続"
     },
     "metrics": {
       "apiEquivalent": "API-equivalent",
@@ -287,6 +290,7 @@
       "agents": "Agents",
       "commandPeriods": "Command periods",
       "commandSpend": "Command spend",
+      "taskSpend": "Task spend",
       "commands": "Commands",
       "expensiveRuns": "Expensive runs",
       "modelUsage": "Model usage",
@@ -294,7 +298,8 @@
       "recentRuns": "Recent runs",
       "runtimeMix": "Runtime mix",
       "sessions": "Sessions",
-      "sources": "Sources",
+      "sources": "ソースイベント",
+      "tasks": "Tasks",
       "teams": "Teams",
       "usageTrend": "Usage trend",
       "billingSplit": "Billing split",

--- a/src/features/localization/renderer/locales/ko/dashboard.json
+++ b/src/features/localization/renderer/locales/ko/dashboard.json
@@ -199,7 +199,8 @@
     "partialData": "일부 데이터",
     "actions": {
       "refresh": "새로고침",
-      "openTeam": "{{team}} 열기"
+      "openTeam": "{{team}} 열기",
+      "openTask": "Open task {{task}}"
     },
     "aria": {
       "modelUsageBySegment": "세그먼트별 모델 사용량"
@@ -264,7 +265,9 @@
       "tokensCost": "{{tokens}} 토큰 / {{cost}}",
       "total": "합계",
       "unassigned": "미할당",
-      "unknownAgent": "알 수 없는 에이전트"
+      "unknownAgent": "알 수 없는 에이전트",
+      "eventCount": "{{count}} 이벤트",
+      "streakCount": "{{count}}일 연속"
     },
     "metrics": {
       "apiEquivalent": "API-equivalent",
@@ -287,6 +290,7 @@
       "agents": "Agents",
       "commandPeriods": "Command periods",
       "commandSpend": "Command spend",
+      "taskSpend": "Task spend",
       "commands": "Commands",
       "expensiveRuns": "Expensive runs",
       "modelUsage": "Model usage",
@@ -294,7 +298,8 @@
       "recentRuns": "Recent runs",
       "runtimeMix": "Runtime mix",
       "sessions": "Sessions",
-      "sources": "Sources",
+      "sources": "소스 이벤트",
+      "tasks": "Tasks",
       "teams": "Teams",
       "usageTrend": "Usage trend",
       "billingSplit": "Billing split",

--- a/src/features/localization/renderer/locales/mr/dashboard.json
+++ b/src/features/localization/renderer/locales/mr/dashboard.json
@@ -199,7 +199,8 @@
     "partialData": "आंशिक डेटा",
     "actions": {
       "refresh": "रीफ्रेश",
-      "openTeam": "{{team}} उघडा"
+      "openTeam": "{{team}} उघडा",
+      "openTask": "Open task {{task}}"
     },
     "aria": {
       "modelUsageBySegment": "सेगमेंटनुसार मॉडेल वापर"
@@ -264,7 +265,9 @@
       "tokensCost": "{{tokens}} टोकन / {{cost}}",
       "total": "एकूण",
       "unassigned": "नसोपवलेले",
-      "unknownAgent": "अज्ञात एजंट"
+      "unknownAgent": "अज्ञात एजंट",
+      "eventCount": "{{count}} इव्हेंट",
+      "streakCount": "{{count}} दिवसांची स्ट्रीक"
     },
     "metrics": {
       "apiEquivalent": "API-equivalent",
@@ -287,6 +290,7 @@
       "agents": "Agents",
       "commandPeriods": "Command periods",
       "commandSpend": "Command spend",
+      "taskSpend": "Task spend",
       "commands": "Commands",
       "expensiveRuns": "Expensive runs",
       "modelUsage": "Model usage",
@@ -294,7 +298,8 @@
       "recentRuns": "Recent runs",
       "runtimeMix": "Runtime mix",
       "sessions": "Sessions",
-      "sources": "Sources",
+      "sources": "स्रोत इव्हेंट",
+      "tasks": "Tasks",
       "teams": "Teams",
       "usageTrend": "Usage trend",
       "billingSplit": "Billing split",

--- a/src/features/localization/renderer/locales/ms/dashboard.json
+++ b/src/features/localization/renderer/locales/ms/dashboard.json
@@ -199,7 +199,8 @@
     "partialData": "Data separa",
     "actions": {
       "refresh": "Segar semula",
-      "openTeam": "Buka {{team}}"
+      "openTeam": "Buka {{team}}",
+      "openTask": "Open task {{task}}"
     },
     "aria": {
       "modelUsageBySegment": "Penggunaan model mengikut segmen"
@@ -264,7 +265,9 @@
       "tokensCost": "{{tokens}} token / {{cost}}",
       "total": "Jumlah",
       "unassigned": "Belum ditetapkan",
-      "unknownAgent": "Agen tidak diketahui"
+      "unknownAgent": "Agen tidak diketahui",
+      "eventCount": "{{count}} peristiwa",
+      "streakCount": "{{count}} hari berturut-turut"
     },
     "metrics": {
       "apiEquivalent": "API-equivalent",
@@ -287,6 +290,7 @@
       "agents": "Agents",
       "commandPeriods": "Command periods",
       "commandSpend": "Command spend",
+      "taskSpend": "Task spend",
       "commands": "Commands",
       "expensiveRuns": "Expensive runs",
       "modelUsage": "Model usage",
@@ -294,7 +298,8 @@
       "recentRuns": "Recent runs",
       "runtimeMix": "Runtime mix",
       "sessions": "Sessions",
-      "sources": "Sources",
+      "sources": "Peristiwa sumber",
+      "tasks": "Tasks",
       "teams": "Teams",
       "usageTrend": "Usage trend",
       "billingSplit": "Billing split",

--- a/src/features/localization/renderer/locales/nl/dashboard.json
+++ b/src/features/localization/renderer/locales/nl/dashboard.json
@@ -199,7 +199,8 @@
     "partialData": "Gedeeltelijke data",
     "actions": {
       "refresh": "Vernieuwen",
-      "openTeam": "Open {{team}}"
+      "openTeam": "Open {{team}}",
+      "openTask": "Open task {{task}}"
     },
     "aria": {
       "modelUsageBySegment": "Modelgebruik per segment"
@@ -264,7 +265,9 @@
       "tokensCost": "{{tokens}} tokens / {{cost}}",
       "total": "Totaal",
       "unassigned": "Niet toegewezen",
-      "unknownAgent": "Onbekende agent"
+      "unknownAgent": "Onbekende agent",
+      "eventCount": "{{count}} gebeurtenissen",
+      "streakCount": "{{count}} dagen reeks"
     },
     "metrics": {
       "apiEquivalent": "API-equivalent",
@@ -287,6 +290,7 @@
       "agents": "Agents",
       "commandPeriods": "Command periods",
       "commandSpend": "Command spend",
+      "taskSpend": "Task spend",
       "commands": "Commands",
       "expensiveRuns": "Expensive runs",
       "modelUsage": "Model usage",
@@ -294,7 +298,8 @@
       "recentRuns": "Recent runs",
       "runtimeMix": "Runtime mix",
       "sessions": "Sessions",
-      "sources": "Sources",
+      "sources": "Brongebeurtenissen",
+      "tasks": "Tasks",
       "teams": "Teams",
       "usageTrend": "Usage trend",
       "billingSplit": "Billing split",

--- a/src/features/localization/renderer/locales/pl/dashboard.json
+++ b/src/features/localization/renderer/locales/pl/dashboard.json
@@ -199,7 +199,8 @@
     "partialData": "Dane częściowe",
     "actions": {
       "refresh": "Odśwież",
-      "openTeam": "Otwórz {{team}}"
+      "openTeam": "Otwórz {{team}}",
+      "openTask": "Open task {{task}}"
     },
     "aria": {
       "modelUsageBySegment": "Użycie modeli według segmentu"
@@ -264,7 +265,9 @@
       "tokensCost": "{{tokens}} tokenów / {{cost}}",
       "total": "Razem",
       "unassigned": "Nieprzypisane",
-      "unknownAgent": "Nieznany agent"
+      "unknownAgent": "Nieznany agent",
+      "eventCount": "{{count}} zdarzeń",
+      "streakCount": "{{count}} dni serii"
     },
     "metrics": {
       "apiEquivalent": "API-equivalent",
@@ -287,6 +290,7 @@
       "agents": "Agents",
       "commandPeriods": "Command periods",
       "commandSpend": "Command spend",
+      "taskSpend": "Task spend",
       "commands": "Commands",
       "expensiveRuns": "Expensive runs",
       "modelUsage": "Model usage",
@@ -294,7 +298,8 @@
       "recentRuns": "Recent runs",
       "runtimeMix": "Runtime mix",
       "sessions": "Sessions",
-      "sources": "Sources",
+      "sources": "Zdarzenia źródeł",
+      "tasks": "Tasks",
       "teams": "Teams",
       "usageTrend": "Usage trend",
       "billingSplit": "Billing split",

--- a/src/features/localization/renderer/locales/pt/dashboard.json
+++ b/src/features/localization/renderer/locales/pt/dashboard.json
@@ -199,7 +199,8 @@
     "partialData": "Dados parciais",
     "actions": {
       "refresh": "Atualizar",
-      "openTeam": "Abrir {{team}}"
+      "openTeam": "Abrir {{team}}",
+      "openTask": "Open task {{task}}"
     },
     "aria": {
       "modelUsageBySegment": "Uso de modelos por segmento"
@@ -264,7 +265,9 @@
       "tokensCost": "{{tokens}} tokens / {{cost}}",
       "total": "Total",
       "unassigned": "Não atribuído",
-      "unknownAgent": "Agente desconhecido"
+      "unknownAgent": "Agente desconhecido",
+      "eventCount": "{{count}} eventos",
+      "streakCount": "{{count}} dias seguidos"
     },
     "metrics": {
       "apiEquivalent": "API-equivalent",
@@ -287,6 +290,7 @@
       "agents": "Agents",
       "commandPeriods": "Command periods",
       "commandSpend": "Command spend",
+      "taskSpend": "Task spend",
       "commands": "Commands",
       "expensiveRuns": "Expensive runs",
       "modelUsage": "Model usage",
@@ -294,7 +298,8 @@
       "recentRuns": "Recent runs",
       "runtimeMix": "Runtime mix",
       "sessions": "Sessions",
-      "sources": "Sources",
+      "sources": "Eventos de origem",
+      "tasks": "Tasks",
       "teams": "Teams",
       "usageTrend": "Usage trend",
       "billingSplit": "Billing split",

--- a/src/features/localization/renderer/locales/ro/dashboard.json
+++ b/src/features/localization/renderer/locales/ro/dashboard.json
@@ -199,7 +199,8 @@
     "partialData": "Date parțiale",
     "actions": {
       "refresh": "Actualizează",
-      "openTeam": "Deschide {{team}}"
+      "openTeam": "Deschide {{team}}",
+      "openTask": "Open task {{task}}"
     },
     "aria": {
       "modelUsageBySegment": "Utilizarea modelelor pe segment"
@@ -264,7 +265,9 @@
       "tokensCost": "{{tokens}} tokeni / {{cost}}",
       "total": "Total",
       "unassigned": "Neatribuit",
-      "unknownAgent": "Agent necunoscut"
+      "unknownAgent": "Agent necunoscut",
+      "eventCount": "{{count}} evenimente",
+      "streakCount": "{{count}} zile la rând"
     },
     "metrics": {
       "apiEquivalent": "API-equivalent",
@@ -287,6 +290,7 @@
       "agents": "Agents",
       "commandPeriods": "Command periods",
       "commandSpend": "Command spend",
+      "taskSpend": "Task spend",
       "commands": "Commands",
       "expensiveRuns": "Expensive runs",
       "modelUsage": "Model usage",
@@ -294,7 +298,8 @@
       "recentRuns": "Recent runs",
       "runtimeMix": "Runtime mix",
       "sessions": "Sessions",
-      "sources": "Sources",
+      "sources": "Evenimente sursă",
+      "tasks": "Tasks",
       "teams": "Teams",
       "usageTrend": "Usage trend",
       "billingSplit": "Billing split",

--- a/src/features/localization/renderer/locales/ru/dashboard.json
+++ b/src/features/localization/renderer/locales/ru/dashboard.json
@@ -199,7 +199,8 @@
     "partialData": "Частичные данные",
     "actions": {
       "refresh": "Обновить",
-      "openTeam": "Открыть {{team}}"
+      "openTeam": "Открыть {{team}}",
+      "openTask": "Открыть задачу {{task}}"
     },
     "aria": {
       "modelUsageBySegment": "Использование моделей по сегментам"
@@ -297,7 +298,9 @@
       "tokensCost": "{{tokens}} токенов / {{cost}}",
       "total": "Всего",
       "unassigned": "Без команды",
-      "unknownAgent": "Неизвестный агент"
+      "unknownAgent": "Неизвестный агент",
+      "eventCount": "{{count}} событий",
+      "streakCount": "{{count}} дн. подряд"
     },
     "metrics": {
       "apiEquivalent": "API-equivalent",
@@ -323,6 +326,7 @@
       "burnRate": "Burn rate",
       "commandPeriods": "Периоды команд",
       "commandSpend": "Расход команд",
+      "taskSpend": "Расход задач",
       "commands": "Команды",
       "expensiveRuns": "Дорогие запуски",
       "modelUsage": "Использование моделей",
@@ -330,7 +334,8 @@
       "recentRuns": "Последние запуски",
       "runtimeMix": "Runtime mix",
       "sessions": "Сессии",
-      "sources": "Источники",
+      "sources": "События источников",
+      "tasks": "Задачи",
       "teams": "Команды",
       "usageTrend": "Тренд использования"
     },

--- a/src/features/localization/renderer/locales/sw/dashboard.json
+++ b/src/features/localization/renderer/locales/sw/dashboard.json
@@ -199,7 +199,8 @@
     "partialData": "Data ya sehemu",
     "actions": {
       "refresh": "Onyesha upya",
-      "openTeam": "Fungua {{team}}"
+      "openTeam": "Fungua {{team}}",
+      "openTask": "Open task {{task}}"
     },
     "aria": {
       "modelUsageBySegment": "Matumizi ya model kwa sehemu"
@@ -264,7 +265,9 @@
       "tokensCost": "{{tokens}} tokens / {{cost}}",
       "total": "Jumla",
       "unassigned": "Haijapangiwa",
-      "unknownAgent": "Agent asiyejulikana"
+      "unknownAgent": "Agent asiyejulikana",
+      "eventCount": "{{count}} matukio",
+      "streakCount": "{{count}} siku mfululizo"
     },
     "metrics": {
       "apiEquivalent": "API-equivalent",
@@ -287,6 +290,7 @@
       "agents": "Agents",
       "commandPeriods": "Command periods",
       "commandSpend": "Command spend",
+      "taskSpend": "Task spend",
       "commands": "Commands",
       "expensiveRuns": "Expensive runs",
       "modelUsage": "Model usage",
@@ -294,7 +298,8 @@
       "recentRuns": "Recent runs",
       "runtimeMix": "Runtime mix",
       "sessions": "Sessions",
-      "sources": "Sources",
+      "sources": "Matukio ya chanzo",
+      "tasks": "Tasks",
       "teams": "Teams",
       "usageTrend": "Usage trend",
       "billingSplit": "Billing split",

--- a/src/features/localization/renderer/locales/ta/dashboard.json
+++ b/src/features/localization/renderer/locales/ta/dashboard.json
@@ -199,7 +199,8 @@
     "partialData": "பகுதி தரவு",
     "actions": {
       "refresh": "புதுப்பி",
-      "openTeam": "{{team}} திற"
+      "openTeam": "{{team}} திற",
+      "openTask": "Open task {{task}}"
     },
     "aria": {
       "modelUsageBySegment": "பகுதி வாரியாக model பயன்பாடு"
@@ -264,7 +265,9 @@
       "tokensCost": "{{tokens}} tokens / {{cost}}",
       "total": "மொத்தம்",
       "unassigned": "ஒதுக்கப்படவில்லை",
-      "unknownAgent": "தெரியாத agent"
+      "unknownAgent": "தெரியாத agent",
+      "eventCount": "{{count}} நிகழ்வுகள்",
+      "streakCount": "{{count}} நாள் தொடர்ச்சி"
     },
     "metrics": {
       "apiEquivalent": "API-equivalent",
@@ -287,6 +290,7 @@
       "agents": "Agents",
       "commandPeriods": "Command periods",
       "commandSpend": "Command spend",
+      "taskSpend": "Task spend",
       "commands": "Commands",
       "expensiveRuns": "Expensive runs",
       "modelUsage": "Model usage",
@@ -294,7 +298,8 @@
       "recentRuns": "Recent runs",
       "runtimeMix": "Runtime mix",
       "sessions": "Sessions",
-      "sources": "Sources",
+      "sources": "மூல நிகழ்வுகள்",
+      "tasks": "Tasks",
       "teams": "Teams",
       "usageTrend": "Usage trend",
       "billingSplit": "Billing split",

--- a/src/features/localization/renderer/locales/te/dashboard.json
+++ b/src/features/localization/renderer/locales/te/dashboard.json
@@ -199,7 +199,8 @@
     "partialData": "భాగిక డేటా",
     "actions": {
       "refresh": "రిఫ్రెష్",
-      "openTeam": "{{team}} తెరువు"
+      "openTeam": "{{team}} తెరువు",
+      "openTask": "Open task {{task}}"
     },
     "aria": {
       "modelUsageBySegment": "సెగ్మెంట్ వారీగా model వినియోగం"
@@ -264,7 +265,9 @@
       "tokensCost": "{{tokens}} tokens / {{cost}}",
       "total": "మొత్తం",
       "unassigned": "కేటాయించలేదు",
-      "unknownAgent": "తెలియని agent"
+      "unknownAgent": "తెలియని agent",
+      "eventCount": "{{count}} ఈవెంట్లు",
+      "streakCount": "{{count}} రోజుల స్ట్రీక్"
     },
     "metrics": {
       "apiEquivalent": "API-equivalent",
@@ -287,6 +290,7 @@
       "agents": "Agents",
       "commandPeriods": "Command periods",
       "commandSpend": "Command spend",
+      "taskSpend": "Task spend",
       "commands": "Commands",
       "expensiveRuns": "Expensive runs",
       "modelUsage": "Model usage",
@@ -294,7 +298,8 @@
       "recentRuns": "Recent runs",
       "runtimeMix": "Runtime mix",
       "sessions": "Sessions",
-      "sources": "Sources",
+      "sources": "మూల ఈవెంట్లు",
+      "tasks": "Tasks",
       "teams": "Teams",
       "usageTrend": "Usage trend",
       "billingSplit": "Billing split",

--- a/src/features/localization/renderer/locales/th/dashboard.json
+++ b/src/features/localization/renderer/locales/th/dashboard.json
@@ -199,7 +199,8 @@
     "partialData": "ข้อมูลบางส่วน",
     "actions": {
       "refresh": "รีเฟรช",
-      "openTeam": "เปิด {{team}}"
+      "openTeam": "เปิด {{team}}",
+      "openTask": "Open task {{task}}"
     },
     "aria": {
       "modelUsageBySegment": "การใช้โมเดลตามส่วน"
@@ -264,7 +265,9 @@
       "tokensCost": "{{tokens}} tokens / {{cost}}",
       "total": "รวม",
       "unassigned": "ยังไม่กำหนด",
-      "unknownAgent": "agent ไม่ทราบชื่อ"
+      "unknownAgent": "agent ไม่ทราบชื่อ",
+      "eventCount": "{{count}} เหตุการณ์",
+      "streakCount": "{{count}} วันติดกัน"
     },
     "metrics": {
       "apiEquivalent": "API-equivalent",
@@ -287,6 +290,7 @@
       "agents": "Agents",
       "commandPeriods": "Command periods",
       "commandSpend": "Command spend",
+      "taskSpend": "Task spend",
       "commands": "Commands",
       "expensiveRuns": "Expensive runs",
       "modelUsage": "Model usage",
@@ -294,7 +298,8 @@
       "recentRuns": "Recent runs",
       "runtimeMix": "Runtime mix",
       "sessions": "Sessions",
-      "sources": "Sources",
+      "sources": "เหตุการณ์แหล่งที่มา",
+      "tasks": "Tasks",
       "teams": "Teams",
       "usageTrend": "Usage trend",
       "billingSplit": "Billing split",

--- a/src/features/localization/renderer/locales/tr/dashboard.json
+++ b/src/features/localization/renderer/locales/tr/dashboard.json
@@ -199,7 +199,8 @@
     "partialData": "Kısmi veri",
     "actions": {
       "refresh": "Yenile",
-      "openTeam": "{{team}} aç"
+      "openTeam": "{{team}} aç",
+      "openTask": "Open task {{task}}"
     },
     "aria": {
       "modelUsageBySegment": "Segmente göre model kullanımı"
@@ -264,7 +265,9 @@
       "tokensCost": "{{tokens}} token / {{cost}}",
       "total": "Toplam",
       "unassigned": "Atanmamış",
-      "unknownAgent": "Bilinmeyen agent"
+      "unknownAgent": "Bilinmeyen agent",
+      "eventCount": "{{count}} olay",
+      "streakCount": "{{count}} günlük seri"
     },
     "metrics": {
       "apiEquivalent": "API-equivalent",
@@ -287,6 +290,7 @@
       "agents": "Agents",
       "commandPeriods": "Command periods",
       "commandSpend": "Command spend",
+      "taskSpend": "Task spend",
       "commands": "Commands",
       "expensiveRuns": "Expensive runs",
       "modelUsage": "Model usage",
@@ -294,7 +298,8 @@
       "recentRuns": "Recent runs",
       "runtimeMix": "Runtime mix",
       "sessions": "Sessions",
-      "sources": "Sources",
+      "sources": "Kaynak olayları",
+      "tasks": "Tasks",
       "teams": "Teams",
       "usageTrend": "Usage trend",
       "billingSplit": "Billing split",

--- a/src/features/localization/renderer/locales/uk/dashboard.json
+++ b/src/features/localization/renderer/locales/uk/dashboard.json
@@ -199,7 +199,8 @@
     "partialData": "Часткові дані",
     "actions": {
       "refresh": "Оновити",
-      "openTeam": "Відкрити {{team}}"
+      "openTeam": "Відкрити {{team}}",
+      "openTask": "Open task {{task}}"
     },
     "aria": {
       "modelUsageBySegment": "Використання моделей за сегментами"
@@ -297,7 +298,9 @@
       "tokensCost": "{{tokens}} токенів / {{cost}}",
       "total": "Усього",
       "unassigned": "Без команди",
-      "unknownAgent": "Невідомий агент"
+      "unknownAgent": "Невідомий агент",
+      "eventCount": "{{count}} подій",
+      "streakCount": "{{count}} дн. поспіль"
     },
     "metrics": {
       "apiEquivalent": "API-equivalent",
@@ -323,6 +326,7 @@
       "burnRate": "Burn rate",
       "commandPeriods": "Command periods",
       "commandSpend": "Command spend",
+      "taskSpend": "Task spend",
       "commands": "Commands",
       "expensiveRuns": "Expensive runs",
       "modelUsage": "Model usage",
@@ -330,7 +334,8 @@
       "recentRuns": "Recent runs",
       "runtimeMix": "Runtime mix",
       "sessions": "Sessions",
-      "sources": "Sources",
+      "sources": "Події джерел",
+      "tasks": "Tasks",
       "teams": "Teams",
       "usageTrend": "Usage trend"
     },

--- a/src/features/localization/renderer/locales/ur/dashboard.json
+++ b/src/features/localization/renderer/locales/ur/dashboard.json
@@ -199,7 +199,8 @@
     "partialData": "جزوی ڈیٹا",
     "actions": {
       "refresh": "تازہ کریں",
-      "openTeam": "{{team}} کھولیں"
+      "openTeam": "{{team}} کھولیں",
+      "openTask": "Open task {{task}}"
     },
     "aria": {
       "modelUsageBySegment": "سیگمنٹ کے لحاظ سے ماڈل استعمال"
@@ -264,7 +265,9 @@
       "tokensCost": "{{tokens}} ٹوکن / {{cost}}",
       "total": "کل",
       "unassigned": "غیر تفویض",
-      "unknownAgent": "نامعلوم ایجنٹ"
+      "unknownAgent": "نامعلوم ایجنٹ",
+      "eventCount": "{{count}} ایونٹس",
+      "streakCount": "{{count}} دن کا اسٹریک"
     },
     "metrics": {
       "apiEquivalent": "API-equivalent",
@@ -287,6 +290,7 @@
       "agents": "Agents",
       "commandPeriods": "Command periods",
       "commandSpend": "Command spend",
+      "taskSpend": "Task spend",
       "commands": "Commands",
       "expensiveRuns": "Expensive runs",
       "modelUsage": "Model usage",
@@ -294,7 +298,8 @@
       "recentRuns": "Recent runs",
       "runtimeMix": "Runtime mix",
       "sessions": "Sessions",
-      "sources": "Sources",
+      "sources": "ماخذ ایونٹس",
+      "tasks": "Tasks",
       "teams": "Teams",
       "usageTrend": "Usage trend",
       "billingSplit": "Billing split",

--- a/src/features/localization/renderer/locales/vi/dashboard.json
+++ b/src/features/localization/renderer/locales/vi/dashboard.json
@@ -199,7 +199,8 @@
     "partialData": "Dữ liệu một phần",
     "actions": {
       "refresh": "Làm mới",
-      "openTeam": "Mở {{team}}"
+      "openTeam": "Mở {{team}}",
+      "openTask": "Open task {{task}}"
     },
     "aria": {
       "modelUsageBySegment": "Mức dùng model theo phân đoạn"
@@ -264,7 +265,9 @@
       "tokensCost": "{{tokens}} token / {{cost}}",
       "total": "Tổng",
       "unassigned": "Chưa gán",
-      "unknownAgent": "Agent không rõ"
+      "unknownAgent": "Agent không rõ",
+      "eventCount": "{{count}} sự kiện",
+      "streakCount": "{{count}} ngày liên tiếp"
     },
     "metrics": {
       "apiEquivalent": "API-equivalent",
@@ -287,6 +290,7 @@
       "agents": "Agents",
       "commandPeriods": "Command periods",
       "commandSpend": "Command spend",
+      "taskSpend": "Task spend",
       "commands": "Commands",
       "expensiveRuns": "Expensive runs",
       "modelUsage": "Model usage",
@@ -294,7 +298,8 @@
       "recentRuns": "Recent runs",
       "runtimeMix": "Runtime mix",
       "sessions": "Sessions",
-      "sources": "Sources",
+      "sources": "Sự kiện nguồn",
+      "tasks": "Tasks",
       "teams": "Teams",
       "usageTrend": "Usage trend",
       "billingSplit": "Billing split",

--- a/src/features/localization/renderer/locales/zh/dashboard.json
+++ b/src/features/localization/renderer/locales/zh/dashboard.json
@@ -199,7 +199,8 @@
     "partialData": "部分数据",
     "actions": {
       "refresh": "刷新",
-      "openTeam": "打开 {{team}}"
+      "openTeam": "打开 {{team}}",
+      "openTask": "Open task {{task}}"
     },
     "aria": {
       "modelUsageBySegment": "按分段的模型用量"
@@ -264,7 +265,9 @@
       "tokensCost": "{{tokens}} token / {{cost}}",
       "total": "总计",
       "unassigned": "未分配",
-      "unknownAgent": "未知代理"
+      "unknownAgent": "未知代理",
+      "eventCount": "{{count}} 个事件",
+      "streakCount": "连续 {{count}} 天"
     },
     "metrics": {
       "apiEquivalent": "API-equivalent",
@@ -287,6 +290,7 @@
       "agents": "Agents",
       "commandPeriods": "Command periods",
       "commandSpend": "Command spend",
+      "taskSpend": "Task spend",
       "commands": "Commands",
       "expensiveRuns": "Expensive runs",
       "modelUsage": "Model usage",
@@ -294,7 +298,8 @@
       "recentRuns": "Recent runs",
       "runtimeMix": "Runtime mix",
       "sessions": "Sessions",
-      "sources": "Sources",
+      "sources": "来源事件",
+      "tasks": "Tasks",
       "teams": "Teams",
       "usageTrend": "Usage trend",
       "billingSplit": "Billing split",

--- a/src/features/localization/renderer/resources.d.ts
+++ b/src/features/localization/renderer/resources.d.ts
@@ -1113,6 +1113,7 @@ export default interface Resources {
     tokenUsage: {
       actions: {
         openTeam: 'Open {{team}}';
+        openTask: 'Open task {{task}}';
         refresh: 'Refresh';
       };
       aria: {
@@ -1207,6 +1208,8 @@ export default interface Resources {
         runCount: '{{count}} runs';
         share: 'Share';
         sourceCount: '{{count}} sources';
+        eventCount: '{{count}} events';
+        streakCount: '{{count}} day streak';
         tokens: 'tokens';
         tokensCost: '{{tokens}} tokens / {{cost}}';
         total: 'Total';
@@ -1237,6 +1240,7 @@ export default interface Resources {
         burnRate: 'Burn rate';
         commandPeriods: 'Command periods';
         commandSpend: 'Command spend';
+        taskSpend: 'Task spend';
         commands: 'Commands';
         expensiveRuns: 'Expensive runs';
         modelUsage: 'Model usage';
@@ -1244,7 +1248,8 @@ export default interface Resources {
         recentRuns: 'Recent runs';
         runtimeMix: 'Runtime mix';
         sessions: 'Sessions';
-        sources: 'Sources';
+        sources: 'Source events';
+        tasks: 'Tasks';
         teams: 'Teams';
         usageTrend: 'Usage trend';
       };

--- a/src/features/token-usage/contracts/dto.ts
+++ b/src/features/token-usage/contracts/dto.ts
@@ -157,6 +157,29 @@ export interface TokenUsageBreakdownItemDto {
   lastActivityAt?: string;
 }
 
+export interface TokenUsageTaskWorkIntervalDto {
+  startedAt: string;
+  completedAt?: string;
+}
+
+export interface TokenUsageTaskAttributionDto {
+  id: string;
+  displayId?: string;
+  teamName: string;
+  owner?: string;
+  subject: string;
+  status?: string;
+  workIntervals: TokenUsageTaskWorkIntervalDto[];
+}
+
+export interface TokenUsageTaskBreakdownItemDto extends TokenUsageBreakdownItemDto {
+  taskId: string;
+  displayId?: string;
+  subject: string;
+  owner?: string;
+  status?: string;
+}
+
 export interface TokenUsageRecentRunDto {
   appRunId: string;
   teamName?: string;
@@ -232,6 +255,7 @@ export interface TokenUsageAnalyticsSnapshotDto {
   byProject: TokenUsageBreakdownItemDto[];
   byRuntime: TokenUsageBreakdownItemDto[];
   byModel: TokenUsageBreakdownItemDto[];
+  byTask: TokenUsageTaskBreakdownItemDto[];
   commandRuns: TokenUsageCommandRunDto[];
   sessionRuns: TokenUsageSessionRunDto[];
   tokenTrend: TokenUsageTimeSeriesPointDto[];

--- a/src/features/token-usage/contracts/normalize.ts
+++ b/src/features/token-usage/contracts/normalize.ts
@@ -11,6 +11,7 @@ import type {
   TokenUsageRuntimeKind,
   TokenUsageSessionRunDto,
   TokenUsageSummaryDto,
+  TokenUsageTaskBreakdownItemDto,
   TokenUsageTimeSeriesPointDto,
   TokenUsageTokenBreakdownDto,
 } from './dto';
@@ -115,6 +116,22 @@ function normalizeBreakdownItem(value: unknown): TokenUsageBreakdownItemDto | nu
     agentName: readString(record?.agentName),
     summary: normalizeTokenUsageSummary(record?.summary),
     lastActivityAt: readString(record?.lastActivityAt),
+  };
+}
+
+function normalizeTaskBreakdownItem(value: unknown): TokenUsageTaskBreakdownItemDto | null {
+  const item = normalizeBreakdownItem(value);
+  const record = isRecord(value) ? value : null;
+  const taskId = readString(record?.taskId);
+  const subject = readString(record?.subject);
+  if (!item || !taskId || !subject) return null;
+  return {
+    ...item,
+    taskId,
+    displayId: readString(record?.displayId),
+    subject,
+    owner: readString(record?.owner),
+    status: readString(record?.status),
   };
 }
 
@@ -253,6 +270,10 @@ export function normalizeTokenUsageSnapshot(value: unknown): TokenUsageAnalytics
     (Array.isArray(items) ? items : [])
       .map((item) => normalizeBreakdownItem(item))
       .filter((item): item is TokenUsageBreakdownItemDto => item !== null);
+  const normalizeTaskItems = (items: unknown): TokenUsageTaskBreakdownItemDto[] =>
+    (Array.isArray(items) ? items : [])
+      .map((item) => normalizeTaskBreakdownItem(item))
+      .filter((item): item is TokenUsageTaskBreakdownItemDto => item !== null);
   const normalizeRuns = (items: unknown): TokenUsageRecentRunDto[] =>
     (Array.isArray(items) ? items : [])
       .map((item) => normalizeRecentRun(item))
@@ -297,6 +318,7 @@ export function normalizeTokenUsageSnapshot(value: unknown): TokenUsageAnalytics
     byProject: normalizeItems(record?.byProject),
     byRuntime: normalizeItems(record?.byRuntime),
     byModel: normalizeItems(record?.byModel),
+    byTask: normalizeTaskItems(record?.byTask),
     commandRuns: normalizeCommandRuns(record?.commandRuns),
     sessionRuns: normalizeSessionRuns(record?.sessionRuns),
     tokenTrend: normalizeTrend(record?.tokenTrend),

--- a/src/features/token-usage/core/application/TokenUsageAnalyticsService.ts
+++ b/src/features/token-usage/core/application/TokenUsageAnalyticsService.ts
@@ -6,6 +6,7 @@ import type {
   TokenUsageEventDto,
   TokenUsageRunDto,
   TokenUsageSnapshotRequest,
+  TokenUsageTaskAttributionDto,
 } from '../../contracts';
 import type {
   TokenUsageAnalyticsServicePort,
@@ -17,6 +18,7 @@ import type {
   TokenUsageLoggerPort,
   TokenUsageRealtimePublisherPort,
   TokenUsageRunSourceDiscoveryPort,
+  TokenUsageTaskAttributionSourcePort,
 } from './ports';
 
 export interface TokenUsageAnalyticsServiceDeps {
@@ -27,6 +29,7 @@ export interface TokenUsageAnalyticsServiceDeps {
   budgets?: TokenUsageBudgetSettingsRepositoryPort;
   budgetNotifications?: TokenUsageBudgetNotificationEvaluatorPort;
   publisher?: TokenUsageRealtimePublisherPort;
+  taskAttributionSource?: TokenUsageTaskAttributionSourcePort;
   logger?: TokenUsageLoggerPort;
 }
 
@@ -34,13 +37,15 @@ export class TokenUsageAnalyticsService implements TokenUsageAnalyticsServicePor
   constructor(private readonly deps: TokenUsageAnalyticsServiceDeps) {}
 
   async getSnapshot(request?: TokenUsageSnapshotRequest): Promise<TokenUsageAnalyticsSnapshotDto> {
-    const [runs, events] = await Promise.all([
+    const [runs, events, tasks] = await Promise.all([
       this.deps.ledger.listRuns(),
       this.deps.ledger.listEvents(),
+      this.listTaskAttributions(false),
     ]);
     return buildTokenUsageSnapshot({
       runs,
       events,
+      tasks,
       request,
       nowIso: this.deps.clock.now().toISOString(),
     });
@@ -69,13 +74,18 @@ export class TokenUsageAnalyticsService implements TokenUsageAnalyticsServicePor
       }
     }
 
-    const [nextRuns, nextEvents] = await Promise.all([
+    const [nextRuns, nextEvents, taskAttributionResult] = await Promise.all([
       this.deps.ledger.listRuns(),
       this.deps.ledger.listEvents(),
+      this.listTaskAttributions(true),
     ]);
+    if (taskAttributionResult.degraded) {
+      degraded = true;
+    }
     const canonicalSnapshot = buildTokenUsageSnapshot({
       runs: nextRuns,
       events: nextEvents,
+      tasks: taskAttributionResult.tasks,
       nowIso: this.deps.clock.now().toISOString(),
       degraded,
     });
@@ -83,6 +93,7 @@ export class TokenUsageAnalyticsService implements TokenUsageAnalyticsServicePor
       ? buildTokenUsageSnapshot({
           runs: nextRuns,
           events: nextEvents,
+          tasks: taskAttributionResult.tasks,
           request,
           nowIso: canonicalSnapshot.updatedAt,
           degraded,
@@ -118,17 +129,44 @@ export class TokenUsageAnalyticsService implements TokenUsageAnalyticsServicePor
 
   private async publishCurrentSnapshot(): Promise<void> {
     if (!this.deps.publisher) return;
-    const [runs, events] = await Promise.all([
+    const [runs, events, tasks] = await Promise.all([
       this.deps.ledger.listRuns(),
       this.deps.ledger.listEvents(),
+      this.listTaskAttributions(false),
     ]);
     const snapshot = buildTokenUsageSnapshot({
       runs,
       events,
+      tasks,
       nowIso: this.deps.clock.now().toISOString(),
     });
     this.deps.publisher.publishSnapshot(snapshot);
     this.evaluateBudgetNotifications(snapshot, 'snapshot');
+  }
+
+  private async listTaskAttributions(
+    withDegradedFlag: true
+  ): Promise<{ tasks: TokenUsageTaskAttributionDto[]; degraded: boolean }>;
+  private async listTaskAttributions(
+    withDegradedFlag: false
+  ): Promise<TokenUsageTaskAttributionDto[]>;
+  private async listTaskAttributions(withDegradedFlag: boolean): Promise<
+    | TokenUsageTaskAttributionDto[]
+    | {
+        tasks: TokenUsageTaskAttributionDto[];
+        degraded: boolean;
+      }
+  > {
+    if (!this.deps.taskAttributionSource) {
+      return withDegradedFlag ? { tasks: [], degraded: false } : [];
+    }
+    try {
+      const tasks = await this.deps.taskAttributionSource.listTaskAttributions();
+      return withDegradedFlag ? { tasks, degraded: false } : tasks;
+    } catch (error) {
+      this.deps.logger?.warn('Failed to list token usage task attribution refs', error);
+      return withDegradedFlag ? { tasks: [], degraded: true } : [];
+    }
   }
 
   private evaluateBudgetNotifications(

--- a/src/features/token-usage/core/application/__tests__/TokenUsageAnalyticsService.test.ts
+++ b/src/features/token-usage/core/application/__tests__/TokenUsageAnalyticsService.test.ts
@@ -34,12 +34,46 @@ describe('TokenUsageAnalyticsService', () => {
       clock: { now: () => new Date(NOW) },
       publisher: { publishSnapshot: (snapshot) => published.push(snapshot) },
       budgetNotifications: evaluator,
+      taskAttributionSource: {
+        listTaskAttributions: async () => [
+          {
+            id: '1',
+            displayId: 'AT-1',
+            teamName: 'alpha',
+            owner: 'builder',
+            subject: 'Alpha task',
+            status: 'in_progress',
+            workIntervals: [
+              {
+                startedAt: '2026-06-30T00:00:00.000Z',
+                completedAt: '2026-06-30T00:05:00.000Z',
+              },
+            ],
+          },
+          {
+            id: '2',
+            displayId: 'BT-2',
+            teamName: 'beta',
+            owner: 'builder',
+            subject: 'Beta task',
+            status: 'in_progress',
+            workIntervals: [
+              {
+                startedAt: '2026-06-30T00:00:00.000Z',
+                completedAt: '2026-06-30T00:05:00.000Z',
+              },
+            ],
+          },
+        ],
+      },
     });
 
     const filtered = await service.refreshSnapshot({ teamNames: ['alpha'] });
 
     expect(filtered.summary.totalTokens).toBe(100);
+    expect(filtered.byTask.map((item) => item.id)).toEqual(['task:alpha:1']);
     expect(published[0]?.summary.totalTokens).toBe(300);
+    expect(published[0]?.byTask.map((item) => item.id)).toEqual(['task:beta:2', 'task:alpha:1']);
     expect(evaluator.snapshots[0]?.summary.totalTokens).toBe(300);
   });
 });

--- a/src/features/token-usage/core/application/__tests__/TokenUsageBudgetNotificationEvaluator.test.ts
+++ b/src/features/token-usage/core/application/__tests__/TokenUsageBudgetNotificationEvaluator.test.ts
@@ -184,6 +184,7 @@ function makeSnapshot({
     byProject: [],
     byRuntime: [],
     byModel: [],
+    byTask: [],
     commandRuns: [],
     sessionRuns: [],
     tokenTrend: [],

--- a/src/features/token-usage/core/application/ports.ts
+++ b/src/features/token-usage/core/application/ports.ts
@@ -4,6 +4,7 @@ import type {
   TokenUsageEventDto,
   TokenUsageRunDto,
   TokenUsageSnapshotRequest,
+  TokenUsageTaskAttributionDto,
 } from '../../contracts';
 
 export interface TokenUsageLedgerRepositoryPort {
@@ -27,6 +28,10 @@ export interface TokenUsageImporterPort {
 
 export interface TokenUsageRealtimePublisherPort {
   publishSnapshot(snapshot: TokenUsageAnalyticsSnapshotDto): void;
+}
+
+export interface TokenUsageTaskAttributionSourcePort {
+  listTaskAttributions(): Promise<TokenUsageTaskAttributionDto[]>;
 }
 
 export interface TokenUsageClockPort {

--- a/src/features/token-usage/core/domain/__tests__/snapshotProjection.test.ts
+++ b/src/features/token-usage/core/domain/__tests__/snapshotProjection.test.ts
@@ -256,6 +256,95 @@ describe('buildTokenUsageSnapshot', () => {
     expect(snapshot.byModel.map((item) => item.id)).toEqual(['gpt-5.4']);
   });
 
+  it('attributes events to the owner-matched task work interval', () => {
+    const snapshot = buildTokenUsageSnapshot({
+      runs: [run()],
+      events: [
+        event({
+          id: 'builder-event',
+          occurredAt: '2026-06-30T00:03:00.000Z',
+          tokens: {
+            inputTokens: 120,
+            outputTokens: 80,
+            cacheCreationTokens: 0,
+            cacheReadTokens: 0,
+            reasoningTokens: 0,
+            audioTokens: 0,
+            imageTokens: 0,
+            totalTokens: 200,
+          },
+          cost: {
+            estimatedUsd: 0.24,
+            billableUsd: 0,
+            apiEquivalentUsd: 0.24,
+            source: 'pricing_table',
+            billingMode: 'subscription',
+          },
+        }),
+        event({
+          id: 'reviewer-event',
+          agentId: 'alpha:reviewer',
+          agentName: 'reviewer',
+          occurredAt: '2026-06-30T00:04:00.000Z',
+        }),
+        event({
+          id: 'outside-task-interval',
+          occurredAt: '2026-06-30T00:20:00.000Z',
+        }),
+      ],
+      tasks: [
+        {
+          id: '1',
+          displayId: 'AT-1',
+          teamName: 'alpha',
+          owner: 'reviewer',
+          subject: 'Review task',
+          status: 'in_progress',
+          workIntervals: [
+            {
+              startedAt: '2026-06-30T00:00:00.000Z',
+              completedAt: '2026-06-30T00:10:00.000Z',
+            },
+          ],
+        },
+        {
+          id: '2',
+          displayId: 'AT-2',
+          teamName: 'alpha',
+          owner: 'builder',
+          subject: 'Build task',
+          status: 'in_progress',
+          workIntervals: [
+            {
+              startedAt: '2026-06-30T00:02:00.000Z',
+              completedAt: '2026-06-30T00:08:00.000Z',
+            },
+          ],
+        },
+      ],
+      nowIso: NOW,
+    });
+
+    expect(snapshot.byTask).toEqual([
+      expect.objectContaining({
+        id: 'task:alpha:2',
+        taskId: '2',
+        displayId: 'AT-2',
+        label: 'AT-2 Build task',
+        teamName: 'alpha',
+        agentName: 'builder',
+        summary: expect.objectContaining({ requestCount: 1, totalTokens: 200 }),
+      }),
+      expect.objectContaining({
+        id: 'task:alpha:1',
+        taskId: '1',
+        label: 'AT-1 Review task',
+        agentName: 'reviewer',
+        summary: expect.objectContaining({ requestCount: 1, totalTokens: 100 }),
+      }),
+    ]);
+  });
+
   it('sorts model breakdowns by token usage before cost', () => {
     const snapshot = buildTokenUsageSnapshot({
       runs: [

--- a/src/features/token-usage/core/domain/snapshotProjection.ts
+++ b/src/features/token-usage/core/domain/snapshotProjection.ts
@@ -11,6 +11,8 @@ import type {
   TokenUsageSessionRunDto,
   TokenUsageSnapshotRequest,
   TokenUsageSourceKind,
+  TokenUsageTaskAttributionDto,
+  TokenUsageTaskBreakdownItemDto,
   TokenUsageTimeSeriesPointDto,
 } from '../../contracts';
 
@@ -25,9 +27,24 @@ const HEATMAP_DAY_LIMIT = 366 * HEATMAP_ALL_TIME_YEAR_LIMIT;
 interface BuildSnapshotInput {
   runs: readonly TokenUsageRunDto[];
   events: readonly TokenUsageEventDto[];
+  tasks?: readonly TokenUsageTaskAttributionDto[];
   request?: TokenUsageSnapshotRequest;
   nowIso: string;
   degraded?: boolean;
+}
+
+interface NormalizedTaskAttribution {
+  key: string;
+  task: TokenUsageTaskAttributionDto;
+  label: string;
+  intervals: NormalizedTaskWorkInterval[];
+}
+
+interface NormalizedTaskWorkInterval {
+  startedAt: string;
+  completedAt?: string;
+  startMs: number;
+  endMs: number;
 }
 
 export function buildTokenUsageSnapshot(input: BuildSnapshotInput): TokenUsageAnalyticsSnapshotDto {
@@ -60,6 +77,7 @@ export function buildTokenUsageSnapshot(input: BuildSnapshotInput): TokenUsageAn
       (run) => runModelKey(run, eventsByRun.get(run.appRunId)),
       compareBreakdownItemsByTokens
     ),
+    byTask: buildTaskBreakdown(input.tasks ?? [], events, input.nowIso),
     commandRuns: buildCommandRuns(runs, events, runById, eventsByRun, input.nowIso),
     sessionRuns: buildSessionRuns(runs, eventsByRun, input.nowIso),
     tokenTrend: buildTokenTrend(events),
@@ -201,6 +219,166 @@ function buildBreakdown(
   }
 
   return [...groups.values()].sort(compareItems);
+}
+
+function buildTaskBreakdown(
+  tasks: readonly TokenUsageTaskAttributionDto[],
+  events: readonly TokenUsageEventDto[],
+  nowIso: string
+): TokenUsageTaskBreakdownItemDto[] {
+  const tasksByTeam = groupTaskAttributionsByTeam(tasks, nowIso);
+  const groups = new Map<string, TokenUsageTaskBreakdownItemDto>();
+
+  for (const event of events) {
+    const task = selectTaskForEvent(event, tasksByTeam);
+    if (!task) continue;
+
+    const current = groups.get(task.key) ?? {
+      id: task.key,
+      taskId: task.task.id,
+      displayId: task.task.displayId,
+      subject: task.task.subject,
+      owner: task.task.owner,
+      status: task.task.status,
+      label: task.label,
+      teamName: task.task.teamName,
+      agentName: task.task.owner,
+      summary: { ...ZERO_TOKEN_USAGE_SUMMARY },
+      lastActivityAt: undefined,
+    };
+    current.summary = addEventToSummary(current.summary, event);
+    current.lastActivityAt = maxIso(current.lastActivityAt, event.occurredAt);
+    groups.set(task.key, current);
+  }
+
+  return [...groups.values()].sort(compareBreakdownItems);
+}
+
+function groupTaskAttributionsByTeam(
+  tasks: readonly TokenUsageTaskAttributionDto[],
+  nowIso: string
+): Map<string, NormalizedTaskAttribution[]> {
+  const nowMs = parseIso(nowIso);
+  const byTeam = new Map<string, NormalizedTaskAttribution[]>();
+
+  for (const task of tasks) {
+    const teamName = task.teamName.trim();
+    if (!teamName) continue;
+
+    const intervals = task.workIntervals
+      .map((interval): NormalizedTaskWorkInterval | null => {
+        const startMs = parseIso(interval.startedAt);
+        const endMs = parseIso(interval.completedAt ?? nowIso) ?? nowMs;
+        if (startMs === undefined || endMs === undefined || endMs < startMs) return null;
+        return {
+          startedAt: interval.startedAt,
+          completedAt: interval.completedAt,
+          startMs,
+          endMs,
+        };
+      })
+      .filter((interval): interval is NormalizedTaskWorkInterval => interval !== null);
+
+    if (intervals.length === 0) continue;
+
+    const current = byTeam.get(teamName) ?? [];
+    current.push({
+      key: taskBreakdownId(teamName, task.id),
+      task,
+      label: taskLabel(task),
+      intervals,
+    });
+    byTeam.set(teamName, current);
+  }
+
+  return byTeam;
+}
+
+function selectTaskForEvent(
+  event: TokenUsageEventDto,
+  tasksByTeam: Map<string, NormalizedTaskAttribution[]>
+): NormalizedTaskAttribution | null {
+  if (!event.teamName) return null;
+  const eventMs = parseIso(event.occurredAt);
+  if (eventMs === undefined) return null;
+
+  let best: {
+    task: NormalizedTaskAttribution;
+    ownerScore: number;
+    intervalMs: number;
+    startedAtMs: number;
+  } | null = null;
+
+  for (const task of tasksByTeam.get(event.teamName) ?? []) {
+    const ownerScore = taskOwnerScore(task.task.owner, event);
+    if (ownerScore < 0) continue;
+
+    for (const interval of task.intervals) {
+      if (eventMs < interval.startMs || eventMs > interval.endMs) continue;
+      const candidate = {
+        task,
+        ownerScore,
+        intervalMs: interval.endMs - interval.startMs,
+        startedAtMs: interval.startMs,
+      };
+      if (!best || compareTaskCandidate(candidate, best) < 0) {
+        best = candidate;
+      }
+    }
+  }
+
+  return best?.task ?? null;
+}
+
+function compareTaskCandidate(
+  left: {
+    ownerScore: number;
+    intervalMs: number;
+    startedAtMs: number;
+  },
+  right: {
+    ownerScore: number;
+    intervalMs: number;
+    startedAtMs: number;
+  }
+): number {
+  return (
+    right.ownerScore - left.ownerScore ||
+    left.intervalMs - right.intervalMs ||
+    right.startedAtMs - left.startedAtMs
+  );
+}
+
+function taskOwnerScore(owner: string | undefined, event: TokenUsageEventDto): number {
+  const normalizedOwner = normalizeIdentity(owner);
+  if (!normalizedOwner) return 0;
+
+  const eventAgents = [
+    event.agentName,
+    event.agentId,
+    event.agentId?.includes(':') ? event.agentId.split(':').pop() : undefined,
+  ]
+    .map(normalizeIdentity)
+    .filter((value): value is string => Boolean(value));
+
+  if (eventAgents.length === 0) return 0;
+  return eventAgents.includes(normalizedOwner) ? 1 : -1;
+}
+
+function taskBreakdownId(teamName: string, taskId: string): string {
+  return `task:${teamName}:${taskId}`;
+}
+
+function taskLabel(task: TokenUsageTaskAttributionDto): string {
+  const displayId = task.displayId?.trim();
+  const subject = task.subject.trim();
+  if (displayId && subject) return `${displayId} ${subject}`;
+  return subject || displayId || task.id;
+}
+
+function normalizeIdentity(value: string | undefined): string | undefined {
+  const normalized = value?.trim().toLowerCase();
+  return normalized || undefined;
 }
 
 function buildRecentRuns(

--- a/src/features/token-usage/main/adapters/input/http/registerTokenUsageHttp.ts
+++ b/src/features/token-usage/main/adapters/input/http/registerTokenUsageHttp.ts
@@ -63,6 +63,7 @@ export function registerTokenUsageHttp(
         byProject: [],
         byRuntime: [],
         byModel: [],
+        byTask: [],
         commandRuns: [],
         sessionRuns: [],
         tokenTrend: [],

--- a/src/features/token-usage/main/composition/createTokenUsageFeature.ts
+++ b/src/features/token-usage/main/composition/createTokenUsageFeature.ts
@@ -25,6 +25,7 @@ import type {
   TokenUsageImporterPort,
   TokenUsageLoggerPort,
   TokenUsageRealtimePublisherPort,
+  TokenUsageTaskAttributionSourcePort,
 } from '../../core/application';
 
 export interface TokenUsageFeatureFacade {
@@ -53,6 +54,7 @@ export interface CreateTokenUsageFeatureDeps {
   budgetNotificationSink?: TokenUsageBudgetNotificationSinkPort;
   budgetNotificationSettings?: TokenUsageBudgetNotificationSettingsPort;
   publisher?: TokenUsageRealtimePublisherPort;
+  taskAttributionSource?: TokenUsageTaskAttributionSourcePort;
   logger?: TokenUsageLoggerPort;
 }
 
@@ -86,6 +88,7 @@ export function createTokenUsageFeature(
     budgets: budgetSettingsRepository,
     budgetNotifications: budgetNotificationEvaluator,
     publisher: deps.publisher,
+    taskAttributionSource: deps.taskAttributionSource,
     logger: deps.logger,
   });
 

--- a/src/features/token-usage/main/index.ts
+++ b/src/features/token-usage/main/index.ts
@@ -5,3 +5,4 @@ export {
 } from './adapters/input/ipc/registerTokenUsageIpc';
 export type { TokenUsageFeatureFacade } from './composition/createTokenUsageFeature';
 export { createTokenUsageFeature } from './composition/createTokenUsageFeature';
+export { TeamTaskUsageAttributionSource } from './infrastructure/TeamTaskUsageAttributionSource';

--- a/src/features/token-usage/main/infrastructure/TeamTaskUsageAttributionSource.ts
+++ b/src/features/token-usage/main/infrastructure/TeamTaskUsageAttributionSource.ts
@@ -1,0 +1,40 @@
+import type { TokenUsageTaskAttributionDto } from '../../contracts';
+import type { TokenUsageTaskAttributionSourcePort } from '../../core/application';
+import type { TeamTaskReader } from '@main/services/team/TeamTaskReader';
+import type { TeamTask } from '@shared/types';
+
+type TeamTaskWithTeamName = TeamTask & { teamName: string };
+
+export class TeamTaskUsageAttributionSource implements TokenUsageTaskAttributionSourcePort {
+  constructor(private readonly taskReader: Pick<TeamTaskReader, 'getAllTasks'>) {}
+
+  async listTaskAttributions(): Promise<TokenUsageTaskAttributionDto[]> {
+    const tasks = await this.taskReader.getAllTasks();
+    return tasks
+      .map(toTaskAttribution)
+      .filter((task): task is TokenUsageTaskAttributionDto => task !== null);
+  }
+}
+
+function toTaskAttribution(task: TeamTaskWithTeamName): TokenUsageTaskAttributionDto | null {
+  const workIntervals = (task.workIntervals ?? [])
+    .map((interval) => ({
+      startedAt: interval.startedAt,
+      completedAt: interval.completedAt,
+    }))
+    .filter((interval) => interval.startedAt);
+
+  if (!task.id || !task.teamName || workIntervals.length === 0) {
+    return null;
+  }
+
+  return {
+    id: task.id,
+    displayId: task.displayId,
+    teamName: task.teamName,
+    owner: task.owner,
+    subject: task.subject,
+    status: task.status,
+    workIntervals,
+  };
+}

--- a/src/features/token-usage/renderer/adapters/__tests__/tokenUsageViewModel.test.ts
+++ b/src/features/token-usage/renderer/adapters/__tests__/tokenUsageViewModel.test.ts
@@ -175,6 +175,47 @@ function snapshot(): TokenUsageAnalyticsSnapshotDto {
         lastActivityAt: '2026-06-28T00:00:00.000Z',
       },
     ],
+    byTask: [
+      {
+        id: 'task:alpha:2',
+        taskId: '2',
+        displayId: 'AT-2',
+        subject: 'Build cache stats',
+        owner: 'builder',
+        status: 'in_progress',
+        label: 'AT-2 Build cache stats',
+        teamName: 'alpha',
+        agentName: 'builder',
+        summary: {
+          ...ZERO_SUMMARY,
+          totalTokens: 200,
+          cacheReadTokens: 150,
+          requestCount: 1,
+          estimatedCostUsd: 0.75,
+          apiEquivalentCostUsd: 0.75,
+        },
+        lastActivityAt: '2026-06-30T00:00:00.000Z',
+      },
+      {
+        id: 'task:alpha:1',
+        taskId: '1',
+        displayId: 'AT-1',
+        subject: 'Fix usage UI',
+        owner: 'builder',
+        status: 'completed',
+        label: 'AT-1 Fix usage UI',
+        teamName: 'alpha',
+        agentName: 'builder',
+        summary: {
+          ...ZERO_SUMMARY,
+          totalTokens: 100,
+          requestCount: 1,
+          estimatedCostUsd: 0.5,
+          apiEquivalentCostUsd: 0.5,
+        },
+        lastActivityAt: '2026-06-29T00:00:00.000Z',
+      },
+    ],
     commandRuns: [
       {
         id: 'command-run-a',
@@ -332,8 +373,8 @@ function snapshot(): TokenUsageAnalyticsSnapshotDto {
 }
 
 describe('toTokenUsageDashboardViewModel', () => {
-  it('builds numeric chart models without parsing formatted labels', () => {
-    const viewModel = toTokenUsageDashboardViewModel(snapshot());
+  it('builds numeric chart models with cache tokens when explicitly enabled', () => {
+    const viewModel = toTokenUsageDashboardViewModel(snapshot(), { includeCacheTokens: true });
 
     expect(viewModel.trendPoints.map((point) => point.heightPercent)).toEqual([
       expect.any(Number),
@@ -358,6 +399,30 @@ describe('toTokenUsageDashboardViewModel', () => {
       })
     );
     expect(viewModel.commandSpendBars.map((item) => item.percent)).toEqual([100, 50]);
+    expect(
+      viewModel.taskSpendBars.map((item) => ({
+        id: item.id,
+        label: item.label,
+        taskDisplayId: item.taskDisplayId,
+        taskId: item.taskId,
+        percent: item.percent,
+      }))
+    ).toEqual([
+      {
+        id: 'task:alpha:2',
+        label: 'Build cache stats',
+        taskDisplayId: 'AT-2',
+        taskId: '2',
+        percent: 100,
+      },
+      {
+        id: 'task:alpha:1',
+        label: 'Fix usage UI',
+        taskDisplayId: 'AT-1',
+        taskId: '1',
+        percent: 50,
+      },
+    ]);
     expect(viewModel.metrics.find((metric) => metric.id === 'billing')).toEqual(
       expect.objectContaining({
         label: 'Billing',
@@ -397,9 +462,8 @@ describe('toTokenUsageDashboardViewModel', () => {
     expect(viewModel.unmappedEventCount).toBe(3);
   });
 
-  it('excludes cache tokens from dashboard token statistics when disabled', () => {
+  it('excludes cache tokens from dashboard token statistics by default', () => {
     const viewModel = toTokenUsageDashboardViewModel(snapshot(), {
-      includeCacheTokens: false,
       budgetLimits: {
         global: { monthlyTokenLimit: 300 },
         projects: { 'project:workspace-a': { monthlyTokenLimit: 300 } },
@@ -430,6 +494,20 @@ describe('toTokenUsageDashboardViewModel', () => {
     expect(viewModel.commandSpendBars.map((item) => item.id)).toEqual(['cmd-b', 'cmd-a']);
     expect(viewModel.commandSpendBars.map((item) => item.value)).toEqual(['100', '50']);
     expect(viewModel.commandSpendBars.map((item) => item.percent)).toEqual([100, 50]);
+    expect(viewModel.taskSpendBars.map((item) => item.id)).toEqual([
+      'task:alpha:1',
+      'task:alpha:2',
+    ]);
+    expect(viewModel.taskSpendBars.map((item) => item.label)).toEqual([
+      'Fix usage UI',
+      'Build cache stats',
+    ]);
+    expect(viewModel.taskSpendBars.map((item) => item.value)).toEqual(['100', '50']);
+    expect(viewModel.taskRows.map((row) => row.id)).toEqual(['task:alpha:1', 'task:alpha:2']);
+    expect(viewModel.taskRows.map((row) => [row.label, row.taskDisplayId, row.taskId])).toEqual([
+      ['Fix usage UI', 'AT-1', '1'],
+      ['Build cache stats', 'AT-2', '2'],
+    ]);
     expect(viewModel.commandBreakdownRows.map((row) => row.id)).toEqual(['cmd-b', 'cmd-a']);
     expect(viewModel.modelUsage.map((segment) => segment.id)).toEqual(['claude-sonnet', 'gpt-5.4']);
     expect(viewModel.modelUsage.map((segment) => Math.round(segment.percent))).toEqual([67, 33]);
@@ -462,6 +540,7 @@ describe('toTokenUsageDashboardViewModel', () => {
 
   it('builds billing split, burn rate, and budget alerts', () => {
     const viewModel = toTokenUsageDashboardViewModel(snapshot(), {
+      includeCacheTokens: true,
       budgetLimits: {
         global: { monthlyTokenLimit: 500 },
         projects: { 'project:workspace-a': { monthlyTokenLimit: 100 } },

--- a/src/features/token-usage/renderer/adapters/tokenUsageViewModel.ts
+++ b/src/features/token-usage/renderer/adapters/tokenUsageViewModel.ts
@@ -32,6 +32,8 @@ export interface TokenUsageBreakdownRowViewModel {
   label: string;
   teamName?: string;
   agentName?: string;
+  taskId?: string;
+  taskDisplayId?: string;
   tokens: string;
   cost: string;
   requests: string;
@@ -74,6 +76,7 @@ export interface TokenUsageModelSegmentViewModel {
 export interface TokenUsageSourceQualityViewModel {
   label: string;
   count: number;
+  countLabel: string;
   percent: number;
   tone: 'exact' | 'parsed' | 'estimated';
 }
@@ -148,13 +151,15 @@ export interface TokenUsageBarChartItemViewModel {
   id: string;
   label: string;
   teamName?: string;
+  taskId?: string;
+  taskDisplayId?: string;
   value: string;
   cost: string;
   requests: string;
   detail: string;
   tooltip: string;
   percent: number;
-  tone: 'team' | 'agent' | 'command' | 'runtime' | 'model';
+  tone: 'team' | 'agent' | 'command' | 'runtime' | 'model' | 'task';
 }
 
 export interface TokenUsageTeamFilterOptionViewModel {
@@ -179,12 +184,14 @@ export interface TokenUsageDashboardViewModel {
   trendPoints: TokenUsageTrendPointViewModel[];
   activityDays: TokenUsageActivityDayViewModel[];
   commandSpendBars: TokenUsageBarChartItemViewModel[];
+  taskSpendBars: TokenUsageBarChartItemViewModel[];
   runtimeBars: TokenUsageBarChartItemViewModel[];
   modelBars: TokenUsageBarChartItemViewModel[];
   teamFilterOptions: TokenUsageTeamFilterOptionViewModel[];
   budgetTargetOptions: TokenUsageBudgetTargetOptionViewModel[];
   teamRows: TokenUsageBreakdownRowViewModel[];
   agentRows: TokenUsageBreakdownRowViewModel[];
+  taskRows: TokenUsageBreakdownRowViewModel[];
   commandBreakdownRows: TokenUsageBreakdownRowViewModel[];
   sessionBreakdownRows: TokenUsageBreakdownRowViewModel[];
   projectRows: TokenUsageBreakdownRowViewModel[];
@@ -253,6 +260,7 @@ export interface TokenUsageViewModelText {
   runningSessions: (running: string, sessions: string) => string;
   sdkExact: string;
   sourceCount: (count: string) => string;
+  sourceEventCount: (count: string) => string;
   subscriptionUsage: string;
   subscriptionUsageHelp: string;
   tokenLimitDetail: (tokens: string, limit: string) => string;
@@ -313,6 +321,7 @@ const DEFAULT_TEXT: TokenUsageViewModelText = {
   runningSessions: (running, sessions) => `${running} running / ${sessions} sessions`,
   sdkExact: 'SDK exact',
   sourceCount: (count) => `${count} ${count === '1' ? 'source' : 'sources'}`,
+  sourceEventCount: (count) => `${count} ${count === '1' ? 'event' : 'events'}`,
   subscriptionUsage: 'Subscription usage',
   subscriptionUsageHelp:
     'Requests and tokens attributed to subscription mode. No billable API dollars are counted for this bucket.',
@@ -343,7 +352,7 @@ export function toTokenUsageDashboardViewModel(
 ): TokenUsageDashboardViewModel {
   const text = { ...DEFAULT_TEXT, ...options.text };
   const locale = options.locale;
-  const includeCacheTokens = options.includeCacheTokens ?? true;
+  const includeCacheTokens = options.includeCacheTokens ?? false;
   const summary = snapshot?.summary ?? emptySummary();
   const visibleSummaryTotal = visibleTokenTotal(summary, includeCacheTokens);
   const metrics: TokenUsageMetricViewModel[] = [
@@ -409,6 +418,14 @@ export function toTokenUsageDashboardViewModel(
       text,
       locale
     ),
+    taskSpendBars: toBarChartItems(
+      snapshot?.byTask ?? [],
+      'task',
+      8,
+      includeCacheTokens,
+      text,
+      locale
+    ),
     runtimeBars: toBarChartItems(
       snapshot?.byRuntime ?? [],
       'runtime',
@@ -434,6 +451,7 @@ export function toTokenUsageDashboardViewModel(
     budgetTargetOptions: toBudgetTargetOptions(snapshot, includeCacheTokens, text, locale),
     teamRows: toBreakdownRows(snapshot?.byTeam ?? [], includeCacheTokens, text, locale),
     agentRows: toBreakdownRows(snapshot?.byAgent ?? [], includeCacheTokens, text, locale),
+    taskRows: toBreakdownRows(snapshot?.byTask ?? [], includeCacheTokens, text, locale),
     commandBreakdownRows: toBreakdownRows(
       snapshot?.byCommand ?? [],
       includeCacheTokens,
@@ -461,7 +479,7 @@ export function toTokenUsageDashboardViewModel(
     expensiveRuns: (snapshot?.expensiveRuns ?? []).map((run) =>
       toRunRow(run, includeCacheTokens, text, locale)
     ),
-    sourceQuality: toSourceQuality(snapshot?.sourceCounts, text),
+    sourceQuality: toSourceQuality(snapshot?.sourceCounts, text, locale),
     unmappedEventCount: snapshot?.unmappedEventCount ?? 0,
     updatedAtLabel: formatDateTime(snapshot?.updatedAt, text, locale),
     empty: summary.runCount === 0 && summary.requestCount === 0,
@@ -777,9 +795,10 @@ function toBreakdownRow(
   locale: string | undefined
 ): TokenUsageBreakdownRowViewModel {
   const visibleTokens = visibleTokenTotal(item.summary, includeCacheTokens);
-  return {
+  const task = toTaskItemMetadata(item);
+  const row: TokenUsageBreakdownRowViewModel = {
     id: item.id,
-    label: item.label,
+    label: task?.subject ?? item.label,
     teamName: item.teamName,
     agentName: item.agentName,
     tokens: formatCompactNumber(visibleTokens, locale),
@@ -791,6 +810,11 @@ function toBreakdownRow(
     percent:
       maxTokens > 0 && visibleTokens > 0 ? Math.max(2, (visibleTokens / maxTokens) * 100) : 0,
   };
+  if (task) {
+    row.taskId = task.taskId;
+    if (task.displayId) row.taskDisplayId = task.displayId;
+  }
+  return row;
 }
 
 function toModelUsageSegments(
@@ -967,7 +991,8 @@ function toTokenMix(
 
 function toSourceQuality(
   sourceCounts: TokenUsageAnalyticsSnapshotDto['sourceCounts'] | undefined,
-  text: TokenUsageViewModelText
+  text: TokenUsageViewModelText,
+  locale: string | undefined
 ): TokenUsageSourceQualityViewModel[] {
   const sourceLabels: Record<TokenUsageSourceKind, string> = {
     sdk_exact: text.sdkExact,
@@ -977,17 +1002,24 @@ function toSourceQuality(
     cost_estimated: text.costEstimated,
   };
   const total = Object.values(sourceCounts ?? {}).reduce((sum, value) => sum + value, 0);
-  return (Object.keys(sourceLabels) as TokenUsageSourceKind[]).map((sourceKind) => ({
-    label: sourceLabels[sourceKind],
-    count: sourceCounts?.[sourceKind] ?? 0,
-    percent: total > 0 ? ((sourceCounts?.[sourceKind] ?? 0) / total) * 100 : 0,
-    tone:
-      sourceKind === 'sdk_exact' || sourceKind === 'gateway_exact'
-        ? 'exact'
-        : sourceKind === 'log_parsed'
-          ? 'parsed'
-          : 'estimated',
-  }));
+  return (Object.keys(sourceLabels) as TokenUsageSourceKind[])
+    .map((sourceKind) => {
+      const count = sourceCounts?.[sourceKind] ?? 0;
+      const tone: TokenUsageSourceQualityViewModel['tone'] =
+        sourceKind === 'sdk_exact' || sourceKind === 'gateway_exact'
+          ? 'exact'
+          : sourceKind === 'log_parsed'
+            ? 'parsed'
+            : 'estimated';
+      return {
+        label: sourceLabels[sourceKind],
+        count,
+        countLabel: text.sourceEventCount(formatCompactNumber(count, locale)),
+        percent: total > 0 ? (count / total) * 100 : 0,
+        tone,
+      };
+    })
+    .filter((item) => item.count > 0);
 }
 
 function toTrendPoints(
@@ -1090,23 +1122,41 @@ function toBarChartItems(
     ...limitedRows.map((item) => visibleTokenTotal(item.summary, includeCacheTokens))
   );
   return limitedRows.map((item) => {
+    const task = toTaskItemMetadata(item);
     const tokenValue = visibleTokenTotal(item.summary, includeCacheTokens);
     const value = formatCompactNumber(tokenValue, locale);
     const cost = formatCostLabel(item.summary, text, locale);
     const requests = text.requestCount(formatCompactNumber(item.summary.requestCount, locale));
-    return {
+    const chartItem: TokenUsageBarChartItemViewModel = {
       id: item.id,
-      label: item.label,
+      label: task?.subject ?? item.label,
       teamName: item.teamName,
       value,
       cost,
       requests,
       detail: `${cost} / ${requests}`,
-      tooltip: text.tokenCostTooltip(item.label, value, cost, requests),
+      tooltip: text.tokenCostTooltip(task?.subject ?? item.label, value, cost, requests),
       percent: maxTokens > 0 && tokenValue > 0 ? Math.max(2, (tokenValue / maxTokens) * 100) : 0,
       tone,
     };
+    if (task) {
+      chartItem.taskId = task.taskId;
+      if (task.displayId) chartItem.taskDisplayId = task.displayId;
+    }
+    return chartItem;
   });
+}
+
+function toTaskItemMetadata(
+  item: TokenUsageBreakdownItemDto
+): { taskId: string; displayId?: string; subject: string } | null {
+  if (!('taskId' in item) || !('subject' in item)) return null;
+  const taskId = typeof item.taskId === 'string' ? item.taskId : '';
+  const subject = typeof item.subject === 'string' ? item.subject : '';
+  const displayId =
+    'displayId' in item && typeof item.displayId === 'string' ? item.displayId : undefined;
+  if (!taskId || !subject) return null;
+  return { taskId, displayId, subject };
 }
 
 function emptySummary(): TokenUsageSummaryDto {

--- a/src/features/token-usage/renderer/hooks/useOpenTokenUsageTask.ts
+++ b/src/features/token-usage/renderer/hooks/useOpenTokenUsageTask.ts
@@ -1,0 +1,5 @@
+import { useStore } from '@renderer/store';
+
+export function useOpenTokenUsageTask(): (teamName: string, taskId: string) => void {
+  return useStore((state) => state.openGlobalTaskDetail);
+}

--- a/src/features/token-usage/renderer/ui/TokenUsageDashboard.tsx
+++ b/src/features/token-usage/renderer/ui/TokenUsageDashboard.tsx
@@ -38,6 +38,7 @@ import {
   tokenUsageSnapshotRequestForDateRange,
 } from '../adapters/tokenUsageDateRange';
 import { useOpenTokenUsageNotificationSettings } from '../hooks/useOpenTokenUsageNotificationSettings';
+import { useOpenTokenUsageTask } from '../hooks/useOpenTokenUsageTask';
 import { useOpenTokenUsageTeam } from '../hooks/useOpenTokenUsageTeam';
 import { useTokenUsageBudgetSettings } from '../hooks/useTokenUsageBudgetSettings';
 import { useTokenUsageSnapshot } from '../hooks/useTokenUsageSnapshot';
@@ -65,6 +66,7 @@ import type React from 'react';
 type TokenUsageT = (key: string, options?: Record<string, unknown>) => string;
 
 const DAY_PICKER_CLASS_NAMES = buildDayPickerClassNames();
+const DAY_MS = 24 * 60 * 60 * 1000;
 const PANEL_CLASS =
   'min-w-0 rounded-sm border border-[var(--color-border-emphasis)] bg-surface-raised';
 const MODEL_DONUT_SIZE = 160;
@@ -86,12 +88,13 @@ export const TokenUsageDashboard = (): React.JSX.Element => {
     [t]
   );
   const openTeamTab = useOpenTokenUsageTeam();
+  const openTaskDetail = useOpenTokenUsageTask();
   const openNotificationSettings = useOpenTokenUsageNotificationSettings();
   const [dateRange, setDateRange] = useState<TokenUsageDateRangeValue>(() =>
     createDefaultTokenUsageDateRange()
   );
   const [selectedTeamNames, setSelectedTeamNames] = useState<string[]>([]);
-  const [includeCacheTokens, setIncludeCacheTokens] = useState(true);
+  const [includeCacheTokens, setIncludeCacheTokens] = useState(false);
   const [activeDashboardTab, setActiveDashboardTab] = useState<TokenUsageDashboardTab>('overview');
   const { budgetConfig, budgetConfigError, updateBudgetConfig } = useTokenUsageBudgetSettings({
     loadErrorMessage: tokenUsageT('tokenUsage.budgets.loadFailed'),
@@ -255,6 +258,12 @@ export const TokenUsageDashboard = (): React.JSX.Element => {
                       t={tokenUsageT}
                     />
                     <HorizontalBarsPanel
+                      heading={tokenUsageT('tokenUsage.panels.taskSpend')}
+                      items={viewModel.taskSpendBars}
+                      onOpenTask={openTaskDetail}
+                      t={tokenUsageT}
+                    />
+                    <HorizontalBarsPanel
                       heading={tokenUsageT('tokenUsage.panels.runtimeMix')}
                       items={viewModel.runtimeBars}
                       t={tokenUsageT}
@@ -281,10 +290,25 @@ export const TokenUsageDashboard = (): React.JSX.Element => {
                   />
                 </section>
 
-                <section className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_300px]">
+                <section className="grid gap-5 xl:grid-cols-2">
+                  <BreakdownPanel
+                    heading={tokenUsageT('tokenUsage.panels.tasks')}
+                    rows={viewModel.taskRows}
+                    onOpenTask={openTaskDetail}
+                    t={tokenUsageT}
+                  />
                   <BreakdownPanel
                     heading={tokenUsageT('tokenUsage.panels.commands')}
                     rows={viewModel.commandBreakdownRows}
+                    compact
+                    t={tokenUsageT}
+                  />
+                </section>
+
+                <section className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_300px]">
+                  <BreakdownPanel
+                    heading={tokenUsageT('tokenUsage.panels.sessions')}
+                    rows={viewModel.sessionBreakdownRows}
                     compact
                     t={tokenUsageT}
                   />
@@ -294,13 +318,6 @@ export const TokenUsageDashboard = (): React.JSX.Element => {
                     t={tokenUsageT}
                   />
                 </section>
-
-                <BreakdownPanel
-                  heading={tokenUsageT('tokenUsage.panels.sessions')}
-                  rows={viewModel.sessionBreakdownRows}
-                  compact
-                  t={tokenUsageT}
-                />
               </TabsContent>
 
               <TabsContent value="runs" className="mt-5 space-y-5">
@@ -387,6 +404,7 @@ function createTokenUsageViewModelText(t: TokenUsageT): TokenUsageViewModelText 
       t('tokenUsage.metrics.runningSessions', { running, sessions }),
     sdkExact: t('tokenUsage.sources.sdkExact'),
     sourceCount: (count) => t('tokenUsage.labels.sourceCount', { count }),
+    sourceEventCount: (count) => t('tokenUsage.labels.eventCount', { count }),
     subscriptionUsage: t('tokenUsage.metrics.subscriptionUsage'),
     subscriptionUsageHelp: t('tokenUsage.billingSplit.subscriptionUsageHelp'),
     tokenLimitDetail: (tokens, limit) =>
@@ -1316,10 +1334,14 @@ const ActivityHeatmapPanel = ({
   t: TokenUsageT;
 }): React.JSX.Element => {
   const years = useMemo(() => buildActivityHeatmapYears(days), [days]);
+  const streak = useMemo(() => buildActivityStreak(days), [days]);
 
   return (
     <section className={PANEL_CLASS}>
-      <PanelTitle heading={t('tokenUsage.panels.activityByDay')} />
+      <PanelTitle
+        heading={t('tokenUsage.panels.activityByDay')}
+        action={<ActivityStreakBadge streak={streak} t={t} />}
+      />
       <div className="p-4">
         {days.length === 0 ? (
           <EmptyRows label={t('tokenUsage.empty.noActivityData')} />
@@ -1407,6 +1429,34 @@ const ActivityHeatmapPanel = ({
         )}
       </div>
     </section>
+  );
+};
+
+const ActivityStreakBadge = ({
+  streak,
+  t,
+}: {
+  streak: number;
+  t: TokenUsageT;
+}): React.JSX.Element => {
+  const fireCount = Math.floor(streak / 3);
+  const visibleFireCount = Math.min(fireCount, 5);
+  const hiddenFireCount = fireCount - visibleFireCount;
+
+  return (
+    <div className="flex max-w-[50%] shrink-0 items-center gap-1 rounded-sm border border-amber-400/25 bg-amber-400/10 px-2 py-1 text-[11px] font-medium text-amber-200">
+      <span className="truncate">{t('tokenUsage.labels.streakCount', { count: streak })}</span>
+      {visibleFireCount > 0 && (
+        <span className="shrink-0 whitespace-nowrap" aria-hidden="true">
+          {Array.from({ length: visibleFireCount }, (_, index) => (
+            <span key={index}>🔥</span>
+          ))}
+          {hiddenFireCount > 0 && (
+            <span className="ml-0.5 text-[10px] text-amber-200/80">+{hiddenFireCount}</span>
+          )}
+        </span>
+      )}
+    </div>
   );
 };
 
@@ -1534,11 +1584,13 @@ const HorizontalBarsPanel = ({
   heading,
   items,
   onOpenTeam,
+  onOpenTask,
   t,
 }: {
   heading: string;
   items: TokenUsageBarChartItemViewModel[];
   onOpenTeam?: (teamName: string) => void;
+  onOpenTask?: (teamName: string, taskId: string) => void;
   t: TokenUsageT;
 }): React.JSX.Element => {
   return (
@@ -1550,14 +1602,28 @@ const HorizontalBarsPanel = ({
         ) : (
           items.map((item) => {
             const targetTeamName = item.teamName;
-            const clickable = !!targetTeamName && targetTeamName !== 'unassigned' && !!onOpenTeam;
+            const taskClickable =
+              item.tone === 'task' &&
+              !!targetTeamName &&
+              targetTeamName !== 'unassigned' &&
+              !!item.taskId &&
+              !!onOpenTask;
+            const teamClickable =
+              !taskClickable && !!targetTeamName && targetTeamName !== 'unassigned' && !!onOpenTeam;
+            const clickable = taskClickable || teamClickable;
+            const actionLabel = taskClickable
+              ? t('tokenUsage.actions.openTask', { task: item.label })
+              : t('tokenUsage.actions.openTeam', { team: targetTeamName });
             const itemContent = (
               <>
                 <div className="flex items-center justify-between gap-3 text-sm">
                   <span className="flex min-w-0 items-center gap-1.5">
                     <span className="min-w-0 truncate font-medium text-text">{item.label}</span>
-                    {clickable && (
+                    {teamClickable && (
                       <ArrowUpRight className="size-3.5 shrink-0 text-text-muted transition-colors group-hover:text-text-secondary" />
+                    )}
+                    {taskClickable && (
+                      <Info className="size-3.5 shrink-0 text-text-muted transition-colors group-hover:text-text-secondary" />
                     )}
                   </span>
                   <span className="shrink-0 text-text-secondary">{item.value}</span>
@@ -1565,7 +1631,14 @@ const HorizontalBarsPanel = ({
                 <div className="mt-1 h-2 overflow-hidden rounded-sm bg-surface">
                   <div className={barToneClass(item.tone)} style={{ width: `${item.percent}%` }} />
                 </div>
-                <div className="mt-1 truncate text-xs text-text-muted">{item.detail}</div>
+                <div className="mt-1 flex min-w-0 items-center justify-between gap-3 text-xs text-text-muted">
+                  <span className="min-w-0 truncate">{item.detail}</span>
+                  {item.taskDisplayId && (
+                    <span className="text-text-muted/80 shrink-0 font-mono text-[11px]">
+                      {item.taskDisplayId}
+                    </span>
+                  )}
+                </div>
               </>
             );
 
@@ -1574,16 +1647,20 @@ const HorizontalBarsPanel = ({
                 <TooltipTrigger asChild>
                   <button
                     type="button"
-                    onClick={() => onOpenTeam?.(targetTeamName)}
-                    aria-label={t('tokenUsage.actions.openTeam', { team: targetTeamName })}
+                    onClick={() => {
+                      if (taskClickable && item.taskId) {
+                        onOpenTask?.(targetTeamName, item.taskId);
+                        return;
+                      }
+                      onOpenTeam?.(targetTeamName);
+                    }}
+                    aria-label={actionLabel}
                     className="group -mx-2 block w-[calc(100%+1rem)] min-w-0 rounded-sm px-2 py-1.5 text-left transition-colors hover:bg-surface focus:bg-surface focus:outline-none"
                   >
                     {itemContent}
                   </button>
                 </TooltipTrigger>
-                <TooltipContent side="top">
-                  {t('tokenUsage.actions.openTeam', { team: targetTeamName })}
-                </TooltipContent>
+                <TooltipContent side="top">{actionLabel}</TooltipContent>
               </Tooltip>
             ) : (
               <Tooltip key={item.id}>
@@ -1611,6 +1688,7 @@ const BreakdownPanel = ({
   rows,
   compact = false,
   onOpenTeam,
+  onOpenTask,
   showMemberBadge = false,
   teamPanel = false,
   t,
@@ -1619,6 +1697,7 @@ const BreakdownPanel = ({
   rows: TokenUsageBreakdownRowViewModel[];
   compact?: boolean;
   onOpenTeam?: (teamName: string) => void;
+  onOpenTask?: (teamName: string, taskId: string) => void;
   showMemberBadge?: boolean;
   teamPanel?: boolean;
   t: TokenUsageT;
@@ -1632,7 +1711,14 @@ const BreakdownPanel = ({
         ) : (
           rows.slice(0, compact ? 6 : 8).map((row) => {
             const targetTeamName = row.teamName ?? (teamPanel ? row.id : undefined);
-            const clickable = !!targetTeamName && targetTeamName !== 'unassigned' && !!onOpenTeam;
+            const taskClickable =
+              !!targetTeamName && targetTeamName !== 'unassigned' && !!row.taskId && !!onOpenTask;
+            const teamClickable =
+              !taskClickable && !!targetTeamName && targetTeamName !== 'unassigned' && !!onOpenTeam;
+            const clickable = taskClickable || teamClickable;
+            const actionLabel = taskClickable
+              ? t('tokenUsage.actions.openTask', { task: row.label })
+              : t('tokenUsage.actions.openTeam', { team: targetTeamName });
             const rowClassName = cn(
               'grid w-full grid-cols-[minmax(0,1fr)_auto] gap-3 px-4 py-3 text-left text-sm sm:grid-cols-[minmax(0,1fr)_auto_auto]',
               clickable &&
@@ -1655,11 +1741,21 @@ const BreakdownPanel = ({
                     {showMemberBadge && !row.agentName && (
                       <div className="truncate font-medium text-text">{row.label}</div>
                     )}
-                    {clickable && (
-                      <ArrowUpRight className="size-3.5 shrink-0 text-text-muted transition-colors group-hover:text-text-secondary" />
+                    {clickable &&
+                      (taskClickable ? (
+                        <Info className="size-3.5 shrink-0 text-text-muted transition-colors group-hover:text-text-secondary" />
+                      ) : (
+                        <ArrowUpRight className="size-3.5 shrink-0 text-text-muted transition-colors group-hover:text-text-secondary" />
+                      ))}
+                  </div>
+                  <div className="mt-0.5 flex min-w-0 items-center justify-between gap-3 text-xs text-text-muted">
+                    <span className="min-w-0 truncate">{row.lastActivity}</span>
+                    {row.taskDisplayId && (
+                      <span className="text-text-muted/80 shrink-0 font-mono text-[11px]">
+                        {row.taskDisplayId}
+                      </span>
                     )}
                   </div>
-                  <div className="mt-0.5 text-xs text-text-muted">{row.lastActivity}</div>
                   <div className="mt-2 h-1 overflow-hidden rounded-sm bg-surface">
                     <div className="h-full bg-blue-500" style={{ width: `${row.percent}%` }} />
                   </div>
@@ -1681,16 +1777,21 @@ const BreakdownPanel = ({
                 <TooltipTrigger asChild>
                   <button
                     type="button"
-                    onClick={() => onOpenTeam?.(targetTeamName)}
+                    onClick={() => {
+                      if (!targetTeamName) return;
+                      if (taskClickable && row.taskId) {
+                        onOpenTask?.(targetTeamName, row.taskId);
+                        return;
+                      }
+                      onOpenTeam?.(targetTeamName);
+                    }}
                     className={rowClassName}
-                    aria-label={t('tokenUsage.actions.openTeam', { team: targetTeamName })}
+                    aria-label={actionLabel}
                   >
                     {rowContent}
                   </button>
                 </TooltipTrigger>
-                <TooltipContent side="top">
-                  {t('tokenUsage.actions.openTeam', { team: targetTeamName })}
-                </TooltipContent>
+                <TooltipContent side="top">{actionLabel}</TooltipContent>
               </Tooltip>
             ) : (
               <div key={row.id} className={rowClassName}>
@@ -1724,7 +1825,7 @@ const SourceQualityPanel = ({
                 <span className={`size-2 rounded-full ${sourceToneClass(item.tone)}`} />
                 <span className="truncate text-text-secondary">{item.label}</span>
               </div>
-              <span className="font-medium text-text">{item.count}</span>
+              <span className="font-medium text-text">{item.countLabel}</span>
             </div>
             <div className="mt-1 h-1.5 overflow-hidden rounded-sm bg-surface">
               <div
@@ -1911,6 +2012,7 @@ function formatPanelPercent(value: number): string {
 
 function barToneClass(tone: TokenUsageBarChartItemViewModel['tone']): string {
   if (tone === 'command') return 'h-full bg-blue-500';
+  if (tone === 'task') return 'h-full bg-fuchsia-500';
   if (tone === 'runtime') return 'h-full bg-teal-500';
   if (tone === 'model') return 'h-full bg-indigo-500';
   if (tone === 'agent') return 'h-full bg-emerald-500';
@@ -1960,6 +2062,22 @@ function buildActivityHeatmapCells(
   if (!Number.isFinite(timestamp)) return days;
   const mondayOffset = (new Date(timestamp).getUTCDay() + 6) % 7;
   return [...Array<TokenUsageActivityDayViewModel | null>(mondayOffset).fill(null), ...days];
+}
+
+function buildActivityStreak(days: TokenUsageActivityDayViewModel[]): number {
+  const activeDayIds = new Set(days.filter((day) => day.tokenValue > 0).map((day) => day.id));
+  const latestActiveDayId = [...activeDayIds].sort().at(-1);
+  if (!latestActiveDayId) return 0;
+
+  const latestTimestamp = Date.parse(`${latestActiveDayId}T00:00:00.000Z`);
+  if (!Number.isFinite(latestTimestamp)) return 0;
+
+  let streak = 0;
+  for (let timestamp = latestTimestamp; ; timestamp -= DAY_MS) {
+    const dayId = new Date(timestamp).toISOString().slice(0, 10);
+    if (!activeDayIds.has(dayId)) return streak;
+    streak += 1;
+  }
 }
 
 function mergeTeamFilterOptions(

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -80,6 +80,7 @@ import {
   createTokenUsageFeature,
   registerTokenUsageIpc,
   removeTokenUsageIpc,
+  TeamTaskUsageAttributionSource,
   type TokenUsageFeatureFacade,
 } from '@features/token-usage/main';
 import { createWorkspaceTrustCoordinator } from '@features/workspace-trust/main';
@@ -2130,6 +2131,7 @@ async function initializeServices(): Promise<void> {
         httpServer?.broadcast(TOKEN_USAGE_SNAPSHOT_CHANGED, snapshot);
       },
     },
+    taskAttributionSource: new TeamTaskUsageAttributionSource(new TeamTaskReader()),
     logger: tokenUsageLogger,
   });
   const tokenUsageStartupRefreshTimer = setTimeout(() => {


### PR DESCRIPTION
## Summary
- add best-effort per-task token usage breakdowns from persisted task workIntervals
- surface top tasks and task rows on the Usage page, with the existing Include cache tokens toggle applied consistently
- keep task attribution optional/degraded-safe so usage snapshots still load if tasks cannot be read

## Verification
- pnpm exec vitest run src/features/token-usage/core/domain/__tests__/snapshotProjection.test.ts src/features/token-usage/core/application/__tests__/TokenUsageAnalyticsService.test.ts src/features/token-usage/renderer/adapters/__tests__/tokenUsageViewModel.test.ts
- pnpm i18n:validate
- pnpm typecheck
- pnpm lint:fast:files -- changed TS/TSX files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added task drill-down in the Token Usage dashboard with “Open task” actions, including a Task Spend chart and a dedicated Tasks section.
  * Added an Activity streak badge to the Activity-by-day panel.
  * Extended dashboard localization with task-related labels and updated the “sources” panel wording.
* **Bug Fixes**
  * Improved fallback dashboard rendering so task spend/Tasks data shows empty output when snapshot loading fails.
* **Other**
  * Cache tokens are now excluded by default on the dashboard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->