### PR TITLE
fix(task-board): preserve command identity during submit

### DIFF
--- a/agent-teams-controller/src/internal/taskStore.js
+++ b/agent-teams-controller/src/internal/taskStore.js
@@ -517,9 +517,9 @@ function ensureTaskCreationBacklinks(paths, taskId, blockedByIds, relatedIds) {
   }
   for (const relatedId of relatedIds) {
     const related = readTask(paths, relatedId, { includeDeleted: true });
-    const relatedIds = Array.isArray(related.related) ? related.related : [];
-    if (!relatedIds.includes(taskId)) {
-      related.related = [...relatedIds, taskId];
+    const existingRelatedIds = Array.isArray(related.related) ? related.related : [];
+    if (!existingRelatedIds.includes(taskId)) {
+      related.related = [...existingRelatedIds, taskId];
       related.updatedAt = nowIso();
       writeTask(paths, related);
     }

--- a/src/renderer/components/team/dialogs/CreateTaskDialog.tsx
+++ b/src/renderer/components/team/dialogs/CreateTaskDialog.tsx
@@ -24,6 +24,7 @@ import { useStore } from '@renderer/store';
 import { selectTeamDataForName } from '@renderer/store/slices/teamSlice';
 import { chipToken, serializeChipsWithText } from '@renderer/types/inlineChip';
 import {
+  canCloseCreateTaskDialog,
   type CreateTaskSubmitGate,
   type PendingCreateTaskCommand,
   resetCreateTaskSubmit,
@@ -213,7 +214,7 @@ export const CreateTaskDialog = ({
   };
 
   const handleOpenChange = (nextOpen: boolean): void => {
-    if (!nextOpen) {
+    if (!nextOpen && canCloseCreateTaskDialog(submitting)) {
       onClose();
     }
   };

--- a/src/renderer/utils/createTaskCommandIdentity.ts
+++ b/src/renderer/utils/createTaskCommandIdentity.ts
@@ -21,6 +21,10 @@ export function resetCreateTaskSubmit(gate: CreateTaskSubmitGate): void {
   gate.inFlight = false;
 }
 
+export function canCloseCreateTaskDialog(submitting: boolean): boolean {
+  return !submitting;
+}
+
 export function resolveCreateTaskCommand(
   current: PendingCreateTaskCommand | null,
   teamName: string,

--- a/test/main/services/team/TeamDataService.test.ts
+++ b/test/main/services/team/TeamDataService.test.ts
@@ -1850,11 +1850,13 @@ describe('TeamDataService', () => {
     };
     const service = new TeamDataService(
       {
-        getConfig: vi.fn(async () => ({
-          name: 'My team',
-          members: [],
-          projectPath: '/projects/current',
-        })),
+        getConfig: vi.fn(() =>
+          Promise.resolve({
+            name: 'My team',
+            members: [],
+            projectPath: '/projects/current',
+          })
+        ),
       } as never,
       {} as never,
       {} as never,

--- a/test/renderer/utils/createTaskCommandIdentity.test.ts
+++ b/test/renderer/utils/createTaskCommandIdentity.test.ts
@@ -1,4 +1,5 @@
 import {
+  canCloseCreateTaskDialog,
   resetCreateTaskSubmit,
   resolveCreateTaskCommand,
   tryBeginCreateTaskSubmit,
@@ -59,5 +60,10 @@ describe('resolveCreateTaskCommand', () => {
 
     resetCreateTaskSubmit(gate);
     expect(tryBeginCreateTaskSubmit(gate)).toBe(true);
+  });
+
+  it('keeps the dialog open while a create request is in flight', () => {
+    expect(canCloseCreateTaskDialog(true)).toBe(false);
+    expect(canCloseCreateTaskDialog(false)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- prevent Escape, overlay, and close-button dismissal while task creation is in flight
- preserve the pending command identity until an ambiguous request can be retried safely
- resolve the actionable CodeRabbit test lint finding and remove confusing backlink variable shadowing

## Bug scenario
If the dialog closed while create was still running, its pending command identity was cleared. Reopening and retrying generated another UUID, allowing both requests to create separate tasks.

## Verification
- independent post-merge review confirmed the race as P1 and found no other P0-P2 issues
- agent-teams-controller: 138 tests passed
- focused renderer/service/task-board suite: 140 tests passed
- pnpm typecheck
- pnpm lint:fast:files
- git diff --check

No live agent, provisioning, terminal, or real-project flows were run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the Create Task dialog from closing while a task is being submitted, helping avoid interrupted or duplicate task creation.
  * Improved reliability when maintaining relationships between related tasks.

* **Tests**
  * Added coverage for dialog close behavior during and after task submission.
  * Updated configuration mocking to better reflect application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->