### PR TITLE
fix(team): prefer selected project for create defaults

### DIFF
--- a/src/renderer/components/team/teamProjectSelection.ts
+++ b/src/renderer/components/team/teamProjectSelection.ts
@@ -50,6 +50,36 @@ function findWorktreeSelection(
   return null;
 }
 
+function resolveWorktreeProjectSelection(
+  repositoryGroups: readonly RepositoryGroup[],
+  worktreeId: string | null
+): ResolvedTeamProjectSelection | null {
+  if (!worktreeId) return null;
+  const worktreeSelection = findWorktreeSelection(repositoryGroups, worktreeId);
+  if (!worktreeSelection) return null;
+  return {
+    projectPath: worktreeSelection.projectPath,
+    repositoryId: worktreeSelection.repositoryId,
+    worktreeId: worktreeSelection.worktreeId,
+    projectId: worktreeSelection.worktreeId,
+  };
+}
+
+function resolveFlatProjectSelection(
+  projects: readonly Project[],
+  projectId: string | null
+): ResolvedTeamProjectSelection | null {
+  if (!projectId) return null;
+  const project = projects.find((candidate) => candidate.id === projectId);
+  if (!project) return null;
+  return {
+    projectPath: project.path,
+    repositoryId: null,
+    worktreeId: null,
+    projectId: project.id,
+  };
+}
+
 export function resolveTeamProjectSelection({
   repositoryGroups,
   projects,
@@ -58,31 +88,18 @@ export function resolveTeamProjectSelection({
   selectedProjectId,
   activeProjectId,
 }: ResolveTeamProjectSelectionInput): ResolvedTeamProjectSelection {
-  const effectiveWorktreeId = selectedWorktreeId ?? activeProjectId ?? selectedProjectId ?? null;
-  if (effectiveWorktreeId) {
-    const worktreeSelection = findWorktreeSelection(repositoryGroups, effectiveWorktreeId);
-    if (worktreeSelection) {
-      return {
-        projectPath: worktreeSelection.projectPath,
-        repositoryId: worktreeSelection.repositoryId,
-        worktreeId: worktreeSelection.worktreeId,
-        projectId: worktreeSelection.worktreeId,
-      };
-    }
-  }
+  const selectedWorktreeSelection =
+    resolveWorktreeProjectSelection(repositoryGroups, selectedWorktreeId) ??
+    resolveWorktreeProjectSelection(repositoryGroups, selectedProjectId);
+  if (selectedWorktreeSelection) return selectedWorktreeSelection;
 
-  const effectiveProjectId = activeProjectId ?? selectedProjectId ?? null;
-  if (effectiveProjectId) {
-    const project = projects.find((candidate) => candidate.id === effectiveProjectId);
-    if (project) {
-      return {
-        projectPath: project.path,
-        repositoryId: null,
-        worktreeId: null,
-        projectId: project.id,
-      };
-    }
-  }
+  const selectedFlatProjectSelection = resolveFlatProjectSelection(projects, selectedProjectId);
+  if (selectedFlatProjectSelection) return selectedFlatProjectSelection;
+
+  const activeProjectSelection =
+    resolveWorktreeProjectSelection(repositoryGroups, activeProjectId) ??
+    resolveFlatProjectSelection(projects, activeProjectId);
+  if (activeProjectSelection) return activeProjectSelection;
 
   if (selectedRepositoryId) {
     const repositoryGroup = repositoryGroups.find(

--- a/test/renderer/components/team/teamProjectSelection.test.ts
+++ b/test/renderer/components/team/teamProjectSelection.test.ts
@@ -1,10 +1,9 @@
-import { describe, expect, it } from 'vitest';
-
 import {
   findTeamProjectSelectionTarget,
   resolveTeamProjectSelection,
   teamMatchesProjectSelection,
 } from '@renderer/components/team/teamProjectSelection';
+import { describe, expect, it } from 'vitest';
 
 import type { Project, RepositoryGroup } from '@renderer/types/data';
 import type { TeamSummary } from '@shared/types';
@@ -69,6 +68,42 @@ describe('teamProjectSelection', () => {
         selectedRepositoryId: null,
         selectedWorktreeId: null,
         selectedProjectId: null,
+        activeProjectId: 'wt-headless',
+      })
+    ).toEqual({
+      projectPath: '/Users/test/headless',
+      repositoryId: 'repo-headless',
+      worktreeId: 'wt-headless',
+      projectId: 'wt-headless',
+    });
+  });
+
+  it('prefers the selected project over the active project', () => {
+    expect(
+      resolveTeamProjectSelection({
+        repositoryGroups,
+        projects,
+        selectedRepositoryId: null,
+        selectedWorktreeId: null,
+        selectedProjectId: 'project-standalone',
+        activeProjectId: 'wt-headless',
+      })
+    ).toEqual({
+      projectPath: '/Users/test/standalone',
+      repositoryId: null,
+      worktreeId: null,
+      projectId: 'project-standalone',
+    });
+  });
+
+  it('falls back to the active project when the selected project id is stale', () => {
+    expect(
+      resolveTeamProjectSelection({
+        repositoryGroups,
+        projects,
+        selectedRepositoryId: null,
+        selectedWorktreeId: null,
+        selectedProjectId: 'missing-project',
         activeProjectId: 'wt-headless',
       })
     ).toEqual({


### PR DESCRIPTION
## Summary
- prefer the selected project over the stale active project when resolving team list project context
- keep active project as fallback when the selected id is missing or stale
- add regression coverage for selected-vs-active project resolution

## Tests
- pnpm exec vitest run test/renderer/components/team/teamProjectSelection.test.ts
- pnpm lint:fast:files -- src/renderer/components/team/teamProjectSelection.ts test/renderer/components/team/teamProjectSelection.test.ts
- pnpm typecheck
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved team project selection handling so the app resolves the most relevant project more reliably.
  * When no grouped selection is present, an explicit project choice now takes priority over a fallback active project.
  * Added fallback behavior for cases where the saved project selection is no longer available, helping keep selections consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->