### PR TITLE
feat: bound oversized ReviewRouter reviews

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -15,7 +15,7 @@ jobs:
   codex-review:
     name: codex-review
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 60
     concurrency:
       group: reviewrouter-codex-oauth-${{ github.repository_id }}-codex-rotating-1163183284
       queue: max
@@ -33,12 +33,13 @@ jobs:
           provider-instance-id: "codex-rotating:1163183284"
           workflow-schema-version: "1"
           review-drafts: ${{ vars.REVIEW_ROUTER_REVIEW_DRAFTS == 'true' }}
+          max-changed-lines: ${{ vars.REVIEW_ROUTER_MAX_CHANGED_LINES }}
           auth-json: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON }}
 
   codex-refresh:
     name: codex-refresh
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 60
     concurrency:
       group: reviewrouter-codex-oauth-${{ github.repository_id }}-codex-rotating-1163183284
       queue: max


### PR DESCRIPTION
Adds REVIEW_ROUTER_MAX_CHANGED_LINES admission control before OAuth lease/auth use.

Raises the workflow budget to 60 minutes while the Action reserves 5 minutes for cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased execution time limits for automated OAuth review and refresh jobs.
  * Added configurable limits for the number of changed lines evaluated during automated reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->