### PR TITLE
feat: enable configurable draft reviews

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -18,7 +18,7 @@ jobs:
       group: reviewrouter-codex-oauth-${{ github.repository_id }}-codex-rotating-1163183284
       queue: max
       cancel-in-progress: false
-    if: ${{ github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.type != 'Bot' }}
+    if: ${{ (github.event.pull_request.draft == false || vars.REVIEW_ROUTER_REVIEW_DRAFTS == 'true') && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.type != 'Bot' }}
     permissions:
       id-token: write
     steps:


### PR DESCRIPTION
Adds the ReviewRouter draft review repository-variable gate.

Draft reviews remain disabled unless `REVIEW_ROUTER_REVIEW_DRAFTS` is exactly `true`. Fork and bot pull requests remain blocked.

<!-- review-router-summary:start -->
## Summary

- updates a GitHub Actions workflow; runs it on pull requests


<details>
<summary>📒 Files selected for processing (1)</summary>

* `.github/workflows/reviewrouter-codex.yml`

</details>

<details>
<summary>📝 Walkthrough</summary>

## Walkthrough

This PR updates 1 file across 1 CI workflow. The generated summary is based on the GitHub pull request file list and diff metadata, and the author's description above is preserved.

## Changes

| Cohort / File(s) | Summary |
|---|---|
| **CI workflow** <br> `.github/workflows/reviewrouter-codex.yml` | Updates a GitHub Actions workflow; runs it on pull requests.<br>Line stats: 1 modified; +1/-1. |

</details>
<!-- review-router-summary:end -->