### PR TITLE
test(codex): align member effort export coverage

### DIFF
--- a/test/renderer/components/team/members/membersEditorUtils.test.ts
+++ b/test/renderer/components/team/members/membersEditorUtils.test.ts
@@ -213,7 +213,7 @@ describe('members editor editable input filtering', () => {
           name: 'alice',
           agentType: 'reviewer',
           model: 'gpt-5.4-mini',
-          effort: 'max',
+          effort: 'none',
         },
       ] as any)
     );
@@ -230,6 +230,33 @@ describe('members editor editable input filtering', () => {
     ]);
     expect(exported[0]).not.toHaveProperty('effort');
   });
+
+  it.each(['max', 'ultra'] as const)(
+    'preserves Codex %s effort while exporting teammate overrides',
+    (effort) => {
+      const drafts = createMemberDraftsFromInputs(
+        filterEditableMemberInputs([
+          {
+            name: 'alice',
+            agentType: 'reviewer',
+            providerId: 'codex',
+            providerBackendId: 'codex-native',
+            model: 'gpt-5.6-sol',
+            effort,
+          },
+        ] as any)
+      );
+
+      expect(buildMembersFromDrafts(drafts)).toEqual([
+        expect.objectContaining({
+          name: 'alice',
+          providerId: 'codex',
+          model: 'gpt-5.6-sol',
+          effort,
+        }),
+      ]);
+    }
+  );
 
   it('preserves legacy no-context effort export for callers without inherited provider', () => {
     const drafts = createMemberDraftsFromInputs(
@@ -259,7 +286,7 @@ describe('members editor editable input filtering', () => {
           providerId: 'codex',
           providerBackendId: 'codex-native',
           model: 'gpt-5.4-mini',
-          effort: 'max',
+          effort: 'none',
         },
       ] as any)
     );


### PR DESCRIPTION
## Summary

- Update stale member export fixtures to use `none` as an effort that Codex does not support.
- Add explicit regression coverage that Codex `max` and `ultra` teammate efforts survive export.

## Root cause

PR #247 intentionally added `max` and `ultra` to the Codex provider effort contract. Two legacy tests still expected Codex `max` to be removed, so the full workspace test job failed even though the production behavior was correct.

## Validation

- `pnpm typecheck`
- `membersEditorUtils.test.ts`: 23 tests passed
- `git diff --check`

The focused fast lint still reports pre-existing `any` and import-order findings in this legacy test file; no production source was changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for exporting teammate effort settings.
  - Added validation that Codex-specific effort values, including `max` and `ultra`, are preserved when provider and model details are explicitly configured.
  - Updated scenarios to confirm `none` is exported when effort values are overridden or inherited from another provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->