### PR TITLE
fix: harden team storage and project paths

### DIFF
--- a/agent-teams-controller/src/internal/crossTeam.js
+++ b/agent-teams-controller/src/internal/crossTeam.js
@@ -36,6 +36,7 @@ function normalizeMetaMembers(rawMembers) {
     if (!m || typeof m !== 'object') continue;
     const name = typeof m.name === 'string' ? m.name.trim() : '';
     if (!name) continue;
+    if (!runtimeHelpers.isSafeMemberFileSegment(name)) continue;
     deduped.set(name, {
       name,
       agentType: typeof m.agentType === 'string' ? m.agentType.trim() || undefined : undefined,
@@ -195,7 +196,10 @@ function sendCrossTeamMessage(context, flags) {
   }
 
   // Resolve lead
-  const leadName = resolveTargetLead(targetContext.paths, targetConfig);
+  const leadName = runtimeHelpers.assertSafeMemberFileSegment(
+    'target lead name',
+    resolveTargetLead(targetContext.paths, targetConfig)
+  );
 
   // Format
   const from = `${fromTeam}.${fromMember}`;

--- a/agent-teams-controller/src/internal/messageStore.js
+++ b/agent-teams-controller/src/internal/messageStore.js
@@ -349,7 +349,12 @@ function lookupMessage(paths, messageId) {
   }
 
   for (const file of inboxFiles) {
-    const rows = readJson(path.join(inboxDir, file), []);
+    let rows;
+    try {
+      rows = readJson(path.join(inboxDir, file), []);
+    } catch {
+      continue;
+    }
     if (!Array.isArray(rows)) continue;
     for (const row of rows) {
       if (row && row.messageId === id) {

--- a/agent-teams-controller/src/internal/messageStore.js
+++ b/agent-teams-controller/src/internal/messageStore.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 const { writeJsonFileSync } = require('./atomicFile.js');
+const runtimeHelpers = require('./runtimeHelpers.js');
 
 function nowIso() {
   return new Date().toISOString();
@@ -10,8 +11,11 @@ function nowIso() {
 function readJson(filePath, fallbackValue) {
   try {
     return JSON.parse(fs.readFileSync(filePath, 'utf8'));
-  } catch {
-    return fallbackValue;
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return fallbackValue;
+    }
+    throw error;
   }
 }
 
@@ -20,7 +24,8 @@ function writeJson(filePath, value) {
 }
 
 function getInboxPath(paths, memberName) {
-  return path.join(paths.teamDir, 'inboxes', `${String(memberName).trim()}.json`);
+  const safeMemberName = runtimeHelpers.assertSafeMemberFileSegment('member name', memberName);
+  return path.join(paths.teamDir, 'inboxes', `${safeMemberName}.json`);
 }
 
 function getSentMessagesPath(paths) {

--- a/agent-teams-controller/src/internal/messageStore.js
+++ b/agent-teams-controller/src/internal/messageStore.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 const { writeJsonFileSync } = require('./atomicFile.js');
+const { withFileLockSync } = require('./fileLock.js');
 const runtimeHelpers = require('./runtimeHelpers.js');
 
 function nowIso() {
@@ -202,11 +203,13 @@ function buildMessage(flags, defaults) {
 }
 
 function appendRow(filePath, row) {
-  const current = readJson(filePath, []);
-  const list = Array.isArray(current) ? current : [];
-  list.push(row);
-  writeJson(filePath, list);
-  return row;
+  return withFileLockSync(filePath, () => {
+    const current = readJson(filePath, []);
+    const list = Array.isArray(current) ? current : [];
+    list.push(row);
+    writeJson(filePath, list);
+    return row;
+  });
 }
 
 const RUNTIME_DELIVERY_DUPLICATE_NOTICE =
@@ -254,16 +257,18 @@ function getRuntimeDeliveryDuplicate(list, row) {
 }
 
 function appendInboxRow(filePath, row) {
-  const current = readJson(filePath, []);
-  const list = Array.isArray(current) ? current : [];
-  const duplicate = getRuntimeDeliveryDuplicate(list, row);
-  if (duplicate) {
-    return { row: duplicate, deduplicated: true };
-  }
+  return withFileLockSync(filePath, () => {
+    const current = readJson(filePath, []);
+    const list = Array.isArray(current) ? current : [];
+    const duplicate = getRuntimeDeliveryDuplicate(list, row);
+    if (duplicate) {
+      return { row: duplicate, deduplicated: true };
+    }
 
-  list.push(row);
-  writeJson(filePath, list);
-  return { row, deduplicated: false };
+    list.push(row);
+    writeJson(filePath, list);
+    return { row, deduplicated: false };
+  });
 }
 
 function sendInboxMessage(paths, flags) {

--- a/agent-teams-controller/src/internal/runtimeHelpers.js
+++ b/agent-teams-controller/src/internal/runtimeHelpers.js
@@ -5,6 +5,31 @@ const crypto = require('crypto');
 const TASK_ATTACHMENTS_DIR = 'task-attachments';
 const MAX_TASK_ATTACHMENT_BYTES = 20 * 1024 * 1024;
 const TEAM_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,127}$/;
+const MEMBER_FILE_SEGMENT_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/;
+const WINDOWS_RESERVED_FILE_STEMS = new Set([
+  'con',
+  'prn',
+  'aux',
+  'nul',
+  'com1',
+  'com2',
+  'com3',
+  'com4',
+  'com5',
+  'com6',
+  'com7',
+  'com8',
+  'com9',
+  'lpt1',
+  'lpt2',
+  'lpt3',
+  'lpt4',
+  'lpt5',
+  'lpt6',
+  'lpt7',
+  'lpt8',
+  'lpt9',
+]);
 const LEAD_AGENT_TYPES = new Set(['team-lead', 'lead', 'orchestrator']);
 const CROSS_TEAM_TOOL_RECIPIENT_NAMES = new Set([
   'cross_team_send',
@@ -48,6 +73,35 @@ function isSafePathSegment(value) {
 function assertSafePathSegment(label, value) {
   const normalized = String(value == null ? '' : value);
   if (!isSafePathSegment(normalized)) {
+    throw new Error(`Invalid ${String(label)}`);
+  }
+  return normalized;
+}
+
+function isWindowsReservedFileSegment(value) {
+  const normalized = String(value == null ? '' : value)
+    .trim()
+    .replace(/[. ]+$/g, '')
+    .toLowerCase();
+  if (!normalized) return false;
+  const stem = normalized.split('.')[0] || normalized;
+  return WINDOWS_RESERVED_FILE_STEMS.has(stem);
+}
+
+function isSafeMemberFileSegment(value) {
+  const normalized = String(value == null ? '' : value).trim();
+  if (!MEMBER_FILE_SEGMENT_PATTERN.test(normalized)) return false;
+  if (normalized === '.' || normalized === '..') return false;
+  if (normalized.includes('/') || normalized.includes('\\')) return false;
+  if (normalized.includes('\0')) return false;
+  if (/[. ]$/.test(normalized)) return false;
+  if (isWindowsReservedFileSegment(normalized)) return false;
+  return true;
+}
+
+function assertSafeMemberFileSegment(label, value) {
+  const normalized = String(value == null ? '' : value).trim();
+  if (!isSafeMemberFileSegment(normalized)) {
     throw new Error(`Invalid ${String(label)}`);
   }
   return normalized;
@@ -196,7 +250,8 @@ function inferLeadName(paths) {
   }
   const config = resolved.config;
   if (config && Array.isArray(config.members) && config.members[0]) {
-    return String(config.members[0].name);
+    const firstMember = config.members.map((member) => normalizeMemberRecord(member)).find(Boolean);
+    if (firstMember) return firstMember.name;
   }
   return 'team-lead';
 }
@@ -350,6 +405,7 @@ function listInboxMemberNames(paths) {
     .map((entry) => entry.name.slice(0, -5))
     .map((name) => String(name || '').trim())
     .filter((name) => name && name !== 'user')
+    .filter((name) => isSafeMemberFileSegment(name))
     .filter((name) => !looksLikeCrossTeamPseudoRecipient(name))
     .filter((name) => !looksLikeCrossTeamToolRecipient(name));
 }
@@ -358,6 +414,7 @@ function normalizeMemberRecord(member) {
   if (!member || typeof member !== 'object') return null;
   const name = typeof member.name === 'string' ? member.name.trim() : '';
   if (!name) return null;
+  if (!isSafeMemberFileSegment(name)) return null;
   const copyTrimmedString = (key) =>
     typeof member[key] === 'string' && member[key].trim()
       ? { [key]: member[key].trim() }
@@ -699,10 +756,12 @@ function saveTaskAttachmentFile(paths, taskId, flags) {
 }
 
 module.exports = {
+  assertSafeMemberFileSegment,
   assertExplicitTeamMemberName,
   collectExplicitTeamMembers,
   getPaths,
   inferLeadName,
+  isSafeMemberFileSegment,
   isCanonicalLeadMember,
   looksLikeCrossTeamRecipient,
   looksLikeCrossTeamToolRecipient,

--- a/agent-teams-controller/src/internal/tasks.js
+++ b/agent-teams-controller/src/internal/tasks.js
@@ -32,6 +32,12 @@ function assertTaskNotDeleted(task, action) {
     }
 }
 
+function readMutableTask(context, taskId, action) {
+    const task = taskStore.readTask(context.paths, taskId, { includeDeleted: true });
+    assertTaskNotDeleted(task, action);
+    return task;
+}
+
 function isSameMember(left, right) {
     return normalizeActorName(left).toLowerCase() === normalizeActorName(right).toLowerCase();
 }
@@ -481,7 +487,7 @@ function restoreTask(context, taskId, actor) {
 
 function setTaskOwner(context, taskId, owner, actor) {
     const { previousTask, updatedTask } = withTeamBoardLock(context.paths, () => {
-        const before = taskStore.readTask(context.paths, taskId, { includeDeleted: true });
+        const before = readMutableTask(context, taskId, 'changing owner');
         const nextOwner = isClearOwnerValue(owner)
             ? owner
             : assertKnownTaskActor(context, owner, 'task owner');
@@ -506,9 +512,10 @@ function setTaskOwner(context, taskId, owner, actor) {
 }
 
 function updateTaskFields(context, taskId, fields) {
-    return withTeamBoardLock(context.paths, () =>
-        taskStore.updateTaskFields(context.paths, taskId, fields)
-    );
+    return withTeamBoardLock(context.paths, () => {
+        readMutableTask(context, taskId, 'updating task fields');
+        return taskStore.updateTaskFields(context.paths, taskId, fields);
+    });
 }
 
 function addTaskCommentWithOptions(context, taskId, flags, options = {}) {
@@ -531,16 +538,17 @@ function addTaskCommentWithOptions(context, taskId, flags, options = {}) {
             allowProviderAliases: !fromRequiredForAgentTool,
         }
     );
-    const result = withTeamBoardLock(context.paths, () =>
-        taskStore.addTaskComment(context.paths, taskId, commentFlags.text, {
+    const result = withTeamBoardLock(context.paths, () => {
+        readMutableTask(context, taskId, 'adding a comment');
+        return taskStore.addTaskComment(context.paths, taskId, commentFlags.text, {
             author,
             ...(commentFlags.id ? { id: commentFlags.id } : {}),
             ...(commentFlags.createdAt ? { createdAt: commentFlags.createdAt } : {}),
             ...(commentFlags.type ? { type: commentFlags.type } : {}),
             ...(Array.isArray(commentFlags.taskRefs) ? { taskRefs: commentFlags.taskRefs } : {}),
             ...(Array.isArray(commentFlags.attachments) ? { attachments: commentFlags.attachments } : {}),
-        })
-    );
+        });
+    });
 
     try {
         maybeNotifyTaskOwnerOnComment(context, result.task, result.comment, {
@@ -567,10 +575,12 @@ function addTaskComment(context, taskId, flags) {
 
 function attachTaskFile(context, taskId, flags) {
     const canonicalTaskId = resolveTaskId(context, taskId);
+    withTeamBoardLock(context.paths, () => readMutableTask(context, canonicalTaskId, 'adding an attachment'));
     const saved = runtimeHelpers.saveTaskAttachmentFile(context.paths, canonicalTaskId, flags);
-    const task = withTeamBoardLock(context.paths, () =>
-        taskStore.addTaskAttachmentMeta(context.paths, canonicalTaskId, saved.meta)
-    );
+    const task = withTeamBoardLock(context.paths, () => {
+        readMutableTask(context, canonicalTaskId, 'adding an attachment');
+        return taskStore.addTaskAttachmentMeta(context.paths, canonicalTaskId, saved.meta);
+    });
     return {
         ...saved.meta,
         task,
@@ -579,10 +589,12 @@ function attachTaskFile(context, taskId, flags) {
 
 function attachCommentFile(context, taskId, commentId, flags) {
     const canonicalTaskId = resolveTaskId(context, taskId);
+    withTeamBoardLock(context.paths, () => readMutableTask(context, canonicalTaskId, 'adding a comment attachment'));
     const saved = runtimeHelpers.saveTaskAttachmentFile(context.paths, canonicalTaskId, flags);
-    const task = withTeamBoardLock(context.paths, () =>
-        taskStore.addCommentAttachmentMeta(context.paths, canonicalTaskId, commentId, saved.meta)
-    );
+    const task = withTeamBoardLock(context.paths, () => {
+        readMutableTask(context, canonicalTaskId, 'adding a comment attachment');
+        return taskStore.addCommentAttachmentMeta(context.paths, canonicalTaskId, commentId, saved.meta);
+    });
     return {
         ...saved.meta,
         task,
@@ -590,21 +602,24 @@ function attachCommentFile(context, taskId, commentId, flags) {
 }
 
 function addTaskAttachmentMeta(context, taskId, meta) {
-    return withTeamBoardLock(context.paths, () =>
-        taskStore.addTaskAttachmentMeta(context.paths, taskId, meta)
-    );
+    return withTeamBoardLock(context.paths, () => {
+        readMutableTask(context, taskId, 'adding an attachment');
+        return taskStore.addTaskAttachmentMeta(context.paths, taskId, meta);
+    });
 }
 
 function removeTaskAttachment(context, taskId, attachmentId) {
-    return withTeamBoardLock(context.paths, () =>
-        taskStore.removeTaskAttachment(context.paths, taskId, attachmentId)
-    );
+    return withTeamBoardLock(context.paths, () => {
+        readMutableTask(context, taskId, 'removing an attachment');
+        return taskStore.removeTaskAttachment(context.paths, taskId, attachmentId);
+    });
 }
 
 function setNeedsClarification(context, taskId, value) {
-    return withTeamBoardLock(context.paths, () =>
-        taskStore.setNeedsClarification(context.paths, taskId, value == null ? 'clear' : String(value))
-    );
+    return withTeamBoardLock(context.paths, () => {
+        readMutableTask(context, taskId, 'changing clarification');
+        return taskStore.setNeedsClarification(context.paths, taskId, value == null ? 'clear' : String(value));
+    });
 }
 
 function linkTask(context, taskId, targetId, linkType) {
@@ -1038,6 +1053,9 @@ module.exports = {
     taskBriefing,
     unlinkTask,
     updateTask: (context, taskRef, updater) =>
-        withTeamBoardLock(context.paths, () => taskStore.updateTask(context.paths, taskRef, updater)),
+        withTeamBoardLock(context.paths, () => {
+            readMutableTask(context, taskRef, 'updating task');
+            return taskStore.updateTask(context.paths, taskRef, updater);
+        }),
     updateTaskFields,
 };

--- a/agent-teams-controller/test/controller.test.js
+++ b/agent-teams-controller/test/controller.test.js
@@ -3190,6 +3190,27 @@ describe('agent-teams-controller API', () => {
       expect(result.store).toBe('inbox:bob');
     });
 
+    it('skips corrupt inbox files while looking up valid inbox messages', () => {
+      const claudeDir = makeClaudeDir();
+      const controller = createController({ teamName: 'my-team', claudeDir });
+
+      const delivered = controller.messages.sendMessage({
+        to: 'bob',
+        from: 'user',
+        text: 'Deploy to staging',
+        source: 'inbox',
+      });
+      const inboxDir = path.join(claudeDir, 'teams', 'my-team', 'inboxes');
+      const corruptPath = path.join(inboxDir, 'alice.json');
+      fs.writeFileSync(corruptPath, '{not json', 'utf8');
+
+      const result = controller.messages.lookupMessage(delivered.messageId);
+
+      expect(result.message.messageId).toBe(delivered.messageId);
+      expect(result.store).toBe('inbox:bob');
+      expect(fs.readFileSync(corruptPath, 'utf8')).toBe('{not json');
+    });
+
     it('throws on unknown messageId', () => {
       const claudeDir = makeClaudeDir();
       const controller = createController({ teamName: 'my-team', claudeDir });

--- a/agent-teams-controller/test/controller.test.js
+++ b/agent-teams-controller/test/controller.test.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const http = require('http');
 const os = require('os');
 const path = require('path');
+const { spawn } = require('child_process');
 
 const { createController } = require('../src/index.js');
 
@@ -75,6 +76,59 @@ describe('agent-teams-controller API', () => {
       path.join(claudeDir, 'team-control-api.json'),
       JSON.stringify({ baseUrl, updatedAt: new Date().toISOString() }, null, 2)
     );
+  }
+
+  function runControllerMessageProcess(env) {
+    const script = `
+const fs = require('fs');
+const path = require('path');
+const sleep = (ms) => Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+const inboxPath = path.resolve(process.env.INBOX_PATH);
+const originalReadFileSync = fs.readFileSync;
+fs.readFileSync = function patchedReadFileSync(filePath, ...args) {
+  const resolved = path.resolve(String(filePath));
+  try {
+    const result = originalReadFileSync.call(this, filePath, ...args);
+    if (resolved === inboxPath) sleep(250);
+    return result;
+  } catch (error) {
+    if (resolved === inboxPath) sleep(250);
+    throw error;
+  }
+};
+const { createController } = require(process.env.CONTROLLER_ENTRY);
+const controller = createController({ teamName: 'my-team', claudeDir: process.env.CLAUDE_DIR });
+controller.messages.sendMessage({
+  to: 'bob',
+  from: 'alice',
+  text: process.env.MESSAGE_TEXT,
+  messageId: process.env.MESSAGE_ID,
+});
+`;
+
+    return new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, ['-e', script], {
+        cwd: path.join(__dirname, '..'),
+        env: { ...process.env, ...env },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', (chunk) => {
+        stdout += chunk;
+      });
+      child.stderr.on('data', (chunk) => {
+        stderr += chunk;
+      });
+      child.on('error', reject);
+      child.on('exit', (code) => {
+        if (code === 0) {
+          resolve();
+          return;
+        }
+        reject(new Error(`child exited ${code}\nstdout:\n${stdout}\nstderr:\n${stderr}`));
+      });
+    });
   }
 
   it('creates tasks and exposes grouped controller modules', () => {
@@ -1270,6 +1324,33 @@ describe('agent-teams-controller API', () => {
       })
     ).toThrow();
     expect(fs.readFileSync(inboxPath, 'utf8')).toBe('{not json');
+  });
+
+  it('keeps concurrent controller message appends from separate processes', async () => {
+    const claudeDir = makeClaudeDir();
+    const inboxPath = path.join(claudeDir, 'teams', 'my-team', 'inboxes', 'bob.json');
+    const controllerEntry = path.join(__dirname, '..', 'src', 'index.js');
+
+    await Promise.all(
+      ['one', 'two', 'three', 'four'].map((label) =>
+        runControllerMessageProcess({
+          CLAUDE_DIR: claudeDir,
+          CONTROLLER_ENTRY: controllerEntry,
+          INBOX_PATH: inboxPath,
+          MESSAGE_ID: `msg-${label}`,
+          MESSAGE_TEXT: `parallel ${label}`,
+        })
+      )
+    );
+
+    const rows = JSON.parse(fs.readFileSync(inboxPath, 'utf8'));
+    expect(rows).toHaveLength(4);
+    expect(rows.map((row) => row.messageId).sort()).toEqual([
+      'msg-four',
+      'msg-one',
+      'msg-three',
+      'msg-two',
+    ]);
   });
 
   it('persists slash command metadata through controller messages.appendSentMessage', () => {

--- a/agent-teams-controller/test/controller.test.js
+++ b/agent-teams-controller/test/controller.test.js
@@ -1224,6 +1224,54 @@ describe('agent-teams-controller API', () => {
     expect(rows[0].attachments[0].filename).toBe('note.txt');
   });
 
+  it('rejects unsafe configured member names before inbox path construction', () => {
+    const claudeDir = makeClaudeDir();
+    const configPath = path.join(claudeDir, 'teams', 'my-team', 'config.json');
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify(
+        {
+          name: 'my-team',
+          members: [
+            { name: '../config', role: 'developer' },
+            { name: 'alice', role: 'team-lead' },
+          ],
+        },
+        null,
+        2
+      )
+    );
+    const originalConfig = fs.readFileSync(configPath, 'utf8');
+    const controller = createController({ teamName: 'my-team', claudeDir });
+
+    expect(() =>
+      controller.messages.sendMessage({
+        to: '../config',
+        from: 'alice',
+        text: 'should not overwrite config',
+      })
+    ).toThrow('Unknown to: ../config');
+    expect(fs.readFileSync(configPath, 'utf8')).toBe(originalConfig);
+  });
+
+  it('does not overwrite a corrupt inbox JSON file when appending a message', () => {
+    const claudeDir = makeClaudeDir();
+    const inboxDir = path.join(claudeDir, 'teams', 'my-team', 'inboxes');
+    const inboxPath = path.join(inboxDir, 'bob.json');
+    fs.mkdirSync(inboxDir, { recursive: true });
+    fs.writeFileSync(inboxPath, '{not json', 'utf8');
+    const controller = createController({ teamName: 'my-team', claudeDir });
+
+    expect(() =>
+      controller.messages.sendMessage({
+        to: 'bob',
+        from: 'alice',
+        text: 'after corruption',
+      })
+    ).toThrow();
+    expect(fs.readFileSync(inboxPath, 'utf8')).toBe('{not json');
+  });
+
   it('persists slash command metadata through controller messages.appendSentMessage', () => {
     const claudeDir = makeClaudeDir();
     const controller = createController({ teamName: 'my-team', claudeDir });
@@ -2243,6 +2291,7 @@ describe('agent-teams-controller API', () => {
     const task = controller.tasks.createTask({ subject: 'Deleted work guard', owner: 'bob' });
 
     controller.tasks.softDeleteTask(task.id, 'bob');
+    const deletedBefore = controller.tasks.getTask(task.id);
 
     expect(() => controller.tasks.startTask(task.id, 'bob')).toThrow(
       'use task_restore before starting work'
@@ -2253,6 +2302,29 @@ describe('agent-teams-controller API', () => {
     expect(() => controller.tasks.setTaskStatus(task.id, 'pending', 'bob')).toThrow(
       'use task_restore before changing status'
     );
+    expect(() => controller.tasks.setTaskOwner(task.id, 'alice', 'alice')).toThrow(
+      'use task_restore before changing owner'
+    );
+    expect(() => controller.tasks.updateTaskFields(task.id, { description: 'mutated' })).toThrow(
+      'use task_restore before updating task fields'
+    );
+    expect(() =>
+      controller.tasks.addTaskComment(task.id, {
+        from: 'alice',
+        text: 'still writing',
+      })
+    ).toThrow('use task_restore before adding a comment');
+    expect(() => controller.tasks.setNeedsClarification(task.id, 'lead')).toThrow(
+      'use task_restore before changing clarification'
+    );
+
+    const stillDeleted = controller.tasks.getTask(task.id);
+    expect(stillDeleted.status).toBe('deleted');
+    expect(stillDeleted.owner).toBe('bob');
+    expect(stillDeleted.subject).toBe(deletedBefore.subject);
+    expect(stillDeleted.description).toBe(deletedBefore.description);
+    expect(stillDeleted.comments || []).toEqual([]);
+    expect(stillDeleted.needsClarification).toBeUndefined();
 
     const restored = controller.tasks.restoreTask(task.id, 'alice');
     expect(restored.status).toBe('pending');

--- a/agent-teams-controller/test/crossTeam.test.js
+++ b/agent-teams-controller/test/crossTeam.test.js
@@ -328,6 +328,33 @@ describe('crossTeam module', () => {
       ).toThrow('Target team not found');
     });
 
+    it('rejects unsafe target lead names before inbox writes', () => {
+      const claudeDir = makeClaudeDir({
+        'team-a': {
+          name: 'team-a',
+          members: [{ name: 'team-lead', agentType: 'team-lead' }],
+        },
+        'team-b': {
+          name: 'team-b',
+          members: [{ name: '../config', agentType: 'team-lead' }],
+        },
+      });
+      const targetConfigPath = path.join(claudeDir, 'teams', 'team-b', 'config.json');
+      const originalConfig = fs.readFileSync(targetConfigPath, 'utf8');
+
+      const controller = createController({ teamName: 'team-a', claudeDir });
+      expect(() =>
+        controller.crossTeam.sendCrossTeamMessage({
+          toTeam: 'team-b',
+          text: 'Hello',
+        })
+      ).toThrow('Invalid target lead name');
+      expect(fs.readFileSync(targetConfigPath, 'utf8')).toBe(originalConfig);
+      expect(fs.existsSync(path.join(claudeDir, 'teams', 'team-a', 'sent-cross-team.json'))).toBe(
+        false
+      );
+    });
+
     it('rejects excessive chain depth', () => {
       const claudeDir = makeClaudeDir({
         'team-a': {

--- a/src/features/recent-projects/renderer/adapters/RecentProjectsSectionAdapter.ts
+++ b/src/features/recent-projects/renderer/adapters/RecentProjectsSectionAdapter.ts
@@ -1,5 +1,9 @@
 import { formatProjectPath } from '@renderer/utils/pathDisplay';
-import { normalizePath, type TaskStatusCounts } from '@renderer/utils/pathNormalize';
+import {
+  normalizePath,
+  normalizePathForMatching,
+  type TaskStatusCounts,
+} from '@renderer/utils/pathNormalize';
 import { formatDistanceToNow } from 'date-fns';
 
 import { sortDashboardProviderIds } from '../utils/projectDecorations';
@@ -37,13 +41,30 @@ interface RecentProjectsSectionAdapterInput {
   tasksLoading: boolean;
 }
 
+function getProjectPathMapValue<T>(map: Map<string, T>, projectPath: string): T | undefined {
+  const identityKey = normalizePath(projectPath);
+  const exact = map.get(identityKey);
+  if (exact !== undefined) {
+    return exact;
+  }
+
+  const matchingKey = normalizePathForMatching(projectPath);
+  for (const [key, value] of map) {
+    if (normalizePathForMatching(key) === matchingKey) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
 function sumTaskCounts(
   project: DashboardRecentProject,
   taskCountsByProject: Map<string, TaskStatusCounts>
 ): TaskStatusCounts | undefined {
   const total = project.associatedPaths.reduce<TaskStatusCounts>(
     (counts, currentPath) => {
-      const next = taskCountsByProject.get(normalizePath(currentPath));
+      const next = getProjectPathMapValue(taskCountsByProject, currentPath);
       if (!next) {
         return counts;
       }
@@ -68,7 +89,7 @@ function collectActiveTeams(
   const activeTeams: TeamSummary[] = [];
 
   for (const projectPath of project.associatedPaths) {
-    const teams = activeTeamsByProject.get(normalizePath(projectPath));
+    const teams = getProjectPathMapValue(activeTeamsByProject, projectPath);
     if (!teams) {
       continue;
     }

--- a/src/features/recent-projects/renderer/utils/activeProjectTeams.ts
+++ b/src/features/recent-projects/renderer/utils/activeProjectTeams.ts
@@ -1,4 +1,4 @@
-import { normalizePath } from '@renderer/utils/pathNormalize';
+import { normalizePathForMatching } from '@renderer/utils/pathNormalize';
 
 import type { TeamSummary } from '@shared/types';
 
@@ -35,7 +35,7 @@ export function buildActiveTeamsByProject({
       continue;
     }
 
-    const key = normalizePath(team.projectPath);
+    const key = normalizePathForMatching(team.projectPath);
     const existing = teamsByProject.get(key);
     if (existing) {
       existing.push(team);

--- a/src/features/recent-projects/renderer/utils/navigation.ts
+++ b/src/features/recent-projects/renderer/utils/navigation.ts
@@ -1,4 +1,4 @@
-import { normalizePath } from '@renderer/utils/pathNormalize';
+import { normalizePathForMatching } from '@renderer/utils/pathNormalize';
 
 import type { RepositoryGroup } from '@renderer/types/data';
 
@@ -11,11 +11,13 @@ export function findMatchingWorktree(
   groups: RepositoryGroup[],
   candidatePaths: readonly string[]
 ): WorktreeMatch | null {
-  const normalizedPaths = new Set(candidatePaths.map((projectPath) => normalizePath(projectPath)));
+  const normalizedPaths = new Set(
+    candidatePaths.map((projectPath) => normalizePathForMatching(projectPath))
+  );
 
   for (const repo of groups) {
     for (const worktree of repo.worktrees) {
-      if (normalizedPaths.has(normalizePath(worktree.path))) {
+      if (normalizedPaths.has(normalizePathForMatching(worktree.path))) {
         return { repoId: repo.id, worktreeId: worktree.id };
       }
     }

--- a/src/main/services/team/TeamInboxWriter.ts
+++ b/src/main/services/team/TeamInboxWriter.ts
@@ -1,4 +1,5 @@
 import { getTeamsBasePath } from '@main/utils/pathDecoder';
+import { isPathWithinRoot, validateFileName } from '@main/utils/pathValidation';
 import { randomUUID } from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -9,6 +10,23 @@ import { withInboxLock } from './inboxLock';
 import { getEffectiveInboxMessageId } from './inboxMessageIdentity';
 
 import type { InboxMessage, SendMessageRequest, SendMessageResult, TaskRef } from '@shared/types';
+
+function resolveInboxPath(teamName: string, inboxName: string): string {
+  const safeTeamName = teamName.trim();
+  const safeInboxName = inboxName.trim();
+  if (!validateFileName(safeTeamName).valid || !validateFileName(safeInboxName).valid) {
+    throw new Error('Invalid inbox path');
+  }
+
+  const teamsBasePath = getTeamsBasePath();
+  const inboxDir = path.join(teamsBasePath, safeTeamName, 'inboxes');
+  const inboxPath = path.join(inboxDir, `${safeInboxName}.json`);
+  if (!isPathWithinRoot(inboxDir, teamsBasePath) || !isPathWithinRoot(inboxPath, inboxDir)) {
+    throw new Error('Invalid inbox path');
+  }
+
+  return inboxPath;
+}
 
 export interface UpdateInboxMessageTextRequest {
   member: string;
@@ -53,7 +71,7 @@ export interface CorrelateRuntimeDeliveryReplyResult {
 
 export class TeamInboxWriter {
   async sendMessage(teamName: string, request: SendMessageRequest): Promise<SendMessageResult> {
-    const inboxPath = path.join(getTeamsBasePath(), teamName, 'inboxes', `${request.member}.json`);
+    const inboxPath = resolveInboxPath(teamName, request.member);
     const messageId = request.messageId?.trim() || randomUUID();
 
     const attachmentMeta = request.attachments?.map((a) => ({
@@ -160,7 +178,7 @@ export class TeamInboxWriter {
       return { found: false, updated: false };
     }
 
-    const inboxPath = path.join(getTeamsBasePath(), teamName, 'inboxes', `${request.member}.json`);
+    const inboxPath = resolveInboxPath(teamName, request.member);
     let result: UpdateInboxMessageTextResult = { found: false, updated: false };
 
     await withFileLock(inboxPath, async () => {
@@ -235,7 +253,7 @@ export class TeamInboxWriter {
       return { found: false, updated: false };
     }
 
-    const inboxPath = path.join(getTeamsBasePath(), teamName, 'inboxes', `${inboxName}.json`);
+    const inboxPath = resolveInboxPath(teamName, inboxName);
     const expectedFrom = this.normalizeComparableParticipant(request.from);
     if (!expectedFrom) {
       return { found: false, updated: false };
@@ -321,7 +339,7 @@ export class TeamInboxWriter {
       return { found: false, updated: false };
     }
 
-    const inboxPath = path.join(getTeamsBasePath(), teamName, 'inboxes', `${inboxName}.json`);
+    const inboxPath = resolveInboxPath(teamName, inboxName);
     const taskRefs = this.normalizeTaskRefs(request.taskRefs);
     let result: CorrelateRuntimeDeliveryReplyResult = { found: false, updated: false };
     await withFileLock(inboxPath, async () => {

--- a/src/main/services/team/TeamSentMessagesStore.ts
+++ b/src/main/services/team/TeamSentMessagesStore.ts
@@ -5,6 +5,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import { atomicWriteAsync } from './atomicWrite';
+import { withFileLock } from './fileLock';
 
 import type { InboxMessage } from '@shared/types';
 
@@ -48,10 +49,45 @@ export class TeamSentMessagesStore {
       return [];
     }
 
+    return this.normalizeMessages(parsed);
+  }
+
+  private async readMessagesForAppend(teamName: string, filePath: string): Promise<InboxMessage[]> {
+    let raw: string;
+    try {
+      const stat = await fs.promises.stat(filePath);
+      if (!stat.isFile() || stat.size > MAX_SENT_MESSAGES_FILE_BYTES) {
+        throw new Error('sent messages file is not a regular readable file');
+      }
+      raw = await readFileUtf8WithTimeout(filePath, 5_000);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return [];
+      }
+      if (error instanceof FileReadTimeoutError) {
+        throw new Error(`Timed out reading sent messages for ${teamName}`);
+      }
+      throw error;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw) as unknown;
+    } catch (error) {
+      throw new Error(`Failed to parse sent messages for ${teamName}: ${String(error)}`);
+    }
+
+    if (!Array.isArray(parsed)) {
+      throw new Error(`Sent messages file for ${teamName} is not an array`);
+    }
+
+    return this.normalizeMessages(parsed);
+  }
+
+  private normalizeMessages(parsed: unknown): InboxMessage[] {
     if (!Array.isArray(parsed)) {
       return [];
     }
-
     const messages: InboxMessage[] = [];
     for (const item of parsed) {
       if (!item || typeof item !== 'object') continue;
@@ -139,15 +175,16 @@ export class TeamSentMessagesStore {
   }
 
   async appendMessage(teamName: string, message: InboxMessage): Promise<void> {
-    // Bug #6: wrap in try/catch to prevent crash on IO errors
+    const filePath = this.getFilePath(teamName);
     try {
-      const existing = await this.readMessages(teamName);
-      existing.push(message);
+      await withFileLock(filePath, async () => {
+        const existing = await this.readMessagesForAppend(teamName, filePath);
+        existing.push(message);
 
-      // Trim to MAX_MESSAGES (keep newest)
-      const trimmed = existing.length > MAX_MESSAGES ? existing.slice(-MAX_MESSAGES) : existing;
+        const trimmed = existing.length > MAX_MESSAGES ? existing.slice(-MAX_MESSAGES) : existing;
 
-      await atomicWriteAsync(this.getFilePath(teamName), JSON.stringify(trimmed, null, 2));
+        await atomicWriteAsync(filePath, JSON.stringify(trimmed, null, 2));
+      });
     } catch (error) {
       logger.error(`Failed to append sent message for ${teamName}: ${String(error)}`);
     }

--- a/src/renderer/components/team/TeamListFilterPopover.tsx
+++ b/src/renderer/components/team/TeamListFilterPopover.tsx
@@ -6,7 +6,7 @@ import { Button } from '@renderer/components/ui/button';
 import { Checkbox } from '@renderer/components/ui/checkbox';
 import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@renderer/components/ui/tooltip';
-import { normalizePath } from '@renderer/utils/pathNormalize';
+import { normalizePathForMatching } from '@renderer/utils/pathNormalize';
 import { getBaseName } from '@renderer/utils/pathUtils';
 import { Filter } from 'lucide-react';
 
@@ -39,7 +39,7 @@ export function isTeamProjectPathSelected(
   projectPath: string
 ): boolean {
   return selectedProjectPath
-    ? normalizePath(selectedProjectPath) === normalizePath(projectPath)
+    ? normalizePathForMatching(selectedProjectPath) === normalizePathForMatching(projectPath)
     : false;
 }
 

--- a/src/renderer/components/team/dialogs/projectPathOptions.ts
+++ b/src/renderer/components/team/dialogs/projectPathOptions.ts
@@ -1,4 +1,4 @@
-import { normalizePath } from '@renderer/utils/pathNormalize';
+import { normalizePathForMatching } from '@renderer/utils/pathNormalize';
 import { isEphemeralProjectPath } from '@shared/utils/ephemeralProjectPath';
 
 import type {
@@ -53,8 +53,8 @@ export function findProjectPathProjectByPath(
   projects: readonly ProjectPathProject[],
   projectPath: string
 ): ProjectPathProject | undefined {
-  const normalizedPath = normalizePath(projectPath);
-  return projects.find((project) => normalizePath(project.path) === normalizedPath);
+  const normalizedPath = normalizePathForMatching(projectPath);
+  return projects.find((project) => normalizePathForMatching(project.path) === normalizedPath);
 }
 
 export function isDeletedProjectPathSelection(
@@ -74,14 +74,14 @@ export function buildProjectPathOptions(
 ): ComboboxOption[] {
   const options: ComboboxOption[] = [];
   const optionIndexByNormalizedPath = new Map<string, number>();
-  const normalizedPreferredPath = preferredPath ? normalizePath(preferredPath) : null;
+  const normalizedPreferredPath = preferredPath ? normalizePathForMatching(preferredPath) : null;
 
   for (const project of projects) {
     if (isEphemeralProjectPath(project.path)) {
       continue;
     }
 
-    const normalizedProjectPath = normalizePath(project.path);
+    const normalizedProjectPath = normalizePathForMatching(project.path);
     const existingIndex = optionIndexByNormalizedPath.get(normalizedProjectPath);
 
     if (existingIndex === undefined) {

--- a/src/renderer/components/team/teamProjectSelection.ts
+++ b/src/renderer/components/team/teamProjectSelection.ts
@@ -1,4 +1,4 @@
-import { normalizePath } from '@renderer/utils/pathNormalize';
+import { normalizePathForMatching } from '@renderer/utils/pathNormalize';
 
 import type { Project, RepositoryGroup } from '@renderer/types/data';
 import type { TeamSummary } from '@shared/types';
@@ -148,11 +148,11 @@ export function findTeamProjectSelectionTarget(
   projects: readonly Project[],
   projectPath: string
 ): TeamProjectSelectionTarget | null {
-  const normalizedProjectPath = normalizePath(projectPath);
+  const normalizedProjectPath = normalizePathForMatching(projectPath);
 
   for (const repositoryGroup of repositoryGroups) {
     const worktree = repositoryGroup.worktrees.find(
-      (candidate) => normalizePath(candidate.path) === normalizedProjectPath
+      (candidate) => normalizePathForMatching(candidate.path) === normalizedProjectPath
     );
     if (worktree) {
       return {
@@ -165,7 +165,7 @@ export function findTeamProjectSelectionTarget(
   }
 
   const project = projects.find(
-    (candidate) => normalizePath(candidate.path) === normalizedProjectPath
+    (candidate) => normalizePathForMatching(candidate.path) === normalizedProjectPath
   );
   if (project) {
     return {
@@ -179,14 +179,14 @@ export function findTeamProjectSelectionTarget(
 }
 
 export function teamMatchesProjectSelection(team: TeamSummary, projectPath: string): boolean {
-  const normalizedProjectPath = normalizePath(projectPath);
-  if (team.projectPath && normalizePath(team.projectPath) === normalizedProjectPath) {
+  const normalizedProjectPath = normalizePathForMatching(projectPath);
+  if (team.projectPath && normalizePathForMatching(team.projectPath) === normalizedProjectPath) {
     return true;
   }
 
   return (
     team.projectPathHistory?.some(
-      (candidate) => normalizePath(candidate) === normalizedProjectPath
+      (candidate) => normalizePathForMatching(candidate) === normalizedProjectPath
     ) ?? false
   );
 }

--- a/src/renderer/utils/pathNormalize.ts
+++ b/src/renderer/utils/pathNormalize.ts
@@ -1,3 +1,4 @@
+import { normalizePathForComparison, stripTrailingSeparators } from '@shared/utils/platformPath';
 import {
   getTeamTaskWorkflowColumn,
   isTeamTaskDeleted,
@@ -8,12 +9,7 @@ import {
 import type { GlobalTask } from '@shared/types';
 
 export function normalizePath(p: string): string {
-  let s = p.replace(/\\/g, '/');
-  // Preserve root paths like "/" or "C:/"
-  if (s !== '/' && !/^[A-Za-z]:\/$/.test(s)) {
-    while (s.endsWith('/')) s = s.slice(0, -1);
-  }
-  return s.toLowerCase();
+  return stripTrailingSeparators(normalizePathForComparison(p));
 }
 
 export interface TaskStatusCounts {

--- a/src/renderer/utils/pathNormalize.ts
+++ b/src/renderer/utils/pathNormalize.ts
@@ -12,6 +12,11 @@ export function normalizePath(p: string): string {
   return stripTrailingSeparators(normalizePathForComparison(p));
 }
 
+/** Case-insensitive UI comparison key. Keep normalizePath for identity maps. */
+export function normalizePathForMatching(p: string): string {
+  return normalizePath(p).toLowerCase();
+}
+
 export interface TaskStatusCounts {
   pending: number;
   inProgress: number;

--- a/test/main/services/team/TeamInboxWriter.test.ts
+++ b/test/main/services/team/TeamInboxWriter.test.ts
@@ -112,6 +112,18 @@ describe('TeamInboxWriter', () => {
     expect(typeof persisted[0].timestamp).toBe('string');
   });
 
+  it('rejects unsafe inbox member names before writing', async () => {
+    await expect(
+      writer.sendMessage('my-team', {
+        member: '../config',
+        text: 'should not escape inboxes',
+      })
+    ).rejects.toThrow('Invalid inbox path');
+
+    expect(hoisted.atomicWrite).not.toHaveBeenCalled();
+    expect(hoisted.files.has('/mock/teams/my-team/config.json')).toBe(false);
+  });
+
   it('retries write when verify cannot find messageId', async () => {
     hoisted.setDropWrites(2);
     const result = await writer.sendMessage('my-team', {

--- a/test/main/services/team/TeamSentMessagesStore.test.ts
+++ b/test/main/services/team/TeamSentMessagesStore.test.ts
@@ -117,4 +117,33 @@ describe('TeamSentMessagesStore', () => {
     expect(messages[0].messageId).toBe('sent-5');
     expect(messages.at(-1)?.messageId).toBe('sent-204');
   });
+
+  it('does not overwrite corrupt sent message history when appending', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'team-sent-store-'));
+    tempDirs.push(root);
+
+    const teamDir = path.join(root, 'my-team');
+    const sentMessagesPath = path.join(teamDir, 'sentMessages.json');
+    await fs.mkdir(teamDir, { recursive: true });
+    await fs.writeFile(sentMessagesPath, 'NOT VALID JSON', 'utf8');
+
+    const store = new TeamSentMessagesStore();
+    expect(await store.readMessages('my-team')).toEqual([]);
+
+    await store.appendMessage('my-team', {
+      from: 'alice',
+      to: 'user',
+      text: 'should not replace corrupt history',
+      timestamp: '2026-03-27T12:00:00.000Z',
+      read: true,
+      messageId: 'msg-after-corruption',
+    });
+
+    expect(console.error).toHaveBeenCalledWith(
+      '[TeamSentMessagesStore]',
+      expect.stringContaining('Failed to append sent message for my-team')
+    );
+    vi.mocked(console.error).mockClear();
+    await expect(fs.readFile(sentMessagesPath, 'utf8')).resolves.toBe('NOT VALID JSON');
+  });
 });

--- a/test/renderer/utils/pathNormalize.test.ts
+++ b/test/renderer/utils/pathNormalize.test.ts
@@ -1,8 +1,42 @@
+import {
+  buildTaskCountsByOwner,
+  buildTaskCountsByProject,
+  normalizePath,
+} from '@renderer/utils/pathNormalize';
 import { describe, expect, it } from 'vitest';
 
-import { buildTaskCountsByOwner } from '@renderer/utils/pathNormalize';
-
 describe('pathNormalize task counts', () => {
+  it('normalizes Windows paths case-insensitively but keeps POSIX casing', () => {
+    expect(normalizePath('C:\\Users\\Alice\\Repo\\')).toBe('c:/users/alice/repo');
+    expect(normalizePath('/Users/Alice/Repo/')).toBe('/Users/Alice/Repo');
+    expect(normalizePath('/Users/Alice/repo/')).toBe('/Users/Alice/repo');
+  });
+
+  it('keeps project counts separate for POSIX paths that differ only by case', () => {
+    const counts = buildTaskCountsByProject([
+      {
+        projectPath: '/Users/Alice/Repo',
+        status: 'pending',
+      },
+      {
+        projectPath: '/Users/Alice/repo',
+        status: 'completed',
+      },
+    ] as Parameters<typeof buildTaskCountsByProject>[0]);
+
+    expect(counts.size).toBe(2);
+    expect(counts.get('/Users/Alice/Repo')).toEqual({
+      pending: 1,
+      inProgress: 0,
+      completed: 0,
+    });
+    expect(counts.get('/Users/Alice/repo')).toEqual({
+      pending: 0,
+      inProgress: 0,
+      completed: 1,
+    });
+  });
+
   it('counts approved tasks as completed instead of in-progress', () => {
     const counts = buildTaskCountsByOwner([
       {

--- a/test/renderer/utils/pathNormalize.test.ts
+++ b/test/renderer/utils/pathNormalize.test.ts
@@ -2,6 +2,7 @@ import {
   buildTaskCountsByOwner,
   buildTaskCountsByProject,
   normalizePath,
+  normalizePathForMatching,
 } from '@renderer/utils/pathNormalize';
 import { describe, expect, it } from 'vitest';
 
@@ -10,6 +11,11 @@ describe('pathNormalize task counts', () => {
     expect(normalizePath('C:\\Users\\Alice\\Repo\\')).toBe('c:/users/alice/repo');
     expect(normalizePath('/Users/Alice/Repo/')).toBe('/Users/Alice/Repo');
     expect(normalizePath('/Users/Alice/repo/')).toBe('/Users/Alice/repo');
+  });
+
+  it('normalizes project matching keys case-insensitively', () => {
+    expect(normalizePathForMatching('/Users/Alice/Repo/')).toBe('/users/alice/repo');
+    expect(normalizePathForMatching('/Users/Alice/repo/')).toBe('/users/alice/repo');
   });
 
   it('keeps project counts separate for POSIX paths that differ only by case', () => {


### PR DESCRIPTION
﻿## Summary
- Reject unsafe team member names before they reach controller and main-process inbox file paths.
- Preserve corrupt message stores instead of silently replacing them during read or append flows.
- Prevent deleted tasks from being mutated through normal task APIs until they are restored.
- Serialize controller inbox and sent-message appends with the existing file lock so concurrent senders do not drop rows.
- Keep team sent-message appends strict on corrupt or unreadable history while leaving the UI read path tolerant.
- Preserve POSIX project path case while retaining case-insensitive comparison for Windows paths.

## Root cause
Several JSON-backed team storage paths validated only the public creation path, then trusted persisted names and metadata later. Message appends also used read-modify-write without holding a lock across the full cycle, so a slower writer could overwrite a faster writer's newly appended row. Renderer project aggregation lowercased all paths, which can merge distinct case-sensitive POSIX directories.

## Validation
- Controller suite: 131 passed
- TeamInboxWriter suite: 16 passed
- TeamSentMessagesStore and pathNormalize suites: 11 passed
- TypeScript noEmit: passed
- eslint on touched TypeScript files: passed
- Controller build: passed
- git diff --check: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened inbox, cross-team, sent-message, and inbox-path handling with filename/path-safety validation for configured member and lead names, rejecting unsafe values before any writes.
  * Improved robustness with corrupted inbox/sent history: missing files fall back, corrupt JSON is skipped for lookups, and sent history is no longer overwritten/“repaired” when invalid.
  * Tightened “deleted work” protection: deleted tasks can’t be updated, commented on, receive/modify attachments, or be restored via normal mutation paths.
* **New Features**
  * Improved project-path matching in the UI with case-insensitive comparison for navigation, filtering, and recent-projects lookups.
* **Tests**
  * Added regression coverage for unsafe names, corrupt-message files, and deleted-work mutation guards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->