### PR TITLE
fix: bound ReviewRouter large PR batches

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -27,6 +27,10 @@ jobs:
       - name: ReviewRouter Codex OAuth review
         id: run_codex
         uses: 777genius/review-router@main
+        env:
+          BATCH_MAX_FILES: "100"
+          CODEX_AGENTIC_CONTEXT: "false"
+          TARGET_TOKENS_PER_BATCH: "240000"
         with:
           mode: codex-oauth-rotating
           api-url: "https://api.reviewrouter.site"


### PR DESCRIPTION
Bounds Codex review batching for oversized PRs and disables agentic retry in the checkout-free OAuth workflow. This keeps draft reviews within the 30-minute workflow budget.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated code review processing to handle larger batches more efficiently.
  * Updated review context handling for more consistent automated analysis.
  * No changes to end-user features, interfaces, or application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->