### PR TITLE
fix: bound ReviewRouter large PR batches

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -27,6 +27,10 @@ jobs:
       - name: ReviewRouter Codex OAuth review
         id: run_codex
         uses: 777genius/review-router@main
+        env:
+          BATCH_MAX_FILES: "100"
+          CODEX_AGENTIC_CONTEXT: "false"
+          TARGET_TOKENS_PER_BATCH: "240000"
         with:
           mode: codex-oauth-rotating
           api-url: "https://api.reviewrouter.site"


### PR DESCRIPTION
Keeps oversized Codex reviews within the workflow budget by using larger bounded batches and disabling agentic retry when the OAuth workflow has no checkout.