### PR TITLE
chore(runtime): update orchestrator to 0.0.62

### DIFF
--- a/runtime.lock.json
+++ b/runtime.lock.json
@@ -1,27 +1,27 @@
 {
-  "version": "0.0.61",
-  "sourceRef": "v0.0.61",
+  "version": "0.0.62",
+  "sourceRef": "v0.0.62",
   "sourceRepository": "777genius/agent_teams_orchestrator",
   "releaseRepository": "777genius/agent_teams_orchestrator",
-  "releaseTag": "v0.0.61",
+  "releaseTag": "v0.0.62",
   "assets": {
     "darwin-arm64": {
-      "file": "agent-teams-runtime-darwin-arm64-v0.0.61.tar.gz",
+      "file": "agent-teams-runtime-darwin-arm64-v0.0.62.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel"
     },
     "darwin-x64": {
-      "file": "agent-teams-runtime-darwin-x64-v0.0.61.tar.gz",
+      "file": "agent-teams-runtime-darwin-x64-v0.0.62.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel"
     },
     "linux-x64": {
-      "file": "agent-teams-runtime-linux-x64-v0.0.61.tar.gz",
+      "file": "agent-teams-runtime-linux-x64-v0.0.62.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel"
     },
     "win32-x64": {
-      "file": "agent-teams-runtime-win32-x64-v0.0.61.zip",
+      "file": "agent-teams-runtime-win32-x64-v0.0.62.zip",
       "archiveKind": "zip",
       "binaryName": "claude-multimodel.exe"
     }


### PR DESCRIPTION
## Summary
- update the bundled Agent Teams runtime to 0.0.62
- include proactive and coordinated long-running SuperGrok OAuth refresh
- point every supported desktop platform at the published v0.0.62 assets

## Verification
- runtime release workflow passed for macOS ARM/x64, Linux, and Windows
- darwin-arm64 runtime staging passed
- underlying OAuth/session change passed 250 focused tests