### PR TITLE
refactor(hosted-web): decouple runtime from Electron

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@ landing/node_modules/
 # Local build output
 dist/
 dist-electron/
+dist-hosted/
 dist-standalone/
 out/
 release/

--- a/README.md
+++ b/README.md
@@ -372,6 +372,8 @@ local packaging.
 | `pnpm dev`                    | Desktop app development with hot reload                                      |
 | `pnpm dev:mcp`                | Desktop app development with hot reload and local CDP debugging on port 9222 |
 | `pnpm build`                  | Production build                                                             |
+| `pnpm hosted:build`           | Hosted startup shell build for renderer assets and the static shell server   |
+| `pnpm hosted:start`           | Start the static hosted shell from `dist-hosted/server.cjs`                  |
 | `pnpm typecheck`              | TypeScript type checking                                                     |
 | `pnpm lint`                   | Lint (no auto-fix)                                                           |
 | `pnpm lint:fix`               | Lint and auto-fix                                                            |
@@ -385,6 +387,40 @@ local packaging.
 | `pnpm quality`                | Full check + format check + knip                                             |
 
 </details>
+
+---
+
+## Hosted Startup Shell
+
+`pnpm hosted:build` builds the browser renderer and a small static Node server in
+`dist-hosted/`. The hosted server only serves static renderer assets. It does not
+start desktop-owned runtime APIs, agent flows, IPC bridges, filesystem APIs, or
+session data endpoints.
+
+The server binds to `127.0.0.1` by default. Any non-loopback bind requires
+`HOSTED_ALLOW_REMOTE=1` alongside `HOST`, for example:
+
+```bash
+HOST=0.0.0.0 HOSTED_ALLOW_REMOTE=1 pnpm hosted:start
+```
+
+Docker keeps host exposure explicit. The default compose service binds to
+`127.0.0.1` inside the container and publishes no host port:
+
+```bash
+docker compose -f docker/docker-compose.yml up
+```
+
+For local browser access, use the explicit local profile, which maps only host
+loopback:
+
+```bash
+docker compose -f docker/docker-compose.yml --profile local up agent-teams-ai-local
+```
+
+To expose Docker beyond the local host, change that profile's port mapping from
+`127.0.0.1:3456:3456` to the intended non-loopback address only on a trusted
+network.
 
 ---
 
@@ -422,7 +458,7 @@ Contact: [quantjumppro@gmail.com](mailto:quantjumppro@gmail.com)
 
 ## Security
 
-IPC and standalone HTTP handlers validate IDs, paths, and payload shape at the boundary. Project editing and write operations are constrained to the selected project root, while read-only discovery also accesses local Claude data under `~/.claude/` and app-owned state paths when required. Path traversal and sensitive config/credential targets are blocked. See [SECURITY.md](.github/SECURITY.md) for details.
+IPC and standalone HTTP handlers validate IDs, paths, and payload shape at the boundary. Project editing and write operations are constrained to the selected project root, while read-only discovery also accesses local Claude data under `~/.claude/` and app-owned state paths when required. Path traversal and sensitive config/credential targets are blocked. The hosted startup shell serves static assets only and does not expose runtime APIs. See [SECURITY.md](.github/SECURITY.md) for details.
 
 GitHub Dependabot monitors dependencies for known vulnerabilities, so security updates are surfaced quickly and applied in time.
 

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,6 +1,7 @@
 node_modules
 dist
 dist-electron
+dist-hosted
 dist-standalone
 out
 release

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,14 @@
 # =============================================================================
-# Agent Teams standalone Docker image
+# Agent Teams hosted startup Docker image
 #
-# Runs the HTTP server without Electron, serving the full UI over HTTP.
-# Mount your ~/.claude directory to make session data available.
+# Runs the non-Electron hosted startup shell server and serves the renderer
+# build over HTTP. Desktop/runtime APIs are intentionally not launched here.
 #
-# Build:  docker build -t agent-teams-ai .
-# Run:    docker run -p 3456:3456 -v ~/.claude:/data/.claude:ro agent-teams-ai
+# Build:  docker build -f docker/Dockerfile -t agent-teams-ai-hosted .
+# Local host access:
+#   docker run --rm -e HOST=0.0.0.0 -e HOSTED_ALLOW_REMOTE=1 -p 127.0.0.1:3456:3456 agent-teams-ai-hosted
+# Remote exposure is not the default. To expose beyond host loopback, publish an
+# explicit non-loopback port only on a trusted network.
 # =============================================================================
 
 ARG NODE_VERSION=24.16.0
@@ -24,52 +27,38 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends python3 make g++ \
   && rm -rf /var/lib/apt/lists/*
 
-# Install dependencies first (better layer caching)
-COPY package.json pnpm-lock.yaml ./
+# Install dependencies first (better layer caching). Workspace package manifests
+# are copied because the root package pins workspace dependencies.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY agent-teams-controller/package.json ./agent-teams-controller/package.json
+COPY landing/package.json ./landing/package.json
+COPY mcp-server/package.json ./mcp-server/package.json
+COPY packages/agent-graph/package.json ./packages/agent-graph/package.json
+COPY vendor/terminal-platform/manifest.json ./vendor/terminal-platform/manifest.json
+COPY vendor/terminal-platform/sdk ./vendor/terminal-platform/sdk
+COPY vendor/terminal-platform/terminal-platform-node-stub ./vendor/terminal-platform/terminal-platform-node-stub
 COPY patches ./patches
+COPY scripts/ci/enforce-pnpm-install.mjs ./scripts/ci/enforce-pnpm-install.mjs
+COPY scripts/ensure-electron-install.cjs ./scripts/ensure-electron-install.cjs
 RUN pnpm install --frozen-lockfile
 
 # Copy source and build
 COPY . .
-RUN AGENT_TEAMS_DISABLE_SOURCEMAPS=1 pnpm standalone:build
+RUN AGENT_TEAMS_DISABLE_SOURCEMAPS=1 pnpm hosted:build
 
 # =============================================================================
-# Production dependencies stage
-# =============================================================================
-FROM base AS prod-deps
-
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends python3 make g++ \
-  && rm -rf /var/lib/apt/lists/*
-
-# Install production-only dependencies
-# (fastify, @fastify/cors, @fastify/static are externalized from the bundle)
-COPY package.json pnpm-lock.yaml ./
-COPY patches ./patches
-RUN pnpm install --frozen-lockfile --prod --ignore-scripts \
-  && pnpm rebuild node-pty cpu-features ssh2
-
-# =============================================================================
-# Production stage - minimal image with only runtime dependencies and built output
+# Production stage - minimal image with only the built hosted startup output
 # =============================================================================
 FROM base
 
-COPY --from=prod-deps /app/package.json /app/pnpm-lock.yaml ./
-COPY --from=prod-deps /app/node_modules ./node_modules
-COPY --from=builder /app/agent-teams-controller ./agent-teams-controller
-
-# Copy built standalone server and renderer output
-COPY --from=builder /app/dist-standalone ./dist-standalone
+# Copy built hosted shell server and renderer output
+COPY --from=builder /app/dist-hosted ./dist-hosted
 COPY --from=builder /app/out/renderer ./out/renderer
 
-# Create data directory for Claude session mount
-RUN mkdir -p /data/.claude
-
 ENV NODE_ENV=production
-ENV CLAUDE_ROOT=/data/.claude
-ENV HOST=0.0.0.0
+ENV HOST=127.0.0.1
 ENV PORT=3456
 
 EXPOSE 3456
 
-CMD ["node", "dist-standalone/index.cjs"]
+CMD ["node", "dist-hosted/server.cjs"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,15 +1,20 @@
 # =============================================================================
-# Agent Teams - Docker Compose
+# Agent Teams hosted startup - Docker Compose
 #
-# Quick start:
+# Container-only default:
 #   docker compose -f docker/docker-compose.yml up
 #
-# Then open http://localhost:3456 in your browser.
+# Local browser opt-in:
+#   docker compose -f docker/docker-compose.yml --profile local up agent-teams-ai-local
+#   Then open http://127.0.0.1:3456 in your browser.
 #
 # Security note:
-#   The standalone server has zero outbound network calls — no telemetry,
-#   no analytics, no auto-updater. For maximum isolation, uncomment
-#   network_mode below.
+#   This serves a static hosted startup shell only. Desktop-owned runtime APIs
+#   are intentionally not launched in this image. The default service binds to
+#   127.0.0.1 inside the container and publishes no host port. Host access is an
+#   explicit profile with a host-loopback port mapping. Remote exposure requires
+#   changing the host-side address from 127.0.0.1 to a non-loopback address on
+#   purpose.
 # =============================================================================
 
 services:
@@ -17,15 +22,23 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile
-    ports:
-      - "3456:3456"
-    volumes:
-      - ${CLAUDE_DIR:-~/.claude}:/data/.claude:ro
     environment:
       - NODE_ENV=production
-      - CLAUDE_ROOT=/data/.claude
-      - HOST=0.0.0.0
+      - HOST=127.0.0.1
       - PORT=3456
     restart: unless-stopped
-    # Uncomment for maximum network isolation (no outbound connections):
-    # network_mode: "none"
+
+  agent-teams-ai-local:
+    profiles:
+      - local
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    ports:
+      - '127.0.0.1:3456:3456'
+    environment:
+      - NODE_ENV=production
+      - HOST=0.0.0.0
+      - HOSTED_ALLOW_REMOTE=1
+      - PORT=3456
+    restart: unless-stopped

--- a/docker/vite.hosted-server.config.ts
+++ b/docker/vite.hosted-server.config.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { defineConfig } from 'vite';
+
+const ROOT = resolve(__dirname, '..');
+const pkg = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf-8')) as { version: string };
+const sourceMapsEnabled = process.env.AGENT_TEAMS_DISABLE_SOURCEMAPS !== '1';
+
+export default defineConfig({
+  root: ROOT,
+  build: {
+    emptyOutDir: true,
+    minify: false,
+    outDir: 'dist-hosted',
+    rollupOptions: {
+      input: {
+        server: resolve(ROOT, 'src/hosted/server.ts'),
+      },
+      output: {
+        entryFileNames: '[name].cjs',
+        format: 'cjs',
+      },
+    },
+    sourcemap: sourceMapsEnabled,
+    ssr: true,
+    target: 'node24',
+  },
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1060,6 +1060,40 @@ export default defineConfig([
   },
 
   {
+    name: 'hosted-composition-boundary',
+    files: ['src/hosted/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            { name: 'electron', message: 'Hosted shell code must stay Electron-free.' },
+            { name: '@renderer/api', message: 'Hosted shell code must not use renderer transport.' },
+            { name: '@renderer/store', message: 'Hosted shell code must not use renderer state.' },
+          ],
+          patterns: [
+            {
+              group: [
+                '@main/**',
+                '!@main/application/hosted',
+                '!@main/application/hosted/**',
+                '@preload/**',
+                '@renderer/**',
+                '@features/*/core/**',
+                '@features/*/main/**',
+                '@features/*/preload/**',
+                '@features/*/renderer/**',
+              ],
+              message:
+                'Hosted shell code may import only an approved hosted application facade, not raw desktop internals.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+
+  {
     name: 'feature-core-domain-guards',
     files: ['src/features/*/core/domain/**/*.ts'],
     rules: {

--- a/eslint.fast.config.js
+++ b/eslint.fast.config.js
@@ -203,6 +203,40 @@ export default defineConfig([
   },
 
   {
+    name: 'fast-hosted-composition-boundary',
+    files: ['src/hosted/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            { name: 'electron', message: 'Hosted shell code must stay Electron-free.' },
+            { name: '@renderer/api', message: 'Hosted shell code must not use renderer transport.' },
+            { name: '@renderer/store', message: 'Hosted shell code must not use renderer state.' },
+          ],
+          patterns: [
+            {
+              group: [
+                '@main/**',
+                '!@main/application/hosted',
+                '!@main/application/hosted/**',
+                '@preload/**',
+                '@renderer/**',
+                '@features/*/core/**',
+                '@features/*/main/**',
+                '@features/*/preload/**',
+                '@features/*/renderer/**',
+              ],
+              message:
+                'Hosted shell code may import only an approved hosted application facade, not raw desktop internals.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+
+  {
     name: 'fast-feature-core-guards',
     files: ['src/features/*/core/{domain,application}/**/*.ts'],
     rules: {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,10 @@
     "prebuild": "node ./scripts/ci/verify-radix-presence-patch.mjs && tsx scripts/fetch-pricing-data.ts && pnpm --filter agent-teams-controller build && pnpm --filter agent-teams-mcp build",
     "build": "node --max-old-space-size=8192 ./node_modules/electron-vite/bin/electron-vite.js build",
     "postbuild": "node ./scripts/ci/verify-radix-renderer-bundle.mjs",
+    "hosted:build": "pnpm hosted:build:renderer && pnpm hosted:build:server",
+    "hosted:build:renderer": "node --max-old-space-size=8192 ./node_modules/vite/bin/vite.js build --config vite.web.config.ts",
+    "hosted:build:server": "node --max-old-space-size=8192 ./node_modules/vite/bin/vite.js build --config docker/vite.hosted-server.config.ts",
+    "hosted:start": "node dist-hosted/server.cjs",
     "stage-runtime": "node ./scripts/stage-runtime.mjs",
     "stage-terminal-platform-runtime": "node ./scripts/stage-terminal-platform-runtime.mjs",
     "ensure-terminal-platform-runtime": "node ./scripts/ensure-terminal-platform-runtime.mjs",
@@ -422,9 +426,12 @@
     "entry": [
       "src/main/index.ts",
       "src/main/standalone.ts",
+      "src/hosted/server.ts",
       "src/preload/index.ts",
       "src/renderer/main.tsx",
       "electron.vite.config.ts",
+      "vite.web.config.ts",
+      "docker/vite.hosted-server.config.ts",
       "docker/vite.standalone.config.ts"
     ],
     "project": [

--- a/src/features/hosted-web-transport/contracts/events.ts
+++ b/src/features/hosted-web-transport/contracts/events.ts
@@ -1,0 +1,272 @@
+import { isHostedWebErrorCode } from './http';
+
+import type {
+  HostedWebErrorCode,
+  HostedWebEventCursor,
+  HostedWebRunId,
+  HostedWebTaskSummary,
+  HostedWebTeamId,
+  HostedWebTeamSnapshotResponse,
+  HostedWebTerminalSessionId,
+} from './http';
+import type { TeamProvisioningState } from '@shared/types/team';
+
+export const HOSTED_WEB_SSE_EVENT_TYPES = [
+  'hosted.team.snapshot',
+  'hosted.task.changed',
+  'hosted.provisioning.progress',
+  'hosted.member.message',
+  'hosted.runtime.state',
+  'hosted.error',
+] as const;
+
+export type HostedWebSseEventType = (typeof HOSTED_WEB_SSE_EVENT_TYPES)[number];
+
+interface HostedWebEventBase<Type extends HostedWebSseEventType, Payload> {
+  type: Type;
+  eventId: HostedWebEventCursor;
+  teamId: HostedWebTeamId;
+  emittedAt: string;
+  payload: Payload;
+}
+
+export interface HostedWebProvisioningProgressPayload {
+  runId: HostedWebRunId;
+  state: Exclude<TeamProvisioningState, 'idle'>;
+  message: string;
+  severity?: 'info' | 'warning' | 'error';
+  startedAt: string;
+  updatedAt: string;
+  configReady?: boolean;
+}
+
+export interface HostedWebMemberMessagePayload {
+  messageId: string;
+  fromMemberId: string;
+  summary?: string;
+  body: string;
+  taskIds?: string[];
+  createdAt: string;
+}
+
+export interface HostedWebRuntimeStatePayload {
+  isAlive: boolean;
+  terminalAvailable: boolean;
+  activeTerminalSessionIds: HostedWebTerminalSessionId[];
+}
+
+export interface HostedWebErrorPayload {
+  code: HostedWebErrorCode;
+  message: string;
+  retryable?: boolean;
+}
+
+export type HostedWebTeamSnapshotEvent = HostedWebEventBase<
+  'hosted.team.snapshot',
+  HostedWebTeamSnapshotResponse
+>;
+
+export type HostedWebTaskChangedEvent = HostedWebEventBase<
+  'hosted.task.changed',
+  { task: HostedWebTaskSummary; revision: string }
+>;
+
+export type HostedWebProvisioningProgressEvent = HostedWebEventBase<
+  'hosted.provisioning.progress',
+  HostedWebProvisioningProgressPayload
+>;
+
+export type HostedWebMemberMessageEvent = HostedWebEventBase<
+  'hosted.member.message',
+  HostedWebMemberMessagePayload
+>;
+
+export type HostedWebRuntimeStateEvent = HostedWebEventBase<
+  'hosted.runtime.state',
+  HostedWebRuntimeStatePayload
+>;
+
+export type HostedWebErrorEvent = HostedWebEventBase<'hosted.error', HostedWebErrorPayload>;
+
+export type HostedWebEvent =
+  | HostedWebTeamSnapshotEvent
+  | HostedWebTaskChangedEvent
+  | HostedWebProvisioningProgressEvent
+  | HostedWebMemberMessageEvent
+  | HostedWebRuntimeStateEvent
+  | HostedWebErrorEvent;
+
+export interface ParseHostedWebSseEventOptions {
+  lastEventId?: string;
+}
+
+export function isHostedWebSseEventType(value: string): value is HostedWebSseEventType {
+  return HOSTED_WEB_SSE_EVENT_TYPES.includes(value as HostedWebSseEventType);
+}
+
+export function parseHostedWebSseEvent(
+  type: string,
+  data: string,
+  options: ParseHostedWebSseEventOptions = {}
+): HostedWebEvent {
+  if (!isHostedWebSseEventType(type)) {
+    throw new Error(`Unsupported hosted web SSE event type: ${type}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(data);
+  } catch (error) {
+    throw new Error(`Invalid hosted web SSE JSON: ${toErrorMessage(error)}`);
+  }
+
+  assertEventEnvelope(parsed, type, options.lastEventId);
+  assertPayload(parsed.type, parsed.payload);
+  return parsed;
+}
+
+function assertEventEnvelope(
+  value: unknown,
+  expectedType: HostedWebSseEventType,
+  lastEventId: string | undefined
+): asserts value is HostedWebEvent {
+  if (!isRecord(value)) {
+    throw new Error('Hosted web SSE event must be an object');
+  }
+  if (value.type !== expectedType) {
+    throw new Error(
+      `Hosted web SSE event type mismatch: expected ${expectedType}, got ${String(value.type)}`
+    );
+  }
+  assertNonEmptyString(value.eventId, 'eventId');
+  assertNonEmptyString(value.teamId, 'teamId');
+  assertIsoTimestamp(value.emittedAt, 'emittedAt');
+  if (lastEventId && lastEventId !== value.eventId) {
+    throw new Error(
+      `Hosted web SSE cursor mismatch: Last-Event-ID ${lastEventId} did not match envelope ${value.eventId}`
+    );
+  }
+}
+
+function assertPayload(type: HostedWebSseEventType, payload: unknown): void {
+  if (!isRecord(payload)) {
+    throw new Error(`Hosted web SSE ${type} payload must be an object`);
+  }
+
+  switch (type) {
+    case 'hosted.team.snapshot':
+      assertTeamSnapshotPayload(payload);
+      return;
+    case 'hosted.task.changed':
+      assertRecord(payload.task, 'payload.task');
+      assertNonEmptyString(payload.revision, 'payload.revision');
+      return;
+    case 'hosted.provisioning.progress':
+      assertNonEmptyString(payload.runId, 'payload.runId');
+      assertNonEmptyString(payload.state, 'payload.state');
+      if (payload.state === 'idle') {
+        throw new Error('Hosted web provisioning progress state must not be idle');
+      }
+      assertNonEmptyString(payload.message, 'payload.message');
+      assertIsoTimestamp(payload.startedAt, 'payload.startedAt');
+      assertIsoTimestamp(payload.updatedAt, 'payload.updatedAt');
+      if (
+        payload.severity != null &&
+        !['info', 'warning', 'error'].includes(String(payload.severity))
+      ) {
+        throw new Error('Hosted web provisioning severity is invalid');
+      }
+      return;
+    case 'hosted.member.message':
+      assertNonEmptyString(payload.messageId, 'payload.messageId');
+      assertNonEmptyString(payload.fromMemberId, 'payload.fromMemberId');
+      assertNonEmptyString(payload.body, 'payload.body');
+      assertIsoTimestamp(payload.createdAt, 'payload.createdAt');
+      if (payload.taskIds != null) {
+        assertStringArray(payload.taskIds, 'payload.taskIds');
+      }
+      return;
+    case 'hosted.runtime.state':
+      assertBoolean(payload.isAlive, 'payload.isAlive');
+      assertBoolean(payload.terminalAvailable, 'payload.terminalAvailable');
+      assertStringArray(payload.activeTerminalSessionIds, 'payload.activeTerminalSessionIds');
+      return;
+    case 'hosted.error':
+      if (!isHostedWebErrorCode(payload.code)) {
+        throw new Error('Hosted web error code must be namespaced under /api/hosted/v1');
+      }
+      assertNonEmptyString(payload.message, 'payload.message');
+      if (payload.retryable != null) {
+        assertBoolean(payload.retryable, 'payload.retryable');
+      }
+      return;
+  }
+}
+
+function assertTeamSnapshotPayload(payload: Record<string, unknown>): void {
+  assertRecord(payload.team, 'payload.team');
+  assertNonEmptyString(payload.revision, 'payload.revision');
+  if (!Array.isArray(payload.tasks)) {
+    throw new Error('Hosted web team snapshot tasks must be an array');
+  }
+  if (!Array.isArray(payload.kanban)) {
+    throw new Error('Hosted web team snapshot kanban must be an array');
+  }
+  assertRecord(payload.team.runtime, 'payload.team.runtime');
+  assertBoolean(payload.team.runtime.isAlive, 'payload.team.runtime.isAlive');
+  assertBoolean(payload.team.runtime.terminalAvailable, 'payload.team.runtime.terminalAvailable');
+  if (!Array.isArray(payload.team.members)) {
+    throw new Error('Hosted web team snapshot members must be an array');
+  }
+  if (payload.team.project !== null && payload.team.project !== undefined) {
+    assertRecord(payload.team.project, 'payload.team.project');
+    assertRecord(payload.team.project.workspaceRef, 'payload.team.project.workspaceRef');
+    assertNonEmptyString(
+      payload.team.project.workspaceRef.id,
+      'payload.team.project.workspaceRef.id'
+    );
+    assertNonEmptyString(
+      payload.team.project.workspaceRef.displayName,
+      'payload.team.project.workspaceRef.displayName'
+    );
+  }
+}
+
+function assertRecord(value: unknown, fieldName: string): asserts value is Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new Error(`Hosted web SSE ${fieldName} must be an object`);
+  }
+}
+
+function assertNonEmptyString(value: unknown, fieldName: string): asserts value is string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`Hosted web SSE ${fieldName} must be a non-empty string`);
+  }
+}
+
+function assertIsoTimestamp(value: unknown, fieldName: string): asserts value is string {
+  assertNonEmptyString(value, fieldName);
+  if (Number.isNaN(Date.parse(value))) {
+    throw new Error(`Hosted web SSE ${fieldName} must be a valid timestamp`);
+  }
+}
+
+function assertBoolean(value: unknown, fieldName: string): asserts value is boolean {
+  if (typeof value !== 'boolean') {
+    throw new Error(`Hosted web SSE ${fieldName} must be a boolean`);
+  }
+}
+
+function assertStringArray(value: unknown, fieldName: string): asserts value is string[] {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    throw new Error(`Hosted web SSE ${fieldName} must be a string array`);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/features/hosted-web-transport/contracts/events.ts
+++ b/src/features/hosted-web-transport/contracts/events.ts
@@ -1,4 +1,13 @@
 import { isHostedWebErrorCode } from './http';
+import {
+  HOSTED_WEB_EFFORT_LEVELS,
+  HOSTED_WEB_PROVISIONING_STATES,
+  HOSTED_WEB_TEAM_FAST_MODES,
+  HOSTED_WEB_TEAM_PROVIDER_IDS,
+  HOSTED_WEB_TEAM_REVIEW_STATES,
+  HOSTED_WEB_TEAM_TASK_STATUSES,
+  type HostedWebProvisioningState,
+} from './primitives';
 
 import type {
   HostedWebErrorCode,
@@ -9,7 +18,6 @@ import type {
   HostedWebTeamSnapshotResponse,
   HostedWebTerminalSessionId,
 } from './http';
-import type { TeamProvisioningState } from '@shared/types/team';
 
 export const HOSTED_WEB_SSE_EVENT_TYPES = [
   'hosted.team.snapshot',
@@ -32,7 +40,7 @@ interface HostedWebEventBase<Type extends HostedWebSseEventType, Payload> {
 
 export interface HostedWebProvisioningProgressPayload {
   runId: HostedWebRunId;
-  state: Exclude<TeamProvisioningState, 'idle'>;
+  state: HostedWebProvisioningState;
   message: string;
   severity?: 'info' | 'warning' | 'error';
   startedAt: string;
@@ -104,6 +112,12 @@ export function isHostedWebSseEventType(value: string): value is HostedWebSseEve
   return HOSTED_WEB_SSE_EVENT_TYPES.includes(value as HostedWebSseEventType);
 }
 
+const HOSTED_WEB_KANBAN_STATUSES = [
+  ...HOSTED_WEB_TEAM_TASK_STATUSES,
+  'review',
+  'approved',
+] as const;
+
 export function parseHostedWebSseEvent(
   type: string,
   data: string,
@@ -158,14 +172,13 @@ function assertPayload(type: HostedWebSseEventType, payload: unknown): void {
       assertTeamSnapshotPayload(payload);
       return;
     case 'hosted.task.changed':
-      assertRecord(payload.task, 'payload.task');
+      assertTaskSummary(payload.task, 'payload.task');
       assertNonEmptyString(payload.revision, 'payload.revision');
       return;
     case 'hosted.provisioning.progress':
       assertNonEmptyString(payload.runId, 'payload.runId');
-      assertNonEmptyString(payload.state, 'payload.state');
-      if (payload.state === 'idle') {
-        throw new Error('Hosted web provisioning progress state must not be idle');
+      if (!isOneOf(payload.state, HOSTED_WEB_PROVISIONING_STATES)) {
+        throw new Error('Hosted web provisioning progress state is invalid');
       }
       assertNonEmptyString(payload.message, 'payload.message');
       assertIsoTimestamp(payload.startedAt, 'payload.startedAt');
@@ -176,10 +189,14 @@ function assertPayload(type: HostedWebSseEventType, payload: unknown): void {
       ) {
         throw new Error('Hosted web provisioning severity is invalid');
       }
+      if (payload.configReady != null) {
+        assertBoolean(payload.configReady, 'payload.configReady');
+      }
       return;
     case 'hosted.member.message':
       assertNonEmptyString(payload.messageId, 'payload.messageId');
       assertNonEmptyString(payload.fromMemberId, 'payload.fromMemberId');
+      assertOptionalString(payload.summary, 'payload.summary');
       assertNonEmptyString(payload.body, 'payload.body');
       assertIsoTimestamp(payload.createdAt, 'payload.createdAt');
       if (payload.taskIds != null) {
@@ -204,31 +221,142 @@ function assertPayload(type: HostedWebSseEventType, payload: unknown): void {
 }
 
 function assertTeamSnapshotPayload(payload: Record<string, unknown>): void {
-  assertRecord(payload.team, 'payload.team');
+  assertTeamSummary(payload.team, 'payload.team');
   assertNonEmptyString(payload.revision, 'payload.revision');
   if (!Array.isArray(payload.tasks)) {
     throw new Error('Hosted web team snapshot tasks must be an array');
   }
+  for (const task of payload.tasks) {
+    assertTaskSummary(task, 'payload.tasks[]');
+  }
   if (!Array.isArray(payload.kanban)) {
     throw new Error('Hosted web team snapshot kanban must be an array');
   }
-  assertRecord(payload.team.runtime, 'payload.team.runtime');
-  assertBoolean(payload.team.runtime.isAlive, 'payload.team.runtime.isAlive');
-  assertBoolean(payload.team.runtime.terminalAvailable, 'payload.team.runtime.terminalAvailable');
-  if (!Array.isArray(payload.team.members)) {
-    throw new Error('Hosted web team snapshot members must be an array');
+  for (const column of payload.kanban) {
+    assertRecord(column, 'payload.kanban[]');
+    if (!isOneOf(column.status, HOSTED_WEB_KANBAN_STATUSES)) {
+      throw new Error('Hosted web team snapshot kanban status is invalid');
+    }
+    assertStringArray(column.taskIds, 'payload.kanban[].taskIds');
   }
-  if (payload.team.project !== null && payload.team.project !== undefined) {
-    assertRecord(payload.team.project, 'payload.team.project');
-    assertRecord(payload.team.project.workspaceRef, 'payload.team.project.workspaceRef');
+}
+
+function assertTeamSummary(value: unknown, fieldName: string): void {
+  assertRecord(value, fieldName);
+  assertNonEmptyString(value.teamId, `${fieldName}.teamId`);
+  assertNonEmptyString(value.displayName, `${fieldName}.displayName`);
+  assertString(value.description, `${fieldName}.description`);
+  if (value.project !== null && value.project !== undefined) {
+    assertRecord(value.project, `${fieldName}.project`);
+    assertRecord(value.project.workspaceRef, `${fieldName}.project.workspaceRef`);
+    assertNonEmptyString(value.project.workspaceRef.id, `${fieldName}.project.workspaceRef.id`);
     assertNonEmptyString(
-      payload.team.project.workspaceRef.id,
-      'payload.team.project.workspaceRef.id'
+      value.project.workspaceRef.displayName,
+      `${fieldName}.project.workspaceRef.displayName`
     );
-    assertNonEmptyString(
-      payload.team.project.workspaceRef.displayName,
-      'payload.team.project.workspaceRef.displayName'
+    assertOptionalString(
+      value.project.workspaceRef.repositoryLabel,
+      `${fieldName}.project.workspaceRef.repositoryLabel`
     );
+    assertOptionalString(
+      value.project.workspaceRef.branchLabel,
+      `${fieldName}.project.workspaceRef.branchLabel`
+    );
+  }
+  if (value.color !== undefined) {
+    assertString(value.color, `${fieldName}.color`);
+  }
+  if (!Array.isArray(value.members)) {
+    throw new Error(`Hosted web SSE ${fieldName}.members must be an array`);
+  }
+  for (const member of value.members) {
+    assertRecord(member, `${fieldName}.members[]`);
+    assertNonEmptyString(member.memberId, `${fieldName}.members[].memberId`);
+    assertNonEmptyString(member.displayName, `${fieldName}.members[].displayName`);
+    assertOptionalString(member.role, `${fieldName}.members[].role`);
+    assertOptionalString(member.color, `${fieldName}.members[].color`);
+    if (member.provider !== undefined) {
+      assertProviderSelection(member.provider, `${fieldName}.members[].provider`);
+    }
+    if (member.currentTaskId !== null && member.currentTaskId !== undefined) {
+      assertNonEmptyString(member.currentTaskId, `${fieldName}.members[].currentTaskId`);
+    }
+    assertNumber(member.taskCount, `${fieldName}.members[].taskCount`);
+    if (
+      member.isolation !== undefined &&
+      member.isolation !== 'shared-workspace' &&
+      member.isolation !== 'managed-worktree'
+    ) {
+      throw new Error(`Hosted web SSE ${fieldName}.members[].isolation is invalid`);
+    }
+  }
+  assertNumber(value.taskCount, `${fieldName}.taskCount`);
+  if (value.lastActivity !== null && value.lastActivity !== undefined) {
+    assertString(value.lastActivity, `${fieldName}.lastActivity`);
+  }
+  if (value.pendingCreate !== undefined) {
+    assertBoolean(value.pendingCreate, `${fieldName}.pendingCreate`);
+  }
+  if (value.partialLaunchFailure !== undefined) {
+    assertBoolean(value.partialLaunchFailure, `${fieldName}.partialLaunchFailure`);
+  }
+  assertRecord(value.runtime, `${fieldName}.runtime`);
+  assertBoolean(value.runtime.isAlive, `${fieldName}.runtime.isAlive`);
+  assertBoolean(value.runtime.terminalAvailable, `${fieldName}.runtime.terminalAvailable`);
+  assertNumber(value.runtime.activeProcessCount, `${fieldName}.runtime.activeProcessCount`);
+}
+
+function assertTaskSummary(value: unknown, fieldName: string): void {
+  assertRecord(value, fieldName);
+  assertNonEmptyString(value.taskId, `${fieldName}.taskId`);
+  if (value.displayId !== undefined) {
+    assertString(value.displayId, `${fieldName}.displayId`);
+  }
+  assertNonEmptyString(value.subject, `${fieldName}.subject`);
+  if (!isOneOf(value.status, HOSTED_WEB_TEAM_TASK_STATUSES)) {
+    throw new Error(`Hosted web SSE ${fieldName}.status is invalid`);
+  }
+  if (value.ownerMemberId !== undefined) {
+    assertString(value.ownerMemberId, `${fieldName}.ownerMemberId`);
+  }
+  if (
+    value.reviewState !== undefined &&
+    !isOneOf(value.reviewState, HOSTED_WEB_TEAM_REVIEW_STATES)
+  ) {
+    throw new Error(`Hosted web SSE ${fieldName}.reviewState is invalid`);
+  }
+  if (value.blockedBy !== undefined) {
+    assertStringArray(value.blockedBy, `${fieldName}.blockedBy`);
+  }
+  if (value.related !== undefined) {
+    assertStringArray(value.related, `${fieldName}.related`);
+  }
+  if (value.createdAt !== undefined) {
+    assertIsoTimestamp(value.createdAt, `${fieldName}.createdAt`);
+  }
+  if (value.updatedAt !== undefined) {
+    assertIsoTimestamp(value.updatedAt, `${fieldName}.updatedAt`);
+  }
+  if (
+    value.needsClarification !== undefined &&
+    value.needsClarification !== 'lead' &&
+    value.needsClarification !== 'user'
+  ) {
+    throw new Error(`Hosted web SSE ${fieldName}.needsClarification is invalid`);
+  }
+}
+
+function assertProviderSelection(value: unknown, fieldName: string): void {
+  assertRecord(value, fieldName);
+  if (!isOneOf(value.providerId, HOSTED_WEB_TEAM_PROVIDER_IDS)) {
+    throw new Error(`Hosted web SSE ${fieldName}.providerId is invalid`);
+  }
+  assertOptionalString(value.modelId, `${fieldName}.modelId`);
+  if (value.effort !== undefined && !isOneOf(value.effort, HOSTED_WEB_EFFORT_LEVELS)) {
+    throw new Error(`Hosted web SSE ${fieldName}.effort is invalid`);
+  }
+  if (value.fastMode !== undefined && !isOneOf(value.fastMode, HOSTED_WEB_TEAM_FAST_MODES)) {
+    throw new Error(`Hosted web SSE ${fieldName}.fastMode is invalid`);
   }
 }
 
@@ -241,6 +369,18 @@ function assertRecord(value: unknown, fieldName: string): asserts value is Recor
 function assertNonEmptyString(value: unknown, fieldName: string): asserts value is string {
   if (typeof value !== 'string' || value.length === 0) {
     throw new Error(`Hosted web SSE ${fieldName} must be a non-empty string`);
+  }
+}
+
+function assertString(value: unknown, fieldName: string): asserts value is string {
+  if (typeof value !== 'string') {
+    throw new Error(`Hosted web SSE ${fieldName} must be a string`);
+  }
+}
+
+function assertOptionalString(value: unknown, fieldName: string): void {
+  if (value !== undefined) {
+    assertString(value, fieldName);
   }
 }
 
@@ -257,6 +397,12 @@ function assertBoolean(value: unknown, fieldName: string): asserts value is bool
   }
 }
 
+function assertNumber(value: unknown, fieldName: string): asserts value is number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new Error(`Hosted web SSE ${fieldName} must be a finite number`);
+  }
+}
+
 function assertStringArray(value: unknown, fieldName: string): asserts value is string[] {
   if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
     throw new Error(`Hosted web SSE ${fieldName} must be a string array`);
@@ -265,6 +411,13 @@ function assertStringArray(value: unknown, fieldName: string): asserts value is 
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isOneOf<const Values extends readonly string[]>(
+  value: unknown,
+  allowed: Values
+): value is Values[number] {
+  return typeof value === 'string' && allowed.includes(value);
 }
 
 function toErrorMessage(error: unknown): string {

--- a/src/features/hosted-web-transport/contracts/http.ts
+++ b/src/features/hosted-web-transport/contracts/http.ts
@@ -1,10 +1,10 @@
 import type {
-  EffortLevel,
-  TeamFastMode,
-  TeamProviderId,
-  TeamReviewState,
-  TeamTaskStatus,
-} from '@shared/types/team';
+  HostedWebEffortLevel,
+  HostedWebTeamFastMode,
+  HostedWebTeamProviderId,
+  HostedWebTeamReviewState,
+  HostedWebTeamTaskStatus,
+} from './primitives';
 
 export const HOSTED_WEB_API_BASE = '/api/hosted/v1';
 export const HOSTED_WEB_ERROR_CODE_PREFIX = `${HOSTED_WEB_API_BASE}/errors/` as const;
@@ -39,10 +39,10 @@ export interface HostedWebProjectSummary {
 }
 
 export interface HostedWebProviderSelection {
-  providerId: TeamProviderId;
+  providerId: HostedWebTeamProviderId;
   modelId?: string;
-  effort?: EffortLevel;
-  fastMode?: TeamFastMode;
+  effort?: HostedWebEffortLevel;
+  fastMode?: HostedWebTeamFastMode;
 }
 
 export interface HostedWebTeamMemberSummary {
@@ -60,9 +60,9 @@ export interface HostedWebTaskSummary {
   taskId: HostedWebTaskId;
   displayId?: string;
   subject: string;
-  status: TeamTaskStatus;
+  status: HostedWebTeamTaskStatus;
   ownerMemberId?: HostedWebMemberId;
-  reviewState?: TeamReviewState;
+  reviewState?: HostedWebTeamReviewState;
   blockedBy?: HostedWebTaskId[];
   related?: HostedWebTaskId[];
   createdAt?: string;
@@ -96,7 +96,7 @@ export interface HostedWebTeamsListResponse {
 }
 
 export interface HostedWebKanbanColumn {
-  status: TeamTaskStatus | 'review' | 'approved';
+  status: HostedWebTeamTaskStatus | 'review' | 'approved';
   taskIds: HostedWebTaskId[];
 }
 

--- a/src/features/hosted-web-transport/contracts/http.ts
+++ b/src/features/hosted-web-transport/contracts/http.ts
@@ -1,0 +1,197 @@
+import type {
+  EffortLevel,
+  TeamFastMode,
+  TeamProviderId,
+  TeamReviewState,
+  TeamTaskStatus,
+} from '@shared/types/team';
+
+export const HOSTED_WEB_API_BASE = '/api/hosted/v1';
+export const HOSTED_WEB_ERROR_CODE_PREFIX = `${HOSTED_WEB_API_BASE}/errors/` as const;
+export const HOSTED_WEB_LAST_EVENT_ID_HEADER = 'Last-Event-ID';
+export const HOSTED_WEB_EVENT_CURSOR_QUERY_PARAM = 'cursor';
+
+export type HostedWebTeamId = string;
+export type HostedWebMemberId = string;
+export type HostedWebTaskId = string;
+export type HostedWebRunId = string;
+export type HostedWebEventCursor = string;
+export type HostedWebTerminalSessionId = string;
+export type HostedWebErrorCode = `${typeof HOSTED_WEB_ERROR_CODE_PREFIX}${string}`;
+
+export interface HostedWebWorkspaceRef {
+  id: string;
+  displayName: string;
+  repositoryLabel?: string;
+  branchLabel?: string;
+}
+
+export interface HostedWebErrorResponse {
+  error: {
+    code: HostedWebErrorCode;
+    message: string;
+    retryable?: boolean;
+  };
+}
+
+export interface HostedWebProjectSummary {
+  workspaceRef: HostedWebWorkspaceRef;
+}
+
+export interface HostedWebProviderSelection {
+  providerId: TeamProviderId;
+  modelId?: string;
+  effort?: EffortLevel;
+  fastMode?: TeamFastMode;
+}
+
+export interface HostedWebTeamMemberSummary {
+  memberId: HostedWebMemberId;
+  displayName: string;
+  role?: string;
+  color?: string;
+  provider?: HostedWebProviderSelection;
+  currentTaskId: HostedWebTaskId | null;
+  taskCount: number;
+  isolation?: 'shared-workspace' | 'managed-worktree';
+}
+
+export interface HostedWebTaskSummary {
+  taskId: HostedWebTaskId;
+  displayId?: string;
+  subject: string;
+  status: TeamTaskStatus;
+  ownerMemberId?: HostedWebMemberId;
+  reviewState?: TeamReviewState;
+  blockedBy?: HostedWebTaskId[];
+  related?: HostedWebTaskId[];
+  createdAt?: string;
+  updatedAt?: string;
+  needsClarification?: 'lead' | 'user';
+}
+
+export interface HostedWebRuntimeSummary {
+  isAlive: boolean;
+  terminalAvailable: boolean;
+  activeProcessCount: number;
+}
+
+export interface HostedWebTeamSummary {
+  teamId: HostedWebTeamId;
+  displayName: string;
+  description: string;
+  color?: string;
+  project: HostedWebProjectSummary | null;
+  members: HostedWebTeamMemberSummary[];
+  taskCount: number;
+  lastActivity: string | null;
+  pendingCreate?: boolean;
+  partialLaunchFailure?: boolean;
+  runtime: HostedWebRuntimeSummary;
+}
+
+export interface HostedWebTeamsListResponse {
+  teams: HostedWebTeamSummary[];
+  degraded?: boolean;
+}
+
+export interface HostedWebKanbanColumn {
+  status: TeamTaskStatus | 'review' | 'approved';
+  taskIds: HostedWebTaskId[];
+}
+
+export interface HostedWebTeamSnapshotResponse {
+  team: HostedWebTeamSummary;
+  tasks: HostedWebTaskSummary[];
+  kanban: HostedWebKanbanColumn[];
+  revision: string;
+}
+
+export interface HostedWebLaunchMemberRequest {
+  displayName: string;
+  role?: string;
+  workflow?: string;
+  isolation?: 'shared-workspace' | 'managed-worktree';
+  provider?: HostedWebProviderSelection;
+}
+
+export interface HostedWebLaunchTeamRequest {
+  workspaceRef: HostedWebWorkspaceRef;
+  prompt?: string;
+  provider?: HostedWebProviderSelection;
+  members?: HostedWebLaunchMemberRequest[];
+  limitContext?: boolean;
+  requireManualApproval?: boolean;
+}
+
+export interface HostedWebLaunchTeamResponse {
+  runId: HostedWebRunId;
+  launchStatus: 'started' | 'already_launching' | 'already_running';
+}
+
+export interface HostedWebCreateTaskRequest {
+  subject: string;
+  description?: string;
+  ownerMemberId?: HostedWebMemberId;
+  blockedBy?: HostedWebTaskId[];
+  related?: HostedWebTaskId[];
+  prompt?: string;
+  startImmediately?: boolean;
+}
+
+export interface HostedWebCreateTaskResponse {
+  task: HostedWebTaskSummary;
+}
+
+export interface HostedWebTerminalSessionRequest {
+  preferredMemberId?: HostedWebMemberId;
+  cols?: number;
+  rows?: number;
+}
+
+export interface HostedWebTerminalSessionResponse {
+  terminalSessionId: HostedWebTerminalSessionId;
+  webSocketUrl: string;
+  expiresAt: string;
+}
+
+export function hostedWebErrorCode(code: string): HostedWebErrorCode {
+  return code.startsWith(HOSTED_WEB_ERROR_CODE_PREFIX)
+    ? (code as HostedWebErrorCode)
+    : `${HOSTED_WEB_ERROR_CODE_PREFIX}${code.replace(/^\/+/, '')}`;
+}
+
+export function isHostedWebErrorCode(value: unknown): value is HostedWebErrorCode {
+  return typeof value === 'string' && value.startsWith(HOSTED_WEB_ERROR_CODE_PREFIX);
+}
+
+export function hostedWebTeamsRoute(): string {
+  return `${HOSTED_WEB_API_BASE}/teams`;
+}
+
+export function hostedWebTeamRoute(teamId: HostedWebTeamId): string {
+  return `${HOSTED_WEB_API_BASE}/teams/${encodeURIComponent(teamId)}`;
+}
+
+export function hostedWebTeamLaunchRoute(teamId: HostedWebTeamId): string {
+  return `${hostedWebTeamRoute(teamId)}/launch`;
+}
+
+export function hostedWebTeamTasksRoute(teamId: HostedWebTeamId): string {
+  return `${hostedWebTeamRoute(teamId)}/tasks`;
+}
+
+export function hostedWebTeamEventsRoute(
+  teamId: HostedWebTeamId,
+  options: { cursor?: HostedWebEventCursor } = {}
+): string {
+  const params = new URLSearchParams({ teamId });
+  if (options.cursor) {
+    params.set(HOSTED_WEB_EVENT_CURSOR_QUERY_PARAM, options.cursor);
+  }
+  return `${HOSTED_WEB_API_BASE}/events?${params.toString()}`;
+}
+
+export function hostedWebTerminalSessionsRoute(teamId: HostedWebTeamId): string {
+  return `${hostedWebTeamRoute(teamId)}/terminal/sessions`;
+}

--- a/src/features/hosted-web-transport/contracts/http.ts
+++ b/src/features/hosted-web-transport/contracts/http.ts
@@ -1,5 +1,6 @@
 import type {
   HostedWebEffortLevel,
+  HostedWebProvisioningState,
   HostedWebTeamFastMode,
   HostedWebTeamProviderId,
   HostedWebTeamReviewState,
@@ -129,6 +130,21 @@ export interface HostedWebLaunchTeamResponse {
   launchStatus: 'started' | 'already_launching' | 'already_running';
 }
 
+export interface HostedWebProvisioningStatusResponse {
+  runId: HostedWebRunId;
+  teamId: HostedWebTeamId;
+  state: HostedWebProvisioningState;
+  message: string;
+  startedAt: string;
+  updatedAt: string;
+  error?: string;
+  warnings?: string[];
+}
+
+export interface HostedWebAliveTeamsResponse {
+  teamIds: HostedWebTeamId[];
+}
+
 export interface HostedWebCreateTaskRequest {
   subject: string;
   description?: string;
@@ -175,6 +191,22 @@ export function hostedWebTeamRoute(teamId: HostedWebTeamId): string {
 
 export function hostedWebTeamLaunchRoute(teamId: HostedWebTeamId): string {
   return `${hostedWebTeamRoute(teamId)}/launch`;
+}
+
+export function hostedWebTeamStopRoute(teamId: HostedWebTeamId): string {
+  return `${hostedWebTeamRoute(teamId)}/stop`;
+}
+
+export function hostedWebTeamRuntimeRoute(teamId: HostedWebTeamId): string {
+  return `${hostedWebTeamRoute(teamId)}/runtime`;
+}
+
+export function hostedWebAliveTeamsRoute(): string {
+  return `${HOSTED_WEB_API_BASE}/teams/runtime/alive`;
+}
+
+export function hostedWebProvisioningStatusRoute(runId: HostedWebRunId): string {
+  return `${HOSTED_WEB_API_BASE}/teams/provisioning/${encodeURIComponent(runId)}`;
 }
 
 export function hostedWebTeamTasksRoute(teamId: HostedWebTeamId): string {

--- a/src/features/hosted-web-transport/contracts/index.ts
+++ b/src/features/hosted-web-transport/contracts/index.ts
@@ -1,0 +1,2 @@
+export * from './events';
+export * from './http';

--- a/src/features/hosted-web-transport/contracts/index.ts
+++ b/src/features/hosted-web-transport/contracts/index.ts
@@ -1,2 +1,3 @@
 export * from './events';
 export * from './http';
+export * from './primitives';

--- a/src/features/hosted-web-transport/contracts/primitives.ts
+++ b/src/features/hosted-web-transport/contracts/primitives.ts
@@ -1,0 +1,48 @@
+export const HOSTED_WEB_EFFORT_LEVELS = [
+  'none',
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+  'ultra',
+] as const;
+
+export type HostedWebEffortLevel = (typeof HOSTED_WEB_EFFORT_LEVELS)[number];
+
+export const HOSTED_WEB_TEAM_PROVIDER_IDS = ['anthropic', 'codex', 'gemini', 'opencode'] as const;
+
+export type HostedWebTeamProviderId = (typeof HOSTED_WEB_TEAM_PROVIDER_IDS)[number];
+
+export const HOSTED_WEB_TEAM_FAST_MODES = ['inherit', 'on', 'off'] as const;
+
+export type HostedWebTeamFastMode = (typeof HOSTED_WEB_TEAM_FAST_MODES)[number];
+
+export const HOSTED_WEB_TEAM_TASK_STATUSES = [
+  'pending',
+  'in_progress',
+  'completed',
+  'deleted',
+] as const;
+
+export type HostedWebTeamTaskStatus = (typeof HOSTED_WEB_TEAM_TASK_STATUSES)[number];
+
+export const HOSTED_WEB_TEAM_REVIEW_STATES = ['none', 'review', 'needsFix', 'approved'] as const;
+
+export type HostedWebTeamReviewState = (typeof HOSTED_WEB_TEAM_REVIEW_STATES)[number];
+
+export const HOSTED_WEB_PROVISIONING_STATES = [
+  'validating',
+  'spawning',
+  'configuring',
+  'assembling',
+  'finalizing',
+  'verifying',
+  'ready',
+  'disconnected',
+  'failed',
+  'cancelled',
+] as const;
+
+export type HostedWebProvisioningState = (typeof HOSTED_WEB_PROVISIONING_STATES)[number];

--- a/src/features/hosted-web-transport/index.ts
+++ b/src/features/hosted-web-transport/index.ts
@@ -1,0 +1,1 @@
+export * from './contracts';

--- a/src/features/hosted-web-transport/renderer/adapters/createHostedWebTransportClient.ts
+++ b/src/features/hosted-web-transport/renderer/adapters/createHostedWebTransportClient.ts
@@ -1,0 +1,329 @@
+import {
+  HOSTED_WEB_LAST_EVENT_ID_HEADER,
+  HOSTED_WEB_SSE_EVENT_TYPES,
+  type HostedWebCreateTaskRequest,
+  type HostedWebCreateTaskResponse,
+  type HostedWebErrorCode,
+  hostedWebErrorCode,
+  type HostedWebEvent,
+  type HostedWebEventCursor,
+  type HostedWebLaunchTeamRequest,
+  type HostedWebLaunchTeamResponse,
+  hostedWebTeamEventsRoute,
+  type HostedWebTeamId,
+  hostedWebTeamLaunchRoute,
+  hostedWebTeamRoute,
+  type HostedWebTeamsListResponse,
+  type HostedWebTeamSnapshotResponse,
+  hostedWebTeamsRoute,
+  hostedWebTeamTasksRoute,
+  type HostedWebTerminalSessionRequest,
+  type HostedWebTerminalSessionResponse,
+  hostedWebTerminalSessionsRoute,
+  parseHostedWebSseEvent,
+} from '@features/hosted-web-transport/contracts';
+
+export interface HostedWebEventSubscription {
+  close(): void;
+  getLastEventId(): HostedWebEventCursor | null;
+}
+
+export interface HostedWebEventHandlers {
+  onEvent(event: HostedWebEvent): void;
+  onCursor?(cursor: HostedWebEventCursor): void;
+  onParseError?(error: HostedWebTransportError): void;
+  onStreamError?(error: HostedWebTransportError): void;
+  onError?(error: HostedWebTransportError): void;
+}
+
+export interface HostedWebEventSubscriptionOptions {
+  teamId: HostedWebTeamId;
+  resumeAfterEventId?: HostedWebEventCursor;
+}
+
+export interface HostedWebTerminalStreamOptions {
+  webSocketUrl: string;
+  protocols?: string | string[];
+}
+
+export interface HostedWebTransportClient {
+  listTeams(): Promise<HostedWebTeamsListResponse>;
+  getTeamSnapshot(teamId: HostedWebTeamId): Promise<HostedWebTeamSnapshotResponse>;
+  launchTeam(
+    teamId: HostedWebTeamId,
+    request: HostedWebLaunchTeamRequest
+  ): Promise<HostedWebLaunchTeamResponse>;
+  createTask(
+    teamId: HostedWebTeamId,
+    request: HostedWebCreateTaskRequest
+  ): Promise<HostedWebCreateTaskResponse>;
+  subscribeToTeamEvents(
+    options: HostedWebEventSubscriptionOptions,
+    handlers: HostedWebEventHandlers
+  ): HostedWebEventSubscription;
+  createTerminalSession(
+    teamId: HostedWebTeamId,
+    request: HostedWebTerminalSessionRequest
+  ): Promise<HostedWebTerminalSessionResponse>;
+  openTerminalStream(options: HostedWebTerminalStreamOptions): WebSocket;
+}
+
+export type HostedWebFetch = (
+  input: string,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+    signal?: AbortSignal;
+  }
+) => Promise<Pick<Response, 'ok' | 'status' | 'json' | 'text'>>;
+
+export type HostedWebEventSourceConstructor = new (
+  url: string
+) => Pick<EventSource, 'addEventListener' | 'close'>;
+
+export type HostedWebSocketConstructor = new (
+  url: string,
+  protocols?: string | string[]
+) => WebSocket;
+
+export interface HostedWebTransportClientDependencies {
+  baseUrl?: string;
+  fetch?: HostedWebFetch;
+  EventSource?: HostedWebEventSourceConstructor;
+  WebSocket?: HostedWebSocketConstructor;
+  signal?: AbortSignal;
+}
+
+export type HostedWebTransportErrorKind = 'http' | 'sse_parse' | 'sse_stream';
+
+export class HostedWebTransportError extends Error {
+  readonly kind: HostedWebTransportErrorKind;
+  readonly code: HostedWebErrorCode;
+  readonly status?: number;
+  readonly route?: string;
+
+  constructor(
+    message: string,
+    options: {
+      kind: HostedWebTransportErrorKind;
+      code: HostedWebErrorCode;
+      status?: number;
+      route?: string;
+      cause?: unknown;
+    }
+  ) {
+    super(message, { cause: options.cause });
+    this.name = 'HostedWebTransportError';
+    this.kind = options.kind;
+    this.code = options.code;
+    this.status = options.status;
+    this.route = options.route;
+  }
+}
+
+const JSON_HEADERS = {
+  accept: 'application/json',
+  'content-type': 'application/json',
+};
+
+export function createHostedWebTransportClient(
+  dependencies: HostedWebTransportClientDependencies = {}
+): HostedWebTransportClient {
+  const fetchImpl: HostedWebFetch | undefined =
+    dependencies.fetch ??
+    (globalThis.fetch ? (input, init) => globalThis.fetch(input, init as RequestInit) : undefined);
+  if (!fetchImpl) {
+    throw new Error('Hosted web transport requires a fetch implementation');
+  }
+
+  return {
+    listTeams: () =>
+      requestJson<HostedWebTeamsListResponse>(
+        fetchImpl,
+        buildUrl(dependencies.baseUrl, hostedWebTeamsRoute()),
+        {
+          signal: dependencies.signal,
+        }
+      ),
+
+    getTeamSnapshot: (teamId) =>
+      requestJson<HostedWebTeamSnapshotResponse>(
+        fetchImpl,
+        buildUrl(dependencies.baseUrl, hostedWebTeamRoute(teamId)),
+        { signal: dependencies.signal }
+      ),
+
+    launchTeam: (teamId, request) =>
+      requestJson<HostedWebLaunchTeamResponse>(
+        fetchImpl,
+        buildUrl(dependencies.baseUrl, hostedWebTeamLaunchRoute(teamId)),
+        {
+          method: 'POST',
+          body: JSON.stringify(request),
+          signal: dependencies.signal,
+        }
+      ),
+
+    createTask: (teamId, request) =>
+      requestJson<HostedWebCreateTaskResponse>(
+        fetchImpl,
+        buildUrl(dependencies.baseUrl, hostedWebTeamTasksRoute(teamId)),
+        {
+          method: 'POST',
+          body: JSON.stringify(request),
+          signal: dependencies.signal,
+        }
+      ),
+
+    subscribeToTeamEvents: (options, handlers) => {
+      const EventSourceImpl = dependencies.EventSource ?? globalThis.EventSource;
+      if (!EventSourceImpl) {
+        throw new Error('Hosted web transport requires EventSource for state events');
+      }
+
+      let lastEventId: HostedWebEventCursor | null = options.resumeAfterEventId ?? null;
+      const source = new EventSourceImpl(
+        buildUrl(
+          dependencies.baseUrl,
+          hostedWebTeamEventsRoute(options.teamId, { cursor: options.resumeAfterEventId })
+        )
+      );
+
+      for (const eventType of HOSTED_WEB_SSE_EVENT_TYPES) {
+        source.addEventListener(eventType, (event: Event) => {
+          const messageEvent = event as MessageEvent<string>;
+          const nativeLastEventId =
+            typeof messageEvent.lastEventId === 'string' && messageEvent.lastEventId.length > 0
+              ? messageEvent.lastEventId
+              : undefined;
+          try {
+            const parsed = parseHostedWebSseEvent(eventType, messageEvent.data, {
+              lastEventId: nativeLastEventId,
+            });
+            lastEventId = parsed.eventId;
+            handlers.onCursor?.(parsed.eventId);
+            handlers.onEvent(parsed);
+          } catch (error) {
+            const routedError = new HostedWebTransportError('Hosted web event parse failed', {
+              kind: 'sse_parse',
+              code: hostedWebErrorCode('sse_parse_failed'),
+              route: hostedWebTeamEventsRoute(options.teamId),
+              cause: error,
+            });
+            (handlers.onParseError ?? handlers.onError)?.(routedError);
+          }
+        });
+      }
+
+      source.addEventListener('error', () => {
+        const error = new HostedWebTransportError(
+          `Hosted web event stream failed; reconnect uses SSE ${HOSTED_WEB_LAST_EVENT_ID_HEADER} after server id fields or cursor query on a fresh subscription`,
+          {
+            kind: 'sse_stream',
+            code: hostedWebErrorCode('sse_stream_failed'),
+            route: hostedWebTeamEventsRoute(options.teamId, {
+              cursor: lastEventId ?? undefined,
+            }),
+          }
+        );
+        (handlers.onStreamError ?? handlers.onError)?.(error);
+      });
+
+      return {
+        close: () => source.close(),
+        getLastEventId: () => lastEventId,
+      };
+    },
+
+    createTerminalSession: (teamId, request) =>
+      requestJson<HostedWebTerminalSessionResponse>(
+        fetchImpl,
+        buildUrl(dependencies.baseUrl, hostedWebTerminalSessionsRoute(teamId)),
+        {
+          method: 'POST',
+          body: JSON.stringify(request),
+          signal: dependencies.signal,
+        }
+      ),
+
+    openTerminalStream: (options) => {
+      const WebSocketImpl = dependencies.WebSocket ?? globalThis.WebSocket;
+      if (!WebSocketImpl) {
+        throw new Error('Hosted web terminal transport requires WebSocket');
+      }
+      return new WebSocketImpl(options.webSocketUrl, options.protocols);
+    },
+  };
+}
+
+async function requestJson<T>(
+  fetchImpl: HostedWebFetch,
+  url: string,
+  init: { method?: string; body?: string; signal?: AbortSignal } = {}
+): Promise<T> {
+  const response = await fetchImpl(url, {
+    method: init.method ?? 'GET',
+    headers: JSON_HEADERS,
+    body: init.body,
+    signal: init.signal,
+  });
+
+  if (!response.ok) {
+    throw await buildHttpError(response, url);
+  }
+
+  return (await response.json()) as T;
+}
+
+async function buildHttpError(
+  response: Pick<Response, 'status' | 'json' | 'text'>,
+  route: string
+): Promise<HostedWebTransportError> {
+  try {
+    const payload = (await response.json()) as unknown;
+    const errorPayload = readHostedWebErrorPayload(payload);
+    const code = errorPayload?.code
+      ? hostedWebErrorCode(errorPayload.code)
+      : hostedWebErrorCode(`http_${response.status}`);
+    return new HostedWebTransportError(
+      errorPayload?.message ?? `Hosted web request failed with ${response.status}`,
+      { kind: 'http', code, status: response.status, route }
+    );
+  } catch (cause) {
+    const text = await response.text();
+    return new HostedWebTransportError(
+      text || `Hosted web request failed with ${response.status}`,
+      {
+        kind: 'http',
+        code: hostedWebErrorCode(`http_${response.status}`),
+        status: response.status,
+        route,
+        cause,
+      }
+    );
+  }
+}
+
+function buildUrl(baseUrl: string | undefined, route: string): string {
+  if (!baseUrl) {
+    return route;
+  }
+
+  return `${baseUrl.replace(/\/$/, '')}${route}`;
+}
+
+function readHostedWebErrorPayload(payload: unknown): { code?: string; message?: string } | null {
+  if (!isRecord(payload) || !isRecord(payload.error)) {
+    return null;
+  }
+
+  return {
+    ...(typeof payload.error.code === 'string' ? { code: payload.error.code } : {}),
+    ...(typeof payload.error.message === 'string' ? { message: payload.error.message } : {}),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/features/hosted-web-transport/renderer/adapters/createHostedWebTransportClient.ts
+++ b/src/features/hosted-web-transport/renderer/adapters/createHostedWebTransportClient.ts
@@ -1,6 +1,12 @@
 import {
+  HOSTED_WEB_API_BASE,
+  HOSTED_WEB_EFFORT_LEVELS,
   HOSTED_WEB_LAST_EVENT_ID_HEADER,
   HOSTED_WEB_SSE_EVENT_TYPES,
+  HOSTED_WEB_TEAM_FAST_MODES,
+  HOSTED_WEB_TEAM_PROVIDER_IDS,
+  HOSTED_WEB_TEAM_REVIEW_STATES,
+  HOSTED_WEB_TEAM_TASK_STATUSES,
   type HostedWebCreateTaskRequest,
   type HostedWebCreateTaskResponse,
   type HostedWebErrorCode,
@@ -17,6 +23,7 @@ import {
   type HostedWebTeamSnapshotResponse,
   hostedWebTeamsRoute,
   hostedWebTeamTasksRoute,
+  type HostedWebTerminalSessionId,
   type HostedWebTerminalSessionRequest,
   type HostedWebTerminalSessionResponse,
   hostedWebTerminalSessionsRoute,
@@ -42,7 +49,8 @@ export interface HostedWebEventSubscriptionOptions {
 }
 
 export interface HostedWebTerminalStreamOptions {
-  webSocketUrl: string;
+  terminalSessionId?: HostedWebTerminalSessionId;
+  webSocketUrl?: string;
   protocols?: string | string[];
 }
 
@@ -95,7 +103,11 @@ export interface HostedWebTransportClientDependencies {
   signal?: AbortSignal;
 }
 
-export type HostedWebTransportErrorKind = 'http' | 'sse_parse' | 'sse_stream';
+export type HostedWebTransportErrorKind =
+  | 'http'
+  | 'response_validation'
+  | 'sse_parse'
+  | 'sse_stream';
 
 export class HostedWebTransportError extends Error {
   readonly kind: HostedWebTransportErrorKind;
@@ -127,6 +139,16 @@ const JSON_HEADERS = {
   'content-type': 'application/json',
 };
 
+const TERMINAL_WEBSOCKET_PROTOCOLS = new Set(['ws:', 'wss:']);
+const TERMINAL_STREAM_PATH_PATTERN = new RegExp(
+  `^${escapeRegExp(`${HOSTED_WEB_API_BASE}/terminal/`)}[^/?#]+$`
+);
+const HOSTED_WEB_KANBAN_STATUSES = [
+  ...HOSTED_WEB_TEAM_TASK_STATUSES,
+  'review',
+  'approved',
+] as const;
+
 export function createHostedWebTransportClient(
   dependencies: HostedWebTransportClientDependencies = {}
 ): HostedWebTransportClient {
@@ -141,7 +163,9 @@ export function createHostedWebTransportClient(
     listTeams: () =>
       requestJson<HostedWebTeamsListResponse>(
         fetchImpl,
+        hostedWebTeamsRoute(),
         buildUrl(dependencies.baseUrl, hostedWebTeamsRoute()),
+        validateTeamsListResponse,
         {
           signal: dependencies.signal,
         }
@@ -150,14 +174,18 @@ export function createHostedWebTransportClient(
     getTeamSnapshot: (teamId) =>
       requestJson<HostedWebTeamSnapshotResponse>(
         fetchImpl,
+        hostedWebTeamRoute(teamId),
         buildUrl(dependencies.baseUrl, hostedWebTeamRoute(teamId)),
+        validateTeamSnapshotResponse,
         { signal: dependencies.signal }
       ),
 
     launchTeam: (teamId, request) =>
       requestJson<HostedWebLaunchTeamResponse>(
         fetchImpl,
+        hostedWebTeamLaunchRoute(teamId),
         buildUrl(dependencies.baseUrl, hostedWebTeamLaunchRoute(teamId)),
+        validateLaunchTeamResponse,
         {
           method: 'POST',
           body: JSON.stringify(request),
@@ -168,7 +196,9 @@ export function createHostedWebTransportClient(
     createTask: (teamId, request) =>
       requestJson<HostedWebCreateTaskResponse>(
         fetchImpl,
+        hostedWebTeamTasksRoute(teamId),
         buildUrl(dependencies.baseUrl, hostedWebTeamTasksRoute(teamId)),
+        validateCreateTaskResponse,
         {
           method: 'POST',
           body: JSON.stringify(request),
@@ -239,7 +269,9 @@ export function createHostedWebTransportClient(
     createTerminalSession: (teamId, request) =>
       requestJson<HostedWebTerminalSessionResponse>(
         fetchImpl,
+        hostedWebTerminalSessionsRoute(teamId),
         buildUrl(dependencies.baseUrl, hostedWebTerminalSessionsRoute(teamId)),
+        (payload) => validateTerminalSessionResponse(payload, dependencies.baseUrl),
         {
           method: 'POST',
           body: JSON.stringify(request),
@@ -252,14 +284,21 @@ export function createHostedWebTransportClient(
       if (!WebSocketImpl) {
         throw new Error('Hosted web terminal transport requires WebSocket');
       }
-      return new WebSocketImpl(options.webSocketUrl, options.protocols);
+      const url = resolveTerminalWebSocketUrl({
+        baseUrl: dependencies.baseUrl,
+        terminalSessionId: options.terminalSessionId,
+        webSocketUrl: options.webSocketUrl,
+      });
+      return new WebSocketImpl(url, options.protocols);
     },
   };
 }
 
 async function requestJson<T>(
   fetchImpl: HostedWebFetch,
+  route: string,
   url: string,
+  validate: (payload: unknown) => T,
   init: { method?: string; body?: string; signal?: AbortSignal } = {}
 ): Promise<T> {
   const response = await fetchImpl(url, {
@@ -270,39 +309,55 @@ async function requestJson<T>(
   });
 
   if (!response.ok) {
-    throw await buildHttpError(response, url);
+    throw await buildHttpError(response, route);
   }
 
-  return (await response.json()) as T;
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (cause) {
+    throw new HostedWebTransportError('Hosted web response was not valid JSON', {
+      kind: 'response_validation',
+      code: hostedWebErrorCode('invalid_json_response'),
+      status: response.status,
+      route,
+      cause,
+    });
+  }
+
+  try {
+    return validate(payload);
+  } catch (cause) {
+    throw new HostedWebTransportError('Hosted web response did not match the expected schema', {
+      kind: 'response_validation',
+      code: hostedWebErrorCode('invalid_response'),
+      status: response.status,
+      route,
+      cause,
+    });
+  }
 }
 
 async function buildHttpError(
-  response: Pick<Response, 'status' | 'json' | 'text'>,
+  response: Pick<Response, 'status' | 'text'>,
   route: string
 ): Promise<HostedWebTransportError> {
+  let text = '';
   try {
-    const payload = (await response.json()) as unknown;
-    const errorPayload = readHostedWebErrorPayload(payload);
-    const code = errorPayload?.code
-      ? hostedWebErrorCode(errorPayload.code)
-      : hostedWebErrorCode(`http_${response.status}`);
-    return new HostedWebTransportError(
-      errorPayload?.message ?? `Hosted web request failed with ${response.status}`,
-      { kind: 'http', code, status: response.status, route }
-    );
-  } catch (cause) {
-    const text = await response.text();
-    return new HostedWebTransportError(
-      text || `Hosted web request failed with ${response.status}`,
-      {
-        kind: 'http',
-        code: hostedWebErrorCode(`http_${response.status}`),
-        status: response.status,
-        route,
-        cause,
-      }
-    );
+    text = await response.text();
+  } catch {
+    text = '';
   }
+
+  const payload = parseJsonText(text);
+  const errorPayload = readHostedWebErrorPayload(payload);
+  const code = normalizeHostedWebErrorCode(errorPayload?.code, response.status);
+  return new HostedWebTransportError(`Hosted web request failed with status ${response.status}`, {
+    kind: 'http',
+    code,
+    status: response.status,
+    route,
+  });
 }
 
 function buildUrl(baseUrl: string | undefined, route: string): string {
@@ -313,17 +368,430 @@ function buildUrl(baseUrl: string | undefined, route: string): string {
   return `${baseUrl.replace(/\/$/, '')}${route}`;
 }
 
-function readHostedWebErrorPayload(payload: unknown): { code?: string; message?: string } | null {
+function readHostedWebErrorPayload(payload: unknown): { code?: string } | null {
   if (!isRecord(payload) || !isRecord(payload.error)) {
     return null;
   }
 
   return {
     ...(typeof payload.error.code === 'string' ? { code: payload.error.code } : {}),
-    ...(typeof payload.error.message === 'string' ? { message: payload.error.message } : {}),
   };
+}
+
+function parseJsonText(text: string): unknown {
+  if (!text) {
+    return null;
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function normalizeHostedWebErrorCode(code: string | undefined, status: number): HostedWebErrorCode {
+  const fallback = hostedWebErrorCode(`http_${status}`);
+  if (!code) {
+    return fallback;
+  }
+  const unprefixed = code.startsWith(`${HOSTED_WEB_API_BASE}/errors/`)
+    ? code.slice(`${HOSTED_WEB_API_BASE}/errors/`.length)
+    : code;
+  if (!/^[a-z0-9][a-z0-9_-]{0,79}$/.test(unprefixed)) {
+    return fallback;
+  }
+  return hostedWebErrorCode(unprefixed);
+}
+
+function validateTeamsListResponse(payload: unknown): HostedWebTeamsListResponse {
+  assertRecord(payload, 'response');
+  assertArray(payload.teams, 'response.teams');
+  for (const team of payload.teams) {
+    assertTeamSummary(team, 'response.teams[]');
+  }
+  if (payload.degraded != null) {
+    assertBoolean(payload.degraded, 'response.degraded');
+  }
+  return payload as unknown as HostedWebTeamsListResponse;
+}
+
+function validateTeamSnapshotResponse(payload: unknown): HostedWebTeamSnapshotResponse {
+  assertRecord(payload, 'response');
+  assertTeamSummary(payload.team, 'response.team');
+  assertTaskSummaryArray(payload.tasks, 'response.tasks');
+  assertArray(payload.kanban, 'response.kanban');
+  for (const column of payload.kanban) {
+    assertRecord(column, 'response.kanban[]');
+    if (!isOneOf(column.status, HOSTED_WEB_KANBAN_STATUSES)) {
+      throw new Error('Hosted web response.kanban[].status is invalid');
+    }
+    assertStringArray(column.taskIds, 'response.kanban[].taskIds');
+  }
+  assertNonEmptyString(payload.revision, 'response.revision');
+  return payload as unknown as HostedWebTeamSnapshotResponse;
+}
+
+function validateLaunchTeamResponse(payload: unknown): HostedWebLaunchTeamResponse {
+  assertRecord(payload, 'response');
+  assertNonEmptyString(payload.runId, 'response.runId');
+  if (
+    payload.launchStatus !== 'started' &&
+    payload.launchStatus !== 'already_launching' &&
+    payload.launchStatus !== 'already_running'
+  ) {
+    throw new Error('Hosted web response.launchStatus is invalid');
+  }
+  return payload as unknown as HostedWebLaunchTeamResponse;
+}
+
+function validateCreateTaskResponse(payload: unknown): HostedWebCreateTaskResponse {
+  assertRecord(payload, 'response');
+  assertTaskSummary(payload.task, 'response.task');
+  return payload as unknown as HostedWebCreateTaskResponse;
+}
+
+function validateTerminalSessionResponse(
+  payload: unknown,
+  baseUrl: string | undefined
+): HostedWebTerminalSessionResponse {
+  assertRecord(payload, 'response');
+  assertNonEmptyString(payload.terminalSessionId, 'response.terminalSessionId');
+  assertNonEmptyString(payload.webSocketUrl, 'response.webSocketUrl');
+  assertValidTimestamp(payload.expiresAt, 'response.expiresAt');
+  validateTerminalWebSocketTarget({
+    baseUrl,
+    terminalSessionId: payload.terminalSessionId,
+    webSocketUrl: payload.webSocketUrl,
+  });
+  return payload as unknown as HostedWebTerminalSessionResponse;
+}
+
+function assertTeamSummary(value: unknown, fieldName: string): void {
+  assertRecord(value, fieldName);
+  assertNonEmptyString(value.teamId, `${fieldName}.teamId`);
+  assertNonEmptyString(value.displayName, `${fieldName}.displayName`);
+  assertString(value.description, `${fieldName}.description`);
+  assertOptionalString(value.color, `${fieldName}.color`);
+  if (value.project !== null && value.project !== undefined) {
+    assertRecord(value.project, `${fieldName}.project`);
+    assertRecord(value.project.workspaceRef, `${fieldName}.project.workspaceRef`);
+    assertNonEmptyString(value.project.workspaceRef.id, `${fieldName}.project.workspaceRef.id`);
+    assertNonEmptyString(
+      value.project.workspaceRef.displayName,
+      `${fieldName}.project.workspaceRef.displayName`
+    );
+    assertOptionalString(
+      value.project.workspaceRef.repositoryLabel,
+      `${fieldName}.project.workspaceRef.repositoryLabel`
+    );
+    assertOptionalString(
+      value.project.workspaceRef.branchLabel,
+      `${fieldName}.project.workspaceRef.branchLabel`
+    );
+  }
+  assertArray(value.members, `${fieldName}.members`);
+  for (const member of value.members) {
+    assertRecord(member, `${fieldName}.members[]`);
+    assertNonEmptyString(member.memberId, `${fieldName}.members[].memberId`);
+    assertNonEmptyString(member.displayName, `${fieldName}.members[].displayName`);
+    assertOptionalString(member.role, `${fieldName}.members[].role`);
+    assertOptionalString(member.color, `${fieldName}.members[].color`);
+    if (member.provider !== undefined) {
+      assertProviderSelection(member.provider, `${fieldName}.members[].provider`);
+    }
+    if (member.currentTaskId !== null && member.currentTaskId !== undefined) {
+      assertNonEmptyString(member.currentTaskId, `${fieldName}.members[].currentTaskId`);
+    }
+    assertNumber(member.taskCount, `${fieldName}.members[].taskCount`);
+    if (
+      member.isolation !== undefined &&
+      member.isolation !== 'shared-workspace' &&
+      member.isolation !== 'managed-worktree'
+    ) {
+      throw new Error(`Hosted web ${fieldName}.members[].isolation is invalid`);
+    }
+  }
+  assertNumber(value.taskCount, `${fieldName}.taskCount`);
+  if (value.lastActivity !== null && value.lastActivity !== undefined) {
+    assertString(value.lastActivity, `${fieldName}.lastActivity`);
+  }
+  if (value.pendingCreate !== undefined) {
+    assertBoolean(value.pendingCreate, `${fieldName}.pendingCreate`);
+  }
+  if (value.partialLaunchFailure !== undefined) {
+    assertBoolean(value.partialLaunchFailure, `${fieldName}.partialLaunchFailure`);
+  }
+  assertRecord(value.runtime, `${fieldName}.runtime`);
+  assertBoolean(value.runtime.isAlive, `${fieldName}.runtime.isAlive`);
+  assertBoolean(value.runtime.terminalAvailable, `${fieldName}.runtime.terminalAvailable`);
+  assertNumber(value.runtime.activeProcessCount, `${fieldName}.runtime.activeProcessCount`);
+}
+
+function assertTaskSummaryArray(value: unknown, fieldName: string): void {
+  assertArray(value, fieldName);
+  for (const task of value) {
+    assertTaskSummary(task, `${fieldName}[]`);
+  }
+}
+
+function assertTaskSummary(value: unknown, fieldName: string): void {
+  assertRecord(value, fieldName);
+  assertNonEmptyString(value.taskId, `${fieldName}.taskId`);
+  assertOptionalString(value.displayId, `${fieldName}.displayId`);
+  assertNonEmptyString(value.subject, `${fieldName}.subject`);
+  if (!isOneOf(value.status, HOSTED_WEB_TEAM_TASK_STATUSES)) {
+    throw new Error(`Hosted web ${fieldName}.status is invalid`);
+  }
+  assertOptionalString(value.ownerMemberId, `${fieldName}.ownerMemberId`);
+  if (
+    value.reviewState !== undefined &&
+    !isOneOf(value.reviewState, HOSTED_WEB_TEAM_REVIEW_STATES)
+  ) {
+    throw new Error(`Hosted web ${fieldName}.reviewState is invalid`);
+  }
+  if (value.blockedBy !== undefined) {
+    assertStringArray(value.blockedBy, `${fieldName}.blockedBy`);
+  }
+  if (value.related !== undefined) {
+    assertStringArray(value.related, `${fieldName}.related`);
+  }
+  if (value.createdAt !== undefined) {
+    assertValidTimestamp(value.createdAt, `${fieldName}.createdAt`);
+  }
+  if (value.updatedAt !== undefined) {
+    assertValidTimestamp(value.updatedAt, `${fieldName}.updatedAt`);
+  }
+  if (
+    value.needsClarification !== undefined &&
+    value.needsClarification !== 'lead' &&
+    value.needsClarification !== 'user'
+  ) {
+    throw new Error(`Hosted web ${fieldName}.needsClarification is invalid`);
+  }
+}
+
+function assertProviderSelection(value: unknown, fieldName: string): void {
+  assertRecord(value, fieldName);
+  if (!isOneOf(value.providerId, HOSTED_WEB_TEAM_PROVIDER_IDS)) {
+    throw new Error(`Hosted web ${fieldName}.providerId is invalid`);
+  }
+  assertOptionalString(value.modelId, `${fieldName}.modelId`);
+  if (value.effort !== undefined && !isOneOf(value.effort, HOSTED_WEB_EFFORT_LEVELS)) {
+    throw new Error(`Hosted web ${fieldName}.effort is invalid`);
+  }
+  if (value.fastMode !== undefined && !isOneOf(value.fastMode, HOSTED_WEB_TEAM_FAST_MODES)) {
+    throw new Error(`Hosted web ${fieldName}.fastMode is invalid`);
+  }
+}
+
+function resolveTerminalWebSocketUrl(options: {
+  baseUrl: string | undefined;
+  terminalSessionId: HostedWebTerminalSessionId | undefined;
+  webSocketUrl: string | undefined;
+}): string {
+  if (options.terminalSessionId) {
+    const url = buildWebSocketUrl(
+      options.baseUrl,
+      hostedWebTerminalStreamRoute(options.terminalSessionId)
+    );
+    validateTerminalWebSocketTarget({
+      baseUrl: options.baseUrl,
+      terminalSessionId: options.terminalSessionId,
+      webSocketUrl: url,
+    });
+    return url;
+  }
+
+  if (!options.webSocketUrl) {
+    throw new HostedWebTransportError('Hosted web terminal stream target is missing', {
+      kind: 'response_validation',
+      code: hostedWebErrorCode('invalid_terminal_websocket_target'),
+    });
+  }
+
+  validateTerminalWebSocketTarget({
+    baseUrl: options.baseUrl,
+    terminalSessionId: undefined,
+    webSocketUrl: options.webSocketUrl,
+  });
+  return options.webSocketUrl;
+}
+
+function validateTerminalWebSocketTarget(options: {
+  baseUrl: string | undefined;
+  terminalSessionId: HostedWebTerminalSessionId | undefined;
+  webSocketUrl: string;
+}): void {
+  const parsed = parseTerminalWebSocketUrl(options.webSocketUrl, options.baseUrl);
+  if (!parsed || !TERMINAL_WEBSOCKET_PROTOCOLS.has(parsed.protocol)) {
+    throw invalidTerminalWebSocketTargetError();
+  }
+
+  if (
+    !isAbsoluteUrl(options.webSocketUrl) &&
+    (!options.webSocketUrl.startsWith('/') || options.webSocketUrl.startsWith('//'))
+  ) {
+    throw invalidTerminalWebSocketTargetError();
+  }
+
+  const expectedOrigin = getTrustedHttpOrigin(options.baseUrl);
+  if (expectedOrigin && webSocketOriginToHttpOrigin(parsed) !== expectedOrigin) {
+    throw invalidTerminalWebSocketTargetError();
+  }
+
+  if (!expectedOrigin && isAbsoluteUrl(options.webSocketUrl)) {
+    throw invalidTerminalWebSocketTargetError();
+  }
+
+  const expectedPath = options.terminalSessionId
+    ? hostedWebTerminalStreamRoute(options.terminalSessionId)
+    : null;
+  if (parsed.search || parsed.hash) {
+    throw invalidTerminalWebSocketTargetError();
+  }
+  if (
+    expectedPath
+      ? parsed.pathname !== expectedPath
+      : !TERMINAL_STREAM_PATH_PATTERN.test(parsed.pathname)
+  ) {
+    throw invalidTerminalWebSocketTargetError();
+  }
+}
+
+function hostedWebTerminalStreamRoute(sessionId: HostedWebTerminalSessionId): string {
+  return `${HOSTED_WEB_API_BASE}/terminal/${encodeURIComponent(sessionId)}`;
+}
+
+function buildWebSocketUrl(baseUrl: string | undefined, route: string): string {
+  const origin = getTrustedHttpOrigin(baseUrl);
+  if (!origin) {
+    return route;
+  }
+  const url = new URL(route, origin);
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+  return url.toString();
+}
+
+function parseTerminalWebSocketUrl(value: string, baseUrl: string | undefined): URL | null {
+  try {
+    if (isAbsoluteUrl(value)) {
+      return new URL(value);
+    }
+    const origin = getTrustedHttpOrigin(baseUrl);
+    return origin
+      ? new URL(value, origin.replace(/^http/, 'ws'))
+      : new URL(value, 'ws://localhost');
+  } catch {
+    return null;
+  }
+}
+
+function getTrustedHttpOrigin(baseUrl: string | undefined): string | null {
+  if (baseUrl && isAbsoluteUrl(baseUrl)) {
+    const parsed = new URL(baseUrl);
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return parsed.origin;
+    }
+  }
+
+  const locationOrigin =
+    typeof globalThis.location?.origin === 'string' ? globalThis.location.origin : null;
+  if (locationOrigin && isAbsoluteUrl(locationOrigin)) {
+    const parsed = new URL(locationOrigin);
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return parsed.origin;
+    }
+  }
+
+  return null;
+}
+
+function webSocketOriginToHttpOrigin(url: URL): string {
+  const normalized = new URL(url.toString());
+  normalized.protocol = normalized.protocol === 'wss:' ? 'https:' : 'http:';
+  normalized.pathname = '/';
+  normalized.search = '';
+  normalized.hash = '';
+  return normalized.origin;
+}
+
+function invalidTerminalWebSocketTargetError(): HostedWebTransportError {
+  return new HostedWebTransportError('Hosted web terminal stream target is not allowed', {
+    kind: 'response_validation',
+    code: hostedWebErrorCode('invalid_terminal_websocket_target'),
+  });
+}
+
+function assertRecord(value: unknown, fieldName: string): asserts value is Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new Error(`Hosted web ${fieldName} must be an object`);
+  }
+}
+
+function assertArray(value: unknown, fieldName: string): asserts value is unknown[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`Hosted web ${fieldName} must be an array`);
+  }
+}
+
+function assertString(value: unknown, fieldName: string): asserts value is string {
+  if (typeof value !== 'string') {
+    throw new Error(`Hosted web ${fieldName} must be a string`);
+  }
+}
+
+function assertOptionalString(value: unknown, fieldName: string): void {
+  if (value !== undefined) {
+    assertString(value, fieldName);
+  }
+}
+
+function assertNonEmptyString(value: unknown, fieldName: string): asserts value is string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`Hosted web ${fieldName} must be a non-empty string`);
+  }
+}
+
+function assertStringArray(value: unknown, fieldName: string): asserts value is string[] {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    throw new Error(`Hosted web ${fieldName} must be a string array`);
+  }
+}
+
+function assertBoolean(value: unknown, fieldName: string): asserts value is boolean {
+  if (typeof value !== 'boolean') {
+    throw new Error(`Hosted web ${fieldName} must be a boolean`);
+  }
+}
+
+function assertNumber(value: unknown, fieldName: string): asserts value is number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new Error(`Hosted web ${fieldName} must be a finite number`);
+  }
+}
+
+function assertValidTimestamp(value: unknown, fieldName: string): asserts value is string {
+  assertNonEmptyString(value, fieldName);
+  if (Number.isNaN(Date.parse(value))) {
+    throw new Error(`Hosted web ${fieldName} must be a valid timestamp`);
+  }
+}
+
+function isAbsoluteUrl(value: string): boolean {
+  return /^[a-z][a-z0-9+.-]*:/i.test(value);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isOneOf<const Values extends readonly string[]>(
+  value: unknown,
+  allowed: Values
+): value is Values[number] {
+  return typeof value === 'string' && allowed.includes(value);
 }

--- a/src/features/hosted-web-transport/renderer/adapters/createHostedWebTransportClient.ts
+++ b/src/features/hosted-web-transport/renderer/adapters/createHostedWebTransportClient.ts
@@ -550,17 +550,27 @@ function validateProvisioningStatusResponse(payload: unknown): HostedWebProvisio
 }
 
 function validateAliveTeamsResponse(payload: unknown): HostedWebAliveTeamsResponse {
+  assertAliveTeamsResponse(payload);
+  return payload;
+}
+
+function assertAliveTeamsResponse(
+  payload: unknown
+): asserts payload is HostedWebAliveTeamsResponse {
   assertRecord(payload, 'response');
   assertStringArray(payload.teamIds, 'response.teamIds');
-  return payload as HostedWebAliveTeamsResponse;
 }
 
 function validateRuntimeSummary(payload: unknown): HostedWebRuntimeSummary {
+  assertRuntimeSummary(payload);
+  return payload;
+}
+
+function assertRuntimeSummary(payload: unknown): asserts payload is HostedWebRuntimeSummary {
   assertRecord(payload, 'response');
   assertBoolean(payload.isAlive, 'response.isAlive');
   assertBoolean(payload.terminalAvailable, 'response.terminalAvailable');
   assertNumber(payload.activeProcessCount, 'response.activeProcessCount');
-  return payload as HostedWebRuntimeSummary;
 }
 
 function validateCreateTaskResponse(payload: unknown): HostedWebCreateTaskResponse {

--- a/src/features/hosted-web-transport/renderer/adapters/createHostedWebTransportClient.ts
+++ b/src/features/hosted-web-transport/renderer/adapters/createHostedWebTransportClient.ts
@@ -2,11 +2,14 @@ import {
   HOSTED_WEB_API_BASE,
   HOSTED_WEB_EFFORT_LEVELS,
   HOSTED_WEB_LAST_EVENT_ID_HEADER,
+  HOSTED_WEB_PROVISIONING_STATES,
   HOSTED_WEB_SSE_EVENT_TYPES,
   HOSTED_WEB_TEAM_FAST_MODES,
   HOSTED_WEB_TEAM_PROVIDER_IDS,
   HOSTED_WEB_TEAM_REVIEW_STATES,
   HOSTED_WEB_TEAM_TASK_STATUSES,
+  type HostedWebAliveTeamsResponse,
+  hostedWebAliveTeamsRoute,
   type HostedWebCreateTaskRequest,
   type HostedWebCreateTaskResponse,
   type HostedWebErrorCode,
@@ -15,13 +18,19 @@ import {
   type HostedWebEventCursor,
   type HostedWebLaunchTeamRequest,
   type HostedWebLaunchTeamResponse,
+  type HostedWebProvisioningStatusResponse,
+  hostedWebProvisioningStatusRoute,
+  type HostedWebRunId,
+  type HostedWebRuntimeSummary,
   hostedWebTeamEventsRoute,
   type HostedWebTeamId,
   hostedWebTeamLaunchRoute,
   hostedWebTeamRoute,
+  hostedWebTeamRuntimeRoute,
   type HostedWebTeamsListResponse,
   type HostedWebTeamSnapshotResponse,
   hostedWebTeamsRoute,
+  hostedWebTeamStopRoute,
   hostedWebTeamTasksRoute,
   type HostedWebTerminalSessionId,
   type HostedWebTerminalSessionRequest,
@@ -61,6 +70,10 @@ export interface HostedWebTransportClient {
     teamId: HostedWebTeamId,
     request: HostedWebLaunchTeamRequest
   ): Promise<HostedWebLaunchTeamResponse>;
+  getProvisioningStatus(runId: HostedWebRunId): Promise<HostedWebProvisioningStatusResponse>;
+  getRuntimeState(teamId: HostedWebTeamId): Promise<HostedWebRuntimeSummary>;
+  listAliveTeams(): Promise<HostedWebAliveTeamsResponse>;
+  stopTeam(teamId: HostedWebTeamId): Promise<HostedWebRuntimeSummary>;
   createTask(
     teamId: HostedWebTeamId,
     request: HostedWebCreateTaskRequest
@@ -158,13 +171,14 @@ export function createHostedWebTransportClient(
   if (!fetchImpl) {
     throw new Error('Hosted web transport requires a fetch implementation');
   }
+  const baseUrl = normalizeHostedBaseUrl(dependencies.baseUrl);
 
   return {
     listTeams: () =>
       requestJson<HostedWebTeamsListResponse>(
         fetchImpl,
         hostedWebTeamsRoute(),
-        buildUrl(dependencies.baseUrl, hostedWebTeamsRoute()),
+        buildUrl(baseUrl, hostedWebTeamsRoute()),
         validateTeamsListResponse,
         {
           signal: dependencies.signal,
@@ -175,7 +189,7 @@ export function createHostedWebTransportClient(
       requestJson<HostedWebTeamSnapshotResponse>(
         fetchImpl,
         hostedWebTeamRoute(teamId),
-        buildUrl(dependencies.baseUrl, hostedWebTeamRoute(teamId)),
+        buildUrl(baseUrl, hostedWebTeamRoute(teamId)),
         validateTeamSnapshotResponse,
         { signal: dependencies.signal }
       ),
@@ -184,7 +198,7 @@ export function createHostedWebTransportClient(
       requestJson<HostedWebLaunchTeamResponse>(
         fetchImpl,
         hostedWebTeamLaunchRoute(teamId),
-        buildUrl(dependencies.baseUrl, hostedWebTeamLaunchRoute(teamId)),
+        buildUrl(baseUrl, hostedWebTeamLaunchRoute(teamId)),
         validateLaunchTeamResponse,
         {
           method: 'POST',
@@ -193,11 +207,50 @@ export function createHostedWebTransportClient(
         }
       ),
 
+    getProvisioningStatus: (runId) =>
+      requestJson<HostedWebProvisioningStatusResponse>(
+        fetchImpl,
+        hostedWebProvisioningStatusRoute(runId),
+        buildUrl(baseUrl, hostedWebProvisioningStatusRoute(runId)),
+        validateProvisioningStatusResponse,
+        { signal: dependencies.signal }
+      ),
+
+    getRuntimeState: (teamId) =>
+      requestJson<HostedWebRuntimeSummary>(
+        fetchImpl,
+        hostedWebTeamRuntimeRoute(teamId),
+        buildUrl(baseUrl, hostedWebTeamRuntimeRoute(teamId)),
+        validateRuntimeSummary,
+        { signal: dependencies.signal }
+      ),
+
+    listAliveTeams: () =>
+      requestJson<HostedWebAliveTeamsResponse>(
+        fetchImpl,
+        hostedWebAliveTeamsRoute(),
+        buildUrl(baseUrl, hostedWebAliveTeamsRoute()),
+        validateAliveTeamsResponse,
+        { signal: dependencies.signal }
+      ),
+
+    stopTeam: (teamId) =>
+      requestJson<HostedWebRuntimeSummary>(
+        fetchImpl,
+        hostedWebTeamStopRoute(teamId),
+        buildUrl(baseUrl, hostedWebTeamStopRoute(teamId)),
+        validateRuntimeSummary,
+        {
+          method: 'POST',
+          signal: dependencies.signal,
+        }
+      ),
+
     createTask: (teamId, request) =>
       requestJson<HostedWebCreateTaskResponse>(
         fetchImpl,
         hostedWebTeamTasksRoute(teamId),
-        buildUrl(dependencies.baseUrl, hostedWebTeamTasksRoute(teamId)),
+        buildUrl(baseUrl, hostedWebTeamTasksRoute(teamId)),
         validateCreateTaskResponse,
         {
           method: 'POST',
@@ -215,7 +268,7 @@ export function createHostedWebTransportClient(
       let lastEventId: HostedWebEventCursor | null = options.resumeAfterEventId ?? null;
       const source = new EventSourceImpl(
         buildUrl(
-          dependencies.baseUrl,
+          baseUrl,
           hostedWebTeamEventsRoute(options.teamId, { cursor: options.resumeAfterEventId })
         )
       );
@@ -270,8 +323,8 @@ export function createHostedWebTransportClient(
       requestJson<HostedWebTerminalSessionResponse>(
         fetchImpl,
         hostedWebTerminalSessionsRoute(teamId),
-        buildUrl(dependencies.baseUrl, hostedWebTerminalSessionsRoute(teamId)),
-        (payload) => validateTerminalSessionResponse(payload, dependencies.baseUrl),
+        buildUrl(baseUrl, hostedWebTerminalSessionsRoute(teamId)),
+        (payload) => validateTerminalSessionResponse(payload, baseUrl),
         {
           method: 'POST',
           body: JSON.stringify(request),
@@ -285,7 +338,7 @@ export function createHostedWebTransportClient(
         throw new Error('Hosted web terminal transport requires WebSocket');
       }
       const url = resolveTerminalWebSocketUrl({
-        baseUrl: dependencies.baseUrl,
+        baseUrl,
         terminalSessionId: options.terminalSessionId,
         webSocketUrl: options.webSocketUrl,
       });
@@ -368,6 +421,41 @@ function buildUrl(baseUrl: string | undefined, route: string): string {
   return `${baseUrl.replace(/\/$/, '')}${route}`;
 }
 
+function normalizeHostedBaseUrl(baseUrl: string | undefined): string | undefined {
+  if (!baseUrl) {
+    return undefined;
+  }
+
+  const trimmed = baseUrl.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  if (!isAbsoluteUrl(trimmed)) {
+    return trimmed.replace(/\/$/, '');
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch (cause) {
+    throw invalidBaseUrlError(cause);
+  }
+
+  if (
+    (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') ||
+    parsed.username ||
+    parsed.password ||
+    parsed.pathname !== '/' ||
+    parsed.search ||
+    parsed.hash
+  ) {
+    throw invalidBaseUrlError();
+  }
+
+  return parsed.origin;
+}
+
 function readHostedWebErrorPayload(payload: unknown): { code?: string } | null {
   if (!isRecord(payload) || !isRecord(payload.error)) {
     return null;
@@ -442,6 +530,37 @@ function validateLaunchTeamResponse(payload: unknown): HostedWebLaunchTeamRespon
     throw new Error('Hosted web response.launchStatus is invalid');
   }
   return payload as unknown as HostedWebLaunchTeamResponse;
+}
+
+function validateProvisioningStatusResponse(payload: unknown): HostedWebProvisioningStatusResponse {
+  assertRecord(payload, 'response');
+  assertNonEmptyString(payload.runId, 'response.runId');
+  assertNonEmptyString(payload.teamId, 'response.teamId');
+  if (!isOneOf(payload.state, HOSTED_WEB_PROVISIONING_STATES)) {
+    throw new Error('Hosted web response.state is invalid');
+  }
+  assertString(payload.message, 'response.message');
+  assertValidTimestamp(payload.startedAt, 'response.startedAt');
+  assertValidTimestamp(payload.updatedAt, 'response.updatedAt');
+  assertOptionalString(payload.error, 'response.error');
+  if (payload.warnings !== undefined) {
+    assertStringArray(payload.warnings, 'response.warnings');
+  }
+  return payload as unknown as HostedWebProvisioningStatusResponse;
+}
+
+function validateAliveTeamsResponse(payload: unknown): HostedWebAliveTeamsResponse {
+  assertRecord(payload, 'response');
+  assertStringArray(payload.teamIds, 'response.teamIds');
+  return payload as HostedWebAliveTeamsResponse;
+}
+
+function validateRuntimeSummary(payload: unknown): HostedWebRuntimeSummary {
+  assertRecord(payload, 'response');
+  assertBoolean(payload.isAlive, 'response.isAlive');
+  assertBoolean(payload.terminalAvailable, 'response.terminalAvailable');
+  assertNumber(payload.activeProcessCount, 'response.activeProcessCount');
+  return payload as HostedWebRuntimeSummary;
 }
 
 function validateCreateTaskResponse(payload: unknown): HostedWebCreateTaskResponse {
@@ -614,7 +733,7 @@ function resolveTerminalWebSocketUrl(options: {
     terminalSessionId: undefined,
     webSocketUrl: options.webSocketUrl,
   });
-  return options.webSocketUrl;
+  return normalizeTerminalWebSocketUrl(options.webSocketUrl, options.baseUrl);
 }
 
 function validateTerminalWebSocketTarget(options: {
@@ -686,6 +805,14 @@ function parseTerminalWebSocketUrl(value: string, baseUrl: string | undefined): 
   }
 }
 
+function normalizeTerminalWebSocketUrl(value: string, baseUrl: string | undefined): string {
+  if (isAbsoluteUrl(value) || !getTrustedHttpOrigin(baseUrl)) {
+    return value;
+  }
+
+  return parseTerminalWebSocketUrl(value, baseUrl)?.toString() ?? value;
+}
+
 function getTrustedHttpOrigin(baseUrl: string | undefined): string | null {
   if (baseUrl && isAbsoluteUrl(baseUrl)) {
     const parsed = new URL(baseUrl);
@@ -719,6 +846,14 @@ function invalidTerminalWebSocketTargetError(): HostedWebTransportError {
   return new HostedWebTransportError('Hosted web terminal stream target is not allowed', {
     kind: 'response_validation',
     code: hostedWebErrorCode('invalid_terminal_websocket_target'),
+  });
+}
+
+function invalidBaseUrlError(cause?: unknown): HostedWebTransportError {
+  return new HostedWebTransportError('Hosted web base URL is not allowed', {
+    kind: 'response_validation',
+    code: hostedWebErrorCode('invalid_base_url'),
+    cause,
   });
 }
 

--- a/src/features/hosted-web-transport/renderer/index.ts
+++ b/src/features/hosted-web-transport/renderer/index.ts
@@ -1,0 +1,1 @@
+export * from './adapters/createHostedWebTransportClient';

--- a/src/features/runtime-core/main/composition/__tests__/createRuntimeCoreFeature.test.ts
+++ b/src/features/runtime-core/main/composition/__tests__/createRuntimeCoreFeature.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createRuntimeCoreFeature,
+  createRuntimeCoreProviderJsonParsingServices,
+  createRuntimeCoreTeamUseCases,
+  type RuntimeCoreTeamOrchestrationSource,
+} from '../createRuntimeCoreFeature';
+
+import type { TeamHttpDataApi } from '@main/services/team/contracts/TeamProvisioningApis';
+
+const ORCHESTRATION_METHOD_NAMES = [
+  'createTeam',
+  'launchTeam',
+  'getProvisioningStatus',
+  'getCliHelpOutput',
+  'prepareForProvisioning',
+  'cancelProvisioning',
+  'hasProvisioningRun',
+  'repairStaleTaskActivityIntervalsBeforeSnapshot',
+  'getRuntimeState',
+  'stopTeam',
+  'isTeamAlive',
+  'getAliveTeams',
+  'getCurrentRunId',
+  'getMemberSpawnStatuses',
+  'attachLiveRosterMember',
+  'detachLiveRosterMember',
+  'restartMember',
+  'retryFailedOpenCodeSecondaryLanes',
+  'skipMemberForLaunch',
+  'getLeadActivityState',
+  'getLeadContextUsage',
+  'getTeamAgentRuntimeSnapshot',
+  'getClaudeLogs',
+  'sendMessageToTeam',
+  'relayOpenCodeMemberInboxMessages',
+  'relayLeadInboxMessages',
+  'getOpenCodeRuntimeDeliveryStatus',
+  'resolveRuntimeRecipientProviderId',
+  'getLiveLeadProcessMessages',
+  'getCurrentLeadSessionId',
+  'pushLiveLeadProcessMessage',
+  'respondToToolApproval',
+  'updateToolApprovalSettings',
+  'recordOpenCodeRuntimeBootstrapCheckin',
+  'deliverOpenCodeRuntimeMessage',
+  'recordOpenCodeRuntimeTaskEvent',
+  'recordOpenCodeRuntimeHeartbeat',
+  'answerOpenCodeRuntimePermission',
+] as const;
+
+function makeOrchestrationSource(): RuntimeCoreTeamOrchestrationSource & {
+  calls: string[];
+  marker: string;
+} {
+  const source: Record<string, unknown> = {
+    calls: [],
+    marker: 'bound-source',
+  };
+  for (const name of ORCHESTRATION_METHOD_NAMES) {
+    source[name] = function boundMethod(this: { calls: string[]; marker: string }) {
+      this.calls.push(name);
+      return this.marker;
+    };
+  }
+  return source as unknown as RuntimeCoreTeamOrchestrationSource & {
+    calls: string[];
+    marker: string;
+  };
+}
+
+function makeTeamDataApi(): TeamHttpDataApi & { calls: string[]; marker: string } {
+  const calls: string[] = [];
+  const marker = 'data-source';
+  return {
+    calls,
+    marker,
+    listTeams() {
+      calls.push('listTeams');
+      return Promise.resolve([]);
+    },
+    getTeamData() {
+      calls.push('getTeamData');
+      return Promise.resolve({ teamName: marker } as never);
+    },
+    getSavedRequest() {
+      calls.push('getSavedRequest');
+      return Promise.resolve(null);
+    },
+    createTeamConfig() {
+      calls.push('createTeamConfig');
+      return Promise.resolve();
+    },
+  };
+}
+
+describe('createRuntimeCoreFeature', () => {
+  it('keeps provider JSON parsing services in the backend runtime facade', () => {
+    const providerJsonParsing = {
+      projectScanner: { scan: vi.fn() },
+      sessionParser: { parseSession: vi.fn() },
+      subagentResolver: { resolveSubagents: vi.fn() },
+      chunkBuilder: { buildGroups: vi.fn() },
+      dataCache: { get: vi.fn() },
+    };
+
+    const result = createRuntimeCoreProviderJsonParsingServices(providerJsonParsing as never);
+
+    expect(result).toEqual(providerJsonParsing);
+  });
+
+  it('exposes bound team use cases for HTTP and IPC adapters', async () => {
+    const data = makeTeamDataApi();
+    const orchestration = makeOrchestrationSource();
+
+    const useCases = createRuntimeCoreTeamUseCases({ data, orchestration });
+
+    await useCases.data.listTeams();
+    expect(useCases.http.runtime.getAliveTeams()).toBe('bound-source');
+    expect(useCases.http.taskActivity.repairStaleTaskActivityIntervalsBeforeSnapshot('alpha')).toBe(
+      'bound-source'
+    );
+    expect(useCases.ipc.preflight.getCliHelpOutput()).toBe('bound-source');
+    expect(useCases.ipc.memberLifecycle.restartMember('alpha', 'lead')).toBe('bound-source');
+
+    expect(data.calls).toEqual(['listTeams']);
+    expect(orchestration.calls).toEqual([
+      'getAliveTeams',
+      'repairStaleTaskActivityIntervalsBeforeSnapshot',
+      'getCliHelpOutput',
+      'restartMember',
+    ]);
+    expect('preflight' in useCases.http).toBe(false);
+  });
+
+  it('can compose provider parsing without team runtime sources', () => {
+    const providerJsonParsing = {
+      projectScanner: {},
+      sessionParser: {},
+      subagentResolver: {},
+      chunkBuilder: {},
+      dataCache: {},
+    };
+
+    const feature = createRuntimeCoreFeature({
+      providerJsonParsing: providerJsonParsing as never,
+    });
+
+    expect(feature.providerJsonParsing).toEqual(providerJsonParsing);
+    expect(feature.teams).toBeUndefined();
+  });
+});

--- a/src/features/runtime-core/main/composition/createRuntimeCoreFeature.ts
+++ b/src/features/runtime-core/main/composition/createRuntimeCoreFeature.ts
@@ -1,0 +1,79 @@
+import {
+  bindTeamHttpDataApi,
+  bindTeamHttpHandlerApis,
+  bindTeamIpcHandlerApis,
+  type TeamHttpDataApi,
+  type TeamHttpHandlerApis,
+  type TeamIpcHandlerApis,
+} from '@main/services/team/contracts/TeamProvisioningApis';
+
+import type {
+  ChunkBuilder,
+  DataCache,
+  ProjectScanner,
+  SessionParser,
+  SubagentResolver,
+} from '@main/services';
+
+export interface RuntimeCoreProviderJsonParsingServices {
+  projectScanner: ProjectScanner;
+  sessionParser: SessionParser;
+  subagentResolver: SubagentResolver;
+  chunkBuilder: ChunkBuilder;
+  dataCache: DataCache;
+}
+
+export type RuntimeCoreTeamOrchestrationSource = Parameters<typeof bindTeamIpcHandlerApis>[0] &
+  Parameters<typeof bindTeamHttpHandlerApis>[0];
+
+export interface RuntimeCoreTeamSources {
+  data: TeamHttpDataApi;
+  orchestration: RuntimeCoreTeamOrchestrationSource;
+}
+
+export interface RuntimeCoreTeamUseCases {
+  data: TeamHttpDataApi;
+  http: TeamHttpHandlerApis;
+  ipc: TeamIpcHandlerApis;
+}
+
+export interface RuntimeCoreFeatureFacade {
+  providerJsonParsing: RuntimeCoreProviderJsonParsingServices;
+  teams?: RuntimeCoreTeamUseCases;
+}
+
+export interface CreateRuntimeCoreFeatureDeps {
+  providerJsonParsing: RuntimeCoreProviderJsonParsingServices;
+  teams?: RuntimeCoreTeamSources;
+}
+
+export function createRuntimeCoreProviderJsonParsingServices(
+  source: RuntimeCoreProviderJsonParsingServices
+): RuntimeCoreProviderJsonParsingServices {
+  return {
+    projectScanner: source.projectScanner,
+    sessionParser: source.sessionParser,
+    subagentResolver: source.subagentResolver,
+    chunkBuilder: source.chunkBuilder,
+    dataCache: source.dataCache,
+  };
+}
+
+export function createRuntimeCoreTeamUseCases(
+  sources: RuntimeCoreTeamSources
+): RuntimeCoreTeamUseCases {
+  return {
+    data: bindTeamHttpDataApi(sources.data),
+    http: bindTeamHttpHandlerApis(sources.orchestration),
+    ipc: bindTeamIpcHandlerApis(sources.orchestration),
+  };
+}
+
+export function createRuntimeCoreFeature(
+  deps: CreateRuntimeCoreFeatureDeps
+): RuntimeCoreFeatureFacade {
+  return {
+    providerJsonParsing: createRuntimeCoreProviderJsonParsingServices(deps.providerJsonParsing),
+    ...(deps.teams ? { teams: createRuntimeCoreTeamUseCases(deps.teams) } : {}),
+  };
+}

--- a/src/features/runtime-core/main/index.ts
+++ b/src/features/runtime-core/main/index.ts
@@ -1,0 +1,11 @@
+export {
+  createRuntimeCoreFeature,
+  type CreateRuntimeCoreFeatureDeps,
+  createRuntimeCoreProviderJsonParsingServices,
+  createRuntimeCoreTeamUseCases,
+  type RuntimeCoreFeatureFacade,
+  type RuntimeCoreProviderJsonParsingServices,
+  type RuntimeCoreTeamOrchestrationSource,
+  type RuntimeCoreTeamSources,
+  type RuntimeCoreTeamUseCases,
+} from './composition/createRuntimeCoreFeature';

--- a/src/features/team-application/README.md
+++ b/src/features/team-application/README.md
@@ -1,0 +1,18 @@
+# Team Application
+
+Process-limited application facade for team workflows that need to be callable
+from Electron IPC today and hosted web/server adapters later.
+
+Shape:
+
+- `core/domain` owns Electron-neutral validation rules for team application input.
+- `core/application` owns Electron-neutral use cases and ports.
+- `main/composition` wires backend adapters into a small `TeamApplicationFacade`.
+- `main/infrastructure` contains filesystem and main-process service adapters.
+- `main/index.ts` is the public main-process entrypoint.
+
+Current slice:
+
+- `deleteDraftTeam(teamName)` preserves the existing `TEAM_DELETE_DRAFT` behavior
+  while moving input validation, the draft-team guard, and permanent delete
+  orchestration behind a use-case boundary.

--- a/src/features/team-application/core/application/ports/TeamDraftRepositoryPort.ts
+++ b/src/features/team-application/core/application/ports/TeamDraftRepositoryPort.ts
@@ -1,0 +1,6 @@
+export type TeamDraftState = 'draft' | 'materialized';
+
+export interface TeamDraftRepositoryPort {
+  getDraftState(teamName: string): Promise<TeamDraftState>;
+  permanentlyDeleteTeam(teamName: string): Promise<void>;
+}

--- a/src/features/team-application/core/application/use-cases/DeleteDraftTeamUseCase.ts
+++ b/src/features/team-application/core/application/use-cases/DeleteDraftTeamUseCase.ts
@@ -1,0 +1,25 @@
+import { validateTeamApplicationTeamName } from '../../domain/TeamName';
+
+import type { TeamDraftRepositoryPort } from '../ports/TeamDraftRepositoryPort';
+
+export interface DeleteDraftTeamUseCaseDeps {
+  draftRepository: TeamDraftRepositoryPort;
+}
+
+export class DeleteDraftTeamUseCase {
+  constructor(private readonly deps: DeleteDraftTeamUseCaseDeps) {}
+
+  async execute(teamName: unknown): Promise<void> {
+    const validated = validateTeamApplicationTeamName(teamName);
+    if (!validated.valid) {
+      throw new Error(validated.error ?? 'Invalid teamName');
+    }
+
+    const draftState = await this.deps.draftRepository.getDraftState(validated.value!);
+    if (draftState !== 'draft') {
+      throw new Error('Cannot delete draft: team has config.json (use deleteTeam instead)');
+    }
+
+    await this.deps.draftRepository.permanentlyDeleteTeam(validated.value!);
+  }
+}

--- a/src/features/team-application/core/application/use-cases/__tests__/DeleteDraftTeamUseCase.test.ts
+++ b/src/features/team-application/core/application/use-cases/__tests__/DeleteDraftTeamUseCase.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { DeleteDraftTeamUseCase } from '../DeleteDraftTeamUseCase';
+
+import type { TeamDraftRepositoryPort } from '../../ports/TeamDraftRepositoryPort';
+
+function createDraftRepository(state: 'draft' | 'materialized'): TeamDraftRepositoryPort {
+  return {
+    getDraftState: vi.fn(async () => state),
+    permanentlyDeleteTeam: vi.fn(async () => undefined),
+  };
+}
+
+describe('DeleteDraftTeamUseCase', () => {
+  it('permanently deletes teams that are still drafts', async () => {
+    const draftRepository = createDraftRepository('draft');
+    const useCase = new DeleteDraftTeamUseCase({ draftRepository });
+
+    await useCase.execute('team-a');
+
+    expect(draftRepository.getDraftState).toHaveBeenCalledWith('team-a');
+    expect(draftRepository.permanentlyDeleteTeam).toHaveBeenCalledWith('team-a');
+  });
+
+  it('normalizes valid team names before checking draft state', async () => {
+    const draftRepository = createDraftRepository('draft');
+    const useCase = new DeleteDraftTeamUseCase({ draftRepository });
+
+    await useCase.execute(' team-a ');
+
+    expect(draftRepository.getDraftState).toHaveBeenCalledWith('team-a');
+    expect(draftRepository.permanentlyDeleteTeam).toHaveBeenCalledWith('team-a');
+  });
+
+  it('refuses to delete materialized teams through the draft path', async () => {
+    const draftRepository = createDraftRepository('materialized');
+    const useCase = new DeleteDraftTeamUseCase({ draftRepository });
+
+    await expect(useCase.execute('team-a')).rejects.toThrow(
+      'Cannot delete draft: team has config.json (use deleteTeam instead)'
+    );
+
+    expect(draftRepository.permanentlyDeleteTeam).not.toHaveBeenCalled();
+  });
+
+  it.each(['../outside', 'team/a', 'Team', 'con'])(
+    'rejects unsafe team names before touching the repository: %s',
+    async (teamName) => {
+      const draftRepository = createDraftRepository('draft');
+      const useCase = new DeleteDraftTeamUseCase({ draftRepository });
+
+      await expect(useCase.execute(teamName)).rejects.toThrow(/teamName/);
+
+      expect(draftRepository.getDraftState).not.toHaveBeenCalled();
+      expect(draftRepository.permanentlyDeleteTeam).not.toHaveBeenCalled();
+    }
+  );
+});

--- a/src/features/team-application/core/domain/TeamName.ts
+++ b/src/features/team-application/core/domain/TeamName.ts
@@ -1,0 +1,69 @@
+const TEAM_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,127}$/;
+const WINDOWS_RESERVED_BASENAMES = new Set([
+  'con',
+  'prn',
+  'aux',
+  'nul',
+  'com1',
+  'com2',
+  'com3',
+  'com4',
+  'com5',
+  'com6',
+  'com7',
+  'com8',
+  'com9',
+  'lpt1',
+  'lpt2',
+  'lpt3',
+  'lpt4',
+  'lpt5',
+  'lpt6',
+  'lpt7',
+  'lpt8',
+  'lpt9',
+]);
+
+export interface TeamNameValidationResult {
+  valid: boolean;
+  value?: string;
+  error?: string;
+}
+
+function isWindowsReservedFileName(name: string): boolean {
+  const normalized = name
+    .trim()
+    .replace(/[. ]+$/g, '')
+    .toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+
+  const stem = normalized.split('.')[0] ?? normalized;
+  return WINDOWS_RESERVED_BASENAMES.has(stem);
+}
+
+export function validateTeamApplicationTeamName(teamName: unknown): TeamNameValidationResult {
+  if (typeof teamName !== 'string') {
+    return { valid: false, error: 'teamName must be a string' };
+  }
+
+  const trimmed = teamName.trim();
+  if (trimmed.length === 0) {
+    return { valid: false, error: 'teamName cannot be empty' };
+  }
+
+  if (trimmed.length > 128) {
+    return { valid: false, error: 'teamName exceeds max length (128)' };
+  }
+
+  if (!TEAM_NAME_PATTERN.test(trimmed)) {
+    return { valid: false, error: 'teamName contains invalid characters' };
+  }
+
+  if (isWindowsReservedFileName(trimmed)) {
+    return { valid: false, error: 'teamName is reserved on Windows' };
+  }
+
+  return { valid: true, value: trimmed };
+}

--- a/src/features/team-application/main/composition/createTeamApplicationFacade.ts
+++ b/src/features/team-application/main/composition/createTeamApplicationFacade.ts
@@ -1,0 +1,24 @@
+import { getTeamsBasePath } from '@main/utils/pathDecoder';
+
+import { DeleteDraftTeamUseCase } from '../../core/application/use-cases/DeleteDraftTeamUseCase';
+import { FileSystemTeamDraftRepository } from '../infrastructure/FileSystemTeamDraftRepository';
+
+import type { TeamDataService } from '@main/services';
+
+export interface TeamApplicationFacade {
+  deleteDraftTeam(teamName: unknown): Promise<void>;
+}
+
+export function createTeamApplicationFacade(deps: {
+  teamDataService: TeamDataService;
+}): TeamApplicationFacade {
+  const draftRepository = new FileSystemTeamDraftRepository({
+    getTeamsBasePath,
+    permanentlyDeleteTeam: (teamName) => deps.teamDataService.permanentlyDeleteTeam(teamName),
+  });
+  const deleteDraftTeamUseCase = new DeleteDraftTeamUseCase({ draftRepository });
+
+  return {
+    deleteDraftTeam: (teamName) => deleteDraftTeamUseCase.execute(teamName),
+  };
+}

--- a/src/features/team-application/main/index.ts
+++ b/src/features/team-application/main/index.ts
@@ -1,0 +1,4 @@
+export {
+  createTeamApplicationFacade,
+  type TeamApplicationFacade,
+} from './composition/createTeamApplicationFacade';

--- a/src/features/team-application/main/infrastructure/FileSystemTeamDraftRepository.ts
+++ b/src/features/team-application/main/infrastructure/FileSystemTeamDraftRepository.ts
@@ -1,0 +1,55 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import type {
+  TeamDraftRepositoryPort,
+  TeamDraftState,
+} from '../../core/application/ports/TeamDraftRepositoryPort';
+
+export interface FileSystemTeamDraftRepositoryDeps {
+  getTeamsBasePath: () => string;
+  permanentlyDeleteTeam: (teamName: string) => Promise<void>;
+}
+
+export class FileSystemTeamDraftRepository implements TeamDraftRepositoryPort {
+  constructor(private readonly deps: FileSystemTeamDraftRepositoryDeps) {}
+
+  async getDraftState(teamName: string): Promise<TeamDraftState> {
+    const configPath = this.getTeamPath(teamName, 'config.json');
+    try {
+      await fs.promises.access(configPath, fs.constants.F_OK);
+      return 'materialized';
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return 'draft';
+      }
+      throw error;
+    }
+  }
+
+  async permanentlyDeleteTeam(teamName: string): Promise<void> {
+    this.getTeamPath(teamName);
+    await this.deps.permanentlyDeleteTeam(teamName);
+  }
+
+  private getTeamPath(teamName: string, ...segments: string[]): string {
+    const basePath = path.resolve(this.deps.getTeamsBasePath());
+    const teamRootPath = path.resolve(basePath, teamName);
+    const teamRootRelative = path.relative(basePath, teamRootPath);
+    if (
+      teamRootRelative === '' ||
+      teamRootRelative.startsWith('..') ||
+      path.isAbsolute(teamRootRelative)
+    ) {
+      throw new Error('Unsafe team draft path');
+    }
+
+    const teamPath = path.resolve(teamRootPath, ...segments);
+    const relative = path.relative(basePath, teamPath);
+    if (relative.startsWith('..') || path.isAbsolute(relative)) {
+      throw new Error('Unsafe team draft path');
+    }
+
+    return teamPath;
+  }
+}

--- a/src/features/team-application/main/infrastructure/__tests__/FileSystemTeamDraftRepository.test.ts
+++ b/src/features/team-application/main/infrastructure/__tests__/FileSystemTeamDraftRepository.test.ts
@@ -1,0 +1,72 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { FileSystemTeamDraftRepository } from '../FileSystemTeamDraftRepository';
+
+const tempRoots: string[] = [];
+
+async function createTempRoot(): Promise<string> {
+  const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'team-draft-repository-'));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => fs.promises.rm(root, { recursive: true })));
+});
+
+describe('FileSystemTeamDraftRepository', () => {
+  it('classifies a team without config.json as a draft', async () => {
+    const root = await createTempRoot();
+    const repository = new FileSystemTeamDraftRepository({
+      getTeamsBasePath: () => root,
+      permanentlyDeleteTeam: vi.fn(),
+    });
+
+    await expect(repository.getDraftState('team-a')).resolves.toBe('draft');
+  });
+
+  it('classifies a team with config.json as materialized', async () => {
+    const root = await createTempRoot();
+    await fs.promises.mkdir(path.join(root, 'team-a'), { recursive: true });
+    await fs.promises.writeFile(path.join(root, 'team-a', 'config.json'), '{}');
+    const repository = new FileSystemTeamDraftRepository({
+      getTeamsBasePath: () => root,
+      permanentlyDeleteTeam: vi.fn(),
+    });
+
+    await expect(repository.getDraftState('team-a')).resolves.toBe('materialized');
+  });
+
+  it('delegates permanent deletion to the backend team service', async () => {
+    const permanentlyDeleteTeam = vi.fn(async () => undefined);
+    const repository = new FileSystemTeamDraftRepository({
+      getTeamsBasePath: () => '/tmp/unused',
+      permanentlyDeleteTeam,
+    });
+
+    await repository.permanentlyDeleteTeam('team-a');
+
+    expect(permanentlyDeleteTeam).toHaveBeenCalledWith('team-a');
+  });
+
+  it.each(['../outside', ''])(
+    'rejects unsafe team paths before filesystem checks or delete delegation: %s',
+    async (teamName) => {
+      const root = await createTempRoot();
+      const permanentlyDeleteTeam = vi.fn(async () => undefined);
+      const repository = new FileSystemTeamDraftRepository({
+        getTeamsBasePath: () => root,
+        permanentlyDeleteTeam,
+      });
+
+      await expect(repository.getDraftState(teamName)).rejects.toThrow('Unsafe team draft path');
+      await expect(repository.permanentlyDeleteTeam(teamName)).rejects.toThrow(
+        'Unsafe team draft path'
+      );
+      expect(permanentlyDeleteTeam).not.toHaveBeenCalled();
+    }
+  );
+});

--- a/src/hosted/server.ts
+++ b/src/hosted/server.ts
@@ -1,0 +1,255 @@
+import { createReadStream, existsSync, statSync } from 'node:fs';
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import { dirname, extname, join, normalize, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export interface HostedServerConfig {
+  host: string;
+  port: number;
+  rendererRoot: string;
+}
+
+export interface HostedServerHandle {
+  close: () => Promise<void>;
+  port: number;
+  server: Server;
+  url: string;
+}
+
+export interface HostedStaticResolution {
+  cacheControl?: string;
+  contentType?: string;
+  filePath?: string;
+  statusCode: number;
+}
+
+const DEFAULT_HOST = '127.0.0.1';
+const DEFAULT_PORT = 3456;
+const DEFAULT_RENDERER_ROOT = 'out/renderer';
+const HOSTED_SOURCE_DIR = dirname(fileURLToPath(import.meta.url));
+const REMOTE_BIND_OPT_IN = 'HOSTED_ALLOW_REMOTE';
+
+const MIME_TYPES: Record<string, string> = {
+  '.css': 'text/css; charset=utf-8',
+  '.gif': 'image/gif',
+  '.html': 'text/html; charset=utf-8',
+  '.ico': 'image/x-icon',
+  '.jpeg': 'image/jpeg',
+  '.jpg': 'image/jpeg',
+  '.js': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.map': 'application/json; charset=utf-8',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.txt': 'text/plain; charset=utf-8',
+  '.wasm': 'application/wasm',
+  '.webp': 'image/webp',
+};
+
+function parsePort(value: string | undefined, fallback: number): number {
+  const trimmed = value?.trim();
+  if (!trimmed) return fallback;
+  if (!/^\d+$/.test(trimmed)) {
+    throw new Error(`Invalid hosted server port: ${value}`);
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0 || parsed > 65_535) {
+    throw new Error(`Invalid hosted server port: ${value}`);
+  }
+  return parsed;
+}
+
+function isLoopbackHost(host: string): boolean {
+  return host === DEFAULT_HOST || host === 'localhost' || host === '::1' || host === '[::1]';
+}
+
+function parseHost(env: NodeJS.ProcessEnv): string {
+  const host = env.HOST?.trim() || DEFAULT_HOST;
+  if (!isLoopbackHost(host) && env[REMOTE_BIND_OPT_IN] !== '1') {
+    throw new Error(
+      `Hosted server remote binding requires ${REMOTE_BIND_OPT_IN}=1. Prefer HOST=${DEFAULT_HOST}.`
+    );
+  }
+  return host;
+}
+
+function firstExistingPath(paths: string[]): string {
+  return paths.find((candidate) => existsSync(candidate)) ?? paths[0];
+}
+
+export function resolveHostedServerConfig(
+  env: NodeJS.ProcessEnv = process.env
+): HostedServerConfig {
+  return {
+    host: parseHost(env),
+    port: parsePort(env.PORT, DEFAULT_PORT),
+    rendererRoot: firstExistingPath([
+      resolve(process.cwd(), DEFAULT_RENDERER_ROOT),
+      resolve(HOSTED_SOURCE_DIR, '..', DEFAULT_RENDERER_ROOT),
+    ]),
+  };
+}
+
+function sendStatus(reply: ServerResponse, statusCode: number): void {
+  reply.writeHead(statusCode, {
+    'Cache-Control': 'no-store',
+    'Content-Length': '0',
+  });
+  reply.end();
+}
+
+function resolveStaticFile(rendererRoot: string, requestUrl: string | undefined): string | null {
+  let url: URL;
+  try {
+    url = new URL(requestUrl || '/', 'http://hosted.local');
+  } catch {
+    return null;
+  }
+  const rawPathname = url.pathname === '/' ? '/index.html' : url.pathname;
+  let decodedPathname: string;
+  try {
+    decodedPathname = decodeURIComponent(rawPathname);
+  } catch {
+    return null;
+  }
+
+  const normalizedPath = normalize(decodedPathname).replace(/^[/\\]+/, '');
+  const candidate = resolve(rendererRoot, normalizedPath);
+  const rel = relative(rendererRoot, candidate);
+  if (rel === '..' || rel.startsWith(`..${sep}`) || rel.startsWith('/')) {
+    return null;
+  }
+  return candidate;
+}
+
+function isReadableFile(path: string): boolean {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
+
+export function resolveHostedStaticRequest(
+  config: HostedServerConfig,
+  method: string | undefined,
+  requestUrl: string | undefined
+): HostedStaticResolution {
+  if (method !== 'GET' && method !== 'HEAD') {
+    return { statusCode: 405 };
+  }
+
+  const candidate = resolveStaticFile(config.rendererRoot, requestUrl);
+  if (!candidate) {
+    return { statusCode: 404 };
+  }
+
+  const pathname = new URL(requestUrl || '/', 'http://hosted.local').pathname;
+  if (pathname === '/api' || pathname.startsWith('/api/')) {
+    return { statusCode: 404 };
+  }
+
+  const indexPath = join(config.rendererRoot, 'index.html');
+  const filePath =
+    candidate && existsSync(candidate) && isReadableFile(candidate)
+      ? candidate
+      : extname(pathname)
+        ? null
+        : indexPath;
+
+  if (!filePath || !existsSync(filePath) || !isReadableFile(filePath)) {
+    return { statusCode: 404 };
+  }
+
+  return {
+    cacheControl: filePath === indexPath ? 'no-cache' : 'public, max-age=31536000, immutable',
+    contentType: MIME_TYPES[extname(filePath)] ?? 'application/octet-stream',
+    filePath,
+    statusCode: 200,
+  };
+}
+
+function sendStaticFile(
+  config: HostedServerConfig,
+  request: IncomingMessage,
+  reply: ServerResponse
+): void {
+  const resolution = resolveHostedStaticRequest(config, request.method, request.url);
+  if (resolution.statusCode !== 200 || !resolution.filePath) {
+    sendStatus(reply, resolution.statusCode);
+    return;
+  }
+
+  if (!existsSync(resolution.filePath) || !isReadableFile(resolution.filePath)) {
+    sendStatus(reply, 404);
+    return;
+  }
+
+  reply.writeHead(200, {
+    'Cache-Control': resolution.cacheControl ?? 'no-store',
+    'Content-Type': resolution.contentType ?? 'application/octet-stream',
+  });
+
+  if (request.method === 'HEAD') {
+    reply.end();
+    return;
+  }
+
+  const stream = createReadStream(resolution.filePath);
+  stream.pipe(reply);
+  stream.on('error', () => {
+    reply.destroy();
+  });
+}
+
+export function createHostedServer(config: HostedServerConfig): Server {
+  return createServer((request, reply) => {
+    sendStaticFile(config, request, reply);
+  });
+}
+
+export function startHostedServer(
+  config = resolveHostedServerConfig()
+): Promise<HostedServerHandle> {
+  const server = createHostedServer(config);
+  return new Promise((resolveStart, rejectStart) => {
+    server.once('error', rejectStart);
+    server.listen(config.port, config.host, () => {
+      server.off('error', rejectStart);
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : config.port;
+      const urlHost =
+        config.host === '0.0.0.0' || config.host === '::' ? DEFAULT_HOST : config.host;
+      resolveStart({
+        close: () =>
+          new Promise((resolveClose, rejectClose) => {
+            server.close((error) => (error ? rejectClose(error) : resolveClose()));
+          }),
+        port,
+        server,
+        url: `http://${urlHost}:${port}`,
+      });
+    });
+  });
+}
+
+async function runFromEnv(): Promise<void> {
+  const handle = await startHostedServer(resolveHostedServerConfig());
+  console.log(`Agent Teams hosted startup shell listening at ${handle.url}`);
+
+  const shutdown = (): void => {
+    void handle.close().finally(() => process.exit(0));
+  };
+  process.on('SIGINT', shutdown);
+  if (process.platform !== 'win32') {
+    process.on('SIGTERM', shutdown);
+  }
+}
+
+const entryPath = process.argv[1] ? resolve(process.argv[1]) : '';
+if (entryPath && fileURLToPath(import.meta.url) === entryPath) {
+  void runFromEnv().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : 'Hosted server failed to start');
+    process.exit(1);
+  });
+}

--- a/src/main/http/config.ts
+++ b/src/main/http/config.ts
@@ -54,7 +54,7 @@ export function registerConfigRoutes(app: FastifyInstance): void {
   // Get full config
   app.get('/api/config', async () => {
     try {
-      const config = configManager.getConfig();
+      const config = configManager.getConfigForHttpResponse();
       return { success: true, data: config };
     } catch (error) {
       logger.error('Error in GET /api/config:', error);
@@ -72,7 +72,7 @@ export function registerConfigRoutes(app: FastifyInstance): void {
       }
 
       configManager.updateConfig(validation.section, validation.data);
-      const updatedConfig = configManager.getConfig();
+      const updatedConfig = configManager.getConfigForHttpResponse();
       return { success: true, data: updatedConfig };
     } catch (error) {
       logger.error('Error in POST /api/config/update:', error);

--- a/src/main/http/index.ts
+++ b/src/main/http/index.ts
@@ -43,6 +43,7 @@ import type {
   TeamHttpHandlerApis,
 } from '../services/team/contracts/TeamProvisioningApis';
 import type { MemberWorkSyncFeatureFacade } from '@features/member-work-sync/main';
+import type { RuntimeCoreFeatureFacade } from '@features/runtime-core/main';
 import type { FastifyInstance } from 'fastify';
 
 const logger = createLogger('HTTP:routes');
@@ -59,6 +60,7 @@ export interface HttpServices {
   memberWorkSyncFeature?: MemberWorkSyncFeatureFacade;
   updaterService: UpdaterService;
   sshConnectionManager: SshConnectionManager;
+  runtimeCore?: RuntimeCoreFeatureFacade;
   teamApis?: TeamHttpHandlerApis;
   teamDataApi?: TeamHttpDataApi;
 }
@@ -72,7 +74,12 @@ export function registerHttpRoutes(
   registerSessionRoutes(app, services);
   registerSearchRoutes(app, services);
   registerSubagentRoutes(app, services);
-  if (services.teamDataApi || services.teamApis) {
+  if (
+    services.runtimeCore?.teams ||
+    services.teamDataApi ||
+    services.teamApis ||
+    services.memberWorkSyncFeature
+  ) {
     registerTeamRoutes(app, services);
   }
   registerNotificationRoutes(app);

--- a/src/main/http/projects.ts
+++ b/src/main/http/projects.ts
@@ -11,15 +11,19 @@ import { createLogger } from '@shared/utils/logger';
 
 import { validateProjectId } from '../ipc/guards';
 
+import { getHttpProviderJsonParsingServices } from './runtimeCore';
+
 import type { HttpServices } from './index';
 import type { FastifyInstance } from 'fastify';
 
 const logger = createLogger('HTTP:projects');
 
 export function registerProjectRoutes(app: FastifyInstance, services: HttpServices): void {
+  const runtimeCore = getHttpProviderJsonParsingServices(services);
+
   app.get('/api/projects', async () => {
     try {
-      const projects = await services.projectScanner.scan();
+      const projects = await runtimeCore.projectScanner.scan();
       return projects;
     } catch (error) {
       logger.error('Error in GET /api/projects:', error);
@@ -29,7 +33,7 @@ export function registerProjectRoutes(app: FastifyInstance, services: HttpServic
 
   app.get('/api/repository-groups', async () => {
     try {
-      const groups = await services.projectScanner.scanWithWorktreeGrouping();
+      const groups = await runtimeCore.projectScanner.scanWithWorktreeGrouping();
       return groups;
     } catch (error) {
       logger.error('Error in GET /api/repository-groups:', error);
@@ -45,7 +49,7 @@ export function registerProjectRoutes(app: FastifyInstance, services: HttpServic
         return [];
       }
 
-      const sessions = await services.projectScanner.listWorktreeSessions(validated.value!);
+      const sessions = await runtimeCore.projectScanner.listWorktreeSessions(validated.value!);
       return sessions;
     } catch (error) {
       logger.error(`Error in GET /api/worktrees/${request.params.id}/sessions:`, error);

--- a/src/main/http/runtimeCore.ts
+++ b/src/main/http/runtimeCore.ts
@@ -1,0 +1,15 @@
+import type { HttpServices } from './index';
+import type {
+  RuntimeCoreProviderJsonParsingServices,
+  RuntimeCoreTeamUseCases,
+} from '@features/runtime-core/main';
+
+export function getHttpProviderJsonParsingServices(
+  services: HttpServices
+): RuntimeCoreProviderJsonParsingServices {
+  return services.runtimeCore?.providerJsonParsing ?? services;
+}
+
+export function getHttpTeamUseCases(services: HttpServices): RuntimeCoreTeamUseCases | null {
+  return services.runtimeCore?.teams ?? null;
+}

--- a/src/main/http/search.ts
+++ b/src/main/http/search.ts
@@ -9,12 +9,16 @@ import { createLogger } from '@shared/utils/logger';
 
 import { coerceSearchMaxResults, validateProjectId, validateSearchQuery } from '../ipc/guards';
 
+import { getHttpProviderJsonParsingServices } from './runtimeCore';
+
 import type { HttpServices } from './index';
 import type { FastifyInstance } from 'fastify';
 
 const logger = createLogger('HTTP:search');
 
 export function registerSearchRoutes(app: FastifyInstance, services: HttpServices): void {
+  const runtimeCore = getHttpProviderJsonParsingServices(services);
+
   app.get<{
     Params: { projectId: string };
     Querystring: { q?: string; maxResults?: string };
@@ -36,7 +40,7 @@ export function registerSearchRoutes(app: FastifyInstance, services: HttpService
         50
       );
 
-      const result = await services.projectScanner.searchSessions(
+      const result = await runtimeCore.projectScanner.searchSessions(
         validatedProject.value!,
         validatedQuery.value!,
         maxResults
@@ -65,7 +69,7 @@ export function registerSearchRoutes(app: FastifyInstance, services: HttpService
         50
       );
 
-      const result = await services.projectScanner.searchAllProjects(
+      const result = await runtimeCore.projectScanner.searchAllProjects(
         validatedQuery.value!,
         maxResults
       );

--- a/src/main/http/sessions.ts
+++ b/src/main/http/sessions.ts
@@ -15,6 +15,8 @@ import { createLogger } from '@shared/utils/logger';
 import { coercePageLimit, validateProjectId, validateSessionId } from '../ipc/guards';
 import { DataCache } from '../services/infrastructure/DataCache';
 
+import { getHttpProviderJsonParsingServices } from './runtimeCore';
+
 import type { SessionsByIdsOptions, SessionsPaginationOptions } from '../types';
 import type { HttpServices } from './index';
 import type { FastifyInstance } from 'fastify';
@@ -22,6 +24,8 @@ import type { FastifyInstance } from 'fastify';
 const logger = createLogger('HTTP:sessions');
 
 export function registerSessionRoutes(app: FastifyInstance, services: HttpServices): void {
+  const runtimeCore = getHttpProviderJsonParsingServices(services);
+
   // List sessions
   app.get<{ Params: { projectId: string } }>(
     '/api/projects/:projectId/sessions',
@@ -33,7 +37,7 @@ export function registerSessionRoutes(app: FastifyInstance, services: HttpServic
           return [];
         }
 
-        const sessions = await services.projectScanner.listSessions(validated.value!);
+        const sessions = await runtimeCore.projectScanner.listSessions(validated.value!);
         return sessions;
       } catch (error) {
         logger.error(`Error in GET sessions for ${request.params.projectId}:`, error);
@@ -71,7 +75,7 @@ export function registerSessionRoutes(app: FastifyInstance, services: HttpServic
         metadataLevel: request.query.metadataLevel,
       };
 
-      const result = await services.projectScanner.listSessionsPaginated(
+      const result = await runtimeCore.projectScanner.listSessionsPaginated(
         validated.value!,
         cursor,
         limit,
@@ -118,11 +122,11 @@ export function registerSessionRoutes(app: FastifyInstance, services: HttpServic
           return [];
         }
 
-        const fsType = services.projectScanner.getFileSystemProvider().type;
+        const fsType = runtimeCore.projectScanner.getFileSystemProvider().type;
         const effectiveMetadataLevel = metadataLevel ?? (fsType === 'ssh' ? 'light' : 'deep');
         const results = await Promise.all(
           validIds.map((id) =>
-            services.projectScanner.getSessionWithOptions(validated.value!, id, {
+            runtimeCore.projectScanner.getSessionWithOptions(validated.value!, id, {
               metadataLevel: effectiveMetadataLevel,
             })
           )
@@ -157,14 +161,14 @@ export function registerSessionRoutes(app: FastifyInstance, services: HttpServic
       const bypassCache = request.query?.bypassCache === 'true';
 
       // Check cache first
-      let sessionDetail = services.dataCache.get(cacheKey);
+      let sessionDetail = runtimeCore.dataCache.get(cacheKey);
       if (sessionDetail && !bypassCache) {
         return sessionDetail;
       }
 
-      const fsType = services.projectScanner.getFileSystemProvider().type;
+      const fsType = runtimeCore.projectScanner.getFileSystemProvider().type;
       // In SSH mode, avoid an extra deep metadata scan before full parse.
-      const session = await services.projectScanner.getSessionWithOptions(
+      const session = await runtimeCore.projectScanner.getSessionWithOptions(
         safeProjectId,
         safeSessionId,
         {
@@ -177,10 +181,13 @@ export function registerSessionRoutes(app: FastifyInstance, services: HttpServic
       }
 
       // Parse session messages
-      const parsedSession = await services.sessionParser.parseSession(safeProjectId, safeSessionId);
+      const parsedSession = await runtimeCore.sessionParser.parseSession(
+        safeProjectId,
+        safeSessionId
+      );
 
       // Resolve subagents
-      const subagents = await services.subagentResolver.resolveSubagents(
+      const subagents = await runtimeCore.subagentResolver.resolveSubagents(
         safeProjectId,
         safeSessionId,
         parsedSession.taskCalls,
@@ -189,14 +196,14 @@ export function registerSessionRoutes(app: FastifyInstance, services: HttpServic
       session.hasSubagents = subagents.length > 0;
 
       // Build session detail with chunks
-      sessionDetail = services.chunkBuilder.buildSessionDetail(
+      sessionDetail = runtimeCore.chunkBuilder.buildSessionDetail(
         session,
         parsedSession.messages,
         subagents
       );
 
       // Cache the result
-      services.dataCache.set(cacheKey, sessionDetail);
+      runtimeCore.dataCache.set(cacheKey, sessionDetail);
 
       return sessionDetail;
     } catch (error) {
@@ -225,19 +232,19 @@ export function registerSessionRoutes(app: FastifyInstance, services: HttpServic
         const safeProjectId = validatedProject.value!;
         const safeSessionId = validatedSession.value!;
 
-        const parsedSession = await services.sessionParser.parseSession(
+        const parsedSession = await runtimeCore.sessionParser.parseSession(
           safeProjectId,
           safeSessionId
         );
 
-        const subagents = await services.subagentResolver.resolveSubagents(
+        const subagents = await runtimeCore.subagentResolver.resolveSubagents(
           safeProjectId,
           safeSessionId,
           parsedSession.taskCalls,
           parsedSession.messages
         );
 
-        const groups = services.chunkBuilder.buildGroups(parsedSession.messages, subagents);
+        const groups = runtimeCore.chunkBuilder.buildGroups(parsedSession.messages, subagents);
         return groups;
       } catch (error) {
         logger.error(
@@ -265,12 +272,12 @@ export function registerSessionRoutes(app: FastifyInstance, services: HttpServic
 
         // Try cache first
         const cacheKey = DataCache.buildKey(safeProjectId, safeSessionId);
-        const cached = services.dataCache.get(cacheKey);
+        const cached = runtimeCore.dataCache.get(cacheKey);
         if (cached) {
           return cached.metrics;
         }
 
-        const parsedSession = await services.sessionParser.parseSession(
+        const parsedSession = await runtimeCore.sessionParser.parseSession(
           safeProjectId,
           safeSessionId
         );
@@ -301,32 +308,32 @@ export function registerSessionRoutes(app: FastifyInstance, services: HttpServic
         const cacheKey = DataCache.buildKey(safeProjectId, safeSessionId);
 
         // Try cache first for session detail
-        let detail = services.dataCache.get(cacheKey);
+        let detail = runtimeCore.dataCache.get(cacheKey);
 
         if (!detail) {
-          const session = await services.projectScanner.getSession(safeProjectId, safeSessionId);
+          const session = await runtimeCore.projectScanner.getSession(safeProjectId, safeSessionId);
           if (!session) return null;
 
-          const parsedSession = await services.sessionParser.parseSession(
+          const parsedSession = await runtimeCore.sessionParser.parseSession(
             safeProjectId,
             safeSessionId
           );
-          const subagents = await services.subagentResolver.resolveSubagents(
+          const subagents = await runtimeCore.subagentResolver.resolveSubagents(
             safeProjectId,
             safeSessionId,
             parsedSession.taskCalls,
             parsedSession.messages
           );
 
-          detail = services.chunkBuilder.buildSessionDetail(
+          detail = runtimeCore.chunkBuilder.buildSessionDetail(
             session,
             parsedSession.messages,
             subagents
           );
-          services.dataCache.set(cacheKey, detail);
+          runtimeCore.dataCache.set(cacheKey, detail);
         }
 
-        return services.chunkBuilder.buildWaterfallData(detail.chunks, detail.processes);
+        return runtimeCore.chunkBuilder.buildWaterfallData(detail.chunks, detail.processes);
       } catch (error) {
         logger.error(
           `Error in GET waterfall for ${request.params.projectId}/${request.params.sessionId}:`,

--- a/src/main/http/ssh.ts
+++ b/src/main/http/ssh.ts
@@ -2,8 +2,8 @@
  * HTTP route handlers for SSH Connection Management.
  *
  * Routes:
- * - POST /api/ssh/connect - Connect to SSH host
- * - POST /api/ssh/disconnect - Disconnect SSH
+ * - POST /api/ssh/connect - Unsupported over HTTP until route rebinding is context-aware
+ * - POST /api/ssh/disconnect - Unsupported over HTTP until route rebinding is context-aware
  * - GET /api/ssh/state - Get connection state
  * - POST /api/ssh/test - Test connection
  * - GET /api/ssh/config-hosts - Get SSH config hosts
@@ -24,38 +24,32 @@ import type { SshLastConnection } from '@shared/types';
 import type { FastifyInstance } from 'fastify';
 
 const logger = createLogger('HTTP:ssh');
+const HTTP_SSH_CONNECT_UNSUPPORTED_ERROR =
+  'HTTP SSH connect is not supported until context-aware route rebinding exists. Use the desktop Electron SSH controls.';
+const HTTP_SSH_DISCONNECT_UNSUPPORTED_ERROR =
+  'HTTP SSH disconnect is not supported until context-aware route rebinding exists. Use the desktop Electron SSH controls.';
 
 export function registerSshRoutes(
   app: FastifyInstance,
   connectionManager: SshConnectionManager,
-  modeSwitchCallback: (mode: 'local' | 'ssh') => Promise<void>
+  _modeSwitchCallback: (mode: 'local' | 'ssh') => Promise<void>
 ): void {
   const configManager = ConfigManager.getInstance();
 
   // Connect
-  app.post<{ Body: SshConnectionConfig }>('/api/ssh/connect', async (request) => {
-    try {
-      await connectionManager.connect(request.body);
-      await modeSwitchCallback('ssh');
-      return { success: true, data: connectionManager.getStatus() };
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      logger.error('SSH connect failed:', message);
-      return { success: false, error: message };
-    }
+  app.post<{ Body: SshConnectionConfig }>('/api/ssh/connect', async (_request, reply) => {
+    return reply.status(501).send({
+      success: false,
+      error: HTTP_SSH_CONNECT_UNSUPPORTED_ERROR,
+    });
   });
 
   // Disconnect
-  app.post('/api/ssh/disconnect', async () => {
-    try {
-      connectionManager.disconnect();
-      await modeSwitchCallback('local');
-      return { success: true, data: connectionManager.getStatus() };
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      logger.error('SSH disconnect failed:', message);
-      return { success: false, error: message };
-    }
+  app.post('/api/ssh/disconnect', async (_request, reply) => {
+    return reply.status(501).send({
+      success: false,
+      error: HTTP_SSH_DISCONNECT_UNSUPPORTED_ERROR,
+    });
   });
 
   // Get state

--- a/src/main/http/subagents.ts
+++ b/src/main/http/subagents.ts
@@ -9,12 +9,16 @@ import { createLogger } from '@shared/utils/logger';
 
 import { validateProjectId, validateSessionId, validateSubagentId } from '../ipc/guards';
 
+import { getHttpProviderJsonParsingServices } from './runtimeCore';
+
 import type { HttpServices } from './index';
 import type { FastifyInstance } from 'fastify';
 
 const logger = createLogger('HTTP:subagents');
 
 export function registerSubagentRoutes(app: FastifyInstance, services: HttpServices): void {
+  const runtimeCore = getHttpProviderJsonParsingServices(services);
+
   app.get<{
     Params: { projectId: string; sessionId: string; subagentId: string };
     Querystring: { bypassCache?: string };
@@ -43,20 +47,20 @@ export function registerSubagentRoutes(app: FastifyInstance, services: HttpServi
       const cacheKey = `subagent-${safeProjectId}-${safeSessionId}-${safeSubagentId}`;
 
       // Check cache first
-      let subagentDetail = services.dataCache.getSubagent(cacheKey);
+      let subagentDetail = runtimeCore.dataCache.getSubagent(cacheKey);
       if (subagentDetail && !bypassCache) {
         return subagentDetail;
       }
 
-      const fsProvider = services.projectScanner.getFileSystemProvider();
-      const projectsDir = services.projectScanner.getProjectsDir();
+      const fsProvider = runtimeCore.projectScanner.getFileSystemProvider();
+      const projectsDir = runtimeCore.projectScanner.getProjectsDir();
 
-      const builtDetail = await services.chunkBuilder.buildSubagentDetail(
+      const builtDetail = await runtimeCore.chunkBuilder.buildSubagentDetail(
         safeProjectId,
         safeSessionId,
         safeSubagentId,
-        services.sessionParser,
-        services.subagentResolver,
+        runtimeCore.sessionParser,
+        runtimeCore.subagentResolver,
         fsProvider,
         projectsDir
       );
@@ -67,7 +71,7 @@ export function registerSubagentRoutes(app: FastifyInstance, services: HttpServi
       }
 
       subagentDetail = builtDetail;
-      services.dataCache.setSubagent(cacheKey, subagentDetail);
+      runtimeCore.dataCache.setSubagent(cacheKey, subagentDetail);
 
       return subagentDetail;
     } catch (error) {

--- a/src/main/http/teamRouteParsers.ts
+++ b/src/main/http/teamRouteParsers.ts
@@ -7,7 +7,7 @@ import {
   formatEffortLevelListForProvider,
   isTeamEffortLevelForProvider,
 } from '@shared/utils/effortLevels';
-import { isTeamProviderBackendId, migrateProviderBackendId } from '@shared/utils/providerBackend';
+import { migrateProviderBackendId } from '@shared/utils/providerBackend';
 import { normalizeTeamMemberMcpPolicy } from '@shared/utils/teamMemberMcpPolicy';
 import { isTeamProviderId } from '@shared/utils/teamProvider';
 import { isAbsolute } from 'path';
@@ -167,13 +167,17 @@ export function parseLaunchProviderBackendId(
 ): TeamLaunchRequest['providerBackendId'] | undefined {
   const rawProviderBackendId = assertOptionalString(value, 'providerBackendId');
   const providerBackendId = migrateProviderBackendId(providerId, rawProviderBackendId);
-  if (providerBackendId || !rawProviderBackendId) {
-    return providerBackendId;
+  if (rawProviderBackendId && !providerBackendId) {
+    throw new HttpBadRequestError(PROVIDER_BACKEND_ERROR);
   }
-  if (isTeamProviderBackendId(rawProviderBackendId)) {
-    return undefined;
-  }
-  throw new HttpBadRequestError(PROVIDER_BACKEND_ERROR);
+  return providerBackendId;
+}
+
+function migrateSavedLaunchProviderBackendId(
+  providerId: TeamLaunchRequest['providerId'],
+  value: TeamCreateRequest['providerBackendId']
+): TeamLaunchRequest['providerBackendId'] | undefined {
+  return migrateProviderBackendId(providerId, value);
 }
 
 export function parseCreateMembers(
@@ -360,14 +364,11 @@ export function parseDraftLaunchCreateRequest(
     : (savedRequest.providerId ?? 'anthropic');
   const providerChangedFromSaved =
     Object.hasOwn(payload, 'providerId') && providerId !== (savedRequest.providerId ?? 'anthropic');
-  const providerBackendId = parseLaunchProviderBackendId(
-    providerId,
-    Object.hasOwn(payload, 'providerBackendId')
-      ? payload.providerBackendId
-      : providerChangedFromSaved
-        ? undefined
-        : savedRequest.providerBackendId
-  );
+  const providerBackendId = Object.hasOwn(payload, 'providerBackendId')
+    ? parseLaunchProviderBackendId(providerId, payload.providerBackendId)
+    : providerChangedFromSaved
+      ? undefined
+      : migrateSavedLaunchProviderBackendId(providerId, savedRequest.providerBackendId);
   const effort = assertOptionalEffort(
     Object.hasOwn(payload, 'effort')
       ? payload.effort

--- a/src/main/http/teams.ts
+++ b/src/main/http/teams.ts
@@ -7,6 +7,7 @@ import { constants as fsConstants } from 'fs';
 import { access } from 'fs/promises';
 import { join } from 'path';
 
+import { getHttpTeamUseCases } from './runtimeCore';
 import {
   HttpBadRequestError,
   parseCreateTeamRequest,
@@ -44,7 +45,8 @@ function isMemberWorkSyncReportState(value: string): value is MemberWorkSyncRepo
 }
 
 function getTeamProvisioningStartApi(services: HttpServices): TeamHttpProvisioningStartApi {
-  const api = services.teamApis?.provisioningStart;
+  const api =
+    getHttpTeamUseCases(services)?.http.provisioningStart ?? services.teamApis?.provisioningStart;
   if (!api) {
     throw new HttpFeatureUnavailableError('Team launch control is not available in this mode');
   }
@@ -52,7 +54,8 @@ function getTeamProvisioningStartApi(services: HttpServices): TeamHttpProvisioni
 }
 
 function getTeamProvisioningStatusApi(services: HttpServices): TeamHttpProvisioningStatusApi {
-  const api = services.teamApis?.provisioningStatus;
+  const api =
+    getHttpTeamUseCases(services)?.http.provisioningStatus ?? services.teamApis?.provisioningStatus;
   if (!api) {
     throw new HttpFeatureUnavailableError('Team provisioning status is not available in this mode');
   }
@@ -60,7 +63,7 @@ function getTeamProvisioningStatusApi(services: HttpServices): TeamHttpProvision
 }
 
 function getTeamRuntimeApi(services: HttpServices): TeamHttpRuntimeApi {
-  const api = services.teamApis?.runtime;
+  const api = getHttpTeamUseCases(services)?.http.runtime ?? services.teamApis?.runtime;
   if (!api) {
     throw new HttpFeatureUnavailableError('Team runtime control is not available in this mode');
   }
@@ -68,7 +71,8 @@ function getTeamRuntimeApi(services: HttpServices): TeamHttpRuntimeApi {
 }
 
 function getTeamRuntimeControlApi(services: HttpServices): TeamHttpRuntimeControlApi {
-  const api = services.teamApis?.runtimeControl;
+  const api =
+    getHttpTeamUseCases(services)?.http.runtimeControl ?? services.teamApis?.runtimeControl;
   if (!api) {
     throw new HttpFeatureUnavailableError('Team runtime callbacks are not available in this mode');
   }
@@ -76,10 +80,11 @@ function getTeamRuntimeControlApi(services: HttpServices): TeamHttpRuntimeContro
 }
 
 function getTeamDataApi(services: HttpServices): NonNullable<HttpServices['teamDataApi']> {
-  if (!services.teamDataApi) {
+  const api = getHttpTeamUseCases(services)?.data ?? services.teamDataApi;
+  if (!api) {
     throw new HttpFeatureUnavailableError('Team data control is not available in this mode');
   }
-  return services.teamDataApi;
+  return api;
 }
 
 function getStatusCode(error: unknown, fallback: number = 500): number {
@@ -133,7 +138,7 @@ async function getDraftSavedRequest(
   services: HttpServices,
   teamName: string
 ): Promise<TeamCreateRequest | null> {
-  if (!services.teamDataApi) {
+  if (!getHttpTeamUseCases(services)?.data && !services.teamDataApi) {
     return null;
   }
 
@@ -166,7 +171,7 @@ async function getTeamDataWithRuntimeOverlay(
   const data = await getTeamDataApi(services).getTeamData(teamName);
   let runtimeState: Awaited<ReturnType<TeamHttpRuntimeApi['getRuntimeState']>> | null = null;
   try {
-    const runtimeApi = services.teamApis?.runtime;
+    const runtimeApi = getHttpTeamUseCases(services)?.http.runtime ?? services.teamApis?.runtime;
     runtimeState = (await runtimeApi?.getRuntimeState(teamName)) ?? null;
   } catch {
     runtimeState = null;
@@ -219,7 +224,8 @@ export function registerTeamRoutes(app: FastifyInstance, services: HttpServices)
         });
       }
 
-      const taskActivityApi = services.teamApis?.taskActivity;
+      const taskActivityApi =
+        getHttpTeamUseCases(services)?.http.taskActivity ?? services.teamApis?.taskActivity;
       await taskActivityApi?.repairStaleTaskActivityIntervalsBeforeSnapshot(teamName);
       return reply.send(await getTeamDataWithRuntimeOverlay(services, teamName));
     } catch (error) {

--- a/src/main/http/teams.ts
+++ b/src/main/http/teams.ts
@@ -1,3 +1,4 @@
+import { isStandaloneOpenCodeRuntimeAdapterUnavailableError } from '@main/services/team/provisioning/TeamProvisioningStandaloneOpenCodeBoundary';
 import { TeamConfigReader } from '@main/services/team/TeamConfigReader';
 import { validateTeamName } from '@main/services/team/TeamIdentifierValidation';
 import { getTeamsBasePath } from '@main/utils/pathDecoder';
@@ -97,6 +98,9 @@ function getStatusCode(error: unknown, fallback: number = 500): number {
   if (error instanceof HttpFeatureUnavailableError) {
     return 501;
   }
+  if (isStandaloneOpenCodeRuntimeAdapterUnavailableError(error)) {
+    return 501;
+  }
   if (isRuntimeControlProviderRoutingError(error)) {
     return 501;
   }
@@ -130,6 +134,7 @@ function shouldLogError(error: unknown): boolean {
     statusCode >= 500 &&
     !(error instanceof HttpBadRequestError) &&
     !(error instanceof HttpFeatureUnavailableError) &&
+    !isStandaloneOpenCodeRuntimeAdapterUnavailableError(error) &&
     !isRuntimeControlProviderRoutingError(error)
   );
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -68,6 +68,11 @@ import {
   removeRecentProjectsIpc,
 } from '@features/recent-projects/main';
 import {
+  createRuntimeCoreFeature,
+  createRuntimeCoreProviderJsonParsingServices,
+  type RuntimeCoreFeatureFacade,
+} from '@features/runtime-core/main';
+import {
   createRuntimeProviderManagementFeature,
   registerRuntimeProviderManagementIpc,
   removeRuntimeProviderManagementIpc,
@@ -116,11 +121,7 @@ import {
 } from '@main/services/team/opencode/bridge/OpenCodeMcpBridgeEnv';
 import {
   bindTeamCrossTeamMessagingApi,
-  bindTeamHttpDataApi,
-  bindTeamHttpHandlerApis,
-  bindTeamIpcHandlerApis,
   type TeamDiagnosticsApi,
-  type TeamHttpHandlerApis,
   type TeamIpcHandlerApis,
 } from '@main/services/team/contracts/TeamProvisioningApis';
 import { ReviewApplierService } from '@main/services/team/ReviewApplierService';
@@ -1059,7 +1060,7 @@ let tokenUsageFeature: TokenUsageFeatureFacade | null = null;
 let memberWorkSyncFeature: MemberWorkSyncFeatureFacade | null = null;
 let teamDataService: TeamDataService;
 let teamProvisioningService: TeamProvisioningService;
-let teamHttpHandlerApis: TeamHttpHandlerApis | null = null;
+let runtimeCoreFeature: RuntimeCoreFeatureFacade | null = null;
 let launchIoGovernor: LaunchIoGovernor | null = null;
 let cliInstallerService: CliInstallerService;
 let openCodeRuntimeInstallerService: OpenCodeRuntimeInstallerService;
@@ -1846,7 +1847,18 @@ async function initializeServices(): Promise<void> {
     internalStorageFeature.taskCommentNotificationJournalStore
   );
   teamProvisioningService = new TeamProvisioningService();
-  const teamIpcHandlerApis: TeamIpcHandlerApis = bindTeamIpcHandlerApis(teamProvisioningService);
+  runtimeCoreFeature = createRuntimeCoreFeature({
+    providerJsonParsing: createRuntimeCoreProviderJsonParsingServices(localContext),
+    teams: {
+      data: teamDataService,
+      orchestration: teamProvisioningService,
+    },
+  });
+  const teamRuntimeCoreUseCases = runtimeCoreFeature.teams;
+  if (!teamRuntimeCoreUseCases) {
+    throw new Error('Runtime core team use cases are not initialized');
+  }
+  const teamIpcHandlerApis: TeamIpcHandlerApis = teamRuntimeCoreUseCases.ipc;
   const teamDiagnosticsApi = teamIpcHandlerApis.diagnostics;
   const teamMessagingApi = teamIpcHandlerApis.messaging;
   const teamProvisioningRunApi = teamIpcHandlerApis.provisioningRun;
@@ -2594,8 +2606,6 @@ async function initializeServices(): Promise<void> {
     message: 'Wiring app actions...',
   });
 
-  teamHttpHandlerApis = bindTeamHttpHandlerApis(teamProvisioningService);
-
   // Initialize IPC handlers with registry
   initializeIpcHandlers(
     contextRegistry,
@@ -2710,9 +2720,16 @@ async function startHttpServer(
 
     const config = configManager.getConfig();
     const activeContext = contextRegistry.getActive();
-    if (!teamHttpHandlerApis) {
-      throw new Error('Team HTTP APIs are not initialized');
+    if (!runtimeCoreFeature?.teams) {
+      throw new Error('Runtime core team use cases are not initialized');
     }
+    const runtimeCoreForActiveContext = createRuntimeCoreFeature({
+      providerJsonParsing: createRuntimeCoreProviderJsonParsingServices(activeContext),
+      teams: {
+        data: runtimeCoreFeature.teams.data,
+        orchestration: teamProvisioningService,
+      },
+    });
     const port = await httpServer.start(
       {
         projectScanner: activeContext.projectScanner,
@@ -2726,8 +2743,7 @@ async function startHttpServer(
         memberWorkSyncFeature: memberWorkSyncFeature ?? undefined,
         updaterService,
         sshConnectionManager,
-        teamDataApi: bindTeamHttpDataApi(teamDataService),
-        teamApis: teamHttpHandlerApis,
+        runtimeCore: runtimeCoreForActiveContext,
       },
       modeSwitchHandler,
       config.httpServer?.port ?? 3456

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2746,7 +2746,8 @@ async function startHttpServer(
         runtimeCore: runtimeCoreForActiveContext,
       },
       modeSwitchHandler,
-      config.httpServer?.port ?? 3456
+      config.httpServer?.port ?? 3456,
+      config.httpServer?.host ?? '127.0.0.1'
     );
     if (isShutdownStarted()) {
       await httpServer.stop().catch(() => undefined);

--- a/src/main/ipc/configValidation.ts
+++ b/src/main/ipc/configValidation.ts
@@ -7,6 +7,8 @@ import { isAppLocalePreference } from '@features/localization';
 import { migrateProviderBackendId } from '@shared/utils/providerBackend';
 import * as path from 'path';
 
+import { isLoopbackHttpHost } from '../services/infrastructure/httpServerAuth';
+
 import type {
   AppConfig,
   DisplayConfig,
@@ -864,7 +866,7 @@ function validateHttpServerSection(
     return { valid: false, error: 'httpServer update must be an object' };
   }
 
-  const allowedKeys: (keyof HttpServerConfig)[] = ['enabled', 'port'];
+  const allowedKeys: (keyof HttpServerConfig)[] = ['enabled', 'port', 'host'];
   const result: Partial<HttpServerConfig> = {};
 
   for (const [key, value] of Object.entries(data)) {
@@ -887,6 +889,15 @@ function validateHttpServerSection(
           };
         }
         result.port = value;
+        break;
+      case 'host':
+        if (typeof value !== 'string' || !isLoopbackHttpHost(value)) {
+          return {
+            valid: false,
+            error: 'httpServer.host must be a loopback host',
+          };
+        }
+        result.host = value.trim();
         break;
       default:
         return { valid: false, error: `Unsupported httpServer key: ${key}` };

--- a/src/main/ipc/teams.ts
+++ b/src/main/ipc/teams.ts
@@ -2,6 +2,10 @@ import {
   estimateAgentAttachmentSerializedPayloadBytes,
   MAX_AGENT_ATTACHMENT_SERIALIZED_PAYLOAD_BYTES,
 } from '@features/agent-attachments/contracts';
+import {
+  createTeamApplicationFacade,
+  type TeamApplicationFacade,
+} from '@features/team-application/main';
 import { addMainBreadcrumb } from '@main/sentry';
 import { setCurrentMainOp } from '@main/services/infrastructure/EventLoopLagMonitor';
 import { markTeamEngaged } from '@main/services/infrastructure/teamWatchScope';
@@ -773,6 +777,7 @@ let boardTaskActivityDetailService: BoardTaskActivityDetailService | null = null
 let boardTaskLogStreamService: BoardTaskLogStreamService | null = null;
 let boardTaskExactLogsService: BoardTaskExactLogsService | null = null;
 let boardTaskExactLogDetailService: BoardTaskExactLogDetailService | null = null;
+let teamApplicationFacade: TeamApplicationFacade | null = null;
 
 const attachmentStore = new TeamAttachmentStore();
 const taskAttachmentStore = new TeamTaskAttachmentStore();
@@ -852,6 +857,7 @@ export function initializeTeamHandlers(
   boardTaskLogStreamService = taskLogStreamService ?? null;
   boardTaskExactLogsService = taskExactLogsService ?? null;
   boardTaskExactLogDetailService = taskExactLogDetailService ?? null;
+  teamApplicationFacade = createTeamApplicationFacade({ teamDataService: service });
 }
 
 export function registerTeamHandlers(ipcMain: IpcMain): void {
@@ -1166,6 +1172,13 @@ function getBoardTaskExactLogDetailService(): BoardTaskExactLogDetailService {
     throw new Error('Board task exact log detail service is not initialized');
   }
   return boardTaskExactLogDetailService;
+}
+
+function getTeamApplicationFacade(): TeamApplicationFacade {
+  if (!teamApplicationFacade) {
+    throw new Error('Team application facade is not initialized');
+  }
+  return teamApplicationFacade;
 }
 
 async function wrapTeamHandler<T>(
@@ -5738,14 +5751,6 @@ async function handleDeleteDraft(
     return { success: false, error: validated.error ?? 'Invalid teamName' };
   }
   return wrapTeamHandler('deleteDraft', async () => {
-    // Only allow deleting draft teams (no config.json)
-    const configPath = path.join(getTeamsBasePath(), validated.value!, 'config.json');
-    try {
-      await fs.promises.access(configPath, fs.constants.F_OK);
-      throw new Error('Cannot delete draft: team has config.json (use deleteTeam instead)');
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
-    }
-    await getTeamDataService().permanentlyDeleteTeam(validated.value!);
+    await getTeamApplicationFacade().deleteDraftTeam(validated.value!);
   });
 }

--- a/src/main/services/infrastructure/ConfigManager.ts
+++ b/src/main/services/infrastructure/ConfigManager.ts
@@ -19,6 +19,7 @@ import { migrateProviderBackendId } from '@shared/utils/providerBackend';
 import * as fs from 'fs';
 import * as path from 'path';
 
+import { isLoopbackHttpHost } from './httpServerAuth';
 import { DEFAULT_TRIGGERS, TriggerManager } from './TriggerManager';
 
 import type { CodexAccountAuthMode } from '@features/codex-account/contracts';
@@ -340,6 +341,7 @@ export interface SshPersistConfig {
 export interface HttpServerConfig {
   enabled: boolean;
   port: number;
+  host: string;
 }
 
 export interface AppConfig {
@@ -447,6 +449,7 @@ const DEFAULT_CONFIG: AppConfig = {
   httpServer: {
     enabled: false,
     port: 3456,
+    host: '127.0.0.1',
   },
 };
 
@@ -534,6 +537,74 @@ function normalizeCodexCustomProviderConfig(
 
 function shouldPersistNormalizedConfig(loaded: Partial<AppConfig>, normalized: AppConfig): boolean {
   return JSON.stringify(loaded) !== JSON.stringify(normalized);
+}
+
+function normalizeHttpServerConfig(value: unknown): HttpServerConfig {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return { ...DEFAULT_CONFIG.httpServer };
+  }
+
+  const raw = value as Partial<HttpServerConfig>;
+  const persistedHost = typeof raw.host === 'string' ? raw.host : null;
+  const hasPersistedHost = persistedHost !== null;
+  const persistedHostIsLoopback = persistedHost !== null && isLoopbackHttpHost(persistedHost);
+  const host =
+    persistedHost !== null && persistedHostIsLoopback
+      ? persistedHost.trim()
+      : DEFAULT_CONFIG.httpServer.host;
+  const persistedHostIsSafe = !hasPersistedHost || persistedHostIsLoopback;
+  const persistedPort =
+    typeof raw.port === 'number' &&
+    Number.isInteger(raw.port) &&
+    raw.port >= 1024 &&
+    raw.port <= 65535
+      ? raw.port
+      : DEFAULT_CONFIG.httpServer.port;
+
+  return {
+    enabled:
+      typeof raw.enabled === 'boolean' && persistedHostIsSafe
+        ? raw.enabled
+        : DEFAULT_CONFIG.httpServer.enabled,
+    port: persistedPort,
+    host,
+  };
+}
+
+function redactSessionProjectKeys<T>(value: Record<string, T>): Record<string, T> {
+  return Object.fromEntries(
+    Object.entries(value).map(([, entries], index) => [`[redacted-project-${index + 1}]`, entries])
+  );
+}
+
+function redactConfigForHttpResponse(config: AppConfig): AppConfig {
+  return {
+    ...config,
+    general: {
+      ...config.general,
+      claudeRootPath: config.general.claudeRootPath ? '[redacted-path]' : null,
+      customProjectPaths: config.general.customProjectPaths.map(() => '[redacted-path]'),
+    },
+    sessions: {
+      pinnedSessions: redactSessionProjectKeys(config.sessions.pinnedSessions),
+      hiddenSessions: redactSessionProjectKeys(config.sessions.hiddenSessions),
+    },
+    ssh: {
+      ...config.ssh,
+      lastConnection: config.ssh.lastConnection
+        ? {
+            ...config.ssh.lastConnection,
+            privateKeyPath: config.ssh.lastConnection.privateKeyPath
+              ? '[redacted-path]'
+              : undefined,
+          }
+        : null,
+      profiles: config.ssh.profiles.map((profile) => ({
+        ...profile,
+        privateKeyPath: profile.privateKeyPath ? '[redacted-path]' : undefined,
+      })),
+    },
+  };
 }
 
 // ===========================================================================
@@ -755,10 +826,7 @@ export class ConfigManager {
         ...DEFAULT_CONFIG.ssh,
         ...(loaded.ssh ?? {}),
       },
-      httpServer: {
-        ...DEFAULT_CONFIG.httpServer,
-        ...(loaded.httpServer ?? {}),
-      },
+      httpServer: normalizeHttpServerConfig(loaded.httpServer),
     };
   }
 
@@ -778,6 +846,10 @@ export class ConfigManager {
    */
   getConfig(): AppConfig {
     return this.deepClone(this.config);
+  }
+
+  getConfigForHttpResponse(): AppConfig {
+    return redactConfigForHttpResponse(this.getConfig());
   }
 
   /**

--- a/src/main/services/infrastructure/HttpServer.ts
+++ b/src/main/services/infrastructure/HttpServer.ts
@@ -216,10 +216,11 @@ export class HttpServer {
       const tryPort = preferredPort + attempt;
       try {
         await this.app.listen({ host, port: tryPort });
-        this.port = tryPort;
+        const address = this.app.server.address();
+        this.port = address && typeof address !== 'string' ? address.port : tryPort;
         this.running = true;
-        logger.info(`HTTP server started on http://${host}:${tryPort}`);
-        return tryPort;
+        logger.info(`HTTP server started on http://${host}:${this.port}`);
+        return this.port;
       } catch (err: unknown) {
         const error = err as NodeJS.ErrnoException;
         if (error.code === 'EADDRINUSE') {

--- a/src/main/services/infrastructure/HttpServer.ts
+++ b/src/main/services/infrastructure/HttpServer.ts
@@ -17,6 +17,13 @@ import { existsSync } from 'fs';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
 
+import {
+  assertHttpServerBindAllowed,
+  extractBearerAuthToken,
+  getHttpAuthTokenFromEnv,
+  timingSafeHttpAuthTokenEquals,
+} from './httpServerAuth';
+
 const logger = createLogger('Service:HttpServer');
 
 /**
@@ -46,6 +53,87 @@ function resolveRendererPath(): string | null {
   }
 
   return candidates.find((candidate) => existsSync(candidate)) ?? null;
+}
+
+function isCorsPreflightRequest(request: {
+  method: string;
+  headers: Record<string, unknown>;
+}): boolean {
+  return (
+    request.method === 'OPTIONS' &&
+    typeof request.headers.origin === 'string' &&
+    typeof request.headers['access-control-request-method'] === 'string'
+  );
+}
+
+async function registerHttpCors(
+  app: FastifyInstance,
+  corsOrigin: string | undefined
+): Promise<void> {
+  const configuredOrigins = corsOrigin
+    ?.split(',')
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+
+  if (configuredOrigins?.includes('*')) {
+    await app.register(cors, {
+      origin: (origin, cb) => {
+        cb(null, origin || false);
+      },
+      credentials: true,
+    });
+  } else if (configuredOrigins && configuredOrigins.length > 0) {
+    await app.register(cors, { origin: configuredOrigins, credentials: true });
+  } else {
+    // eslint-disable-next-line security/detect-unsafe-regex -- anchored, no backtracking risk
+    const localhostPattern = /^https?:\/\/(?:localhost|127\.0\.0\.1)(?::\d+)?$/;
+    await app.register(cors, {
+      origin: (origin, cb) => {
+        if (!origin) {
+          cb(null, true);
+          return;
+        }
+        if (localhostPattern.test(origin)) {
+          cb(null, true);
+          return;
+        }
+        cb(new Error('Not allowed by CORS'), false);
+      },
+      credentials: true,
+    });
+  }
+}
+
+async function registerHttpAuth(app: FastifyInstance, authToken: string | null): Promise<void> {
+  if (!authToken) {
+    return;
+  }
+
+  app.addHook('onRequest', async (request, reply) => {
+    if (!request.url.startsWith('/api/')) {
+      return;
+    }
+
+    if (isCorsPreflightRequest(request)) {
+      return;
+    }
+
+    const receivedToken = extractBearerAuthToken(request.headers.authorization);
+    if (receivedToken && timingSafeHttpAuthTokenEquals(authToken, receivedToken)) {
+      return;
+    }
+
+    await reply.status(401).send({ success: false, error: 'Unauthorized' });
+  });
+}
+
+export async function registerHttpSecurityMiddleware(
+  app: FastifyInstance,
+  authToken: string | null,
+  corsOrigin: string | undefined = process.env.CORS_ORIGIN
+): Promise<void> {
+  await registerHttpCors(app, corsOrigin);
+  await registerHttpAuth(app, authToken);
 }
 
 export class HttpServer {
@@ -87,36 +175,11 @@ export class HttpServer {
     preferredPort: number,
     host: string
   ): Promise<number> {
-    this.app = Fastify({ logger: false });
+    const authToken = getHttpAuthTokenFromEnv();
+    assertHttpServerBindAllowed(host, authToken);
 
-    // Register CORS
-    const corsOrigin = process.env.CORS_ORIGIN;
-    if (corsOrigin === '*') {
-      // Standalone/Docker mode: allow all origins (Docker network isolation replaces CORS)
-      await this.app.register(cors, { origin: true, credentials: true });
-    } else if (corsOrigin) {
-      // Custom origin(s) from env
-      const origins = corsOrigin.split(',').map((o) => o.trim());
-      await this.app.register(cors, { origin: origins, credentials: true });
-    } else {
-      // Default: allow all localhost origins
-      // eslint-disable-next-line security/detect-unsafe-regex -- anchored, no backtracking risk
-      const localhostPattern = /^https?:\/\/(?:localhost|127\.0\.0\.1)(?::\d+)?$/;
-      await this.app.register(cors, {
-        origin: (origin, cb) => {
-          if (!origin) {
-            cb(null, true);
-            return;
-          }
-          if (localhostPattern.test(origin)) {
-            cb(null, true);
-            return;
-          }
-          cb(new Error('Not allowed by CORS'), false);
-        },
-        credentials: true,
-      });
-    }
+    this.app = Fastify({ logger: false });
+    await registerHttpSecurityMiddleware(this.app, authToken);
 
     // Register static file serving and SPA fallback when renderer output exists.
     // In dev mode this requires a prior `pnpm build`; in production/standalone it's always present.

--- a/src/main/services/infrastructure/httpServerAuth.ts
+++ b/src/main/services/infrastructure/httpServerAuth.ts
@@ -1,0 +1,51 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+export const HTTP_AUTH_TOKEN_ENV = 'AGENT_TEAMS_HTTP_AUTH_TOKEN';
+
+const HTTP_AUTH_HMAC_KEY = 'agent-teams-http-auth-token-v1';
+const HTTP_AUTH_TOKEN_MAX_LENGTH = 4096;
+
+export function isLoopbackHttpHost(host: string): boolean {
+  const normalized = host.trim().toLowerCase();
+  return normalized === 'localhost' || normalized === '127.0.0.1' || normalized === '::1';
+}
+
+export function getHttpAuthTokenFromEnv(env: NodeJS.ProcessEnv = process.env): string | null {
+  const token = env[HTTP_AUTH_TOKEN_ENV]?.trim();
+  return token ? token : null;
+}
+
+export function assertHttpServerBindAllowed(host: string, authToken: string | null): void {
+  if (!isLoopbackHttpHost(host) && !authToken) {
+    throw new Error(
+      `Refusing to bind HTTP server to non-loopback host without ${HTTP_AUTH_TOKEN_ENV}`
+    );
+  }
+}
+
+function digestAuthToken(token: string): Buffer {
+  return createHmac('sha256', HTTP_AUTH_HMAC_KEY).update(token).digest();
+}
+
+export function timingSafeHttpAuthTokenEquals(expected: string, received: string): boolean {
+  if (!received || received.length > HTTP_AUTH_TOKEN_MAX_LENGTH) {
+    return false;
+  }
+
+  const expectedDigest = digestAuthToken(expected);
+  const receivedDigest = digestAuthToken(received);
+  return timingSafeEqual(expectedDigest, receivedDigest);
+}
+
+export function extractBearerAuthToken(header: string | undefined): string | null {
+  if (!header) {
+    return null;
+  }
+
+  const [scheme, ...rest] = header.trim().split(/\s+/);
+  if (!scheme || scheme.toLowerCase() !== 'bearer' || rest.length !== 1) {
+    return null;
+  }
+
+  return rest[0] ?? null;
+}

--- a/src/main/services/team/TeamProvisioningService.ts
+++ b/src/main/services/team/TeamProvisioningService.ts
@@ -157,6 +157,7 @@ import {
   type TeamProvisioningServiceMemberLifecycleHostPortGroups,
 } from './provisioning/TeamProvisioningServiceMemberLifecycleHostPortGroups';
 import { createTeamProvisioningShutdownCoordination } from './provisioning/TeamProvisioningShutdownCoordination';
+import { assertStandaloneOpenCodeRuntimeAdapterAvailableForServiceRequest } from './provisioning/TeamProvisioningStandaloneOpenCodeBoundary';
 import { createNodeStopPrimaryOwnedRosterRuntimeUseCase } from './provisioning/TeamProvisioningStopPrimaryOwnedRosterRuntimeUseCase';
 import {
   killOrphanedTeamAgentProcesses,
@@ -623,10 +624,18 @@ export class TeamProvisioningService extends TeamProvisioningServiceFacadeDelega
     this.teamChangeEmitter = emitter;
   }
 
+  private assertStandaloneOpenCodeRuntimeAdapterBoundary(request: {
+    providerId?: TeamCreateRequest['providerId'];
+    members?: TeamCreateRequest['members'];
+  }): void {
+    assertStandaloneOpenCodeRuntimeAdapterAvailableForServiceRequest(this, request);
+  }
+
   async createTeam(
     request: TeamCreateRequest,
     onProgress: (progress: TeamProvisioningProgress) => void
   ): Promise<TeamCreateResponse> {
+    this.assertStandaloneOpenCodeRuntimeAdapterBoundary(request);
     return this.requestAdmissionBoundary.createTeam(request, onProgress);
   }
 
@@ -634,6 +643,7 @@ export class TeamProvisioningService extends TeamProvisioningServiceFacadeDelega
     request: TeamLaunchRequest,
     onProgress: (progress: TeamProvisioningProgress) => void
   ): Promise<TeamLaunchResponse> {
+    this.assertStandaloneOpenCodeRuntimeAdapterBoundary(request);
     return this.requestAdmissionBoundary.launchTeam(request, onProgress);
   }
 }

--- a/src/main/services/team/provisioning/TeamProvisioningStandaloneOpenCodeBoundary.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningStandaloneOpenCodeBoundary.ts
@@ -1,0 +1,50 @@
+import { isOpenCodeLegacyProvisioningRequest } from './TeamProvisioningLaunchCompatibility';
+
+export const STANDALONE_OPENCODE_RUNTIME_ADAPTER_UNAVAILABLE_ERROR_NAME =
+  'StandaloneOpenCodeRuntimeAdapterUnavailableError';
+
+export class StandaloneOpenCodeRuntimeAdapterUnavailableError extends Error {
+  readonly statusCode = 501;
+
+  constructor() {
+    super(
+      'OpenCode team launch is not available in standalone mode because the OpenCode runtime adapter is unavailable outside Electron.'
+    );
+    this.name = STANDALONE_OPENCODE_RUNTIME_ADAPTER_UNAVAILABLE_ERROR_NAME;
+  }
+}
+
+const standaloneOpenCodeRuntimeAdapterBoundaryEnabledServices = new WeakSet<object>();
+
+export function enableStandaloneOpenCodeRuntimeAdapterBoundary(service: object): void {
+  standaloneOpenCodeRuntimeAdapterBoundaryEnabledServices.add(service);
+}
+
+export function isStandaloneOpenCodeRuntimeAdapterUnavailableError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.name === STANDALONE_OPENCODE_RUNTIME_ADAPTER_UNAVAILABLE_ERROR_NAME
+  );
+}
+
+export function assertStandaloneOpenCodeRuntimeAdapterAvailableForRequest(request: {
+  providerId?: unknown;
+  members?: readonly { providerId?: unknown; provider?: unknown }[];
+}): void {
+  if (isOpenCodeLegacyProvisioningRequest(request)) {
+    throw new StandaloneOpenCodeRuntimeAdapterUnavailableError();
+  }
+}
+
+export function assertStandaloneOpenCodeRuntimeAdapterAvailableForServiceRequest(
+  service: object,
+  request: {
+    providerId?: unknown;
+    members?: readonly { providerId?: unknown; provider?: unknown }[];
+  }
+): void {
+  if (!standaloneOpenCodeRuntimeAdapterBoundaryEnabledServices.has(service)) {
+    return;
+  }
+  assertStandaloneOpenCodeRuntimeAdapterAvailableForRequest(request);
+}

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningServiceComposition.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningServiceComposition.test.ts
@@ -8,6 +8,10 @@ import {
   TEAM_PROVISIONING_SERVICE_COMPOSITION_KEYS,
   TEAM_PROVISIONING_SERVICE_COMPOSITION_KEYS_ARE_EXHAUSTIVE,
 } from '../TeamProvisioningServiceComposition';
+import {
+  enableStandaloneOpenCodeRuntimeAdapterBoundary,
+  STANDALONE_OPENCODE_RUNTIME_ADAPTER_UNAVAILABLE_ERROR_NAME,
+} from '../TeamProvisioningStandaloneOpenCodeBoundary';
 
 const { cleanupStaleAnthropicTeamApiKeyHelpersMock } = vi.hoisted(() => ({
   cleanupStaleAnthropicTeamApiKeyHelpersMock: vi.fn(async () => undefined),
@@ -96,6 +100,58 @@ describe('TeamProvisioningServiceComposition', () => {
       alreadyLaunching: true,
     });
     expect(onProgress).not.toHaveBeenCalled();
+  });
+
+  it('rejects standalone OpenCode create and launch requests before admission', async () => {
+    const service = new TeamProvisioningService();
+    enableStandaloneOpenCodeRuntimeAdapterBoundary(service);
+    const onProgress = vi.fn();
+    const createRequest = {
+      teamName: 'alpha',
+      cwd: '/repo',
+      providerId: 'opencode',
+      members: [{ name: 'Lead', providerId: 'opencode' }],
+    } as CreateTeamRequestInput;
+    const launchRequest = {
+      teamName: 'alpha',
+      cwd: '/repo',
+      providerId: 'opencode',
+    } as LaunchTeamRequestInput;
+
+    await expect(service.createTeam(createRequest, onProgress)).rejects.toMatchObject({
+      name: STANDALONE_OPENCODE_RUNTIME_ADAPTER_UNAVAILABLE_ERROR_NAME,
+      statusCode: 501,
+    });
+    await expect(service.launchTeam(launchRequest, onProgress)).rejects.toMatchObject({
+      name: STANDALONE_OPENCODE_RUNTIME_ADAPTER_UNAVAILABLE_ERROR_NAME,
+      statusCode: 501,
+    });
+    expect(onProgress).not.toHaveBeenCalled();
+  });
+
+  it('does not change non-OpenCode admission behavior when standalone boundary is enabled', async () => {
+    const service = new TeamProvisioningService();
+    enableStandaloneOpenCodeRuntimeAdapterBoundary(service);
+    const onProgress = vi.fn();
+    const existingRunId = 'existing-run';
+    const provisioningRunByTeam = Reflect.get(service, 'provisioningRunByTeam') as Map<
+      string,
+      string
+    >;
+    const runs = Reflect.get(service, 'runs') as Map<string, object>;
+    provisioningRunByTeam.set('alpha', existingRunId);
+    runs.set(existingRunId, {});
+
+    await expect(
+      service.launchTeam(
+        { teamName: 'alpha', cwd: '/repo', providerId: 'codex' } as LaunchTeamRequestInput,
+        onProgress
+      )
+    ).resolves.toEqual({
+      runId: existingRunId,
+      launchStatus: 'already_launching',
+      alreadyLaunching: true,
+    });
   });
 
   it('runs the production runtime-control closure and validates its ingress payload', async () => {

--- a/src/main/standalone.ts
+++ b/src/main/standalone.ts
@@ -6,7 +6,7 @@
  * static files over HTTP.
  *
  * Environment variables:
- * - HOST: Bind address (default '0.0.0.0')
+ * - HOST: Bind address (default '127.0.0.1'; non-loopback requires AGENT_TEAMS_HTTP_AUTH_TOKEN)
  * - PORT: Listen port (default 3456)
  * - CLAUDE_ROOT: Path to .claude directory (default ~/.claude)
  * - CORS_ORIGIN: CORS origin policy (default '*')
@@ -44,7 +44,7 @@ const logger = createLogger('Standalone');
 // Configuration
 // =============================================================================
 
-const HOST = process.env.HOST ?? '0.0.0.0';
+const HOST = process.env.HOST ?? '127.0.0.1';
 const PORT = parseInt(process.env.PORT ?? '3456', 10);
 const CLAUDE_ROOT = process.env.CLAUDE_ROOT;
 

--- a/src/main/standalone.ts
+++ b/src/main/standalone.ts
@@ -24,6 +24,7 @@ import {
 import { createLogger } from '@shared/utils/logger';
 
 import { LocalFileSystemProvider } from './services/infrastructure/LocalFileSystemProvider';
+import { buildTeamControlApiBaseUrl } from './services/team/TeamControlApiState';
 import {
   getProjectsBasePath,
   getTodosBasePath,
@@ -99,6 +100,14 @@ let standaloneTeamServices: StandaloneTeamServices | null = null;
 // Lifecycle
 // =============================================================================
 
+function getStandaloneTeamControlApiBaseUrl(): string | null {
+  if (!httpServer?.isRunning()) {
+    return null;
+  }
+
+  return buildTeamControlApiBaseUrl(httpServer.getPort(), HOST);
+}
+
 async function start(): Promise<void> {
   logger.info('Starting standalone server...');
 
@@ -148,7 +157,9 @@ async function start(): Promise<void> {
     getLocalContext: () => localContext,
     logger: createLogger('Feature:RecentProjects'),
   });
-  standaloneTeamServices = createStandaloneTeamServices();
+  standaloneTeamServices = createStandaloneTeamServices({
+    controlApiBaseUrlResolver: async () => getStandaloneTeamControlApiBaseUrl(),
+  });
   const runtimeCoreFeature = createRuntimeCoreFeature({
     providerJsonParsing: createRuntimeCoreProviderJsonParsingServices(localContext),
     teams: standaloneTeamServices.runtimeCoreTeamSources,
@@ -201,6 +212,9 @@ async function start(): Promise<void> {
 async function shutdown(): Promise<void> {
   logger.info('Shutting down...');
 
+  await standaloneTeamServices?.dispose();
+  standaloneTeamServices = null;
+
   if (httpServer?.isRunning()) {
     await httpServer.stop();
   }
@@ -208,9 +222,6 @@ async function shutdown(): Promise<void> {
   if (localContext) {
     localContext.dispose();
   }
-
-  await standaloneTeamServices?.dispose();
-  standaloneTeamServices = null;
 
   logger.info('Shutdown complete');
   process.exit(0);

--- a/src/main/standalone.ts
+++ b/src/main/standalone.ts
@@ -17,6 +17,10 @@
 // error tracking can be added later with @sentry/node if needed.
 
 import { createRecentProjectsFeature } from '@features/recent-projects/main';
+import {
+  createRuntimeCoreFeature,
+  createRuntimeCoreProviderJsonParsingServices,
+} from '@features/runtime-core/main';
 import { createLogger } from '@shared/utils/logger';
 
 import { LocalFileSystemProvider } from './services/infrastructure/LocalFileSystemProvider';
@@ -32,6 +36,7 @@ import type { NotificationManager } from './services/infrastructure/Notification
 import type { ServiceContext } from './services/infrastructure/ServiceContext';
 import type { SshConnectionManager } from './services/infrastructure/SshConnectionManager';
 import type { UpdaterService } from './services/infrastructure/UpdaterService';
+import type { StandaloneTeamServices } from './standaloneTeamServices';
 
 const logger = createLogger('Standalone');
 
@@ -88,6 +93,7 @@ const sshConnectionManagerStub = {
 let localContext: ServiceContext;
 let notificationManager: NotificationManager;
 let httpServer: HttpServer;
+let standaloneTeamServices: StandaloneTeamServices | null = null;
 
 // =============================================================================
 // Lifecycle
@@ -103,10 +109,16 @@ async function start(): Promise<void> {
   }
 
   // Import services after applying CLAUDE_ROOT so ConfigManager picks up the correct base path.
-  const [{ HttpServer }, { NotificationManager }, { ServiceContext }] = await Promise.all([
+  const [
+    { HttpServer },
+    { NotificationManager },
+    { ServiceContext },
+    { attachStandaloneTeamHttpServices, createStandaloneTeamServices },
+  ] = await Promise.all([
     import('./services/infrastructure/HttpServer'),
     import('./services/infrastructure/NotificationManager'),
     import('./services/infrastructure/ServiceContext'),
+    import('./standaloneTeamServices'),
   ]);
 
   const projectsDir = getProjectsBasePath();
@@ -136,6 +148,11 @@ async function start(): Promise<void> {
     getLocalContext: () => localContext,
     logger: createLogger('Feature:RecentProjects'),
   });
+  standaloneTeamServices = createStandaloneTeamServices();
+  const runtimeCoreFeature = createRuntimeCoreFeature({
+    providerJsonParsing: createRuntimeCoreProviderJsonParsingServices(localContext),
+    teams: standaloneTeamServices.runtimeCoreTeamSources,
+  });
 
   // Wire file watcher events to SSE broadcast
   localContext.fileWatcher.on('file-change', (event: unknown) => {
@@ -157,16 +174,20 @@ async function start(): Promise<void> {
   });
 
   // Build services for HTTP routes
-  const services: HttpServices = {
-    projectScanner: localContext.projectScanner,
-    sessionParser: localContext.sessionParser,
-    subagentResolver: localContext.subagentResolver,
-    chunkBuilder: localContext.chunkBuilder,
-    dataCache: localContext.dataCache,
-    recentProjectsFeature,
-    updaterService: updaterServiceStub,
-    sshConnectionManager: sshConnectionManagerStub,
-  };
+  const services: HttpServices = attachStandaloneTeamHttpServices(
+    {
+      projectScanner: localContext.projectScanner,
+      sessionParser: localContext.sessionParser,
+      subagentResolver: localContext.subagentResolver,
+      chunkBuilder: localContext.chunkBuilder,
+      dataCache: localContext.dataCache,
+      recentProjectsFeature,
+      runtimeCore: runtimeCoreFeature,
+      updaterService: updaterServiceStub,
+      sshConnectionManager: sshConnectionManagerStub,
+    },
+    standaloneTeamServices
+  );
 
   // No-op mode switch handler (no SSH in standalone)
   const modeSwitchHandler = async (): Promise<void> => {};
@@ -187,6 +208,9 @@ async function shutdown(): Promise<void> {
   if (localContext) {
     localContext.dispose();
   }
+
+  await standaloneTeamServices?.dispose();
+  standaloneTeamServices = null;
 
   logger.info('Shutdown complete');
   process.exit(0);

--- a/src/main/standaloneTeamServices.ts
+++ b/src/main/standaloneTeamServices.ts
@@ -5,6 +5,7 @@ import {
   bindTeamHttpDataApi,
   bindTeamHttpHandlerApis,
 } from './services/team/contracts/TeamProvisioningApis';
+import { enableStandaloneOpenCodeRuntimeAdapterBoundary } from './services/team/provisioning/TeamProvisioningStandaloneOpenCodeBoundary';
 import { TeamConfigReader } from './services/team/TeamConfigReader';
 import { TeamDataService } from './services/team/TeamDataService';
 import { TeamKanbanManager } from './services/team/TeamKanbanManager';
@@ -114,6 +115,7 @@ export function createStandaloneTeamServices(
 ): StandaloneTeamServices {
   const teamDataService = new TeamDataService();
   const teamProvisioningService = new TeamProvisioningService();
+  enableStandaloneOpenCodeRuntimeAdapterBoundary(teamProvisioningService);
   const memberWorkSyncFeature = createMemberWorkSyncFeature({
     teamsBasePath: getTeamsBasePath(),
     configReader: new TeamConfigReader(),

--- a/src/main/standaloneTeamServices.ts
+++ b/src/main/standaloneTeamServices.ts
@@ -1,0 +1,141 @@
+import { createMemberWorkSyncFeature } from '@features/member-work-sync/main';
+import { createLogger } from '@shared/utils/logger';
+
+import {
+  bindTeamHttpDataApi,
+  bindTeamHttpHandlerApis,
+} from './services/team/contracts/TeamProvisioningApis';
+import { TeamConfigReader } from './services/team/TeamConfigReader';
+import { TeamDataService } from './services/team/TeamDataService';
+import { TeamKanbanManager } from './services/team/TeamKanbanManager';
+import { TeamMembersMetaStore } from './services/team/TeamMembersMetaStore';
+import { TeamProvisioningService } from './services/team/TeamProvisioningService';
+import { TeamTaskReader } from './services/team/TeamTaskReader';
+import { getTeamsBasePath } from './utils/pathDecoder';
+
+import type { HttpServices } from './http';
+import type {
+  TeamHttpDataApi,
+  TeamHttpHandlerApis,
+  TeamHttpRuntimeApi,
+  TeamProvisioningStartApi,
+  TeamProvisioningStatusApi,
+  TeamRuntimeControlCompatibilityApi,
+  TeamTaskActivityRepairApi,
+} from './services/team/contracts/TeamProvisioningApis';
+import type { MemberWorkSyncFeatureFacade } from '@features/member-work-sync/main';
+import type {
+  RuntimeCoreTeamOrchestrationSource,
+  RuntimeCoreTeamSources,
+} from '@features/runtime-core/main';
+
+export type StandaloneTeamProvisioningHttpApi = TeamProvisioningStartApi &
+  TeamProvisioningStatusApi &
+  TeamTaskActivityRepairApi &
+  TeamHttpRuntimeApi &
+  TeamRuntimeControlCompatibilityApi;
+
+export interface StandaloneTeamHttpServiceSlice {
+  teamDataApi: TeamHttpDataApi;
+  teamApis: TeamHttpHandlerApis;
+  memberWorkSyncFeature: MemberWorkSyncFeatureFacade;
+}
+
+export interface StandaloneTeamServices {
+  teamDataService: TeamDataService;
+  teamProvisioningService: TeamProvisioningService;
+  memberWorkSyncFeature: MemberWorkSyncFeatureFacade;
+  httpServices: StandaloneTeamHttpServiceSlice;
+  runtimeCoreTeamSources: RuntimeCoreTeamSources;
+  dispose(): Promise<void>;
+}
+
+export function buildStandaloneTeamHttpServiceSlice(input: {
+  teamDataService: TeamHttpDataApi;
+  teamProvisioningService: StandaloneTeamProvisioningHttpApi;
+  memberWorkSyncFeature: MemberWorkSyncFeatureFacade;
+}): StandaloneTeamHttpServiceSlice {
+  return {
+    teamDataApi: bindTeamHttpDataApi(input.teamDataService),
+    teamApis: bindTeamHttpHandlerApis(input.teamProvisioningService),
+    memberWorkSyncFeature: input.memberWorkSyncFeature,
+  };
+}
+
+export function createStandaloneRuntimeCoreTeamSources(input: {
+  teamDataService: TeamHttpDataApi;
+  teamProvisioningService: RuntimeCoreTeamOrchestrationSource;
+}): RuntimeCoreTeamSources {
+  return {
+    data: input.teamDataService,
+    orchestration: input.teamProvisioningService,
+  };
+}
+
+export function createStandaloneTeamServices(): StandaloneTeamServices {
+  const teamDataService = new TeamDataService();
+  const teamProvisioningService = new TeamProvisioningService();
+  const memberWorkSyncFeature = createMemberWorkSyncFeature({
+    teamsBasePath: getTeamsBasePath(),
+    configReader: new TeamConfigReader(),
+    taskReader: new TeamTaskReader(),
+    kanbanManager: new TeamKanbanManager(),
+    membersMetaStore: new TeamMembersMetaStore(),
+    isTeamActive: (teamName) => teamProvisioningService.isTeamAlive(teamName),
+    isMemberActive: ({ teamName }) => teamProvisioningService.isTeamAlive(teamName),
+    canDispatchNudges: (teamName) => teamProvisioningService.isTeamAlive(teamName),
+    listLifecycleActiveTeamNames: async () =>
+      (await teamDataService.listTeams())
+        .map((team) => team.teamName)
+        .filter((teamName) => teamProvisioningService.isTeamAlive(teamName)),
+    logger: createLogger('Feature:MemberWorkSync'),
+  });
+
+  teamProvisioningService.setRuntimeTurnSettledHookSettingsProvider((input) =>
+    memberWorkSyncFeature.buildRuntimeTurnSettledHookSettings(input)
+  );
+  teamProvisioningService.setRuntimeTurnSettledEnvironmentProvider((input) =>
+    memberWorkSyncFeature.buildRuntimeTurnSettledEnvironment(input)
+  );
+  teamProvisioningService.setMemberWorkSyncProofMissingRecoveryScheduler((input) =>
+    memberWorkSyncFeature.scheduleProofMissingRecovery(input)
+  );
+  teamProvisioningService.setMemberWorkSyncAcceptedReportChecker(async (input) => {
+    const status = await memberWorkSyncFeature.getStatus(input);
+    const report = status.report;
+    if (report?.accepted !== true || report.agendaFingerprint !== status.agenda.fingerprint) {
+      return false;
+    }
+    if (report.state !== 'still_working' && report.state !== 'blocked') {
+      return true;
+    }
+    const expiresAtMs = Date.parse(report.expiresAt ?? '');
+    return Number.isFinite(expiresAtMs) && expiresAtMs > Date.now();
+  });
+
+  return {
+    teamDataService,
+    teamProvisioningService,
+    memberWorkSyncFeature,
+    httpServices: buildStandaloneTeamHttpServiceSlice({
+      teamDataService,
+      teamProvisioningService,
+      memberWorkSyncFeature,
+    }),
+    runtimeCoreTeamSources: createStandaloneRuntimeCoreTeamSources({
+      teamDataService,
+      teamProvisioningService,
+    }),
+    dispose: () => memberWorkSyncFeature.dispose(),
+  };
+}
+
+export function attachStandaloneTeamHttpServices(
+  services: HttpServices,
+  standaloneTeamServices: Pick<StandaloneTeamServices, 'httpServices'>
+): HttpServices {
+  return {
+    ...services,
+    ...standaloneTeamServices.httpServices,
+  };
+}

--- a/src/main/standaloneTeamServices.ts
+++ b/src/main/standaloneTeamServices.ts
@@ -50,6 +50,8 @@ export interface StandaloneTeamServices {
   dispose(): Promise<void>;
 }
 
+type StandaloneControlApiBaseUrlResolver = () => Promise<string | null>;
+
 export function buildStandaloneTeamHttpServiceSlice(input: {
   teamDataService: TeamHttpDataApi;
   teamProvisioningService: StandaloneTeamProvisioningHttpApi;
@@ -72,7 +74,44 @@ export function createStandaloneRuntimeCoreTeamSources(input: {
   };
 }
 
-export function createStandaloneTeamServices(): StandaloneTeamServices {
+export function buildStandaloneTeamServices(input: {
+  teamDataService: TeamDataService;
+  teamProvisioningService: TeamProvisioningService;
+  memberWorkSyncFeature: MemberWorkSyncFeatureFacade;
+  controlApiBaseUrlResolver?: StandaloneControlApiBaseUrlResolver;
+}): StandaloneTeamServices {
+  if (input.controlApiBaseUrlResolver) {
+    input.teamProvisioningService.setControlApiBaseUrlResolver(input.controlApiBaseUrlResolver);
+  }
+
+  return {
+    teamDataService: input.teamDataService,
+    teamProvisioningService: input.teamProvisioningService,
+    memberWorkSyncFeature: input.memberWorkSyncFeature,
+    httpServices: buildStandaloneTeamHttpServiceSlice({
+      teamDataService: input.teamDataService,
+      teamProvisioningService: input.teamProvisioningService,
+      memberWorkSyncFeature: input.memberWorkSyncFeature,
+    }),
+    runtimeCoreTeamSources: createStandaloneRuntimeCoreTeamSources({
+      teamDataService: input.teamDataService,
+      teamProvisioningService: input.teamProvisioningService,
+    }),
+    dispose: async () => {
+      try {
+        await input.teamProvisioningService.stopAllTeams();
+      } finally {
+        await input.memberWorkSyncFeature.dispose();
+      }
+    },
+  };
+}
+
+export function createStandaloneTeamServices(
+  input: {
+    controlApiBaseUrlResolver?: StandaloneControlApiBaseUrlResolver;
+  } = {}
+): StandaloneTeamServices {
   const teamDataService = new TeamDataService();
   const teamProvisioningService = new TeamProvisioningService();
   const memberWorkSyncFeature = createMemberWorkSyncFeature({
@@ -88,6 +127,7 @@ export function createStandaloneTeamServices(): StandaloneTeamServices {
       (await teamDataService.listTeams())
         .map((team) => team.teamName)
         .filter((teamName) => teamProvisioningService.isTeamAlive(teamName)),
+    resolveControlUrl: input.controlApiBaseUrlResolver,
     logger: createLogger('Feature:MemberWorkSync'),
   });
 
@@ -113,21 +153,12 @@ export function createStandaloneTeamServices(): StandaloneTeamServices {
     return Number.isFinite(expiresAtMs) && expiresAtMs > Date.now();
   });
 
-  return {
+  return buildStandaloneTeamServices({
     teamDataService,
     teamProvisioningService,
     memberWorkSyncFeature,
-    httpServices: buildStandaloneTeamHttpServiceSlice({
-      teamDataService,
-      teamProvisioningService,
-      memberWorkSyncFeature,
-    }),
-    runtimeCoreTeamSources: createStandaloneRuntimeCoreTeamSources({
-      teamDataService,
-      teamProvisioningService,
-    }),
-    dispose: () => memberWorkSyncFeature.dispose(),
-  };
+    controlApiBaseUrlResolver: input.controlApiBaseUrlResolver,
+  });
 }
 
 export function attachStandaloneTeamHttpServices(

--- a/src/renderer/api/httpClient.ts
+++ b/src/renderer/api/httpClient.ts
@@ -7,6 +7,10 @@
  */
 
 import {
+  createHostedWebTransportClient,
+  type HostedWebTransportClient,
+} from '@features/hosted-web-transport/renderer';
+import {
   createEmptyMemberLogPreviewResponse,
   createEmptyMemberLogStreamResponse,
   createEmptyMemberRuntimeLogTailResponse,
@@ -47,6 +51,17 @@ import type {
   CodexStartChatgptLoginOptions,
 } from '@features/codex-account/contracts';
 import type { CodexRuntimeAPI } from '@features/codex-runtime-installer/contracts';
+import type {
+  HostedWebKanbanColumn,
+  HostedWebLaunchMemberRequest,
+  HostedWebLaunchTeamRequest,
+  HostedWebProvisioningStatusResponse,
+  HostedWebTaskSummary,
+  HostedWebTeamMemberSummary,
+  HostedWebTeamSnapshotResponse,
+  HostedWebTeamSummary,
+  HostedWebWorkspaceRef,
+} from '@features/hosted-web-transport/contracts';
 import type { MemberLogStreamApi } from '@features/member-log-stream/contracts';
 import type { DashboardRecentProjectsPayload } from '@features/recent-projects/contracts';
 import type { RuntimeProviderManagementApi } from '@features/runtime-provider-management/contracts';
@@ -75,6 +90,7 @@ import type {
   HttpServerAPI,
   HttpServerStatus,
   KanbanColumnId,
+  KanbanState,
   NotificationsAPI,
   NotificationTrigger,
   OpenCodeRuntimeAPI,
@@ -104,18 +120,22 @@ import type {
   TeamChangeEvent,
   TeamClaudeLogsQuery,
   TeamClaudeLogsResponse,
+  TeamConfig,
   TeamCreateRequest,
   TeamCreateResponse,
   TeamGetDataOptions,
   TeamLaunchFailureDiagnosticsBundle,
   TeamLaunchRequest,
   TeamLaunchResponse,
+  TeamMember,
   TeamMemberActivityMeta,
+  TeamMemberSnapshot,
   TeamProvisioningModelVerificationMode,
   TeamProvisioningPrepareResult,
   TeamProvisioningProgress,
   TeamsAPI,
   TeamSummary,
+  TeamSummaryMember,
   TeamTask,
   TeamTaskChangeSummariesResponse,
   TeamTaskChangeSummaryRequest,
@@ -155,8 +175,252 @@ function buildTokenUsageSnapshotRoute(request?: TokenUsageSnapshotRequest): stri
   return suffix ? `${TOKEN_USAGE_SNAPSHOT_ROUTE}?${suffix}` : TOKEN_USAGE_SNAPSHOT_ROUTE;
 }
 
+function mapHostedTeamSummary(team: HostedWebTeamSummary): TeamSummary {
+  const members = team.members.map(mapHostedTeamSummaryMember);
+  const lead = members[0];
+  return {
+    teamName: team.teamId,
+    displayName: team.displayName,
+    description: team.description,
+    ...(team.color !== undefined ? { color: team.color } : {}),
+    memberCount: members.length,
+    members,
+    ...(lead ? { leadName: lead.name, ...(lead.color ? { leadColor: lead.color } : {}) } : {}),
+    taskCount: team.taskCount,
+    lastActivity: team.lastActivity,
+    ...(team.project?.workspaceRef.id ? { projectPath: team.project.workspaceRef.id } : {}),
+    ...(team.pendingCreate !== undefined ? { pendingCreate: team.pendingCreate } : {}),
+    ...(team.partialLaunchFailure !== undefined
+      ? { partialLaunchFailure: team.partialLaunchFailure }
+      : {}),
+  };
+}
+
+function mapHostedTeamSummaryMember(member: HostedWebTeamMemberSummary): TeamSummaryMember {
+  return {
+    name: member.displayName,
+    agentId: member.memberId,
+    ...(member.role !== undefined ? { role: member.role } : {}),
+    ...(member.color !== undefined ? { color: member.color } : {}),
+  };
+}
+
+function mapHostedTeamSnapshot(snapshot: HostedWebTeamSnapshotResponse): TeamViewSnapshot {
+  const taskById = new Map(snapshot.tasks.map((task) => [task.taskId, task]));
+  const kanbanColumnByTaskId = new Map<string, 'review' | 'approved'>();
+  const columnOrder: KanbanState['columnOrder'] = {};
+  const kanbanTasks: KanbanState['tasks'] = {};
+
+  for (const column of snapshot.kanban) {
+    const columnId = mapHostedKanbanColumnId(column.status);
+    if (columnId) {
+      columnOrder[columnId] = column.taskIds;
+    }
+    if (column.status === 'review' || column.status === 'approved') {
+      for (const taskId of column.taskIds) {
+        kanbanColumnByTaskId.set(taskId, column.status);
+        const task = taskById.get(taskId);
+        kanbanTasks[taskId] = {
+          column: column.status,
+          movedAt: task?.updatedAt ?? task?.createdAt ?? new Date(0).toISOString(),
+        };
+      }
+    }
+  }
+
+  return {
+    teamName: snapshot.team.teamId,
+    config: mapHostedTeamConfig(snapshot.team),
+    tasks: snapshot.tasks.map((task) => mapHostedTask(task, kanbanColumnByTaskId.get(task.taskId))),
+    members: snapshot.team.members.map(mapHostedMemberSnapshot),
+    kanbanState: {
+      teamName: snapshot.team.teamId,
+      reviewers: [],
+      tasks: kanbanTasks,
+      columnOrder,
+    },
+    processes: [],
+    isAlive: snapshot.team.runtime.isAlive,
+  };
+}
+
+function mapHostedKanbanColumnId(
+  status: HostedWebKanbanColumn['status']
+): KanbanColumnId | undefined {
+  switch (status) {
+    case 'pending':
+      return 'todo';
+    case 'in_progress':
+      return 'in_progress';
+    case 'completed':
+      return 'done';
+    case 'review':
+    case 'approved':
+      return status;
+    case 'deleted':
+      return undefined;
+  }
+}
+
+function mapHostedTeamConfig(team: HostedWebTeamSummary): TeamConfig {
+  return {
+    name: team.displayName,
+    description: team.description,
+    ...(team.color !== undefined ? { color: team.color } : {}),
+    members: team.members.map(mapHostedTeamMember),
+    ...(team.project?.workspaceRef.id ? { projectPath: team.project.workspaceRef.id } : {}),
+  };
+}
+
+function mapHostedTeamMember(member: HostedWebTeamMemberSummary): TeamMember {
+  return {
+    name: member.displayName,
+    agentId: member.memberId,
+    ...(member.role !== undefined ? { role: member.role } : {}),
+    ...(member.color !== undefined ? { color: member.color } : {}),
+    ...(member.provider?.providerId !== undefined
+      ? { providerId: member.provider.providerId }
+      : {}),
+    ...(member.provider?.modelId !== undefined ? { model: member.provider.modelId } : {}),
+    ...(member.provider?.effort !== undefined ? { effort: member.provider.effort } : {}),
+    ...(member.provider?.fastMode !== undefined ? { fastMode: member.provider.fastMode } : {}),
+    ...(member.isolation === 'managed-worktree' ? { isolation: 'worktree' as const } : {}),
+  };
+}
+
+function mapHostedMemberSnapshot(member: HostedWebTeamMemberSummary): TeamMemberSnapshot {
+  return {
+    name: member.displayName,
+    agentId: member.memberId,
+    currentTaskId: member.currentTaskId,
+    taskCount: member.taskCount,
+    ...(member.color !== undefined ? { color: member.color } : {}),
+    ...(member.role !== undefined ? { role: member.role } : {}),
+    ...(member.provider?.providerId !== undefined
+      ? { providerId: member.provider.providerId }
+      : {}),
+    ...(member.provider?.modelId !== undefined ? { model: member.provider.modelId } : {}),
+    ...(member.provider?.effort !== undefined ? { effort: member.provider.effort } : {}),
+    ...(member.provider?.fastMode !== undefined
+      ? { selectedFastMode: member.provider.fastMode }
+      : {}),
+    ...(member.isolation === 'managed-worktree' ? { isolation: 'worktree' as const } : {}),
+  };
+}
+
+function mapHostedTask(
+  task: HostedWebTaskSummary,
+  kanbanColumn: 'review' | 'approved' | undefined
+): TeamTaskWithKanban {
+  return {
+    id: task.taskId,
+    ...(task.displayId !== undefined ? { displayId: task.displayId } : {}),
+    subject: task.subject,
+    status: task.status,
+    ...(task.ownerMemberId !== undefined ? { owner: task.ownerMemberId } : {}),
+    ...(task.reviewState !== undefined ? { reviewState: task.reviewState } : {}),
+    ...(task.blockedBy !== undefined ? { blockedBy: task.blockedBy } : {}),
+    ...(task.related !== undefined ? { related: task.related } : {}),
+    ...(task.createdAt !== undefined ? { createdAt: task.createdAt } : {}),
+    ...(task.updatedAt !== undefined ? { updatedAt: task.updatedAt } : {}),
+    ...(task.needsClarification !== undefined
+      ? { needsClarification: task.needsClarification }
+      : {}),
+    ...(kanbanColumn !== undefined ? { kanbanColumn } : {}),
+  };
+}
+
+function mapHostedLaunchResponse(response: {
+  runId: string;
+  launchStatus?: TeamLaunchResponse['launchStatus'];
+}): TeamLaunchResponse {
+  return {
+    runId: response.runId,
+    ...(response.launchStatus !== undefined ? { launchStatus: response.launchStatus } : {}),
+    ...(response.launchStatus === 'already_launching' ? { alreadyLaunching: true } : {}),
+    ...(response.launchStatus === 'already_running' ? { alreadyRunning: true } : {}),
+  };
+}
+
+function mapHostedProvisioningStatus(
+  response: HostedWebProvisioningStatusResponse
+): TeamProvisioningProgress {
+  return {
+    runId: response.runId,
+    teamName: response.teamId,
+    state: response.state,
+    message: response.message,
+    startedAt: response.startedAt,
+    updatedAt: response.updatedAt,
+    ...(response.error !== undefined ? { error: response.error } : {}),
+    ...(response.warnings !== undefined ? { warnings: response.warnings } : {}),
+  };
+}
+
+function mapTeamCreateRequestToHosted(request: TeamCreateRequest): HostedWebLaunchTeamRequest {
+  const provider = mapHostedProviderSelection(request);
+  return {
+    workspaceRef: workspaceRefFromCwd(request.cwd),
+    ...(request.prompt !== undefined ? { prompt: request.prompt } : {}),
+    ...(provider ? { provider } : {}),
+    members: request.members.map(mapHostedLaunchMemberRequest),
+    ...(request.limitContext !== undefined ? { limitContext: request.limitContext } : {}),
+    ...(request.skipPermissions === false ? { requireManualApproval: true } : {}),
+  };
+}
+
+function mapTeamLaunchRequestToHosted(request: TeamLaunchRequest): HostedWebLaunchTeamRequest {
+  const provider = mapHostedProviderSelection(request);
+  return {
+    workspaceRef: workspaceRefFromCwd(request.cwd),
+    ...(request.prompt !== undefined ? { prompt: request.prompt } : {}),
+    ...(provider ? { provider } : {}),
+    ...(request.limitContext !== undefined ? { limitContext: request.limitContext } : {}),
+    ...(request.skipPermissions === false ? { requireManualApproval: true } : {}),
+  };
+}
+
+function mapHostedLaunchMemberRequest(
+  member: TeamCreateRequest['members'][number]
+): HostedWebLaunchMemberRequest {
+  const provider = mapHostedProviderSelection(member);
+  return {
+    displayName: member.name,
+    ...(member.role !== undefined ? { role: member.role } : {}),
+    ...(member.workflow !== undefined ? { workflow: member.workflow } : {}),
+    ...(member.isolation === 'worktree'
+      ? { isolation: 'managed-worktree' as const }
+      : { isolation: 'shared-workspace' as const }),
+    ...(provider ? { provider } : {}),
+  };
+}
+
+function mapHostedProviderSelection(
+  input: Pick<TeamCreateRequest, 'providerId' | 'model' | 'effort' | 'fastMode'>
+): HostedWebLaunchTeamRequest['provider'] | undefined {
+  if (!input.providerId) {
+    return undefined;
+  }
+  return {
+    providerId: input.providerId,
+    ...(input.model !== undefined ? { modelId: input.model } : {}),
+    ...(input.effort !== undefined ? { effort: input.effort } : {}),
+    ...(input.fastMode !== undefined ? { fastMode: input.fastMode } : {}),
+  };
+}
+
+function workspaceRefFromCwd(cwd: string): HostedWebWorkspaceRef {
+  const trimmed = cwd.trim();
+  const pathParts = trimmed.split(/[\\/]/).filter(Boolean);
+  return {
+    id: trimmed,
+    displayName: pathParts[pathParts.length - 1] ?? trimmed,
+  };
+}
+
 export class HttpAPIClient implements ElectronAPI {
   private baseUrl: string;
+  private hostedWebTransport: HostedWebTransportClient;
   private eventSource: EventSource | null = null;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- event callbacks have varying signatures
   private eventListeners = new Map<string, Set<(...args: any[]) => void>>();
@@ -166,6 +430,7 @@ export class HttpAPIClient implements ElectronAPI {
 
   constructor(baseUrl: string) {
     this.baseUrl = baseUrl;
+    this.hostedWebTransport = createHostedWebTransportClient({ baseUrl });
     this.initEventSource();
   }
 
@@ -886,14 +1151,11 @@ export class HttpAPIClient implements ElectronAPI {
 
   teams: TeamsAPI = {
     list: async (): Promise<TeamSummary[]> => {
-      console.warn('[HttpAPIClient] teams API is not available in browser mode');
-      return [];
+      const response = await this.hostedWebTransport.listTeams();
+      return response.teams.map(mapHostedTeamSummary);
     },
-    getData: async (
-      _teamName: string,
-      _options?: TeamGetDataOptions
-    ): Promise<TeamViewSnapshot> => {
-      throw new Error('Teams detail is not available in browser mode');
+    getData: async (teamName: string, _options?: TeamGetDataOptions): Promise<TeamViewSnapshot> => {
+      return mapHostedTeamSnapshot(await this.hostedWebTransport.getTeamSnapshot(teamName));
     },
     getTaskChangePresence: async (): Promise<
       Record<string, 'has_changes' | 'no_changes' | 'unknown'>
@@ -958,14 +1220,26 @@ export class HttpAPIClient implements ElectronAPI {
     createInitialGitCommit: async (_projectPath: string): Promise<TeamWorktreeGitStatus> => {
       throw new Error('Initial Git commit is not available in browser mode');
     },
-    createTeam: async (_request: TeamCreateRequest): Promise<TeamCreateResponse> => {
-      throw new Error('Team provisioning is not available in browser mode');
+    createTeam: async (request: TeamCreateRequest): Promise<TeamCreateResponse> => {
+      return mapHostedLaunchResponse(
+        await this.hostedWebTransport.launchTeam(
+          request.teamName,
+          mapTeamCreateRequestToHosted(request)
+        )
+      );
     },
-    launchTeam: async (_request: TeamLaunchRequest): Promise<TeamLaunchResponse> => {
-      throw new Error('Team launch is not available in browser mode');
+    launchTeam: async (request: TeamLaunchRequest): Promise<TeamLaunchResponse> => {
+      return mapHostedLaunchResponse(
+        await this.hostedWebTransport.launchTeam(
+          request.teamName,
+          mapTeamLaunchRequestToHosted(request)
+        )
+      );
     },
-    getProvisioningStatus: async (_runId: string): Promise<TeamProvisioningProgress> => {
-      throw new Error('Team provisioning is not available in browser mode');
+    getProvisioningStatus: async (runId: string): Promise<TeamProvisioningProgress> => {
+      return mapHostedProvisioningStatus(
+        await this.hostedWebTransport.getProvisioningStatus(runId)
+      );
     },
     getLaunchFailureDiagnostics: async (
       _teamName: string,
@@ -1055,14 +1329,14 @@ export class HttpAPIClient implements ElectronAPI {
     processSend: async (_teamName: string, _message: string): Promise<void> => {
       throw new Error('Team process communication is not available in browser mode');
     },
-    processAlive: async (_teamName: string): Promise<boolean> => {
-      return false;
+    processAlive: async (teamName: string): Promise<boolean> => {
+      return (await this.hostedWebTransport.getRuntimeState(teamName)).isAlive;
     },
     aliveList: async (): Promise<string[]> => {
-      return [];
+      return (await this.hostedWebTransport.listAliveTeams()).teamIds;
     },
-    stop: async (): Promise<void> => {
-      throw new Error('Team stop is not available in browser mode');
+    stop: async (teamName: string): Promise<void> => {
+      await this.hostedWebTransport.stopTeam(teamName);
     },
     createConfig: async (): Promise<void> => {
       throw new Error('Team config creation is not available in browser mode');

--- a/src/renderer/api/index.ts
+++ b/src/renderer/api/index.ts
@@ -16,6 +16,23 @@ import { HttpAPIClient } from './httpClient';
 
 import type { ElectronAPI } from '@shared/types/api';
 
+export type AppApi = ElectronAPI;
+
+export type AppApiRuntime = 'electron-preload' | 'hosted-web-http';
+
+export interface AppApiCapabilities {
+  runtime: AppApiRuntime;
+  electronPreload: boolean;
+  editorFileWatching: boolean;
+  nativeFilePathLookup: boolean;
+  nativeUpdater: boolean;
+  nativeWindowControls: boolean;
+}
+
+export type AppCapability = Exclude<keyof AppApiCapabilities, 'runtime'>;
+
+type WindowWithOptionalElectronApi = Window & { electronAPI?: ElectronAPI };
+
 /**
  * Resolves the base URL for the HTTP API client.
  *
@@ -34,8 +51,56 @@ function getHttpBaseUrl(): string {
 
 let httpClient: HttpAPIClient | null = null;
 
+function getElectronPreloadApi(): ElectronAPI | undefined {
+  return (window as WindowWithOptionalElectronApi).electronAPI;
+}
+
+function hasFunction(value: unknown): boolean {
+  return typeof value === 'function';
+}
+
+function getAppApiRuntime(): AppApiRuntime {
+  return getElectronPreloadApi() ? 'electron-preload' : 'hosted-web-http';
+}
+
+export function getAppCapabilities(): AppApiCapabilities {
+  const electronApi = getElectronPreloadApi();
+  const editor = electronApi?.editor as Partial<ElectronAPI['editor']> | undefined;
+  const updater = electronApi?.updater as Partial<ElectronAPI['updater']> | undefined;
+  const windowControls = electronApi?.windowControls as
+    | Partial<ElectronAPI['windowControls']>
+    | undefined;
+
+  return {
+    runtime: getAppApiRuntime(),
+    electronPreload: Boolean(electronApi),
+    editorFileWatching:
+      hasFunction(editor?.watchDir) &&
+      hasFunction(editor?.setWatchedFiles) &&
+      hasFunction(editor?.setWatchedDirs),
+    nativeFilePathLookup: hasFunction(electronApi?.getPathForFile),
+    nativeUpdater:
+      hasFunction(updater?.check) &&
+      hasFunction(updater?.download) &&
+      hasFunction(updater?.install) &&
+      hasFunction(updater?.onStatus),
+    nativeWindowControls:
+      hasFunction(windowControls?.minimize) &&
+      hasFunction(windowControls?.maximize) &&
+      hasFunction(windowControls?.close) &&
+      hasFunction(windowControls?.isMaximized) &&
+      hasFunction(windowControls?.isFullScreen) &&
+      hasFunction(windowControls?.relaunch),
+  };
+}
+
+export function supportsAppCapability(capability: AppCapability): boolean {
+  return getAppCapabilities()[capability];
+}
+
 function getImpl(): ElectronAPI {
-  if (window.electronAPI) return window.electronAPI;
+  const electronApi = getElectronPreloadApi();
+  if (electronApi) return electronApi;
   // Lazily create the HTTP client only when actually needed (browser mode).
   // Caching avoids creating multiple EventSource connections.
   if (!httpClient) {
@@ -54,9 +119,9 @@ function getImpl(): ElectronAPI {
  * Whether the app is running inside Electron (true) or in a browser via HTTP server (false).
  * Use this to hide Electron-only UI (settings, traffic lights, etc.) in browser mode.
  */
-export const isElectronMode = (): boolean => !!window.electronAPI;
+export const isElectronMode = (): boolean => getAppApiRuntime() === 'electron-preload';
 
-export const api: ElectronAPI = new Proxy({} as ElectronAPI, {
+export const api: AppApi = new Proxy({} as AppApi, {
   get(_target, prop, receiver) {
     const impl = getImpl();
     const value = Reflect.get(impl, prop, receiver) as unknown;

--- a/src/renderer/store/slices/editorSlice.ts
+++ b/src/renderer/store/slices/editorSlice.ts
@@ -7,7 +7,7 @@
  * Group 4: File operations (iter-3)
  */
 
-import { api } from '@renderer/api';
+import { api, supportsAppCapability } from '@renderer/api';
 import { getLanguageFromFileName } from '@renderer/utils/codemirrorLanguages';
 import { editorBridge } from '@renderer/utils/editorBridge';
 import { invalidateQuickOpenCache } from '@renderer/utils/quickOpenCache';
@@ -104,8 +104,7 @@ const WATCHED_DIRS_DEBOUNCE_MS = 250;
 const MAX_WATCHED_DIRS = 120;
 
 function scheduleSyncWatchedFiles(get: () => AppState): void {
-  // Editor watcher is Electron-only. In browser mode, api.editor exists but throws.
-  if (!window.electronAPI?.editor) return;
+  if (!supportsAppCapability('editorFileWatching')) return;
   const state = get();
   if (!state.editorWatcherEnabled) return;
   const projectPath = state.editorProjectPath;
@@ -120,12 +119,12 @@ function scheduleSyncWatchedFiles(get: () => AppState): void {
   if (watchedFilesSyncTimer) clearTimeout(watchedFilesSyncTimer);
   watchedFilesSyncTimer = setTimeout(() => {
     watchedFilesSyncTimer = null;
-    void window.electronAPI.editor.setWatchedFiles(filePaths);
+    void api.editor.setWatchedFiles(filePaths);
   }, 150);
 }
 
 function scheduleSyncWatchedDirs(get: () => AppState): void {
-  if (!window.electronAPI?.editor) return;
+  if (!supportsAppCapability('editorFileWatching')) return;
   const state = get();
   if (!state.editorWatcherEnabled) return;
   const projectPath = state.editorProjectPath;
@@ -146,7 +145,7 @@ function scheduleSyncWatchedDirs(get: () => AppState): void {
   if (watchedDirsSyncTimer) clearTimeout(watchedDirsSyncTimer);
   watchedDirsSyncTimer = setTimeout(() => {
     watchedDirsSyncTimer = null;
-    void window.electronAPI.editor.setWatchedDirs(dirs);
+    void api.editor.setWatchedDirs(dirs);
   }, WATCHED_DIRS_DEBOUNCE_MS);
 }
 
@@ -1190,6 +1189,10 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
   },
 
   toggleWatcher: async (enable: boolean) => {
+    if (!supportsAppCapability('editorFileWatching')) {
+      set({ editorWatcherEnabled: false });
+      return;
+    }
     try {
       await api.editor.watchDir(enable);
       set({ editorWatcherEnabled: enable });

--- a/test/architecture/runtimeCoreImportBoundary.test.ts
+++ b/test/architecture/runtimeCoreImportBoundary.test.ts
@@ -1,0 +1,39 @@
+import { readdir, readFile } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const ROOTS = ['src/renderer', 'src/preload', 'src/shared'] as const;
+const SOURCE_FILE_PATTERN = /\.(?:ts|tsx)$/;
+const FORBIDDEN_RUNTIME_CORE_MAIN_IMPORT =
+  /(?:from\s+|import\s*\()\s*['"][^'"]*(?:@features\/runtime-core\/main|features\/runtime-core\/main)(?:\/[^'"]*)?['"]/;
+
+async function collectSourceFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        return collectSourceFiles(path);
+      }
+      return SOURCE_FILE_PATTERN.test(entry.name) ? [path] : [];
+    })
+  );
+  return files.flat();
+}
+
+describe('runtime-core import boundary', () => {
+  it('keeps runtime-core/main out of renderer, preload, and shared code', async () => {
+    const files = (await Promise.all(ROOTS.map((root) => collectSourceFiles(root)))).flat();
+    const violations: string[] = [];
+
+    for (const file of files) {
+      const source = await readFile(file, 'utf8');
+      if (FORBIDDEN_RUNTIME_CORE_MAIN_IMPORT.test(source)) {
+        violations.push(relative(process.cwd(), file));
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/test/features/hosted-web-transport/contracts-boundary.test.ts
+++ b/test/features/hosted-web-transport/contracts-boundary.test.ts
@@ -1,0 +1,140 @@
+import { existsSync, readFileSync } from 'fs';
+import { dirname, extname, isAbsolute, join, normalize, relative, resolve } from 'path';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = resolve(__dirname, '../../..');
+const srcRoot = join(repoRoot, 'src');
+const contractsRoot = join(srcRoot, 'features/hosted-web-transport/contracts');
+const entrypoints = [
+  join(contractsRoot, 'index.ts'),
+  join(contractsRoot, 'http.ts'),
+  join(contractsRoot, 'events.ts'),
+  join(contractsRoot, 'primitives.ts'),
+];
+
+const forbiddenModulePatterns = [/^electron$/, /^node:electron$/];
+const forbiddenPathSegments = [
+  normalize('/src/main/'),
+  normalize('/src/preload/'),
+  normalize('/src/renderer/'),
+];
+
+describe('hosted web transport contract dependency boundary', () => {
+  it('keeps the public contract graph browser-safe and main-free', () => {
+    const visited = new Set<string>();
+    const edges: string[] = [];
+    const violations: string[] = [];
+
+    for (const entrypoint of entrypoints) {
+      walkImports(entrypoint, visited, edges, violations);
+    }
+
+    expect(violations).toEqual([]);
+    expect(edges).not.toContain(
+      'src/features/hosted-web-transport/contracts/http.ts -> @shared/types/team'
+    );
+    expect(edges).not.toContain(
+      'src/features/hosted-web-transport/contracts/events.ts -> @shared/types/team'
+    );
+  });
+});
+
+function walkImports(
+  filePath: string,
+  visited: Set<string>,
+  edges: string[],
+  violations: string[]
+): void {
+  const normalizedFilePath = normalize(filePath);
+  if (visited.has(normalizedFilePath)) {
+    return;
+  }
+  visited.add(normalizedFilePath);
+
+  const source = readFileSync(normalizedFilePath, 'utf8');
+  for (const specifier of getImportSpecifiers(source)) {
+    const edge = `${toRepoRelative(normalizedFilePath)} -> ${specifier}`;
+    edges.push(edge);
+
+    if (forbiddenModulePatterns.some((pattern) => pattern.test(specifier))) {
+      violations.push(`${edge} imports a non-browser module`);
+      continue;
+    }
+
+    const resolvedImport = resolveImport(normalizedFilePath, specifier);
+    if (!resolvedImport) {
+      continue;
+    }
+
+    if (!isContractSafePath(resolvedImport)) {
+      violations.push(`${edge} resolves to ${toRepoRelative(resolvedImport)}`);
+      continue;
+    }
+
+    walkImports(resolvedImport, visited, edges, violations);
+  }
+}
+
+function getImportSpecifiers(source: string): string[] {
+  const specifiers: string[] = [];
+  const importExportPattern =
+    /\b(?:import|export)\s+(?:type\s+)?(?:[\s\S]*?\s+from\s+)?['"]([^'"]+)['"]/g;
+
+  for (const match of source.matchAll(importExportPattern)) {
+    const specifier = match[1];
+    if (specifier) {
+      specifiers.push(specifier);
+    }
+  }
+
+  return specifiers;
+}
+
+function resolveImport(importer: string, specifier: string): string | null {
+  if (specifier.startsWith('.')) {
+    return resolveTsModule(join(dirname(importer), specifier));
+  }
+  if (specifier.startsWith('@features/')) {
+    return resolveTsModule(join(srcRoot, 'features', specifier.slice('@features/'.length)));
+  }
+  if (specifier.startsWith('@shared/')) {
+    return resolveTsModule(join(srcRoot, 'shared', specifier.slice('@shared/'.length)));
+  }
+  if (specifier.startsWith('@main/')) {
+    return resolveTsModule(join(srcRoot, 'main', specifier.slice('@main/'.length)));
+  }
+  if (specifier.startsWith('@preload/')) {
+    return resolveTsModule(join(srcRoot, 'preload', specifier.slice('@preload/'.length)));
+  }
+  if (specifier.startsWith('@renderer/')) {
+    return resolveTsModule(join(srcRoot, 'renderer', specifier.slice('@renderer/'.length)));
+  }
+  return null;
+}
+
+function resolveTsModule(modulePath: string): string | null {
+  const candidates =
+    extname(modulePath).length > 0
+      ? [modulePath]
+      : [
+          `${modulePath}.ts`,
+          `${modulePath}.tsx`,
+          `${modulePath}.mts`,
+          join(modulePath, 'index.ts'),
+          join(modulePath, 'index.tsx'),
+        ];
+
+  return candidates.find((candidate) => existsSync(candidate)) ?? null;
+}
+
+function isContractSafePath(filePath: string): boolean {
+  const normalizedFilePath = normalize(filePath);
+  if (!isAbsolute(normalizedFilePath) || !normalizedFilePath.startsWith(srcRoot)) {
+    return false;
+  }
+  return !forbiddenPathSegments.some((segment) => normalizedFilePath.includes(segment));
+}
+
+function toRepoRelative(filePath: string): string {
+  return relative(repoRoot, filePath).replaceAll('\\', '/');
+}

--- a/test/features/hosted-web-transport/contracts.test.ts
+++ b/test/features/hosted-web-transport/contracts.test.ts
@@ -111,6 +111,85 @@ describe('hosted web transport contracts', () => {
     ).toThrow(/cursor mismatch/);
   });
 
+  it('validates nested SSE team, task, and member payload fields', () => {
+    const snapshotEvent: HostedWebEvent = {
+      type: 'hosted.team.snapshot',
+      eventId: 'event-snapshot',
+      teamId: 'demo-team',
+      emittedAt: '2026-07-10T00:00:00.000Z',
+      payload: {
+        team: {
+          teamId: 'demo-team',
+          displayName: 'Demo Team',
+          description: '',
+          project: null,
+          members: [
+            {
+              memberId: 'lead',
+              displayName: 'Lead',
+              provider: { providerId: 'codex', modelId: 'gpt-5.2', effort: 'high' },
+              currentTaskId: null,
+              taskCount: 1,
+            },
+          ],
+          taskCount: 1,
+          lastActivity: null,
+          runtime: { isAlive: true, terminalAvailable: true, activeProcessCount: 1 },
+        },
+        tasks: [{ taskId: 'task-1', subject: 'Validate payloads', status: 'pending' }],
+        kanban: [{ status: 'pending', taskIds: ['task-1'] }],
+        revision: 'rev-1',
+      },
+    };
+    expect(parseHostedWebSseEvent('hosted.team.snapshot', JSON.stringify(snapshotEvent))).toEqual(
+      snapshotEvent
+    );
+
+    expect(() =>
+      parseHostedWebSseEvent(
+        'hosted.team.snapshot',
+        JSON.stringify({
+          ...snapshotEvent,
+          payload: {
+            ...snapshotEvent.payload,
+            team: {
+              ...snapshotEvent.payload.team,
+              members: [
+                {
+                  ...snapshotEvent.payload.team.members[0],
+                  provider: { providerId: 'unsafe-provider' },
+                },
+              ],
+            },
+          },
+        })
+      )
+    ).toThrow(/provider\.providerId/);
+
+    const memberMessageEvent: HostedWebEvent = {
+      type: 'hosted.member.message',
+      eventId: 'event-message',
+      teamId: 'demo-team',
+      emittedAt: '2026-07-10T00:00:00.000Z',
+      payload: {
+        messageId: 'message-1',
+        fromMemberId: 'lead',
+        summary: 'Done',
+        body: 'Task finished',
+        createdAt: '2026-07-10T00:00:00.000Z',
+      },
+    };
+    expect(() =>
+      parseHostedWebSseEvent(
+        'hosted.member.message',
+        JSON.stringify({
+          ...memberMessageEvent,
+          payload: { ...memberMessageEvent.payload, summary: 42 },
+        })
+      )
+    ).toThrow(/payload\.summary/);
+  });
+
   it('keeps hosted error payloads namespaced under /api/hosted/v1', () => {
     const namespaced = hostedWebErrorCode('not_found');
     expect(namespaced).toBe(`${HOSTED_WEB_ERROR_CODE_PREFIX}not_found`);

--- a/test/features/hosted-web-transport/contracts.test.ts
+++ b/test/features/hosted-web-transport/contracts.test.ts
@@ -1,0 +1,141 @@
+import {
+  HOSTED_WEB_ERROR_CODE_PREFIX,
+  HOSTED_WEB_LAST_EVENT_ID_HEADER,
+  HOSTED_WEB_SSE_EVENT_TYPES,
+  hostedWebErrorCode,
+  type HostedWebEvent,
+  hostedWebTeamEventsRoute,
+  hostedWebTeamRoute,
+  type HostedWebTeamSnapshotResponse,
+  parseHostedWebSseEvent,
+} from '@features/hosted-web-transport/contracts';
+import { describe, expect, it } from 'vitest';
+
+describe('hosted web transport contracts', () => {
+  it('encodes hosted v1 route identities without raw path segments', () => {
+    expect(hostedWebTeamRoute('team/slash value')).toBe(
+      '/api/hosted/v1/teams/team%2Fslash%20value'
+    );
+    expect(hostedWebTeamEventsRoute('team/slash value', { cursor: 'event 1' })).toBe(
+      '/api/hosted/v1/events?teamId=team%2Fslash+value&cursor=event+1'
+    );
+    expect(HOSTED_WEB_LAST_EVENT_ID_HEADER).toBe('Last-Event-ID');
+  });
+
+  it('models hosted snapshots with workspace ref DTOs and no backend-only provider fields', () => {
+    const snapshot: HostedWebTeamSnapshotResponse = {
+      team: {
+        teamId: 'demo-team',
+        displayName: 'Demo Team',
+        description: 'Hosted-safe team',
+        project: {
+          workspaceRef: {
+            id: 'workspace_123',
+            displayName: 'agent-teams-ai',
+            repositoryLabel: 'agent-teams-ai',
+            branchLabel: 'feature/hosted',
+          },
+        },
+        members: [
+          {
+            memberId: 'lead',
+            displayName: 'Lead',
+            currentTaskId: null,
+            taskCount: 1,
+            isolation: 'managed-worktree',
+            provider: {
+              providerId: 'codex',
+              modelId: 'gpt-5.2',
+            },
+          },
+        ],
+        taskCount: 1,
+        lastActivity: '2026-07-10T00:00:00.000Z',
+        runtime: {
+          isAlive: true,
+          terminalAvailable: true,
+          activeProcessCount: 1,
+        },
+      },
+      tasks: [
+        {
+          taskId: 'task-1',
+          subject: 'Build transport contract',
+          status: 'in_progress',
+          ownerMemberId: 'lead',
+        },
+      ],
+      kanban: [{ status: 'in_progress', taskIds: ['task-1'] }],
+      revision: 'rev-1',
+    };
+
+    const serialized = JSON.stringify(snapshot);
+    expect(serialized).toContain('"workspaceRef":{"id":"workspace_123"');
+    expect(serialized).not.toContain('/Users/');
+    expect(serialized).not.toContain('"cwd"');
+    expect(serialized).not.toContain('"providerBackendId"');
+    expect(serialized).not.toContain('"rawProviderJson"');
+  });
+
+  it('validates typed SSE envelopes, payloads, and resume cursors at runtime', () => {
+    const event: HostedWebEvent = {
+      type: 'hosted.runtime.state',
+      eventId: 'event-1',
+      teamId: 'demo-team',
+      emittedAt: '2026-07-10T00:00:00.000Z',
+      payload: {
+        isAlive: true,
+        terminalAvailable: true,
+        activeTerminalSessionIds: [],
+      },
+    };
+
+    expect(
+      parseHostedWebSseEvent('hosted.runtime.state', JSON.stringify(event), {
+        lastEventId: 'event-1',
+      })
+    ).toEqual(event);
+    expect(() => parseHostedWebSseEvent('hosted.task.changed', JSON.stringify(event))).toThrow(
+      /type mismatch/
+    );
+    expect(() =>
+      parseHostedWebSseEvent(
+        'hosted.runtime.state',
+        JSON.stringify({ ...event, payload: { isAlive: 'yes' } })
+      )
+    ).toThrow(/payload.isAlive/);
+    expect(() =>
+      parseHostedWebSseEvent('hosted.runtime.state', JSON.stringify(event), {
+        lastEventId: 'event-0',
+      })
+    ).toThrow(/cursor mismatch/);
+  });
+
+  it('keeps hosted error payloads namespaced under /api/hosted/v1', () => {
+    const namespaced = hostedWebErrorCode('not_found');
+    expect(namespaced).toBe(`${HOSTED_WEB_ERROR_CODE_PREFIX}not_found`);
+
+    const event: HostedWebEvent = {
+      type: 'hosted.error',
+      eventId: 'event-2',
+      teamId: 'demo-team',
+      emittedAt: '2026-07-10T00:00:00.000Z',
+      payload: {
+        code: namespaced,
+        message: 'Not found',
+      },
+    };
+
+    expect(parseHostedWebSseEvent('hosted.error', JSON.stringify(event))).toEqual(event);
+    expect(() =>
+      parseHostedWebSseEvent(
+        'hosted.error',
+        JSON.stringify({ ...event, payload: { code: 'not_found', message: 'Not found' } })
+      )
+    ).toThrow(/namespaced/);
+  });
+
+  it('does not define terminal byte delivery over SSE', () => {
+    expect(HOSTED_WEB_SSE_EVENT_TYPES).not.toContain('hosted.terminal.bytes');
+  });
+});

--- a/test/features/hosted-web-transport/contracts.test.ts
+++ b/test/features/hosted-web-transport/contracts.test.ts
@@ -2,11 +2,15 @@ import {
   HOSTED_WEB_ERROR_CODE_PREFIX,
   HOSTED_WEB_LAST_EVENT_ID_HEADER,
   HOSTED_WEB_SSE_EVENT_TYPES,
+  hostedWebAliveTeamsRoute,
   hostedWebErrorCode,
   type HostedWebEvent,
+  hostedWebProvisioningStatusRoute,
   hostedWebTeamEventsRoute,
   hostedWebTeamRoute,
+  hostedWebTeamRuntimeRoute,
   type HostedWebTeamSnapshotResponse,
+  hostedWebTeamStopRoute,
   parseHostedWebSseEvent,
 } from '@features/hosted-web-transport/contracts';
 import { describe, expect, it } from 'vitest';
@@ -16,6 +20,16 @@ describe('hosted web transport contracts', () => {
     expect(hostedWebTeamRoute('team/slash value')).toBe(
       '/api/hosted/v1/teams/team%2Fslash%20value'
     );
+    expect(hostedWebTeamRuntimeRoute('team/slash value')).toBe(
+      '/api/hosted/v1/teams/team%2Fslash%20value/runtime'
+    );
+    expect(hostedWebTeamStopRoute('team/slash value')).toBe(
+      '/api/hosted/v1/teams/team%2Fslash%20value/stop'
+    );
+    expect(hostedWebProvisioningStatusRoute('run/slash value')).toBe(
+      '/api/hosted/v1/teams/provisioning/run%2Fslash%20value'
+    );
+    expect(hostedWebAliveTeamsRoute()).toBe('/api/hosted/v1/teams/runtime/alive');
     expect(hostedWebTeamEventsRoute('team/slash value', { cursor: 'event 1' })).toBe(
       '/api/hosted/v1/events?teamId=team%2Fslash+value&cursor=event+1'
     );

--- a/test/features/hosted-web-transport/createHostedWebTransportClient.test.ts
+++ b/test/features/hosted-web-transport/createHostedWebTransportClient.test.ts
@@ -1,0 +1,238 @@
+import {
+  createHostedWebTransportClient,
+  type HostedWebEventSourceConstructor,
+  type HostedWebFetch,
+  type HostedWebSocketConstructor,
+  HostedWebTransportError,
+} from '@features/hosted-web-transport/renderer';
+import { describe, expect, it, vi } from 'vitest';
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+
+  readonly listeners = new Map<string, EventListener>();
+  readonly url: string;
+  closed = false;
+
+  constructor(url: string) {
+    this.url = url;
+    MockEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: EventListener): void {
+    this.listeners.set(type, listener);
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+
+  emit(type: string, data: string, lastEventId?: string): void {
+    this.listeners.get(type)?.({ type, data, lastEventId } as MessageEvent);
+  }
+}
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+
+  readonly url: string;
+  readonly protocols?: string | string[];
+
+  constructor(url: string, protocols?: string | string[]) {
+    this.url = url;
+    this.protocols = protocols;
+    MockWebSocket.instances.push(this);
+  }
+}
+
+describe('createHostedWebTransportClient', () => {
+  it('uses typed HTTP routes and workspaceRef DTOs for the high-value team workflow subset', async () => {
+    const calls: Array<{ url: string; init: Parameters<HostedWebFetch>[1] }> = [];
+    const fetchMock: HostedWebFetch = vi.fn(async (url, init) => {
+      calls.push({ url, init });
+      if (url.endsWith('/teams')) {
+        return jsonResponse({
+          teams: [],
+        });
+      }
+      if (url.endsWith('/teams/team%2F1')) {
+        return jsonResponse({
+          team: {
+            teamId: 'team/1',
+            displayName: 'Team 1',
+            description: '',
+            project: null,
+            members: [],
+            taskCount: 0,
+            lastActivity: null,
+            runtime: { isAlive: false, terminalAvailable: false, activeProcessCount: 0 },
+          },
+          tasks: [],
+          kanban: [],
+          revision: 'rev-1',
+        });
+      }
+      if (url.endsWith('/teams/team%2F1/launch')) {
+        return jsonResponse({ runId: 'run-1', launchStatus: 'started' });
+      }
+      if (url.endsWith('/teams/team%2F1/tasks')) {
+        return jsonResponse({
+          task: { taskId: 'task-1', subject: 'Ship it', status: 'pending' },
+        });
+      }
+      return jsonResponse(
+        { error: { code: '/api/hosted/v1/errors/not_found', message: 'not found' } },
+        false,
+        404
+      );
+    });
+
+    const client = createHostedWebTransportClient({
+      baseUrl: 'https://hosted.example',
+      fetch: fetchMock,
+    });
+
+    await expect(client.listTeams()).resolves.toEqual({ teams: [] });
+    await expect(client.getTeamSnapshot('team/1')).resolves.toMatchObject({ revision: 'rev-1' });
+    await expect(
+      client.launchTeam('team/1', {
+        workspaceRef: {
+          id: 'workspace_123',
+          displayName: 'agent-teams-ai',
+        },
+        provider: { providerId: 'codex', modelId: 'gpt-5.2' },
+      })
+    ).resolves.toEqual({ runId: 'run-1', launchStatus: 'started' });
+    await expect(client.createTask('team/1', { subject: 'Ship it' })).resolves.toMatchObject({
+      task: { taskId: 'task-1' },
+    });
+
+    expect(calls.map((call) => call.url)).toEqual([
+      'https://hosted.example/api/hosted/v1/teams',
+      'https://hosted.example/api/hosted/v1/teams/team%2F1',
+      'https://hosted.example/api/hosted/v1/teams/team%2F1/launch',
+      'https://hosted.example/api/hosted/v1/teams/team%2F1/tasks',
+    ]);
+    expect(calls[2].init?.body).toBe(
+      JSON.stringify({
+        workspaceRef: { id: 'workspace_123', displayName: 'agent-teams-ai' },
+        provider: { providerId: 'codex', modelId: 'gpt-5.2' },
+      })
+    );
+    expect(calls[2].init?.body).not.toContain('providerBackendId');
+  });
+
+  it('uses SSE resume cursors and routes parse errors separately from stream errors', () => {
+    MockEventSource.instances = [];
+    MockWebSocket.instances = [];
+    const onEvent = vi.fn();
+    const onCursor = vi.fn();
+    const onParseError = vi.fn();
+    const onStreamError = vi.fn();
+    const client = createHostedWebTransportClient({
+      fetch: vi.fn() as HostedWebFetch,
+      EventSource: MockEventSource as unknown as HostedWebEventSourceConstructor,
+      WebSocket: MockWebSocket as unknown as HostedWebSocketConstructor,
+    });
+
+    const subscription = client.subscribeToTeamEvents(
+      { teamId: 'team 1', resumeAfterEventId: 'event-0' },
+      { onEvent, onCursor, onParseError, onStreamError }
+    );
+    expect(MockEventSource.instances).toHaveLength(1);
+    expect(MockEventSource.instances[0]?.url).toBe(
+      '/api/hosted/v1/events?teamId=team+1&cursor=event-0'
+    );
+
+    MockEventSource.instances[0]?.emit(
+      'hosted.runtime.state',
+      JSON.stringify({
+        type: 'hosted.runtime.state',
+        eventId: 'event-1',
+        teamId: 'team 1',
+        emittedAt: '2026-07-10T00:00:00.000Z',
+        payload: {
+          isAlive: true,
+          terminalAvailable: true,
+          activeTerminalSessionIds: [],
+        },
+      }),
+      'event-1'
+    );
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'hosted.runtime.state' })
+    );
+    expect(onCursor).toHaveBeenCalledWith('event-1');
+    expect(subscription.getLastEventId()).toBe('event-1');
+
+    MockEventSource.instances[0]?.emit(
+      'hosted.runtime.state',
+      JSON.stringify({
+        type: 'hosted.runtime.state',
+        eventId: 'event-2',
+        teamId: 'team 1',
+        emittedAt: '2026-07-10T00:00:00.000Z',
+        payload: { isAlive: 'invalid' },
+      }),
+      'event-2'
+    );
+    expect(onParseError).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'sse_parse', code: '/api/hosted/v1/errors/sse_parse_failed' })
+    );
+
+    MockEventSource.instances[0]?.emit('error', '');
+    expect(onStreamError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'sse_stream',
+        code: '/api/hosted/v1/errors/sse_stream_failed',
+      })
+    );
+  });
+
+  it('uses WebSocket only for terminal streams and never terminal bytes over SSE', () => {
+    MockEventSource.instances = [];
+    MockWebSocket.instances = [];
+    const client = createHostedWebTransportClient({
+      fetch: vi.fn() as HostedWebFetch,
+      EventSource: MockEventSource as unknown as HostedWebEventSourceConstructor,
+      WebSocket: MockWebSocket as unknown as HostedWebSocketConstructor,
+    });
+
+    client.subscribeToTeamEvents({ teamId: 'team 1' }, { onEvent: vi.fn() });
+    expect(MockWebSocket.instances).toHaveLength(0);
+    expect(MockEventSource.instances[0]?.listeners.has('hosted.terminal.bytes')).toBe(false);
+
+    client.openTerminalStream({
+      webSocketUrl: 'wss://hosted.example/api/hosted/v1/terminal/session-1',
+      protocols: 'agent-teams-terminal.v1',
+    });
+    expect(MockWebSocket.instances).toHaveLength(1);
+    expect(MockWebSocket.instances[0]).toMatchObject({
+      url: 'wss://hosted.example/api/hosted/v1/terminal/session-1',
+      protocols: 'agent-teams-terminal.v1',
+    });
+  });
+
+  it('normalizes hosted HTTP error codes under /api/hosted/v1', async () => {
+    const client = createHostedWebTransportClient({
+      fetch: vi.fn(async () => jsonResponse({ error: { code: 'not_found', message: 'No' } }, false, 404)),
+    });
+
+    await expect(client.listTeams()).rejects.toMatchObject({
+      name: 'HostedWebTransportError',
+      kind: 'http',
+      status: 404,
+      code: '/api/hosted/v1/errors/not_found',
+    });
+    await expect(client.listTeams()).rejects.toBeInstanceOf(HostedWebTransportError);
+  });
+});
+
+function jsonResponse(payload: unknown, ok = true, status = 200): ReturnType<HostedWebFetch> {
+  return Promise.resolve({
+    ok,
+    status,
+    json: () => Promise.resolve(payload),
+    text: () => Promise.resolve(JSON.stringify(payload)),
+  });
+}

--- a/test/features/hosted-web-transport/createHostedWebTransportClient.test.ts
+++ b/test/features/hosted-web-transport/createHostedWebTransportClient.test.ts
@@ -80,6 +80,13 @@ describe('createHostedWebTransportClient', () => {
           task: { taskId: 'task-1', subject: 'Ship it', status: 'pending' },
         });
       }
+      if (url.endsWith('/teams/team%2F1/terminal/sessions')) {
+        return jsonResponse({
+          terminalSessionId: 'session-1',
+          webSocketUrl: 'wss://hosted.example/api/hosted/v1/terminal/session-1',
+          expiresAt: '2026-07-10T00:00:00.000Z',
+        });
+      }
       return jsonResponse(
         { error: { code: '/api/hosted/v1/errors/not_found', message: 'not found' } },
         false,
@@ -106,12 +113,17 @@ describe('createHostedWebTransportClient', () => {
     await expect(client.createTask('team/1', { subject: 'Ship it' })).resolves.toMatchObject({
       task: { taskId: 'task-1' },
     });
+    await expect(client.createTerminalSession('team/1', {})).resolves.toMatchObject({
+      terminalSessionId: 'session-1',
+      webSocketUrl: 'wss://hosted.example/api/hosted/v1/terminal/session-1',
+    });
 
     expect(calls.map((call) => call.url)).toEqual([
       'https://hosted.example/api/hosted/v1/teams',
       'https://hosted.example/api/hosted/v1/teams/team%2F1',
       'https://hosted.example/api/hosted/v1/teams/team%2F1/launch',
       'https://hosted.example/api/hosted/v1/teams/team%2F1/tasks',
+      'https://hosted.example/api/hosted/v1/teams/team%2F1/terminal/sessions',
     ]);
     expect(calls[2].init?.body).toBe(
       JSON.stringify({
@@ -177,7 +189,10 @@ describe('createHostedWebTransportClient', () => {
       'event-2'
     );
     expect(onParseError).toHaveBeenCalledWith(
-      expect.objectContaining({ kind: 'sse_parse', code: '/api/hosted/v1/errors/sse_parse_failed' })
+      expect.objectContaining({
+        kind: 'sse_parse',
+        code: '/api/hosted/v1/errors/sse_parse_failed',
+      })
     );
 
     MockEventSource.instances[0]?.emit('error', '');
@@ -193,6 +208,7 @@ describe('createHostedWebTransportClient', () => {
     MockEventSource.instances = [];
     MockWebSocket.instances = [];
     const client = createHostedWebTransportClient({
+      baseUrl: 'https://hosted.example',
       fetch: vi.fn() as HostedWebFetch,
       EventSource: MockEventSource as unknown as HostedWebEventSourceConstructor,
       WebSocket: MockWebSocket as unknown as HostedWebSocketConstructor,
@@ -203,7 +219,7 @@ describe('createHostedWebTransportClient', () => {
     expect(MockEventSource.instances[0]?.listeners.has('hosted.terminal.bytes')).toBe(false);
 
     client.openTerminalStream({
-      webSocketUrl: 'wss://hosted.example/api/hosted/v1/terminal/session-1',
+      terminalSessionId: 'session-1',
       protocols: 'agent-teams-terminal.v1',
     });
     expect(MockWebSocket.instances).toHaveLength(1);
@@ -215,7 +231,9 @@ describe('createHostedWebTransportClient', () => {
 
   it('normalizes hosted HTTP error codes under /api/hosted/v1', async () => {
     const client = createHostedWebTransportClient({
-      fetch: vi.fn(async () => jsonResponse({ error: { code: 'not_found', message: 'No' } }, false, 404)),
+      fetch: vi.fn(async () =>
+        jsonResponse({ error: { code: 'not_found', message: 'No' } }, false, 404)
+      ),
     });
 
     await expect(client.listTeams()).rejects.toMatchObject({
@@ -225,6 +243,119 @@ describe('createHostedWebTransportClient', () => {
       code: '/api/hosted/v1/errors/not_found',
     });
     await expect(client.listTeams()).rejects.toBeInstanceOf(HostedWebTransportError);
+  });
+
+  it('rejects successful HTTP JSON that does not match the expected response shape', async () => {
+    const client = createHostedWebTransportClient({
+      fetch: vi.fn(async () => jsonResponse({ teams: [{ teamId: 'team-1' }] })),
+    });
+
+    await expect(client.listTeams()).rejects.toMatchObject({
+      name: 'HostedWebTransportError',
+      kind: 'response_validation',
+      status: 200,
+      route: '/api/hosted/v1/teams',
+      code: '/api/hosted/v1/errors/invalid_response',
+      message: 'Hosted web response did not match the expected schema',
+    });
+  });
+
+  it('reads error bodies once and does not expose backend text in renderer errors', async () => {
+    const text = vi.fn(async () =>
+      JSON.stringify({
+        error: {
+          code: '../../../Users/name/project/provider_payload',
+          message: 'Provider failed at /Users/name/project with token sk-secret',
+        },
+      })
+    );
+    const json = vi.fn(async () => {
+      throw new Error('json() must not be used for error bodies');
+    });
+    const client = createHostedWebTransportClient({
+      fetch: vi.fn(async () => ({
+        ok: false,
+        status: 500,
+        json,
+        text,
+      })),
+    });
+
+    let error: unknown;
+    try {
+      await client.listTeams();
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toMatchObject({
+      name: 'HostedWebTransportError',
+      kind: 'http',
+      status: 500,
+      route: '/api/hosted/v1/teams',
+      code: '/api/hosted/v1/errors/http_500',
+      message: 'Hosted web request failed with status 500',
+    });
+    expect(error).toBeInstanceOf(HostedWebTransportError);
+    expect(error instanceof Error ? error.message : String(error)).not.toContain(
+      '/Users/name/project'
+    );
+    expect(text).toHaveBeenCalledTimes(1);
+    expect(json).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsafe terminal WebSocket targets from session responses and stream calls', async () => {
+    MockWebSocket.instances = [];
+    const client = createHostedWebTransportClient({
+      baseUrl: 'https://hosted.example',
+      fetch: vi.fn(async () =>
+        jsonResponse({
+          terminalSessionId: 'session-1',
+          webSocketUrl: 'wss://evil.example/api/hosted/v1/terminal/session-1',
+          expiresAt: '2026-07-10T00:00:00.000Z',
+        })
+      ),
+      WebSocket: MockWebSocket as unknown as HostedWebSocketConstructor,
+    });
+
+    await expect(client.createTerminalSession('team-1', {})).rejects.toMatchObject({
+      name: 'HostedWebTransportError',
+      kind: 'response_validation',
+      code: '/api/hosted/v1/errors/invalid_response',
+      message: 'Hosted web response did not match the expected schema',
+    });
+
+    expect(() =>
+      client.openTerminalStream({
+        webSocketUrl: 'https://hosted.example/api/hosted/v1/terminal/session-1',
+      })
+    ).toThrow(/terminal stream target is not allowed/);
+    expect(() =>
+      client.openTerminalStream({
+        webSocketUrl: 'wss://hosted.example/api/hosted/v1/teams/team-1/terminal/sessions',
+      })
+    ).toThrow(/terminal stream target is not allowed/);
+    expect(() =>
+      client.openTerminalStream({
+        webSocketUrl: 'api/hosted/v1/terminal/session-1',
+      })
+    ).toThrow(/terminal stream target is not allowed/);
+    expect(() =>
+      client.openTerminalStream({
+        webSocketUrl: '//evil.example/api/hosted/v1/terminal/session-1',
+      })
+    ).toThrow(/terminal stream target is not allowed/);
+    expect(() =>
+      client.openTerminalStream({
+        webSocketUrl: 'wss://hosted.example/api/hosted/v1/terminal/session-1?token=secret',
+      })
+    ).toThrow(/terminal stream target is not allowed/);
+    expect(() =>
+      client.openTerminalStream({
+        webSocketUrl: 'wss://hosted.example/api/hosted/v1/terminal/session-1#token',
+      })
+    ).toThrow(/terminal stream target is not allowed/);
+    expect(MockWebSocket.instances).toHaveLength(0);
   });
 });
 

--- a/test/features/hosted-web-transport/createHostedWebTransportClient.test.ts
+++ b/test/features/hosted-web-transport/createHostedWebTransportClient.test.ts
@@ -300,6 +300,38 @@ describe('createHostedWebTransportClient', () => {
     });
   });
 
+  it('rejects malformed alive teams response shapes', async () => {
+    const client = createHostedWebTransportClient({
+      fetch: vi.fn(async () => jsonResponse({ teamIds: ['team-1', 42] })),
+    });
+
+    await expect(client.listAliveTeams()).rejects.toMatchObject({
+      name: 'HostedWebTransportError',
+      kind: 'response_validation',
+      status: 200,
+      route: '/api/hosted/v1/teams/runtime/alive',
+      code: '/api/hosted/v1/errors/invalid_response',
+      message: 'Hosted web response did not match the expected schema',
+    });
+  });
+
+  it('rejects malformed runtime summary response shapes', async () => {
+    const client = createHostedWebTransportClient({
+      fetch: vi.fn(async () =>
+        jsonResponse({ isAlive: true, terminalAvailable: 'yes', activeProcessCount: 1 })
+      ),
+    });
+
+    await expect(client.getRuntimeState('team-1')).rejects.toMatchObject({
+      name: 'HostedWebTransportError',
+      kind: 'response_validation',
+      status: 200,
+      route: '/api/hosted/v1/teams/team-1/runtime',
+      code: '/api/hosted/v1/errors/invalid_response',
+      message: 'Hosted web response did not match the expected schema',
+    });
+  });
+
   it('rejects successful HTTP responses whose JSON cannot be parsed', async () => {
     const text = vi.fn(async () => 'sensitive backend fallback must not be read');
     const client = createHostedWebTransportClient({

--- a/test/features/hosted-web-transport/createHostedWebTransportClient.test.ts
+++ b/test/features/hosted-web-transport/createHostedWebTransportClient.test.ts
@@ -75,6 +75,25 @@ describe('createHostedWebTransportClient', () => {
       if (url.endsWith('/teams/team%2F1/launch')) {
         return jsonResponse({ runId: 'run-1', launchStatus: 'started' });
       }
+      if (url.endsWith('/teams/provisioning/run-1')) {
+        return jsonResponse({
+          runId: 'run-1',
+          teamId: 'team/1',
+          state: 'ready',
+          message: 'Ready',
+          startedAt: '2026-07-10T00:00:00.000Z',
+          updatedAt: '2026-07-10T00:00:01.000Z',
+        });
+      }
+      if (url.endsWith('/teams/team%2F1/runtime')) {
+        return jsonResponse({ isAlive: true, terminalAvailable: true, activeProcessCount: 1 });
+      }
+      if (url.endsWith('/teams/runtime/alive')) {
+        return jsonResponse({ teamIds: ['team/1'] });
+      }
+      if (url.endsWith('/teams/team%2F1/stop')) {
+        return jsonResponse({ isAlive: false, terminalAvailable: false, activeProcessCount: 0 });
+      }
       if (url.endsWith('/teams/team%2F1/tasks')) {
         return jsonResponse({
           task: { taskId: 'task-1', subject: 'Ship it', status: 'pending' },
@@ -110,6 +129,22 @@ describe('createHostedWebTransportClient', () => {
         provider: { providerId: 'codex', modelId: 'gpt-5.2' },
       })
     ).resolves.toEqual({ runId: 'run-1', launchStatus: 'started' });
+    await expect(client.getProvisioningStatus('run-1')).resolves.toMatchObject({
+      runId: 'run-1',
+      teamId: 'team/1',
+      state: 'ready',
+    });
+    await expect(client.getRuntimeState('team/1')).resolves.toEqual({
+      isAlive: true,
+      terminalAvailable: true,
+      activeProcessCount: 1,
+    });
+    await expect(client.listAliveTeams()).resolves.toEqual({ teamIds: ['team/1'] });
+    await expect(client.stopTeam('team/1')).resolves.toEqual({
+      isAlive: false,
+      terminalAvailable: false,
+      activeProcessCount: 0,
+    });
     await expect(client.createTask('team/1', { subject: 'Ship it' })).resolves.toMatchObject({
       task: { taskId: 'task-1' },
     });
@@ -122,6 +157,10 @@ describe('createHostedWebTransportClient', () => {
       'https://hosted.example/api/hosted/v1/teams',
       'https://hosted.example/api/hosted/v1/teams/team%2F1',
       'https://hosted.example/api/hosted/v1/teams/team%2F1/launch',
+      'https://hosted.example/api/hosted/v1/teams/provisioning/run-1',
+      'https://hosted.example/api/hosted/v1/teams/team%2F1/runtime',
+      'https://hosted.example/api/hosted/v1/teams/runtime/alive',
+      'https://hosted.example/api/hosted/v1/teams/team%2F1/stop',
       'https://hosted.example/api/hosted/v1/teams/team%2F1/tasks',
       'https://hosted.example/api/hosted/v1/teams/team%2F1/terminal/sessions',
     ]);
@@ -132,6 +171,7 @@ describe('createHostedWebTransportClient', () => {
       })
     );
     expect(calls[2].init?.body).not.toContain('providerBackendId');
+    expect(calls[6].init?.method).toBe('POST');
   });
 
   it('uses SSE resume cursors and routes parse errors separately from stream errors', () => {
@@ -260,6 +300,58 @@ describe('createHostedWebTransportClient', () => {
     });
   });
 
+  it('rejects successful HTTP responses whose JSON cannot be parsed', async () => {
+    const text = vi.fn(async () => 'sensitive backend fallback must not be read');
+    const client = createHostedWebTransportClient({
+      fetch: vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw new SyntaxError('Unexpected token with /Users/name/project and sk-secret');
+        },
+        text,
+      })),
+    });
+
+    let error: unknown;
+    try {
+      await client.listTeams();
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toMatchObject({
+      name: 'HostedWebTransportError',
+      kind: 'response_validation',
+      status: 200,
+      route: '/api/hosted/v1/teams',
+      code: '/api/hosted/v1/errors/invalid_json_response',
+      message: 'Hosted web response was not valid JSON',
+    });
+    expect(error instanceof Error ? error.message : String(error)).not.toContain('sk-secret');
+    expect(text).not.toHaveBeenCalled();
+  });
+
+  it('passes AbortSignal to fetch and propagates fetch abort rejections unchanged', async () => {
+    const abortController = new AbortController();
+    const abortError = Object.assign(new Error('This operation was aborted'), {
+      name: 'AbortError',
+    });
+    const fetchMock: HostedWebFetch = vi.fn(async (_url, init) => {
+      expect(init?.signal).toBe(abortController.signal);
+      throw abortError;
+    });
+    const client = createHostedWebTransportClient({
+      fetch: fetchMock,
+      signal: abortController.signal,
+    });
+
+    abortController.abort();
+
+    await expect(client.listTeams()).rejects.toBe(abortError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it('reads error bodies once and does not expose backend text in renderer errors', async () => {
     const text = vi.fn(async () =>
       JSON.stringify({
@@ -302,6 +394,86 @@ describe('createHostedWebTransportClient', () => {
     );
     expect(text).toHaveBeenCalledTimes(1);
     expect(json).not.toHaveBeenCalled();
+  });
+
+  it('does not expose sensitive non-JSON error bodies in renderer errors', async () => {
+    const text = vi.fn(async () =>
+      'provider failed at /Users/name/project with Authorization: Bearer sk-secret'
+    );
+    const json = vi.fn(async () => {
+      throw new Error('json() must not be used for error bodies');
+    });
+    const client = createHostedWebTransportClient({
+      fetch: vi.fn(async () => ({
+        ok: false,
+        status: 502,
+        json,
+        text,
+      })),
+    });
+
+    let error: unknown;
+    try {
+      await client.listTeams();
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toMatchObject({
+      name: 'HostedWebTransportError',
+      kind: 'http',
+      status: 502,
+      route: '/api/hosted/v1/teams',
+      code: '/api/hosted/v1/errors/http_502',
+      message: 'Hosted web request failed with status 502',
+    });
+    expect(error instanceof Error ? error.message : String(error)).not.toContain(
+      '/Users/name/project'
+    );
+    expect(error instanceof Error ? error.message : String(error)).not.toContain('sk-secret');
+    expect(text).toHaveBeenCalledTimes(1);
+    expect(json).not.toHaveBeenCalled();
+  });
+
+  it('resolves relative terminal WebSocket URLs against same-origin location when baseUrl is absent', () => {
+    MockWebSocket.instances = [];
+    withLocationOrigin('https://hosted.example', () => {
+      const client = createHostedWebTransportClient({
+        fetch: vi.fn() as HostedWebFetch,
+        WebSocket: MockWebSocket as unknown as HostedWebSocketConstructor,
+      });
+
+      client.openTerminalStream({
+        webSocketUrl: '/api/hosted/v1/terminal/session-1',
+        protocols: 'agent-teams-terminal.v1',
+      });
+    });
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+    expect(MockWebSocket.instances[0]).toMatchObject({
+      url: 'wss://hosted.example/api/hosted/v1/terminal/session-1',
+      protocols: 'agent-teams-terminal.v1',
+    });
+  });
+
+  it('rejects absolute base URLs with credentials or hosted API path confusion', () => {
+    const fetchMock = vi.fn() as HostedWebFetch;
+
+    for (const baseUrl of [
+      'https://hosted.example@evil.example',
+      'https://user:secret@hosted.example',
+      'https://hosted.example/api/hosted/v1',
+      'https://hosted.example/%2F%2Fevil.example',
+    ]) {
+      expect(() =>
+        createHostedWebTransportClient({
+          baseUrl,
+          fetch: fetchMock,
+        })
+      ).toThrow(/base URL is not allowed/);
+    }
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('rejects unsafe terminal WebSocket targets from session responses and stream calls', async () => {
@@ -366,4 +538,21 @@ function jsonResponse(payload: unknown, ok = true, status = 200): ReturnType<Hos
     json: () => Promise.resolve(payload),
     text: () => Promise.resolve(JSON.stringify(payload)),
   });
+}
+
+function withLocationOrigin(origin: string, run: () => void): void {
+  const previousLocation = Object.getOwnPropertyDescriptor(globalThis, 'location');
+  Object.defineProperty(globalThis, 'location', {
+    configurable: true,
+    value: { origin },
+  });
+  try {
+    run();
+  } finally {
+    if (previousLocation) {
+      Object.defineProperty(globalThis, 'location', previousLocation);
+    } else {
+      Reflect.deleteProperty(globalThis, 'location');
+    }
+  }
 }

--- a/test/features/hosted-web-transport/hostedWebStartup.fixture-e2e.test.ts
+++ b/test/features/hosted-web-transport/hostedWebStartup.fixture-e2e.test.ts
@@ -1,0 +1,410 @@
+import {
+  type HostedWebCreateTaskRequest,
+  hostedWebErrorCode,
+  type HostedWebEvent,
+  type HostedWebLaunchTeamRequest,
+  type HostedWebTeamSnapshotResponse,
+  type HostedWebTeamSummary,
+} from '@features/hosted-web-transport/contracts';
+import {
+  createHostedWebTransportClient,
+  type HostedWebEventSourceConstructor,
+  type HostedWebFetch,
+  type HostedWebSocketConstructor,
+} from '@features/hosted-web-transport/renderer';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+
+  readonly listeners = new Map<string, EventListener>();
+  readonly url: string;
+  closed = false;
+
+  constructor(url: string) {
+    this.url = url;
+    MockEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: EventListener): void {
+    this.listeners.set(type, listener);
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+
+  emit(event: HostedWebEvent, lastEventId = event.eventId): void {
+    this.listeners.get(event.type)?.({
+      type: event.type,
+      data: JSON.stringify(event),
+      lastEventId,
+    } as MessageEvent<string>);
+  }
+}
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+
+  readonly url: string;
+  readonly protocols?: string | string[];
+
+  constructor(url: string, protocols?: string | string[]) {
+    this.url = url;
+    this.protocols = protocols;
+    MockWebSocket.instances.push(this);
+  }
+}
+
+describe('hosted web startup fixture fastgate', () => {
+  beforeEach(() => {
+    MockEventSource.instances = [];
+    MockWebSocket.instances = [];
+  });
+
+  it('starts the hosted workflow through a browser-safe transport and sandbox facade only', async () => {
+    const fixture = createSandboxHostedFixture();
+    const onEvent = vi.fn();
+    const client = createHostedWebTransportClient({
+      baseUrl: 'https://hosted.example',
+      fetch: fixture.createBrowserSessionFetch(),
+      EventSource: MockEventSource as unknown as HostedWebEventSourceConstructor,
+      WebSocket: MockWebSocket as unknown as HostedWebSocketConstructor,
+    });
+
+    const subscription = client.subscribeToTeamEvents({ teamId: 'sandbox-team' }, { onEvent });
+    await expect(
+      client.launchTeam('sandbox-team', {
+        workspaceRef: {
+          id: 'sandbox://fixtures/hosted-web-fastgate',
+          displayName: 'Hosted Web Fastgate Sandbox',
+          repositoryLabel: 'synthetic-fixture',
+          branchLabel: 'fixture',
+        },
+        provider: { providerId: 'codex', modelId: 'fake-browser-safe-model' },
+        members: [{ displayName: 'Synthetic Lead', role: 'lead' }],
+        prompt: 'Synthetic startup only; do not launch agents.',
+      })
+    ).resolves.toEqual({ runId: 'run-sandbox-team-1', launchStatus: 'started' });
+    await expect(
+      client.createTask('sandbox-team', {
+        subject: 'Exercise hosted web facade',
+        description: 'Synthetic task stored in the fake facade.',
+        startImmediately: false,
+      })
+    ).resolves.toMatchObject({ task: { taskId: 'task-1', status: 'pending' } });
+    const terminalSession = await client.createTerminalSession('sandbox-team', {
+      preferredMemberId: 'lead',
+      cols: 120,
+      rows: 30,
+    });
+    expect(terminalSession).toMatchObject({
+      terminalSessionId: 'terminal-sandbox-team-1',
+      webSocketUrl: 'wss://hosted.example/api/hosted/v1/terminal/terminal-sandbox-team-1',
+    });
+    client.openTerminalStream({
+      webSocketUrl: terminalSession.webSocketUrl,
+      protocols: 'agent-teams-terminal.v1',
+    });
+
+    const snapshot = await client.getTeamSnapshot('sandbox-team');
+    expect(JSON.stringify(snapshot)).toContain('sandbox://fixtures/hosted-web-fastgate');
+    expect(JSON.stringify(snapshot)).not.toContain('/Users/');
+    expect(JSON.stringify(snapshot)).not.toContain('"cwd"');
+    expect(fixture.facadeStartupRequests).toHaveLength(1);
+    expect(fixture.agentLaunchAttempts).toBe(0);
+    expect(fixture.realProjectTouches).toEqual([]);
+    expect(MockEventSource.instances[0]?.url).toBe(
+      'https://hosted.example/api/hosted/v1/events?teamId=sandbox-team'
+    );
+    expect(MockWebSocket.instances).toHaveLength(1);
+    expect(MockWebSocket.instances[0]).toMatchObject({
+      url: 'wss://hosted.example/api/hosted/v1/terminal/terminal-sandbox-team-1',
+      protocols: 'agent-teams-terminal.v1',
+    });
+
+    MockEventSource.instances[0]?.emit(fixture.createProviderAuthErrorEvent('sandbox-team'));
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'hosted.error',
+        payload: expect.objectContaining({
+          code: '/api/hosted/v1/errors/provider_auth_required',
+        }),
+      })
+    );
+    expect(subscription.getLastEventId()).toBe('event-auth-error-sandbox-team');
+    subscription.close();
+    expect(MockEventSource.instances[0]?.closed).toBe(true);
+  });
+
+  it('rejects missing auth before the app facade can start anything', async () => {
+    const fixture = createSandboxHostedFixture();
+    const client = createHostedWebTransportClient({
+      baseUrl: 'https://hosted.example',
+      fetch: fixture.fetch,
+    });
+
+    await expect(client.listTeams()).rejects.toMatchObject({
+      kind: 'http',
+      status: 401,
+      code: '/api/hosted/v1/errors/auth_required',
+    });
+    expect(fixture.facadeStartupRequests).toEqual([]);
+    expect(fixture.agentLaunchAttempts).toBe(0);
+    expect(fixture.realProjectTouches).toEqual([]);
+  });
+
+  it('rejects non-sandbox workspace refs without launching a runtime', async () => {
+    const fixture = createSandboxHostedFixture();
+    const client = createHostedWebTransportClient({
+      baseUrl: 'https://hosted.example',
+      fetch: fixture.createBrowserSessionFetch(),
+    });
+
+    await expect(
+      client.launchTeam('real-project', {
+        workspaceRef: {
+          id: '/Users/example/real-project',
+          displayName: 'Real Project',
+        },
+      })
+    ).rejects.toMatchObject({
+      kind: 'http',
+      status: 403,
+      code: '/api/hosted/v1/errors/sandbox_only',
+    });
+    expect(fixture.facadeStartupRequests).toEqual([]);
+    expect(fixture.agentLaunchAttempts).toBe(0);
+    expect(fixture.realProjectTouches).toEqual(['/Users/example/real-project']);
+  });
+
+  it('rejects unavailable provider auth before launching a runtime', async () => {
+    const fixture = createSandboxHostedFixture();
+    const client = createHostedWebTransportClient({
+      baseUrl: 'https://hosted.example',
+      fetch: fixture.createBrowserSessionFetch(),
+    });
+
+    await expect(
+      client.launchTeam('provider-auth-required', {
+        workspaceRef: {
+          id: 'sandbox://fixtures/hosted-web-fastgate',
+          displayName: 'Hosted Web Fastgate Sandbox',
+        },
+        provider: { providerId: 'anthropic', modelId: 'requires-real-provider-auth' },
+      })
+    ).rejects.toMatchObject({
+      kind: 'http',
+      status: 401,
+      code: '/api/hosted/v1/errors/provider_auth_required',
+    });
+    expect(fixture.facadeStartupRequests).toEqual([]);
+    expect(fixture.agentLaunchAttempts).toBe(0);
+    expect(fixture.realProjectTouches).toEqual([]);
+  });
+});
+
+interface SandboxHostedFixture {
+  readonly facadeStartupRequests: HostedWebLaunchTeamRequest[];
+  readonly realProjectTouches: string[];
+  readonly fetch: HostedWebFetch;
+  get agentLaunchAttempts(): number;
+  createBrowserSessionFetch(): HostedWebFetch;
+  createProviderAuthErrorEvent(teamId: string): HostedWebEvent;
+}
+
+function createSandboxHostedFixture(): SandboxHostedFixture {
+  const sessionHeaderName = 'x-fixture-hosted-web-session';
+  const sessionHeaderValue = 'sandbox-session';
+  const facadeStartupRequests: HostedWebLaunchTeamRequest[] = [];
+  const realProjectTouches: string[] = [];
+  const teams = new Map<string, HostedWebTeamSnapshotResponse>();
+  const runtime = createFakeHostedRuntime();
+
+  const fetch: HostedWebFetch = async (input, init) => {
+    if (init?.headers?.[sessionHeaderName] !== sessionHeaderValue) {
+      return jsonResponse(
+        {
+          error: {
+            code: hostedWebErrorCode('auth_required'),
+            message: 'Hosted web auth is required for synthetic startup.',
+          },
+        },
+        false,
+        401
+      );
+    }
+
+    const url = new URL(input, 'https://hosted.example');
+    if (url.pathname === '/api/hosted/v1/teams') {
+      return jsonResponse({ teams: [...teams.values()].map((snapshot) => snapshot.team) });
+    }
+
+    const teamMatch = url.pathname.match(
+      /^\/api\/hosted\/v1\/teams\/([^/]+)(?:\/(launch|tasks|terminal\/sessions))?$/u
+    );
+    if (!teamMatch) {
+      return notFound();
+    }
+
+    const teamId = decodeURIComponent(teamMatch[1] ?? '');
+    const action = teamMatch[2] ?? 'snapshot';
+    if (action === 'launch') {
+      const request = parseBody<HostedWebLaunchTeamRequest>(init?.body);
+      if (!request.workspaceRef.id.startsWith('sandbox://')) {
+        realProjectTouches.push(request.workspaceRef.id);
+        return jsonResponse(
+          {
+            error: {
+              code: hostedWebErrorCode('sandbox_only'),
+              message: 'Hosted web fastgate accepts sandbox workspace refs only.',
+            },
+          },
+          false,
+          403
+        );
+      }
+      if (request.provider?.providerId === 'anthropic') {
+        return jsonResponse(
+          {
+            error: {
+              code: hostedWebErrorCode('provider_auth_required'),
+              message: 'Synthetic provider auth is unavailable in the hosted web fastgate.',
+            },
+          },
+          false,
+          401
+        );
+      }
+
+      facadeStartupRequests.push(request);
+      teams.set(teamId, createSnapshot(teamId, request));
+      return jsonResponse({ runId: `run-${teamId}-1`, launchStatus: 'started' });
+    }
+
+    const snapshot = teams.get(teamId);
+    if (!snapshot) {
+      return notFound();
+    }
+
+    if (action === 'tasks') {
+      const request = parseBody<HostedWebCreateTaskRequest>(init?.body);
+      const task = {
+        taskId: `task-${snapshot.tasks.length + 1}`,
+        subject: request.subject,
+        description: request.description,
+        status: 'pending' as const,
+        ownerMemberId: request.ownerMemberId,
+      };
+      snapshot.tasks.push(task);
+      snapshot.kanban = [{ status: 'pending', taskIds: snapshot.tasks.map((item) => item.taskId) }];
+      snapshot.team.taskCount = snapshot.tasks.length;
+      return jsonResponse({ task });
+    }
+
+    if (action === 'terminal/sessions') {
+      return jsonResponse({
+        terminalSessionId: `terminal-${teamId}-1`,
+        webSocketUrl: `wss://hosted.example/api/hosted/v1/terminal/terminal-${teamId}-1`,
+        expiresAt: '2026-07-11T01:00:00.000Z',
+      });
+    }
+
+    return jsonResponse(snapshot);
+  };
+
+  return {
+    facadeStartupRequests,
+    realProjectTouches,
+    fetch,
+    get agentLaunchAttempts() {
+      return runtime.agentLaunchAttempts;
+    },
+    createBrowserSessionFetch() {
+      return (input, init) =>
+        fetch(input, {
+          ...init,
+          headers: {
+            ...init?.headers,
+            [sessionHeaderName]: sessionHeaderValue,
+          },
+        });
+    },
+    createProviderAuthErrorEvent(teamId) {
+      return {
+        type: 'hosted.error',
+        eventId: `event-auth-error-${teamId}`,
+        teamId,
+        emittedAt: '2026-07-11T00:00:00.000Z',
+        payload: {
+          code: hostedWebErrorCode('provider_auth_required'),
+          message: 'Fake runtime reports provider auth missing.',
+          retryable: false,
+        },
+      };
+    },
+  };
+
+  function createSnapshot(
+    teamId: string,
+    request: HostedWebLaunchTeamRequest
+  ): HostedWebTeamSnapshotResponse {
+    const team: HostedWebTeamSummary = {
+      teamId,
+      displayName: teamId,
+      description: 'Synthetic hosted web fixture team',
+      project: { workspaceRef: request.workspaceRef },
+      members: [
+        {
+          memberId: 'lead',
+          displayName: request.members?.[0]?.displayName ?? 'Synthetic Lead',
+          role: request.members?.[0]?.role,
+          provider: request.provider,
+          currentTaskId: null,
+          taskCount: 0,
+          isolation: 'managed-worktree',
+        },
+      ],
+      taskCount: 0,
+      lastActivity: '2026-07-11T00:00:00.000Z',
+      runtime: {
+        isAlive: false,
+        terminalAvailable: true,
+        activeProcessCount: runtime.agentLaunchAttempts,
+      },
+    };
+    return { team, tasks: [], kanban: [{ status: 'pending', taskIds: [] }], revision: 'rev-1' };
+  }
+}
+
+function createFakeHostedRuntime(): { agentLaunchAttempts: number } {
+  return {
+    agentLaunchAttempts: 0,
+  };
+}
+
+function parseBody<T>(body: string | undefined): T {
+  return JSON.parse(body ?? '{}') as T;
+}
+
+function notFound(): ReturnType<HostedWebFetch> {
+  return jsonResponse(
+    {
+      error: {
+        code: hostedWebErrorCode('not_found'),
+        message: 'Synthetic hosted web route was not found.',
+      },
+    },
+    false,
+    404
+  );
+}
+
+function jsonResponse(payload: unknown, ok = true, status = 200): ReturnType<HostedWebFetch> {
+  return Promise.resolve({
+    ok,
+    status,
+    json: () => Promise.resolve(payload),
+    text: () => Promise.resolve(JSON.stringify(payload)),
+  });
+}

--- a/test/hosted/architectureBoundary.test.ts
+++ b/test/hosted/architectureBoundary.test.ts
@@ -1,0 +1,75 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const HOSTED_SOURCE_ROOT = join(process.cwd(), 'src/hosted');
+const APPROVED_HOSTED_APPLICATION_FACADE = '@main/application/hosted';
+
+function listTypeScriptFiles(root: string): string[] {
+  return readdirSync(root).flatMap((entry) => {
+    const absolutePath = join(root, entry);
+    if (statSync(absolutePath).isDirectory()) return listTypeScriptFiles(absolutePath);
+    return absolutePath.endsWith('.ts') || absolutePath.endsWith('.tsx') ? [absolutePath] : [];
+  });
+}
+
+function extractImportSources(sourceText: string): string[] {
+  const sources: string[] = [];
+  const importPattern =
+    /(?:import|export)\s+(?:type\s+)?(?:[^'"]*\s+from\s+)?['"]([^'"]+)['"]|import\(\s*['"]([^'"]+)['"]\s*\)/g;
+  let match: RegExpExecArray | null;
+  while ((match = importPattern.exec(sourceText)) !== null) {
+    sources.push(match[1] ?? match[2]);
+  }
+  return sources;
+}
+
+function isApprovedHostedApplicationFacade(source: string): boolean {
+  return (
+    source === APPROVED_HOSTED_APPLICATION_FACADE ||
+    source.startsWith(`${APPROVED_HOSTED_APPLICATION_FACADE}/`)
+  );
+}
+
+function isForbiddenHostedImport(source: string): boolean {
+  if (isApprovedHostedApplicationFacade(source)) return false;
+  return (
+    source === 'electron' ||
+    source.startsWith('@main/') ||
+    source.startsWith('@preload/') ||
+    source.startsWith('@renderer/') ||
+    /^@features\/[^/]+\/(core|main|preload|renderer)\//.test(source) ||
+    source.startsWith('../main') ||
+    source.startsWith('../preload') ||
+    source.startsWith('../renderer')
+  );
+}
+
+describe('hosted architecture boundary', () => {
+  it('keeps hosted source free of raw desktop internals', () => {
+    const violations = listTypeScriptFiles(HOSTED_SOURCE_ROOT).flatMap((file) => {
+      const sources = extractImportSources(readFileSync(file, 'utf-8'));
+      return sources
+        .filter(isForbiddenHostedImport)
+        .map((source) => `${relative(process.cwd(), file)} imports ${source}`);
+    });
+
+    expect(violations).toEqual([]);
+  });
+
+  it('keeps lint guardrails aligned with the approved hosted application facade', () => {
+    for (const configPath of ['eslint.config.js', 'eslint.fast.config.js']) {
+      const configText = readFileSync(join(process.cwd(), configPath), 'utf-8');
+      expect(configText).toContain('hosted-composition-boundary');
+      expect(configText).toContain('@main/**');
+      expect(configText).toContain('!@main/application/hosted');
+      expect(configText).toContain('!@main/application/hosted/**');
+      expect(configText).toContain('@features/*/core/**');
+      expect(configText).toContain('@features/*/main/**');
+      expect(configText).toContain('@features/*/preload/**');
+      expect(configText).toContain('@features/*/renderer/**');
+      expect(configText).toContain('not raw desktop internals');
+    }
+  });
+});

--- a/test/hosted/server.test.ts
+++ b/test/hosted/server.test.ts
@@ -1,0 +1,106 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { resolveHostedServerConfig, resolveHostedStaticRequest } from '../../src/hosted/server';
+
+describe('hosted startup shell server', () => {
+  const cleanupPaths: string[] = [];
+
+  afterEach(() => {
+    for (const path of cleanupPaths.splice(0)) {
+      rmSync(path, { force: true, recursive: true });
+    }
+  });
+
+  it('defaults to loopback and requires explicit opt-in for remote binds', () => {
+    const defaultConfig = resolveHostedServerConfig({});
+    expect(defaultConfig.host).toBe('127.0.0.1');
+    expect(defaultConfig.port).toBe(3456);
+
+    expect(() => resolveHostedServerConfig({ HOST: '0.0.0.0' })).toThrow(/HOSTED_ALLOW_REMOTE=1/);
+    expect(() => resolveHostedServerConfig({ PORT: '3456abc' })).toThrow(
+      /Invalid hosted server port/
+    );
+    expect(
+      resolveHostedServerConfig({
+        HOST: '0.0.0.0',
+        HOSTED_ALLOW_REMOTE: '1',
+        PORT: '4567',
+      })
+    ).toMatchObject({
+      host: '0.0.0.0',
+      port: 4567,
+    });
+  });
+
+  it('resolves renderer assets and SPA fallback without exposing application APIs', () => {
+    const rendererRoot = mkdtempSync(join(tmpdir(), 'agent-teams-hosted-'));
+    cleanupPaths.push(rendererRoot);
+    mkdirSync(join(rendererRoot, 'assets'));
+    writeFileSync(join(rendererRoot, 'index.html'), '<html><body>hosted shell</body></html>');
+    writeFileSync(join(rendererRoot, 'assets', 'app.js'), 'console.log("hosted");');
+
+    expect(
+      resolveHostedStaticRequest({ host: '127.0.0.1', port: 0, rendererRoot }, 'GET', '/')
+    ).toMatchObject({
+      filePath: join(rendererRoot, 'index.html'),
+      statusCode: 200,
+    });
+    expect(
+      resolveHostedStaticRequest({ host: '127.0.0.1', port: 0, rendererRoot }, 'GET', '/teams/demo')
+    ).toMatchObject({
+      filePath: join(rendererRoot, 'index.html'),
+      statusCode: 200,
+    });
+    expect(
+      resolveHostedStaticRequest(
+        { host: '127.0.0.1', port: 0, rendererRoot },
+        'GET',
+        '/assets/app.js'
+      )
+    ).toMatchObject({
+      contentType: 'text/javascript; charset=utf-8',
+      filePath: join(rendererRoot, 'assets', 'app.js'),
+      statusCode: 200,
+    });
+    expect(
+      resolveHostedStaticRequest({ host: '127.0.0.1', port: 0, rendererRoot }, 'GET', '/api')
+    ).toEqual({
+      statusCode: 404,
+    });
+    expect(
+      resolveHostedStaticRequest({ host: '127.0.0.1', port: 0, rendererRoot }, 'GET', '/api/health')
+    ).toEqual({
+      statusCode: 404,
+    });
+  });
+
+  it('rejects path traversal and non-GET methods before file serving', () => {
+    const rendererRoot = mkdtempSync(join(tmpdir(), 'agent-teams-hosted-'));
+    cleanupPaths.push(rendererRoot);
+    writeFileSync(join(rendererRoot, 'index.html'), '<html><body>hosted shell</body></html>');
+
+    const missingAsset = resolveHostedStaticRequest(
+      { host: '127.0.0.1', port: 0, rendererRoot },
+      'GET',
+      '/assets/missing.js'
+    );
+    const traversal = resolveHostedStaticRequest(
+      { host: '127.0.0.1', port: 0, rendererRoot },
+      'GET',
+      '/%2e%2e/%2e%2e/package.json'
+    );
+    const post = resolveHostedStaticRequest(
+      { host: '127.0.0.1', port: 0, rendererRoot },
+      'POST',
+      '/'
+    );
+
+    expect(missingAsset).toEqual({ statusCode: 404 });
+    expect(traversal).toEqual({ statusCode: 404 });
+    expect(post).toEqual({ statusCode: 405 });
+  });
+});

--- a/test/main/build/hostedBuildScripts.test.ts
+++ b/test/main/build/hostedBuildScripts.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+interface PackageJson {
+  knip?: {
+    entry?: string[];
+  };
+  scripts: Record<string, string>;
+}
+
+const packageJson = JSON.parse(
+  readFileSync(resolve(process.cwd(), 'package.json'), 'utf-8')
+) as PackageJson;
+const webViteConfig = readFileSync(resolve(process.cwd(), 'vite.web.config.ts'), 'utf-8');
+
+describe('hosted build scripts', () => {
+  it('adds hosted build entrypoints without replacing desktop or standalone runtime scripts', () => {
+    expect(packageJson.scripts.build).toContain('electron-vite');
+    expect(packageJson.scripts.dev).toBe('node ./scripts/dev-with-runtime.mjs');
+
+    expect(packageJson.scripts.standalone).toBe('tsx src/main/standalone.ts');
+    expect(packageJson.scripts['standalone:build']).toContain('docker/vite.standalone.config.ts');
+    expect(packageJson.scripts['standalone:start']).toBe('node dist-standalone/index.cjs');
+  });
+
+  it('uses a non-Electron hosted shell build path', () => {
+    expect(packageJson.scripts['hosted:build']).toBe(
+      'pnpm hosted:build:renderer && pnpm hosted:build:server'
+    );
+    expect(packageJson.scripts['hosted:build:renderer']).toContain('--config vite.web.config.ts');
+    expect(packageJson.scripts['hosted:build:server']).toContain(
+      '--config docker/vite.hosted-server.config.ts'
+    );
+    expect(packageJson.scripts['hosted:build']).not.toContain('electron-vite');
+    expect(packageJson.scripts['hosted:start']).toBe('node dist-hosted/server.cjs');
+  });
+
+  it('builds hosted renderer assets where the Docker image serves them from', () => {
+    expect(webViteConfig).toContain("outDir: resolve(ROOT, 'out/renderer')");
+    expect(webViteConfig).toContain("target: 'esnext'");
+  });
+
+  it('registers hosted and standalone entrypoints for dead-code checks', () => {
+    expect(packageJson.knip?.entry).toEqual(
+      expect.arrayContaining([
+        'src/main/standalone.ts',
+        'src/hosted/server.ts',
+        'vite.web.config.ts',
+        'docker/vite.standalone.config.ts',
+        'docker/vite.hosted-server.config.ts',
+      ])
+    );
+  });
+});

--- a/test/main/build/hostedDockerConfig.test.ts
+++ b/test/main/build/hostedDockerConfig.test.ts
@@ -1,0 +1,136 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+interface PackageJson {
+  dependencies?: Record<string, string>;
+  scripts?: Record<string, string>;
+}
+
+describe('hosted Docker config', () => {
+  const dockerfile = readFileSync(resolve(process.cwd(), 'docker/Dockerfile'), 'utf-8');
+  const rootDockerignore = readFileSync(resolve(process.cwd(), '.dockerignore'), 'utf-8');
+  const dockerDockerignore = readFileSync(resolve(process.cwd(), 'docker/.dockerignore'), 'utf-8');
+  const compose = readFileSync(resolve(process.cwd(), 'docker/docker-compose.yml'), 'utf-8');
+  const packageJson = JSON.parse(
+    readFileSync(resolve(process.cwd(), 'package.json'), 'utf-8')
+  ) as PackageJson;
+
+  function terminalPlatformFileDependencies(): string[] {
+    return Object.values(packageJson.dependencies ?? {})
+      .filter((specifier) => specifier.startsWith('file:vendor/terminal-platform/'))
+      .map((specifier) => specifier.slice('file:'.length))
+      .sort();
+  }
+
+  function copySourcesBeforeInstall(): string[] {
+    const installIndex = dockerfile.indexOf('RUN pnpm install --frozen-lockfile');
+    expect(installIndex).toBeGreaterThan(0);
+
+    return dockerfile
+      .slice(0, installIndex)
+      .split('\n')
+      .flatMap((line) => {
+        const copyMatch = /^COPY\s+(?!.*--from=)(.+)$/.exec(line.trim());
+        if (!copyMatch) return [];
+        const copyArgs = copyMatch[1].trim().split(/\s+/);
+        return copyArgs.slice(0, -1);
+      });
+  }
+
+  function isCoveredByCopySource(dependencyPath: string, copySource: string): boolean {
+    return dependencyPath === copySource || dependencyPath.startsWith(`${copySource}/`);
+  }
+
+  function dockerignoreLines(contents: string): string[] {
+    return contents
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith('#'));
+  }
+
+  it('builds only the hosted static shell output by default', () => {
+    expect(dockerfile).toContain('pnpm hosted:build');
+    expect(dockerfile).toContain('COPY --from=builder /app/dist-hosted ./dist-hosted');
+    expect(dockerfile).toContain('CMD ["node", "dist-hosted/server.cjs"]');
+    expect(dockerfile).not.toContain('dist-standalone');
+    expect(dockerfile).not.toContain('CLAUDE_ROOT');
+  });
+
+  it('copies all package.json file: vendor artifacts before frozen install', () => {
+    const vendorDependencies = terminalPlatformFileDependencies();
+    const dependencyLayerCopySources = copySourcesBeforeInstall();
+
+    expect(vendorDependencies).toEqual([
+      'vendor/terminal-platform/sdk/terminal-platform-design-tokens-0.1.0.tgz',
+      'vendor/terminal-platform/sdk/terminal-platform-foundation-0.1.0.tgz',
+      'vendor/terminal-platform/sdk/terminal-platform-runtime-types-0.1.0.tgz',
+      'vendor/terminal-platform/sdk/terminal-platform-workspace-adapter-websocket-0.1.0.tgz',
+      'vendor/terminal-platform/sdk/terminal-platform-workspace-contracts-0.1.0.tgz',
+      'vendor/terminal-platform/sdk/terminal-platform-workspace-core-0.1.0.tgz',
+      'vendor/terminal-platform/sdk/terminal-platform-workspace-elements-0.1.0.tgz',
+      'vendor/terminal-platform/sdk/terminal-platform-workspace-gateway-node-0.1.0.tgz',
+      'vendor/terminal-platform/sdk/terminal-platform-workspace-react-0.1.0.tgz',
+      'vendor/terminal-platform/terminal-platform-node-stub',
+    ]);
+    expect(dependencyLayerCopySources).toEqual(
+      expect.arrayContaining([
+        'vendor/terminal-platform/sdk',
+        'vendor/terminal-platform/terminal-platform-node-stub',
+      ])
+    );
+    for (const dependencyPath of vendorDependencies) {
+      expect(
+        dependencyLayerCopySources.some((copySource) =>
+          isCoveredByCopySource(dependencyPath, copySource)
+        )
+      ).toBe(true);
+    }
+  });
+
+  it('copies package install lifecycle scripts before frozen install', () => {
+    const dependencyLayerCopySources = copySourcesBeforeInstall();
+    const lifecycleScripts = [
+      packageJson.scripts?.preinstall,
+      packageJson.scripts?.postinstall,
+    ].filter((script): script is string => Boolean(script));
+    const lifecycleScriptPaths = lifecycleScripts.flatMap((script) =>
+      Array.from(script.matchAll(/node\s+\.\/(scripts\/[^\s;]+)/g), (match) => match[1])
+    );
+
+    expect(lifecycleScriptPaths).toEqual([
+      'scripts/ci/enforce-pnpm-install.mjs',
+      'scripts/ensure-electron-install.cjs',
+    ]);
+    for (const scriptPath of lifecycleScriptPaths) {
+      expect(
+        dependencyLayerCopySources.some((copySource) =>
+          isCoveredByCopySource(scriptPath, copySource)
+        )
+      ).toBe(true);
+    }
+  });
+
+  it('keeps vendor artifacts available in Docker build contexts', () => {
+    for (const dockerignore of [rootDockerignore, dockerDockerignore]) {
+      const ignoredPaths = dockerignoreLines(dockerignore);
+      expect(ignoredPaths).not.toContain('vendor');
+      expect(ignoredPaths).not.toContain('vendor/');
+      expect(ignoredPaths).not.toContain('vendor/terminal-platform');
+      expect(ignoredPaths).not.toContain('vendor/terminal-platform/');
+    }
+  });
+
+  it('defaults to loopback and keeps Docker host exposure opt-in', () => {
+    expect(dockerfile).toContain('ENV HOST=127.0.0.1');
+    expect(compose).toContain('HOST=127.0.0.1');
+    expect(compose).toContain('profiles:');
+    expect(compose).toContain('- local');
+    expect(compose).toContain('127.0.0.1:3456:3456');
+    expect(compose).toContain('HOSTED_ALLOW_REMOTE=1');
+    expect(compose).toContain('publishes no host port');
+    expect(compose).toContain('Remote exposure requires');
+    expect(compose).not.toContain('/data/.claude');
+  });
+});

--- a/test/main/http/runtimeCoreProviderParsingRoutes.test.ts
+++ b/test/main/http/runtimeCoreProviderParsingRoutes.test.ts
@@ -1,0 +1,193 @@
+import { registerProjectRoutes } from '@main/http/projects';
+import { registerSearchRoutes } from '@main/http/search';
+import { registerSessionRoutes } from '@main/http/sessions';
+import { registerSubagentRoutes } from '@main/http/subagents';
+import Fastify from 'fastify';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { RuntimeCoreProviderJsonParsingServices } from '@features/runtime-core/main';
+import type { HttpServices } from '@main/http';
+import type { FastifyInstance } from 'fastify';
+
+const PROJECT_ID = '-Users-test-project';
+const SESSION_ID = 'session-1';
+const SUBAGENT_ID = 'agent-1';
+
+interface ProviderParsingFixture {
+  services: RuntimeCoreProviderJsonParsingServices;
+  scan: ReturnType<typeof vi.fn>;
+  getSessionWithOptions: ReturnType<typeof vi.fn>;
+  parseSession: ReturnType<typeof vi.fn>;
+  resolveSubagents: ReturnType<typeof vi.fn>;
+  buildSessionDetail: ReturnType<typeof vi.fn>;
+  searchSessions: ReturnType<typeof vi.fn>;
+  buildSubagentDetail: ReturnType<typeof vi.fn>;
+}
+
+function createProviderParsingFixture(source: string): ProviderParsingFixture {
+  const scan = vi.fn(async () => [{ id: source }]);
+  const getSessionWithOptions = vi.fn(async () => ({ id: SESSION_ID, source }));
+  const parseSession = vi.fn(async () => ({
+    messages: [{ type: 'assistant', source }],
+    taskCalls: [],
+  }));
+  const resolveSubagents = vi.fn(async () => []);
+  const buildSessionDetail = vi.fn((session: { source: string }) => ({
+    source: session.source,
+    chunks: [],
+    processes: [],
+  }));
+  const searchSessions = vi.fn(async () => ({
+    source,
+    results: [],
+    totalMatches: 0,
+    sessionsSearched: 0,
+    query: 'needle',
+  }));
+  const buildSubagentDetail = vi.fn(async () => ({ source, id: SUBAGENT_ID }));
+
+  return {
+    services: {
+      projectScanner: {
+        scan,
+        scanWithWorktreeGrouping: vi.fn(async () => []),
+        listWorktreeSessions: vi.fn(async () => []),
+        listSessions: vi.fn(async () => []),
+        listSessionsPaginated: vi.fn(async () => ({ sessions: [], nextCursor: null })),
+        getFileSystemProvider: vi.fn(() => ({ type: 'local' })),
+        getSessionWithOptions,
+        getSession: vi.fn(async () => ({ id: SESSION_ID, source })),
+        searchSessions,
+        searchAllProjects: vi.fn(async () => ({
+          source,
+          results: [],
+          totalMatches: 0,
+          sessionsSearched: 0,
+          query: 'needle',
+        })),
+        getProjectsDir: vi.fn(() => '/projects'),
+      } as unknown as RuntimeCoreProviderJsonParsingServices['projectScanner'],
+      sessionParser: {
+        parseSession,
+      } as unknown as RuntimeCoreProviderJsonParsingServices['sessionParser'],
+      subagentResolver: {
+        resolveSubagents,
+      } as unknown as RuntimeCoreProviderJsonParsingServices['subagentResolver'],
+      chunkBuilder: {
+        buildSessionDetail,
+        buildGroups: vi.fn(() => []),
+        buildWaterfallData: vi.fn(() => ({})),
+        buildSubagentDetail,
+      } as unknown as RuntimeCoreProviderJsonParsingServices['chunkBuilder'],
+      dataCache: {
+        get: vi.fn(() => undefined),
+        set: vi.fn(),
+        getSubagent: vi.fn(() => undefined),
+        setSubagent: vi.fn(),
+      } as unknown as RuntimeCoreProviderJsonParsingServices['dataCache'],
+    },
+    scan,
+    getSessionWithOptions,
+    parseSession,
+    resolveSubagents,
+    buildSessionDetail,
+    searchSessions,
+    buildSubagentDetail,
+  };
+}
+
+function createHttpServices(
+  providerJsonParsing: RuntimeCoreProviderJsonParsingServices
+): HttpServices {
+  return {
+    ...providerJsonParsing,
+    updaterService: {} as HttpServices['updaterService'],
+    sshConnectionManager: {} as HttpServices['sshConnectionManager'],
+  };
+}
+
+function registerProviderParsingRoutes(app: FastifyInstance, services: HttpServices): void {
+  registerProjectRoutes(app, services);
+  registerSessionRoutes(app, services);
+  registerSearchRoutes(app, services);
+  registerSubagentRoutes(app, services);
+}
+
+describe('runtimeCore provider parsing HTTP route wiring', () => {
+  it('routes JSON and JSONL parsing endpoints through runtimeCore when present', async () => {
+    const legacy = createProviderParsingFixture('legacy');
+    const runtimeCore = createProviderParsingFixture('runtime-core');
+    const services = {
+      ...createHttpServices(legacy.services),
+      runtimeCore: {
+        providerJsonParsing: runtimeCore.services,
+      },
+    } satisfies HttpServices;
+    const app = Fastify();
+    registerProviderParsingRoutes(app, services);
+    await app.ready();
+
+    try {
+      const projects = await app.inject({ method: 'GET', url: '/api/projects' });
+      const session = await app.inject({
+        method: 'GET',
+        url: `/api/projects/${PROJECT_ID}/sessions/${SESSION_ID}`,
+      });
+      const search = await app.inject({
+        method: 'GET',
+        url: `/api/projects/${PROJECT_ID}/search?q=needle`,
+      });
+      const subagent = await app.inject({
+        method: 'GET',
+        url: `/api/projects/${PROJECT_ID}/sessions/${SESSION_ID}/subagents/${SUBAGENT_ID}`,
+      });
+
+      expect(projects.json()).toEqual([{ id: 'runtime-core' }]);
+      expect(session.json()).toMatchObject({ source: 'runtime-core' });
+      expect(search.json()).toMatchObject({ source: 'runtime-core' });
+      expect(subagent.json()).toMatchObject({ source: 'runtime-core' });
+      expect(runtimeCore.scan).toHaveBeenCalledTimes(1);
+      expect(runtimeCore.parseSession).toHaveBeenCalledWith(PROJECT_ID, SESSION_ID);
+      expect(runtimeCore.searchSessions).toHaveBeenCalledWith(PROJECT_ID, 'needle', 50);
+      expect(runtimeCore.buildSubagentDetail).toHaveBeenCalledWith(
+        PROJECT_ID,
+        SESSION_ID,
+        SUBAGENT_ID,
+        runtimeCore.services.sessionParser,
+        runtimeCore.services.subagentResolver,
+        expect.objectContaining({ type: 'local' }),
+        '/projects'
+      );
+      expect(legacy.scan).not.toHaveBeenCalled();
+      expect(legacy.parseSession).not.toHaveBeenCalled();
+      expect(legacy.searchSessions).not.toHaveBeenCalled();
+      expect(legacy.buildSubagentDetail).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('falls back to legacy HttpServices provider parsing when runtimeCore is absent', async () => {
+    const legacy = createProviderParsingFixture('legacy');
+    const app = Fastify();
+    registerProviderParsingRoutes(app, createHttpServices(legacy.services));
+    await app.ready();
+
+    try {
+      const session = await app.inject({
+        method: 'GET',
+        url: `/api/projects/${PROJECT_ID}/sessions/${SESSION_ID}`,
+      });
+
+      expect(session.json()).toMatchObject({ source: 'legacy' });
+      expect(legacy.getSessionWithOptions).toHaveBeenCalledWith(PROJECT_ID, SESSION_ID, {
+        metadataLevel: 'deep',
+      });
+      expect(legacy.parseSession).toHaveBeenCalledWith(PROJECT_ID, SESSION_ID);
+      expect(legacy.resolveSubagents).toHaveBeenCalled();
+      expect(legacy.buildSessionDetail).toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/test/main/http/ssh.test.ts
+++ b/test/main/http/ssh.test.ts
@@ -1,0 +1,165 @@
+import { registerSshRoutes } from '@main/http/ssh';
+import Fastify from 'fastify';
+import { describe, expect, it, vi } from 'vitest';
+
+import type {
+  SshConnectionManager,
+  SshConnectionStatus,
+} from '@main/services/infrastructure/SshConnectionManager';
+import type { SshConfigHostEntry } from '@shared/types';
+
+const CONNECT_UNSUPPORTED_ERROR =
+  'HTTP SSH connect is not supported until context-aware route rebinding exists. Use the desktop Electron SSH controls.';
+const DISCONNECT_UNSUPPORTED_ERROR =
+  'HTTP SSH disconnect is not supported until context-aware route rebinding exists. Use the desktop Electron SSH controls.';
+
+function createSshManagerMock() {
+  const status: SshConnectionStatus = {
+    state: 'disconnected',
+    host: null,
+    error: null,
+    remoteProjectsPath: null,
+  };
+  const configHosts: SshConfigHostEntry[] = [
+    {
+      alias: 'dev-box',
+      hostName: 'dev.example.test',
+      user: 'tester',
+      port: 2222,
+      hasIdentityFile: true,
+    },
+  ];
+
+  return {
+    connect: vi.fn(async () => undefined),
+    disconnect: vi.fn(),
+    getStatus: vi.fn(() => status),
+    testConnection: vi.fn(async () => ({ success: true })),
+    getConfigHosts: vi.fn(async () => configHosts),
+    resolveHostConfig: vi.fn(async (alias: string) => ({
+      alias,
+      hostName: 'resolved.example.test',
+      hasIdentityFile: false,
+    })),
+  } as unknown as SshConnectionManager;
+}
+
+async function createApp() {
+  const app = Fastify();
+  const connectionManager = createSshManagerMock();
+  const modeSwitchCallback = vi.fn(async () => undefined);
+  registerSshRoutes(app, connectionManager, modeSwitchCallback);
+  await app.ready();
+
+  return { app, connectionManager, modeSwitchCallback };
+}
+
+describe('HTTP SSH routes', () => {
+  it('returns 501 for connect without opening SSH or switching modes', async () => {
+    const { app, connectionManager, modeSwitchCallback } = await createApp();
+
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/ssh/connect',
+        payload: {
+          host: 'dev.example.test',
+          port: 22,
+          username: 'tester',
+          authMethod: 'password',
+          password: 'secret',
+        },
+      });
+
+      expect(response.statusCode).toBe(501);
+      expect(response.json()).toEqual({
+        success: false,
+        error: CONNECT_UNSUPPORTED_ERROR,
+      });
+      expect(connectionManager.connect).not.toHaveBeenCalled();
+      expect(connectionManager.getStatus).not.toHaveBeenCalled();
+      expect(modeSwitchCallback).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('returns 501 for disconnect without closing SSH or switching modes', async () => {
+    const { app, connectionManager, modeSwitchCallback } = await createApp();
+
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/ssh/disconnect',
+      });
+
+      expect(response.statusCode).toBe(501);
+      expect(response.json()).toEqual({
+        success: false,
+        error: DISCONNECT_UNSUPPORTED_ERROR,
+      });
+      expect(connectionManager.disconnect).not.toHaveBeenCalled();
+      expect(connectionManager.getStatus).not.toHaveBeenCalled();
+      expect(modeSwitchCallback).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('keeps read-only SSH HTTP routes wired to the connection manager', async () => {
+    const { app, connectionManager, modeSwitchCallback } = await createApp();
+
+    try {
+      const stateResponse = await app.inject({
+        method: 'GET',
+        url: '/api/ssh/state',
+      });
+      expect(stateResponse.statusCode).toBe(200);
+      expect(stateResponse.json()).toEqual({
+        state: 'disconnected',
+        host: null,
+        error: null,
+        remoteProjectsPath: null,
+      });
+      expect(connectionManager.getStatus).toHaveBeenCalledTimes(1);
+
+      const hostsResponse = await app.inject({
+        method: 'GET',
+        url: '/api/ssh/config-hosts',
+      });
+      expect(hostsResponse.statusCode).toBe(200);
+      expect(hostsResponse.json()).toEqual({
+        success: true,
+        data: [
+          {
+            alias: 'dev-box',
+            hostName: 'dev.example.test',
+            user: 'tester',
+            port: 2222,
+            hasIdentityFile: true,
+          },
+        ],
+      });
+      expect(connectionManager.getConfigHosts).toHaveBeenCalledTimes(1);
+
+      const resolveResponse = await app.inject({
+        method: 'POST',
+        url: '/api/ssh/resolve-host',
+        payload: { alias: 'dev-box' },
+      });
+      expect(resolveResponse.statusCode).toBe(200);
+      expect(resolveResponse.json()).toEqual({
+        success: true,
+        data: {
+          alias: 'dev-box',
+          hostName: 'resolved.example.test',
+          hasIdentityFile: false,
+        },
+      });
+      expect(connectionManager.resolveHostConfig).toHaveBeenCalledWith('dev-box');
+      expect(modeSwitchCallback).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/test/main/http/standaloneTeamRoutes.test.ts
+++ b/test/main/http/standaloneTeamRoutes.test.ts
@@ -3,6 +3,7 @@ import { registerHttpRoutes } from '@main/http';
 import {
   attachStandaloneTeamHttpServices,
   buildStandaloneTeamHttpServiceSlice,
+  buildStandaloneTeamServices,
 } from '@main/standaloneTeamServices';
 import Fastify from 'fastify';
 import { describe, expect, it, vi } from 'vitest';
@@ -14,6 +15,8 @@ import type {
   OpenCodeRuntimeControlAck,
   TeamHttpDataApi,
 } from '@main/services/team/contracts/TeamProvisioningApis';
+import type { TeamDataService } from '@main/services/team/TeamDataService';
+import type { TeamProvisioningService } from '@main/services/team/TeamProvisioningService';
 import type { StandaloneTeamProvisioningHttpApi } from '@main/standaloneTeamServices';
 import type {
   TeamCreateConfigRequest,
@@ -202,6 +205,44 @@ describe('standalone team HTTP route registration', () => {
     } finally {
       await app.close();
     }
+  });
+
+  it('wires standalone control URL resolver and stops teams before member-work-sync disposal', async () => {
+    const order: string[] = [];
+    const controlApiBaseUrlResolver = vi.fn(async () => 'http://127.0.0.1:43123');
+    const teamProvisioningService = {
+      ...createTeamProvisioningService(),
+      setControlApiBaseUrlResolver: vi.fn(),
+      stopAllTeams: vi.fn(async () => {
+        order.push('stopAllTeams');
+      }),
+    };
+    const memberWorkSyncFeature = {
+      ...createMemberWorkSyncFeature(),
+      dispose: vi.fn(async () => {
+        order.push('memberWorkSync.dispose');
+      }),
+    };
+
+    const services = buildStandaloneTeamServices({
+      teamDataService: createTeamDataApi() as unknown as TeamDataService,
+      teamProvisioningService: teamProvisioningService as unknown as TeamProvisioningService,
+      memberWorkSyncFeature,
+      controlApiBaseUrlResolver,
+    });
+
+    expect(teamProvisioningService.setControlApiBaseUrlResolver).toHaveBeenCalledWith(
+      controlApiBaseUrlResolver
+    );
+    await expect(
+      teamProvisioningService.setControlApiBaseUrlResolver.mock.calls[0]?.[0]?.()
+    ).resolves.toBe('http://127.0.0.1:43123');
+
+    await services.dispose();
+
+    expect(teamProvisioningService.stopAllTeams).toHaveBeenCalledOnce();
+    expect(memberWorkSyncFeature.dispose).toHaveBeenCalledOnce();
+    expect(order).toEqual(['stopAllTeams', 'memberWorkSync.dispose']);
   });
 
   it('registers team routes from runtimeCore team use cases without legacy team service fields', async () => {

--- a/test/main/http/standaloneTeamRoutes.test.ts
+++ b/test/main/http/standaloneTeamRoutes.test.ts
@@ -1,0 +1,249 @@
+import { createRuntimeCoreProviderJsonParsingServices } from '@features/runtime-core/main';
+import { registerHttpRoutes } from '@main/http';
+import {
+  attachStandaloneTeamHttpServices,
+  buildStandaloneTeamHttpServiceSlice,
+} from '@main/standaloneTeamServices';
+import Fastify from 'fastify';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { MemberWorkSyncFeatureFacade } from '@features/member-work-sync/main';
+import type { RuntimeCoreFeatureFacade } from '@features/runtime-core/main';
+import type { HttpServices } from '@main/http';
+import type {
+  OpenCodeRuntimeControlAck,
+  TeamHttpDataApi,
+} from '@main/services/team/contracts/TeamProvisioningApis';
+import type { StandaloneTeamProvisioningHttpApi } from '@main/standaloneTeamServices';
+import type {
+  TeamCreateConfigRequest,
+  TeamCreateRequest,
+  TeamCreateResponse,
+  TeamLaunchRequest,
+  TeamLaunchResponse,
+  TeamProvisioningProgress,
+  TeamRuntimeState,
+} from '@shared/types/team';
+
+function createBaseServices(overrides: Partial<HttpServices> = {}): HttpServices {
+  return {
+    projectScanner: {} as HttpServices['projectScanner'],
+    sessionParser: {} as HttpServices['sessionParser'],
+    subagentResolver: {} as HttpServices['subagentResolver'],
+    chunkBuilder: {} as HttpServices['chunkBuilder'],
+    dataCache: {} as HttpServices['dataCache'],
+    updaterService: {} as HttpServices['updaterService'],
+    sshConnectionManager: {} as HttpServices['sshConnectionManager'],
+    ...overrides,
+  };
+}
+
+function createMemberWorkSyncFeature(): MemberWorkSyncFeatureFacade {
+  return {
+    getStatus: vi.fn(),
+    refreshStatus: vi.fn(),
+    getMetrics: vi.fn(async () => ({
+      teamName: 'demo-team',
+      generatedAt: '2026-07-10T00:00:00.000Z',
+      members: [],
+      totals: {
+        caughtUp: 0,
+        needsSync: 0,
+        stillWorking: 0,
+        blocked: 0,
+        unknown: 0,
+      },
+    })),
+    report: vi.fn(),
+    scheduleProofMissingRecovery: vi.fn(),
+    noteTeamChange: vi.fn(),
+    enqueueStartupScan: vi.fn(),
+    replayPendingReports: vi.fn(),
+    dispatchDueNudges: vi.fn(),
+    buildRuntimeTurnSettledHookSettings: vi.fn(),
+    buildRuntimeTurnSettledEnvironment: vi.fn(),
+    drainRuntimeTurnSettledEvents: vi.fn(),
+    getQueueDiagnostics: vi.fn(() => ({
+      queued: 0,
+      processing: 0,
+      delayed: 0,
+    })),
+    dispose: vi.fn(),
+  } as unknown as MemberWorkSyncFeatureFacade;
+}
+
+function createTeamDataApi(): TeamHttpDataApi {
+  return {
+    listTeams: vi.fn(async () => [
+      {
+        teamName: 'demo-team',
+        displayName: 'Demo Team',
+        description: 'Demo',
+        memberCount: 1,
+        taskCount: 0,
+        lastActivity: null,
+      },
+    ]),
+    getTeamData: vi.fn(),
+    getSavedRequest: vi.fn(async () => null),
+    createTeamConfig: vi.fn(async (_request: TeamCreateConfigRequest) => undefined),
+  } as unknown as TeamHttpDataApi;
+}
+
+function createTeamProvisioningService(): StandaloneTeamProvisioningHttpApi {
+  const progress: TeamProvisioningProgress = {
+    runId: 'run-demo',
+    teamName: 'demo-team',
+    state: 'ready',
+    message: 'ready',
+    startedAt: '2026-07-10T00:00:00.000Z',
+    updatedAt: '2026-07-10T00:00:00.000Z',
+  };
+  const ack = async (): Promise<OpenCodeRuntimeControlAck> => ({
+    ok: true,
+    providerId: 'opencode',
+    teamName: 'demo-team',
+    runId: 'run-demo',
+    state: 'recorded',
+    diagnostics: [],
+    observedAt: '2026-07-10T00:00:00.000Z',
+  });
+
+  return {
+    createTeam: vi.fn(
+      async (
+        _request: TeamCreateRequest,
+        _onProgress: (progress: TeamProvisioningProgress) => void
+      ): Promise<TeamCreateResponse> => ({ runId: 'run-demo' })
+    ),
+    launchTeam: vi.fn(
+      async (
+        _request: TeamLaunchRequest,
+        _onProgress: (progress: TeamProvisioningProgress) => void
+      ): Promise<TeamLaunchResponse> => ({ runId: 'run-demo' })
+    ),
+    getProvisioningStatus: vi.fn(async () => progress),
+    repairStaleTaskActivityIntervalsBeforeSnapshot: vi.fn(async () => undefined),
+    getRuntimeState: vi.fn(
+      async (): Promise<TeamRuntimeState> => ({
+        teamName: 'demo-team',
+        isAlive: true,
+        runId: 'run-demo',
+        progress,
+      })
+    ),
+    stopTeam: vi.fn(async () => undefined),
+    getAliveTeams: vi.fn(() => ['demo-team']),
+    recordOpenCodeRuntimeBootstrapCheckin: vi.fn(ack),
+    deliverOpenCodeRuntimeMessage: vi.fn(ack),
+    recordOpenCodeRuntimeTaskEvent: vi.fn(ack),
+    recordOpenCodeRuntimeHeartbeat: vi.fn(ack),
+    answerOpenCodeRuntimePermission: vi.fn(ack),
+  } satisfies StandaloneTeamProvisioningHttpApi;
+}
+
+describe('standalone team HTTP route registration', () => {
+  it('registers member-work-sync team routes when that is the only team support present', async () => {
+    const app = Fastify();
+    const memberWorkSyncFeature = createMemberWorkSyncFeature();
+    registerHttpRoutes(app, createBaseServices({ memberWorkSyncFeature }), async () => undefined);
+    await app.ready();
+
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/teams/demo-team/member-work-sync/metrics',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(memberWorkSyncFeature.getMetrics).toHaveBeenCalledWith({ teamName: 'demo-team' });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('attaches standalone team data, runtime, and member-work-sync services', async () => {
+    const app = Fastify();
+    const memberWorkSyncFeature = createMemberWorkSyncFeature();
+    const standaloneServices = {
+      httpServices: buildStandaloneTeamHttpServiceSlice({
+        teamDataService: createTeamDataApi(),
+        teamProvisioningService: createTeamProvisioningService(),
+        memberWorkSyncFeature,
+      }),
+    };
+    const services = attachStandaloneTeamHttpServices(createBaseServices(), standaloneServices);
+    registerHttpRoutes(app, services, async () => undefined);
+    await app.ready();
+
+    try {
+      const teamsResponse = await app.inject({ method: 'GET', url: '/api/teams' });
+      expect(teamsResponse.statusCode).toBe(200);
+      expect(teamsResponse.json()).toEqual(
+        expect.arrayContaining([expect.objectContaining({ teamName: 'demo-team' })])
+      );
+
+      const runtimeResponse = await app.inject({
+        method: 'GET',
+        url: '/api/teams/demo-team/runtime',
+      });
+      expect(runtimeResponse.statusCode).toBe(200);
+      expect(runtimeResponse.json()).toMatchObject({
+        teamName: 'demo-team',
+        isAlive: true,
+      });
+
+      const metricsResponse = await app.inject({
+        method: 'GET',
+        url: '/api/teams/demo-team/member-work-sync/metrics',
+      });
+      expect(metricsResponse.statusCode).toBe(200);
+      expect(memberWorkSyncFeature.getMetrics).toHaveBeenCalledWith({ teamName: 'demo-team' });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('registers team routes from runtimeCore team use cases without legacy team service fields', async () => {
+    const app = Fastify();
+    const memberWorkSyncFeature = createMemberWorkSyncFeature();
+    const httpServices = buildStandaloneTeamHttpServiceSlice({
+      teamDataService: createTeamDataApi(),
+      teamProvisioningService: createTeamProvisioningService(),
+      memberWorkSyncFeature,
+    });
+    const baseServices = createBaseServices();
+    const runtimeCore = {
+      providerJsonParsing: createRuntimeCoreProviderJsonParsingServices(baseServices),
+      teams: {
+        data: httpServices.teamDataApi,
+        http: httpServices.teamApis,
+        ipc: {} as never,
+      },
+    } satisfies RuntimeCoreFeatureFacade;
+
+    registerHttpRoutes(
+      app,
+      createBaseServices({
+        memberWorkSyncFeature,
+        runtimeCore,
+      }),
+      async () => undefined
+    );
+    await app.ready();
+
+    try {
+      const teamsResponse = await app.inject({ method: 'GET', url: '/api/teams' });
+      const runtimeResponse = await app.inject({
+        method: 'GET',
+        url: '/api/teams/demo-team/runtime',
+      });
+
+      expect(teamsResponse.statusCode).toBe(200);
+      expect(runtimeResponse.statusCode).toBe(200);
+      expect(runtimeResponse.json()).toMatchObject({ teamName: 'demo-team', isAlive: true });
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/test/main/http/standaloneTeamRoutes.test.ts
+++ b/test/main/http/standaloneTeamRoutes.test.ts
@@ -1,6 +1,9 @@
 import { createRuntimeCoreProviderJsonParsingServices } from '@features/runtime-core/main';
 import { registerHttpRoutes } from '@main/http';
 import {
+  StandaloneOpenCodeRuntimeAdapterUnavailableError,
+} from '@main/services/team/provisioning/TeamProvisioningStandaloneOpenCodeBoundary';
+import {
   attachStandaloneTeamHttpServices,
   buildStandaloneTeamHttpServiceSlice,
   buildStandaloneTeamServices,
@@ -243,6 +246,50 @@ describe('standalone team HTTP route registration', () => {
     expect(teamProvisioningService.stopAllTeams).toHaveBeenCalledOnce();
     expect(memberWorkSyncFeature.dispose).toHaveBeenCalledOnce();
     expect(order).toEqual(['stopAllTeams', 'memberWorkSync.dispose']);
+  });
+
+  it('maps standalone OpenCode runtime-adapter boundary errors to HTTP 501', async () => {
+    const app = Fastify();
+    const launchTeam = vi.fn(async () => {
+      throw new StandaloneOpenCodeRuntimeAdapterUnavailableError();
+    });
+    const memberWorkSyncFeature = createMemberWorkSyncFeature();
+    const standaloneServices = {
+      httpServices: buildStandaloneTeamHttpServiceSlice({
+        teamDataService: createTeamDataApi(),
+        teamProvisioningService: {
+          ...createTeamProvisioningService(),
+          launchTeam,
+        },
+        memberWorkSyncFeature,
+      }),
+    };
+    const services = attachStandaloneTeamHttpServices(createBaseServices(), standaloneServices);
+    registerHttpRoutes(app, services, async () => undefined);
+    await app.ready();
+
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/teams/alpha/launch',
+        payload: {
+          cwd: '/repo',
+          providerId: 'opencode',
+        },
+      });
+
+      expect(response.statusCode).toBe(501);
+      expect(response.json()).toEqual({
+        error:
+          'OpenCode team launch is not available in standalone mode because the OpenCode runtime adapter is unavailable outside Electron.',
+      });
+      expect(launchTeam).toHaveBeenCalledWith(
+        expect.objectContaining({ teamName: 'alpha', providerId: 'opencode' }),
+        expect.any(Function)
+      );
+    } finally {
+      await app.close();
+    }
   });
 
   it('registers team routes from runtimeCore team use cases without legacy team service fields', async () => {

--- a/test/main/http/teamRouteParsers.test.ts
+++ b/test/main/http/teamRouteParsers.test.ts
@@ -32,7 +32,7 @@ describe('HTTP team route parsers', () => {
     expectBadRequest(() => assertOptionalString(42, 'displayName'), 'displayName must be a string');
   });
 
-  it('parses launch requests and preserves launch backend compatibility behavior', () => {
+  it('parses launch requests and rejects explicit incompatible backends', () => {
     expect(
       parseLaunchRequest('demo-team', {
         cwd: ' /Users/test/project ',
@@ -62,17 +62,15 @@ describe('HTTP team route parsers', () => {
       worktree: 'feature-branch',
     });
 
-    expect(
-      parseLaunchRequest('demo-team', {
-        cwd: '/Users/test/project',
-        providerId: 'anthropic',
-        providerBackendId: 'codex-native',
-      })
-    ).toEqual({
-      teamName: 'demo-team',
-      cwd: '/Users/test/project',
-      providerId: 'anthropic',
-    });
+    expectBadRequest(
+      () =>
+        parseLaunchRequest('demo-team', {
+          cwd: '/Users/test/project',
+          providerId: 'anthropic',
+          providerBackendId: 'codex-native',
+        }),
+      'providerBackendId must be valid for the selected provider'
+    );
 
     expectBadRequest(
       () =>
@@ -185,6 +183,23 @@ describe('HTTP team route parsers', () => {
     expect(request.effort).toBeUndefined();
     expect(request.fastMode).toBeUndefined();
     expect(request.limitContext).toBeUndefined();
+
+    expect(
+      parseDraftLaunchCreateRequest(
+        { ...savedRequest, providerId: 'anthropic', providerBackendId: 'codex-native' as never },
+        { cwd: '/Users/test/project' }
+      ).providerBackendId
+    ).toBeUndefined();
+
+    expectBadRequest(
+      () =>
+        parseDraftLaunchCreateRequest(savedRequest, {
+          cwd: '/Users/test/project',
+          providerId: 'anthropic',
+          providerBackendId: 'codex-native',
+        }),
+      'providerBackendId must be valid for the selected provider'
+    );
 
     expectBadRequest(
       () =>

--- a/test/main/http/teams.test.ts
+++ b/test/main/http/teams.test.ts
@@ -269,6 +269,51 @@ describe('HTTP team runtime routes', () => {
     }
   });
 
+  it('uses runtimeCore task activity repair before reading a team snapshot', async () => {
+    const mocks = createServicesMock();
+    const app = Fastify();
+    mocks.getTeamData.mockResolvedValue({
+      teamName: 'demo-team',
+      config: null,
+      tasks: [],
+      members: [],
+      messages: [],
+      processes: [],
+      kanban: null,
+    } as unknown as TeamViewSnapshot);
+    registerTeamRoutes(app, {
+      ...mocks.services,
+      teamApis: undefined,
+      teamDataApi: undefined,
+      runtimeCore: {
+        providerJsonParsing: mocks.services,
+        teams: {
+          data: mocks.services.teamDataApi!,
+          http: mocks.services.teamApis!,
+          ipc: {} as never,
+        },
+      },
+    });
+    await app.ready();
+
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/teams/demo-team',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(mocks.repairStaleTaskActivityIntervalsBeforeSnapshot).toHaveBeenCalledWith(
+        'demo-team'
+      );
+      expect(
+        mocks.repairStaleTaskActivityIntervalsBeforeSnapshot.mock.invocationCallOrder[0]
+      ).toBeLessThan(mocks.getTeamData.mock.invocationCallOrder[0]);
+    } finally {
+      await app.close();
+    }
+  });
+
   it('overlays team get snapshots with live runtime state', async () => {
     const { app, getTeamData, getRuntimeState } = await createApp();
     getTeamData.mockResolvedValue({

--- a/test/main/http/teams.test.ts
+++ b/test/main/http/teams.test.ts
@@ -512,9 +512,8 @@ describe('HTTP team runtime routes', () => {
     }
   });
 
-  it('drops a stale known backend when launching with a different provider over HTTP', async () => {
+  it('rejects explicit incompatible provider backends over HTTP launch', async () => {
     const { app, launchTeam } = await createApp();
-    launchTeam.mockResolvedValue({ runId: 'run-2' });
 
     try {
       const response = await app.inject({
@@ -529,17 +528,9 @@ describe('HTTP team runtime routes', () => {
         },
       });
 
-      expect(response.statusCode).toBe(200);
-      expect(launchTeam).toHaveBeenCalledWith(
-        {
-          teamName: 'demo-team',
-          cwd: '/Users/test/project',
-          providerId: 'anthropic',
-          model: 'sonnet',
-          effort: 'low',
-        },
-        expect.any(Function)
-      );
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error).toContain('providerBackendId must be valid');
+      expect(launchTeam).not.toHaveBeenCalled();
     } finally {
       await app.close();
     }
@@ -708,6 +699,44 @@ describe('HTTP team runtime routes', () => {
       expect(request.effort).toBeUndefined();
       expect(request.fastMode).toBeUndefined();
       expect(request.limitContext).toBeUndefined();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('drops a stale saved draft backend when draft launch keeps the saved provider over HTTP', async () => {
+    const { app, createTeam, getSavedRequest } = await createApp();
+    getSavedRequest.mockResolvedValue({
+      teamName: 'draft-team',
+      displayName: 'Draft Team',
+      cwd: '/Users/test/saved-project',
+      providerId: 'codex',
+      providerBackendId: 'unknown-stale-backend' as never,
+      model: 'gpt-5.2',
+      effort: 'medium',
+      members: [{ name: 'builder', role: 'Engineer', providerId: 'codex' }],
+    });
+    createTeam.mockResolvedValue({ runId: 'run-draft-codex-stale-backend' });
+
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/teams/draft-team/launch',
+        payload: {
+          cwd: '/Users/test/project',
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const [request] = createTeam.mock.calls.at(-1)!;
+      expect(request).toMatchObject({
+        teamName: 'draft-team',
+        cwd: '/Users/test/project',
+        providerId: 'codex',
+        model: 'gpt-5.2',
+        effort: 'medium',
+      });
+      expect(request.providerBackendId).toBeUndefined();
     } finally {
       await app.close();
     }

--- a/test/main/ipc/configValidation.test.ts
+++ b/test/main/ipc/configValidation.test.ts
@@ -233,6 +233,34 @@ describe('configValidation', () => {
     }
   });
 
+  it('accepts loopback httpServer host updates', () => {
+    const result = validateConfigUpdatePayload('httpServer', {
+      enabled: true,
+      port: 4567,
+      host: '127.0.0.1',
+    });
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.data).toEqual({
+        enabled: true,
+        port: 4567,
+        host: '127.0.0.1',
+      });
+    }
+  });
+
+  it('rejects non-loopback httpServer host updates', () => {
+    const result = validateConfigUpdatePayload('httpServer', {
+      host: '0.0.0.0',
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toContain('loopback');
+    }
+  });
+
   it('normalizes legacy Codex provider connection updates to the native-only config shape', () => {
     const result = validateConfigUpdatePayload('providerConnections', {
       codex: {

--- a/test/main/services/infrastructure/ConfigManager.httpSecurity.test.ts
+++ b/test/main/services/infrastructure/ConfigManager.httpSecurity.test.ts
@@ -1,0 +1,92 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ConfigManager } from '../../../../src/main/services/infrastructure/ConfigManager';
+
+describe('ConfigManager HTTP security config', () => {
+  afterEach(() => {
+    ConfigManager.resetInstance();
+    vi.restoreAllMocks();
+  });
+
+  it('fails closed when loading a persisted non-loopback httpServer host', () => {
+    const configPath = path.join(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'agent-teams-http-config-')),
+      'config.json'
+    );
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        httpServer: {
+          enabled: true,
+          port: 4567,
+          host: '0.0.0.0',
+        },
+      })
+    );
+
+    const manager = new ConfigManager(configPath);
+
+    expect(manager.getConfig().httpServer).toEqual({
+      enabled: false,
+      port: 4567,
+      host: '127.0.0.1',
+    });
+  });
+
+  it('redacts path-bearing config fields for HTTP responses', () => {
+    const configPath = path.join(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'agent-teams-http-redact-')),
+      'config.json'
+    );
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        general: {
+          claudeRootPath: '/Users/alice/.claude',
+          customProjectPaths: ['/Users/alice/project-a'],
+        },
+        sessions: {
+          pinnedSessions: {
+            '-Users-alice-project-a': [{ sessionId: 'session-a', pinnedAt: 1 }],
+          },
+          hiddenSessions: {
+            '-Users-alice-project-b': [{ sessionId: 'session-b', hiddenAt: 2 }],
+          },
+        },
+        ssh: {
+          lastConnection: {
+            host: 'example.test',
+            port: 22,
+            username: 'alice',
+            authMethod: 'privateKey',
+            privateKeyPath: '/Users/alice/.ssh/id_ed25519',
+          },
+          profiles: [
+            {
+              id: 'profile-a',
+              name: 'Profile A',
+              host: 'example.test',
+              port: 22,
+              username: 'alice',
+              authMethod: 'privateKey',
+              privateKeyPath: '/Users/alice/.ssh/profile_key',
+            },
+          ],
+        },
+      })
+    );
+
+    const manager = new ConfigManager(configPath);
+    const config = manager.getConfigForHttpResponse();
+
+    expect(config.general.claudeRootPath).toBe('[redacted-path]');
+    expect(config.general.customProjectPaths).toEqual(['[redacted-path]']);
+    expect(Object.keys(config.sessions.pinnedSessions)).toEqual(['[redacted-project-1]']);
+    expect(Object.keys(config.sessions.hiddenSessions)).toEqual(['[redacted-project-1]']);
+    expect(config.ssh.lastConnection?.privateKeyPath).toBe('[redacted-path]');
+    expect(config.ssh.profiles[0]?.privateKeyPath).toBe('[redacted-path]');
+  });
+});

--- a/test/main/services/infrastructure/HttpServer.boundPort.test.ts
+++ b/test/main/services/infrastructure/HttpServer.boundPort.test.ts
@@ -1,0 +1,30 @@
+import { HttpServer } from '@main/services/infrastructure/HttpServer';
+import { describe, expect, it } from 'vitest';
+
+import type { HttpServices } from '@main/http';
+
+function createServices(): HttpServices {
+  return {
+    projectScanner: {} as HttpServices['projectScanner'],
+    sessionParser: {} as HttpServices['sessionParser'],
+    subagentResolver: {} as HttpServices['subagentResolver'],
+    chunkBuilder: {} as HttpServices['chunkBuilder'],
+    dataCache: {} as HttpServices['dataCache'],
+    updaterService: {} as HttpServices['updaterService'],
+    sshConnectionManager: {} as HttpServices['sshConnectionManager'],
+  };
+}
+
+describe('HttpServer bound port tracking', () => {
+  it('records the actual bound port when the OS assigns a standalone port', async () => {
+    const server = new HttpServer();
+    const port = await server.start(createServices(), async () => undefined, 0, '127.0.0.1');
+
+    try {
+      expect(port).toBeGreaterThan(0);
+      expect(server.getPort()).toBe(port);
+    } finally {
+      await server.stop();
+    }
+  });
+});

--- a/test/main/services/infrastructure/HttpServer.security.test.ts
+++ b/test/main/services/infrastructure/HttpServer.security.test.ts
@@ -1,0 +1,125 @@
+import Fastify from 'fastify';
+import { describe, expect, it } from 'vitest';
+
+import { registerHttpSecurityMiddleware } from '../../../../src/main/services/infrastructure/HttpServer';
+
+async function createSecuredTestApp(authToken: string | null, corsOrigin?: string) {
+  const app = Fastify({ logger: false });
+  await registerHttpSecurityMiddleware(app, authToken, corsOrigin);
+
+  app.get('/api/secure', async () => ({ success: true }));
+  app.get('/health', async () => ({ ok: true }));
+
+  return app;
+}
+
+describe('HttpServer security middleware', () => {
+  it('handles authenticated CORS preflight before bearer auth', async () => {
+    const app = await createSecuredTestApp('expected-token', 'http://localhost:5173');
+
+    try {
+      const preflight = await app.inject({
+        method: 'OPTIONS',
+        url: '/api/secure',
+        headers: {
+          origin: 'http://localhost:5173',
+          'access-control-request-method': 'GET',
+          'access-control-request-headers': 'authorization',
+          authorization: 'Bearer wrong-token',
+        },
+      });
+
+      expect(preflight.statusCode).toBe(204);
+      expect(preflight.headers['access-control-allow-origin']).toBe('http://localhost:5173');
+      expect(preflight.headers['access-control-allow-credentials']).toBe('true');
+      expect(preflight.body).not.toContain('Unauthorized');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('keeps non-preflight API requests fail-closed without bearer auth', async () => {
+    const app = await createSecuredTestApp('expected-token', 'http://localhost:5173');
+
+    try {
+      const missingAuth = await app.inject({
+        method: 'GET',
+        url: '/api/secure',
+        headers: {
+          origin: 'http://localhost:5173',
+        },
+      });
+      expect(missingAuth.statusCode).toBe(401);
+
+      const wrongAuth = await app.inject({
+        method: 'GET',
+        url: '/api/secure',
+        headers: {
+          origin: 'http://localhost:5173',
+          authorization: 'Bearer wrong-token',
+        },
+      });
+      expect(wrongAuth.statusCode).toBe(401);
+
+      const malformedAuth = await app.inject({
+        method: 'GET',
+        url: '/api/secure',
+        headers: {
+          origin: 'http://localhost:5173',
+          authorization: 'Bearer expected-token extra',
+        },
+      });
+      expect(malformedAuth.statusCode).toBe(401);
+
+      const validAuth = await app.inject({
+        method: 'GET',
+        url: '/api/secure',
+        headers: {
+          origin: 'http://localhost:5173',
+          authorization: 'Bearer expected-token',
+        },
+      });
+      expect(validAuth.statusCode).toBe(200);
+      expect(validAuth.json()).toEqual({ success: true });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('does not emit wildcard CORS headers with credentials for wildcard origin config', async () => {
+    const app = await createSecuredTestApp('expected-token', '*');
+
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/secure',
+        headers: {
+          origin: 'https://example.test',
+          authorization: 'Bearer expected-token',
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.headers['access-control-allow-origin']).toBe('https://example.test');
+      expect(response.headers['access-control-allow-origin']).not.toBe('*');
+      expect(response.headers['access-control-allow-credentials']).toBe('true');
+
+      const preflight = await app.inject({
+        method: 'OPTIONS',
+        url: '/api/secure',
+        headers: {
+          origin: 'https://example.test',
+          'access-control-request-method': 'GET',
+          'access-control-request-headers': 'authorization',
+        },
+      });
+
+      expect(preflight.statusCode).toBe(204);
+      expect(preflight.headers['access-control-allow-origin']).toBe('https://example.test');
+      expect(preflight.headers['access-control-allow-origin']).not.toBe('*');
+      expect(preflight.headers['access-control-allow-credentials']).toBe('true');
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/test/main/services/infrastructure/httpServerAuth.test.ts
+++ b/test/main/services/infrastructure/httpServerAuth.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertHttpServerBindAllowed,
+  extractBearerAuthToken,
+  timingSafeHttpAuthTokenEquals,
+} from '../../../../src/main/services/infrastructure/httpServerAuth';
+
+describe('httpServerAuth', () => {
+  it('fails closed for non-loopback binds without an auth token', () => {
+    expect(() => assertHttpServerBindAllowed('0.0.0.0', null)).toThrow('non-loopback host');
+    expect(() => assertHttpServerBindAllowed('127.0.0.1', null)).not.toThrow();
+    expect(() => assertHttpServerBindAllowed('0.0.0.0', 'token')).not.toThrow();
+  });
+
+  it('compares bearer tokens through fixed-length digests', () => {
+    expect(timingSafeHttpAuthTokenEquals('expected-token', 'expected-token')).toBe(true);
+    expect(timingSafeHttpAuthTokenEquals('expected-token', 'wrong-token')).toBe(false);
+    expect(timingSafeHttpAuthTokenEquals('expected-token', '')).toBe(false);
+  });
+
+  it('accepts exactly one bearer token value', () => {
+    expect(extractBearerAuthToken('Bearer expected-token')).toBe('expected-token');
+    expect(extractBearerAuthToken('Basic expected-token')).toBeNull();
+    expect(extractBearerAuthToken('Bearer expected-token extra')).toBeNull();
+  });
+});

--- a/test/renderer/api/appCapabilities.test.ts
+++ b/test/renderer/api/appCapabilities.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { ElectronAPI } from '../../../src/shared/types/api';
+
+function installElectronApi(api: Partial<ElectronAPI>): void {
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    value: api,
+  });
+}
+
+describe('renderer app API capabilities', () => {
+  afterEach(() => {
+    Reflect.deleteProperty(window, 'electronAPI');
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it('reports hosted-web capabilities when no Electron preload adapter is present', async () => {
+    const { getAppCapabilities, isElectronMode, supportsAppCapability } = await import(
+      '../../../src/renderer/api'
+    );
+
+    expect(isElectronMode()).toBe(false);
+    expect(getAppCapabilities()).toEqual({
+      runtime: 'hosted-web-http',
+      electronPreload: false,
+      editorFileWatching: false,
+      nativeFilePathLookup: false,
+      nativeUpdater: false,
+      nativeWindowControls: false,
+    });
+    expect(supportsAppCapability('editorFileWatching')).toBe(false);
+  });
+
+  it('reports Electron preload capabilities and keeps the preload adapter as the API implementation', async () => {
+    const setWatchedFiles = vi.fn().mockResolvedValue(undefined);
+    const electronApi = {
+      editor: {
+        watchDir: vi.fn().mockResolvedValue(undefined),
+        setWatchedFiles,
+        setWatchedDirs: vi.fn().mockResolvedValue(undefined),
+      },
+      getPathForFile: vi.fn(),
+      updater: {
+        check: vi.fn().mockResolvedValue(undefined),
+        download: vi.fn().mockResolvedValue(undefined),
+        install: vi.fn().mockResolvedValue(undefined),
+        onStatus: vi.fn(() => vi.fn()),
+      },
+      windowControls: {
+        minimize: vi.fn().mockResolvedValue(undefined),
+        maximize: vi.fn().mockResolvedValue(undefined),
+        close: vi.fn().mockResolvedValue(undefined),
+        isMaximized: vi.fn().mockResolvedValue(false),
+        isFullScreen: vi.fn().mockResolvedValue(false),
+        relaunch: vi.fn().mockResolvedValue(undefined),
+      },
+    } as unknown as Partial<ElectronAPI>;
+    installElectronApi(electronApi);
+
+    const { api, getAppCapabilities, isElectronMode, supportsAppCapability } = await import(
+      '../../../src/renderer/api'
+    );
+
+    expect(isElectronMode()).toBe(true);
+    expect(getAppCapabilities()).toMatchObject({
+      runtime: 'electron-preload',
+      electronPreload: true,
+      editorFileWatching: true,
+      nativeFilePathLookup: true,
+      nativeUpdater: true,
+      nativeWindowControls: true,
+    });
+    expect(supportsAppCapability('editorFileWatching')).toBe(true);
+
+    await api.editor.setWatchedFiles(['/tmp/example.ts']);
+
+    expect(setWatchedFiles).toHaveBeenCalledWith(['/tmp/example.ts']);
+  });
+});

--- a/test/renderer/api/httpClient.teamsHostedWeb.test.ts
+++ b/test/renderer/api/httpClient.teamsHostedWeb.test.ts
@@ -1,0 +1,249 @@
+import { HttpAPIClient } from '@renderer/api/httpClient';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+class FakeEventSource {
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  addEventListener = vi.fn();
+  close = vi.fn();
+}
+
+describe('HttpAPIClient hosted web teams', () => {
+  let calls: Array<{ url: string; init: RequestInit | undefined }>;
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let eventSourceMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    calls = [];
+    fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({ url, init });
+      return routeResponse(url);
+    });
+    eventSourceMock = vi.fn(() => new FakeEventSource());
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('EventSource', eventSourceMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('maps the Electron teams surface to typed hosted-web HTTP routes', async () => {
+    const client = new HttpAPIClient('https://hosted.example');
+
+    await expect(client.teams.list()).resolves.toEqual([
+      expect.objectContaining({
+        teamName: 'team/1',
+        displayName: 'Team 1',
+        memberCount: 1,
+        projectPath: '/workspace/project',
+      }),
+    ]);
+
+    await expect(client.teams.getData('team/1')).resolves.toMatchObject({
+      teamName: 'team/1',
+      config: { projectPath: '/workspace/project' },
+      tasks: [{ id: 'task-1', kanbanColumn: 'review' }],
+      kanbanState: { columnOrder: { review: ['task-1'] } },
+      processes: [],
+      isAlive: true,
+    });
+
+    await expect(
+      client.teams.createTeam({
+        teamName: 'new-team',
+        cwd: '/workspace/new-project',
+        members: [
+          {
+            name: 'Builder',
+            role: 'Implementation',
+            isolation: 'worktree',
+            providerId: 'codex',
+            model: 'gpt-5',
+          },
+        ],
+        providerId: 'codex',
+        model: 'gpt-5',
+        effort: 'high',
+        skipPermissions: false,
+      })
+    ).resolves.toEqual({ runId: 'run-create', launchStatus: 'started' });
+
+    await expect(
+      client.teams.launchTeam({
+        teamName: 'team/1',
+        cwd: '/workspace/project',
+        providerId: 'codex',
+        model: 'gpt-5',
+      })
+    ).resolves.toEqual({
+      runId: 'run-launch',
+      launchStatus: 'already_running',
+      alreadyRunning: true,
+    });
+
+    await expect(client.teams.getProvisioningStatus('run-launch')).resolves.toMatchObject({
+      runId: 'run-launch',
+      teamName: 'team/1',
+      state: 'ready',
+      message: 'Ready',
+    });
+    await expect(client.teams.processAlive('team/1')).resolves.toBe(true);
+    await expect(client.teams.aliveList()).resolves.toEqual(['team/1']);
+    await expect(client.teams.stop('team/1')).resolves.toBeUndefined();
+
+    expect(calls.map((call) => call.url)).toEqual([
+      'https://hosted.example/api/hosted/v1/teams',
+      'https://hosted.example/api/hosted/v1/teams/team%2F1',
+      'https://hosted.example/api/hosted/v1/teams/new-team/launch',
+      'https://hosted.example/api/hosted/v1/teams/team%2F1/launch',
+      'https://hosted.example/api/hosted/v1/teams/provisioning/run-launch',
+      'https://hosted.example/api/hosted/v1/teams/team%2F1/runtime',
+      'https://hosted.example/api/hosted/v1/teams/runtime/alive',
+      'https://hosted.example/api/hosted/v1/teams/team%2F1/stop',
+    ]);
+
+    expect(calls[2].init).toMatchObject({ method: 'POST' });
+    expect(JSON.parse(String(calls[2].init?.body))).toEqual({
+      workspaceRef: { id: '/workspace/new-project', displayName: 'new-project' },
+      provider: { providerId: 'codex', modelId: 'gpt-5', effort: 'high' },
+      members: [
+        {
+          displayName: 'Builder',
+          role: 'Implementation',
+          isolation: 'managed-worktree',
+          provider: { providerId: 'codex', modelId: 'gpt-5' },
+        },
+      ],
+      requireManualApproval: true,
+    });
+    expect(calls[3].init).toMatchObject({ method: 'POST' });
+    expect(JSON.parse(String(calls[3].init?.body))).toEqual({
+      workspaceRef: { id: '/workspace/project', displayName: 'project' },
+      provider: { providerId: 'codex', modelId: 'gpt-5' },
+    });
+    expect(calls[7].init).toMatchObject({ method: 'POST' });
+  });
+
+  it('uses hosted-web safe error mapping for browser teams failures', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: {
+            code: '../../../Users/name/project/provider_payload',
+            message: 'Provider failed at /Users/name/project with token sk-secret',
+          },
+        }),
+        { status: 500, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    const client = new HttpAPIClient('https://hosted.example');
+
+    let error: unknown;
+    try {
+      await client.teams.list();
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toMatchObject({
+      name: 'HostedWebTransportError',
+      kind: 'http',
+      status: 500,
+      route: '/api/hosted/v1/teams',
+      code: '/api/hosted/v1/errors/http_500',
+      message: 'Hosted web request failed with status 500',
+    });
+    expect(error instanceof Error ? error.message : String(error)).not.toContain('/Users/name');
+  });
+});
+
+function routeResponse(url: string): Response {
+  if (url.endsWith('/api/hosted/v1/teams')) {
+    return jsonResponse({ teams: [hostedTeam()] });
+  }
+  if (url.endsWith('/api/hosted/v1/teams/team%2F1')) {
+    return jsonResponse({
+      team: hostedTeam(),
+      tasks: [
+        {
+          taskId: 'task-1',
+          displayId: 'T-1',
+          subject: 'Ship browser teams',
+          status: 'in_progress',
+          ownerMemberId: 'builder',
+          reviewState: 'review',
+          updatedAt: '2026-07-11T00:00:00.000Z',
+        },
+      ],
+      kanban: [{ status: 'review', taskIds: ['task-1'] }],
+      revision: 'rev-1',
+    });
+  }
+  if (url.endsWith('/api/hosted/v1/teams/new-team/launch')) {
+    return jsonResponse({ runId: 'run-create', launchStatus: 'started' });
+  }
+  if (url.endsWith('/api/hosted/v1/teams/team%2F1/launch')) {
+    return jsonResponse({ runId: 'run-launch', launchStatus: 'already_running' });
+  }
+  if (url.endsWith('/api/hosted/v1/teams/provisioning/run-launch')) {
+    return jsonResponse({
+      runId: 'run-launch',
+      teamId: 'team/1',
+      state: 'ready',
+      message: 'Ready',
+      startedAt: '2026-07-11T00:00:00.000Z',
+      updatedAt: '2026-07-11T00:00:01.000Z',
+    });
+  }
+  if (url.endsWith('/api/hosted/v1/teams/team%2F1/runtime')) {
+    return jsonResponse({ isAlive: true, terminalAvailable: true, activeProcessCount: 1 });
+  }
+  if (url.endsWith('/api/hosted/v1/teams/runtime/alive')) {
+    return jsonResponse({ teamIds: ['team/1'] });
+  }
+  if (url.endsWith('/api/hosted/v1/teams/team%2F1/stop')) {
+    return jsonResponse({ isAlive: false, terminalAvailable: false, activeProcessCount: 0 });
+  }
+  return jsonResponse({ error: { code: '/api/hosted/v1/errors/not_found' } }, 404);
+}
+
+function hostedTeam() {
+  return {
+    teamId: 'team/1',
+    displayName: 'Team 1',
+    description: 'Hosted team',
+    color: '#0f766e',
+    project: {
+      workspaceRef: {
+        id: '/workspace/project',
+        displayName: 'project',
+        repositoryLabel: 'agent-teams-ai',
+        branchLabel: 'main',
+      },
+    },
+    members: [
+      {
+        memberId: 'builder',
+        displayName: 'Builder',
+        role: 'Implementation',
+        color: '#2563eb',
+        provider: { providerId: 'codex', modelId: 'gpt-5', effort: 'high' },
+        currentTaskId: 'task-1',
+        taskCount: 1,
+        isolation: 'managed-worktree',
+      },
+    ],
+    taskCount: 1,
+    lastActivity: '2026-07-11T00:00:00.000Z',
+    runtime: { isAlive: true, terminalAvailable: true, activeProcessCount: 1 },
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/test/renderer/store/editorSlice.test.ts
+++ b/test/renderer/store/editorSlice.test.ts
@@ -6,8 +6,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createTestStore } from './storeTestUtils';
 
-import type { TestStore } from './storeTestUtils';
 import type { FileTreeEntry, ReadDirResult } from '../../../src/shared/types/editor';
+import type { TestStore } from './storeTestUtils';
 
 // =============================================================================
 // Mock API
@@ -42,6 +42,7 @@ vi.mock('@renderer/api', () => ({
     getProjects: vi.fn(),
     getSessions: vi.fn(),
   },
+  supportsAppCapability: vi.fn(() => true),
 }));
 
 const mockBridge = {

--- a/test/renderer/store/editorSliceCapabilities.test.ts
+++ b/test/renderer/store/editorSliceCapabilities.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createEditorSlice } from '../../../src/renderer/store/slices/editorSlice';
+
+import type { EditorSlice } from '../../../src/renderer/store/slices/editorSlice';
+import type { AppState } from '../../../src/renderer/store/types';
+
+const mockEditorAPI = {
+  watchDir: vi.fn(),
+  setWatchedFiles: vi.fn(),
+  setWatchedDirs: vi.fn(),
+};
+
+const mockSupportsAppCapability = vi.fn((_capability: string) => true);
+
+vi.mock('@renderer/api', () => ({
+  api: {
+    editor: {
+      watchDir: (...args: unknown[]) => mockEditorAPI.watchDir(...args),
+      setWatchedFiles: (...args: unknown[]) => mockEditorAPI.setWatchedFiles(...args),
+      setWatchedDirs: (...args: unknown[]) => mockEditorAPI.setWatchedDirs(...args),
+    },
+  },
+  supportsAppCapability: (capability: string) => mockSupportsAppCapability(capability),
+}));
+
+vi.mock('@renderer/utils/editorBridge', () => ({
+  editorBridge: {
+    deleteState: vi.fn(),
+    destroy: vi.fn(),
+    getAllModifiedContent: vi.fn(),
+    getContent: vi.fn(),
+    remapState: vi.fn(),
+  },
+}));
+
+vi.mock('@renderer/utils/codemirrorLanguages', () => ({
+  getLanguageFromFileName: () => 'Plain Text',
+}));
+
+vi.mock('@shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  }),
+}));
+
+const PROJECT_PATH = '/Users/test/my-project';
+
+interface Harness {
+  getState: () => AppState;
+  setState: (partial: Partial<AppState>) => void;
+}
+
+function createHarness(): Harness {
+  let state = {} as AppState;
+  const set = (partial: Partial<AppState> | ((current: AppState) => Partial<AppState>)): void => {
+    const next = typeof partial === 'function' ? partial(state) : partial;
+    state = { ...state, ...next };
+  };
+  const get = (): AppState => state;
+  const slice = createEditorSlice(set, get, {} as never) as EditorSlice;
+  state = { ...state, ...slice } as AppState;
+
+  return {
+    getState: () => state,
+    setState: (partial) => {
+      state = { ...state, ...partial };
+    },
+  };
+}
+
+describe('editorSlice app capabilities', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockSupportsAppCapability.mockReturnValue(true);
+  });
+
+  it('syncs watched files and directories through the renderer API abstraction', async () => {
+    vi.useFakeTimers();
+    try {
+      mockEditorAPI.watchDir.mockResolvedValue(undefined);
+      mockEditorAPI.setWatchedFiles.mockResolvedValue(undefined);
+      mockEditorAPI.setWatchedDirs.mockResolvedValue(undefined);
+      const harness = createHarness();
+      harness.setState({ editorProjectPath: PROJECT_PATH });
+
+      await harness.getState().toggleWatcher(true);
+      harness.getState().openFile(`${PROJECT_PATH}/src/index.ts`);
+      vi.runAllTimers();
+
+      expect(mockSupportsAppCapability).toHaveBeenCalledWith('editorFileWatching');
+      expect(mockEditorAPI.watchDir).toHaveBeenCalledWith(true);
+      expect(mockEditorAPI.setWatchedFiles).toHaveBeenLastCalledWith([
+        `${PROJECT_PATH}/src/index.ts`,
+      ]);
+      expect(mockEditorAPI.setWatchedDirs).toHaveBeenLastCalledWith([PROJECT_PATH]);
+    } finally {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not call the editor watcher adapter when the capability is unavailable', async () => {
+    vi.useFakeTimers();
+    try {
+      mockSupportsAppCapability.mockReturnValue(false);
+      const harness = createHarness();
+      harness.setState({
+        editorProjectPath: PROJECT_PATH,
+        editorWatcherEnabled: true,
+      });
+
+      await harness.getState().toggleWatcher(true);
+      harness.getState().openFile(`${PROJECT_PATH}/src/index.ts`);
+      vi.runAllTimers();
+
+      expect(harness.getState().editorWatcherEnabled).toBe(false);
+      expect(mockEditorAPI.watchDir).not.toHaveBeenCalled();
+      expect(mockEditorAPI.setWatchedFiles).not.toHaveBeenCalled();
+      expect(mockEditorAPI.setWatchedDirs).not.toHaveBeenCalled();
+    } finally {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+  });
+});

--- a/vite.web.config.ts
+++ b/vite.web.config.ts
@@ -23,7 +23,15 @@ export default defineConfig({
       },
     },
   },
+  build: {
+    emptyOutDir: true,
+    outDir: resolve(ROOT, 'out/renderer'),
+    target: 'esnext',
+  },
   optimizeDeps: {
+    esbuildOptions: {
+      target: 'esnext',
+    },
     include: ['@codemirror/language-data'],
     exclude: ['@claude-teams/agent-graph'],
   },


### PR DESCRIPTION
## Summary

- introduces hosted web transport contracts and renderer adapters
- extracts runtime and team application boundaries from Electron-specific composition
- adds standalone team lifecycle routes, hosted build targets, and focused architecture/security tests
- adds browser capability fallbacks and hosted renderer build support

## Validation completed

- full TypeScript typecheck passed on branch HEAD
- 13 focused suites passed: 76 tests
- hosted renderer production build passed
- hosted server production build passed
- static hosted server loopback smoke passed
- git diff --check passed
- current branch merges cleanly with the latest base

## Blocking findings from final E2E audit

This PR is intentionally Draft. The final independent audit found production integration gaps that must be fixed before Ready:

- browser client calls /api/hosted/v1/* while the real standalone backend currently exposes /api/teams/*
- Docker currently starts the static-only hosted shell, which intentionally returns 404 for /api/*
- secure non-loopback mode requires bearer auth, but browser fetch/SSE does not yet bootstrap credentials
- the main team UI still gates core flows as Electron-only
- the current hosted startup E2E uses mocked transport and does not prove the built browser + real server together

No real user project or real agent launch was used during validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a hosted web mode for accessing team workflows through a browser, including team management, launches, provisioning status, runtime controls, tasks, and terminal sessions.
  * Added resumable real-time event updates and safer browser-to-server communication.
  * Added hosted Docker build and startup options with loopback-first access and explicit remote-access configuration.
  * Added capability detection so Electron-only features are disabled gracefully in hosted mode.

* **Bug Fixes**
  * Improved configuration redaction in HTTP responses.
  * Added stronger validation for team names, provider backends, paths, and server bindings.
  * SSH connect and disconnect endpoints now clearly report unsupported operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->