### PR TITLE
feat: enable configurable draft reviews on dev

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -3,6 +3,9 @@ name: ReviewRouter Codex OAuth
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+  schedule:
+    - cron: "17 */6 * * *"
 
 permissions: {}
 
@@ -11,15 +14,41 @@ jobs:
     name: codex-review
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    if: ${{ github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.type != 'Bot' }}
+    concurrency:
+      group: reviewrouter-codex-oauth-${{ github.repository_id }}-codex-rotating-1163183284
+      queue: max
+      cancel-in-progress: false
+    if: ${{ (github.event.pull_request.draft == false || vars.REVIEW_ROUTER_REVIEW_DRAFTS == 'true') && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.type != 'Bot' }}
     permissions:
       id-token: write
     steps:
       - name: ReviewRouter Codex OAuth review
         id: run_codex
-        uses: 777genius/review-router@97fdbdf1685350ac9a7f29e0430e82c2360c2821
+        uses: 777genius/review-router@main
         with:
           mode: codex-oauth-rotating
+          api-url: "https://api.reviewrouter.site"
+          provider-instance-id: "codex-rotating:1163183284"
+          workflow-schema-version: "1"
+          auth-json: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON }}
+
+  codex-refresh:
+    name: codex-refresh
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    concurrency:
+      group: reviewrouter-codex-oauth-${{ github.repository_id }}-codex-rotating-1163183284
+      queue: max
+      cancel-in-progress: false
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    permissions:
+      id-token: write
+    steps:
+      - name: ReviewRouter Codex OAuth refresh
+        id: refresh_codex
+        uses: 777genius/review-router@main
+        with:
+          mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"
           provider-instance-id: "codex-rotating:1163183284"
           workflow-schema-version: "1"


### PR DESCRIPTION
Updates the ReviewRouter OAuth workflow on the base branch used by draft PR #240.

Draft review is controlled by `REVIEW_ROUTER_REVIEW_DRAFTS`, which is enabled for this repository. Fork and bot pull requests remain blocked.

<!-- review-router-summary:start -->
## Summary

- updates a GitHub Actions workflow; runs it on pull requests and manual dispatch; restores Codex OAuth credentials; uses the latest reviewer from the main branch


<details>
<summary>📒 Files selected for processing (1)</summary>

* `.github/workflows/reviewrouter-codex.yml`

</details>

<details>
<summary>📝 Walkthrough</summary>

## Walkthrough

This PR updates 1 file across 1 CI workflow. The generated summary is based on the GitHub pull request file list and diff metadata, and the author's description above is preserved.

## Changes

| Cohort / File(s) | Summary |
|---|---|
| **CI workflow** <br> `.github/workflows/reviewrouter-codex.yml` | Updates a GitHub Actions workflow; runs it on pull requests and manual dispatch; restores Codex OAuth credentials; uses the latest reviewer from the main branch.<br>Line stats: 1 modified; +31/-2. |

</details>
<!-- review-router-summary:end -->