### PR TITLE
feat: configure ReviewRouter timeout

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -15,7 +15,7 @@ jobs:
   codex-review:
     name: codex-review
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
+    timeout-minutes: ${{ fromJSON(vars.REVIEW_ROUTER_TIMEOUT_MINUTES || '60') }}
     concurrency:
       group: reviewrouter-codex-oauth-${{ github.repository_id }}-codex-rotating-1163183284
       queue: max
@@ -34,6 +34,7 @@ jobs:
           workflow-schema-version: "1"
           review-drafts: ${{ vars.REVIEW_ROUTER_REVIEW_DRAFTS == 'true' }}
           max-changed-lines: ${{ vars.REVIEW_ROUTER_MAX_CHANGED_LINES }}
+          review-timeout-minutes: ${{ vars.REVIEW_ROUTER_TIMEOUT_MINUTES || '60' }}
           auth-json: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON }}
 
   codex-refresh:


### PR DESCRIPTION
Adds a repository-controlled ReviewRouter job timeout.

The Action receives the same budget and reserves five minutes for cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configurable review timeout settings with a 60-minute default.
  * Applied the setting consistently across automated review workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->