### PR TITLE
chore(runtime): update orchestrator to 0.0.61

### DIFF
--- a/runtime.lock.json
+++ b/runtime.lock.json
@@ -1,27 +1,27 @@
 {
-  "version": "0.0.59",
-  "sourceRef": "v0.0.59",
+  "version": "0.0.61",
+  "sourceRef": "v0.0.61",
   "sourceRepository": "777genius/agent_teams_orchestrator",
   "releaseRepository": "777genius/agent_teams_orchestrator",
-  "releaseTag": "v0.0.59",
+  "releaseTag": "v0.0.61",
   "assets": {
     "darwin-arm64": {
-      "file": "agent-teams-runtime-darwin-arm64-v0.0.59.tar.gz",
+      "file": "agent-teams-runtime-darwin-arm64-v0.0.61.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel"
     },
     "darwin-x64": {
-      "file": "agent-teams-runtime-darwin-x64-v0.0.59.tar.gz",
+      "file": "agent-teams-runtime-darwin-x64-v0.0.61.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel"
     },
     "linux-x64": {
-      "file": "agent-teams-runtime-linux-x64-v0.0.59.tar.gz",
+      "file": "agent-teams-runtime-linux-x64-v0.0.61.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel"
     },
     "win32-x64": {
-      "file": "agent-teams-runtime-win32-x64-v0.0.59.zip",
+      "file": "agent-teams-runtime-win32-x64-v0.0.61.zip",
       "archiveKind": "zip",
       "binaryName": "claude-multimodel.exe"
     }


### PR DESCRIPTION
## Summary
- update the bundled Agent Teams runtime from 0.0.59 to 0.0.61
- include the SuperGrok OAuth refresh-before-launch fix
- point every supported desktop platform at the published v0.0.61 assets

## Verification
- runtime lock asset list matches the published v0.0.61 release
- staged and verified the darwin-arm64 runtime successfully
- runtime release workflow passed for macOS ARM/x64, Linux, and Windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled runtime to version 0.0.61.
  * Refreshed platform-specific runtime artifacts for macOS, Linux, and Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->