### PR TITLE
fix: keep ReviewRouter policy in control plane

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -27,10 +27,6 @@ jobs:
       - name: ReviewRouter Codex OAuth review
         id: run_codex
         uses: 777genius/review-router@main
-        env:
-          BATCH_MAX_FILES: "100"
-          CODEX_AGENTIC_CONTEXT: "false"
-          TARGET_TOKENS_PER_BATCH: "240000"
         with:
           mode: codex-oauth-rotating
           api-url: "https://api.reviewrouter.site"


### PR DESCRIPTION
Removes ineffective workflow-level runtime tuning. Review execution policy is supplied by the ReviewRouter control plane.

<!-- review-router-summary:start -->
## Summary

- updates a GitHub Actions workflow


<details>
<summary>📒 Files selected for processing (1)</summary>

* `.github/workflows/reviewrouter-codex.yml`

</details>

<details>
<summary>📝 Walkthrough</summary>

## Walkthrough

This PR updates 1 file across 1 CI workflow. The generated summary is based on the GitHub pull request file list and diff metadata, and the author's description above is preserved.

## Changes

| Cohort / File(s) | Summary |
|---|---|
| **CI workflow** <br> `.github/workflows/reviewrouter-codex.yml` | Updates a GitHub Actions workflow.<br>Line stats: 1 modified; +0/-4. |

</details>
<!-- review-router-summary:end -->