### PR TITLE
fix(org-map): fit restored graph after reset

### DIFF
--- a/packages/agent-graph/src/ui/GraphView.tsx
+++ b/packages/agent-graph/src/ui/GraphView.tsx
@@ -93,6 +93,8 @@ export interface GraphViewProps {
   focusEdgeIds?: ReadonlySet<string> | null;
   focusOverridesSelection?: boolean;
   revealNodeRequest?: { nodeId: string; requestId: number } | null;
+  /** Increment to fit the graph after the matching data update reaches the simulation. */
+  fitViewRequestId?: number;
   renderTopToolbarContent?: () => React.ReactNode;
   /** Replaces the package toolbar while retaining graph-owned camera and filter actions. */
   renderControls?: (props: GraphControlRenderProps) => React.ReactNode;
@@ -217,6 +219,7 @@ export function GraphView({
   focusEdgeIds,
   focusOverridesSelection = false,
   revealNodeRequest,
+  fitViewRequestId,
   renderTopToolbarContent,
   renderControls,
   onLayoutModeChange,
@@ -278,6 +281,7 @@ export function GraphView({
   const runningRef = useRef(false);
   const hasAutoFit = useRef(false);
   const allowAutoFitRef = useRef(true);
+  const handledFitViewRequestIdRef = useRef(fitViewRequestId);
   const previousLayoutModeRef = useRef(layoutMode);
   const animateNextLayoutFitRef = useRef(false);
   const nodeMapRef = useRef(new Map<string, GraphNode>());
@@ -695,6 +699,14 @@ export function GraphView({
     markUserInteracted();
     fitGraphToViewport(false);
   }, [fitGraphToViewport, markUserInteracted]);
+
+  useEffect(() => {
+    if (fitViewRequestId === undefined || fitViewRequestId === handledFitViewRequestIdRef.current) {
+      return;
+    }
+    handledFitViewRequestIdRef.current = fitViewRequestId;
+    zoomToFit();
+  }, [fitViewRequestId, zoomToFit]);
 
   // ─── Auto-fit: until first user interaction, also react to container resizes ─────
   useEffect(() => {

--- a/src/features/organizations/renderer/ui/OrgGraphSurface.tsx
+++ b/src/features/organizations/renderer/ui/OrgGraphSurface.tsx
@@ -420,6 +420,7 @@ export const OrgGraphSurface = ({
     nodeId: string;
     requestId: number;
   } | null>(null);
+  const [fitViewRequestId, setFitViewRequestId] = useState(0);
   const edgeOverlayText = useMemo(
     () => ({
       runtimeMessages: t('organizations.graph.edgeOverlay.runtimeMessages'),
@@ -568,6 +569,7 @@ export const OrgGraphSurface = ({
         : displayedGraphData,
     [activeViewMode, displayedGraphData]
   );
+
   const events = useMemo<GraphEventPort>(
     () => ({
       onNodeClick: (ref: GraphDomainRef) => {
@@ -631,7 +633,7 @@ export const OrgGraphSurface = ({
             showEdges: true,
             paused: false,
           });
-          controls.onZoomToFit();
+          setFitViewRequestId((current) => current + 1);
         }}
         labels={{
           search: t('organizations.graph.focus.searchLabel'),
@@ -689,6 +691,7 @@ export const OrgGraphSurface = ({
       focusEdgeIds={activeViewMode === 'overview' ? null : effectiveFocus.focusEdgeIds}
       focusOverridesSelection={Boolean(selectedNodeId)}
       revealNodeRequest={revealNodeRequest}
+      fitViewRequestId={fitViewRequestId}
       renderControls={renderControls}
       renderOverlay={renderNodeOverlay}
       renderEdgeOverlay={(overlayProps) => renderEdgeOverlay(overlayProps, edgeOverlayText)}

--- a/test/renderer/features/agent-graph/GraphView.test.ts
+++ b/test/renderer/features/agent-graph/GraphView.test.ts
@@ -33,6 +33,7 @@ const hoisted = vi.hoisted(() => ({
     effects: [],
     time: 0,
   },
+  updateData: vi.fn(),
   setNodePosition: vi.fn(),
   clearNodePosition: vi.fn(),
   clearTransientOwnerPositions: vi.fn(),
@@ -88,7 +89,7 @@ vi.mock('../../../../packages/agent-graph/src/hooks/useGraphInteraction', () => 
 vi.mock('../../../../packages/agent-graph/src/hooks/useGraphSimulation', () => ({
   useGraphSimulation: () => ({
     stateRef: { current: hoisted.simulationState },
-    updateData: vi.fn(),
+    updateData: hoisted.updateData,
     tick: vi.fn(),
     getExtraWorldBounds: vi.fn(() => []),
     getLaunchAnchorWorldPosition: vi.fn(() => null),
@@ -130,6 +131,8 @@ describe('GraphView pan interactions', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    hoisted.updateData.mockImplementation(() => undefined);
+    hoisted.zoomToFit.mockImplementation(() => undefined);
     vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
     hoisted.interaction.hoveredNodeId.current = null;
     hoisted.interaction.dragNodeId.current = null;
@@ -207,6 +210,68 @@ describe('GraphView pan interactions', () => {
     });
 
     expect((hoisted.graphControlsProps?.filters as { showEdges: boolean }).showEdges).toBe(true);
+  });
+
+  it('processes fit requests after syncing the requested graph data', async () => {
+    const firstNode: GraphNode = {
+      id: 'member:alice',
+      kind: 'member',
+      label: 'alice',
+      state: 'idle',
+      x: 0,
+      y: 0,
+      domainRef: { kind: 'member', teamName: 'demo-team', memberName: 'alice' },
+    };
+    const secondNode: GraphNode = {
+      id: 'member:bob',
+      kind: 'member',
+      label: 'bob',
+      state: 'idle',
+      x: 200,
+      y: 0,
+      domainRef: { kind: 'member', teamName: 'demo-team', memberName: 'bob' },
+    };
+    const events: string[] = [];
+    hoisted.updateData.mockImplementation((nodes: GraphNode[]) => {
+      hoisted.simulationState.nodes = nodes;
+      events.push(`update:${nodes.length}`);
+    });
+    hoisted.zoomToFit.mockImplementation((nodes: GraphNode[]) => {
+      events.push(`fit:${nodes.length}`);
+    });
+
+    await act(async () => {
+      root.render(
+        React.createElement(GraphView, {
+          data: {
+            teamName: 'demo-team',
+            nodes: [firstNode],
+            edges: [],
+            particles: [],
+          },
+          config: { animationEnabled: false },
+          fitViewRequestId: 0,
+        })
+      );
+    });
+
+    events.length = 0;
+    await act(async () => {
+      root.render(
+        React.createElement(GraphView, {
+          data: {
+            teamName: 'demo-team',
+            nodes: [firstNode, secondNode],
+            edges: [],
+            particles: [],
+          },
+          config: { animationEnabled: false },
+          fitViewRequestId: 1,
+        })
+      );
+    });
+
+    expect(events).toEqual(['update:2', 'fit:2']);
   });
 
   it('preserves an explicit null returned by a custom controls renderer', async () => {

--- a/test/renderer/features/organizations/OrgGraphSurface.test.tsx
+++ b/test/renderer/features/organizations/OrgGraphSurface.test.tsx
@@ -7,6 +7,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { OrganizationMapPayload } from '@features/organizations/contracts';
 
+const graphViewMock = vi.hoisted(() => ({
+  zoomToFit: vi.fn(),
+}));
+
 vi.mock('@features/localization/renderer', () => ({
   useAppTranslation: () => ({
     t: (key: string) => key,
@@ -30,10 +34,12 @@ vi.mock('@features/organizations/renderer/ui/OrgOverviewHud', () => ({
 vi.mock('@claude-teams/agent-graph', () => ({
   GraphView: ({
     data,
+    fitViewRequestId,
     renderControls,
     renderHud,
   }: {
     data: { nodes: unknown[] };
+    fitViewRequestId?: number;
     renderControls?: (controls: {
       filters: {
         showActivity: boolean;
@@ -55,7 +61,7 @@ vi.mock('@claude-teams/agent-graph', () => ({
       getCameraZoom: () => number;
     }) => React.ReactNode;
   }) => (
-    <div data-graph-node-count={data.nodes.length}>
+    <div data-fit-view-request-id={fitViewRequestId} data-graph-node-count={data.nodes.length}>
       {renderControls?.({
         filters: {
           showActivity: false,
@@ -69,7 +75,7 @@ vi.mock('@claude-teams/agent-graph', () => ({
         onFiltersChange: vi.fn(),
         onZoomIn: vi.fn(),
         onZoomOut: vi.fn(),
-        onZoomToFit: vi.fn(),
+        onZoomToFit: () => graphViewMock.zoomToFit(data.nodes.length),
       })}
       {renderHud?.({
         getGroupFrameScreenPlacements: () => [],
@@ -103,6 +109,7 @@ function buildViewModel() {
 
 describe('OrgGraphSurface', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
   });
 
@@ -178,6 +185,52 @@ describe('OrgGraphSurface', () => {
     });
     expect(onLayoutModeChange).toHaveBeenCalledWith('grid-under-lead');
     expect(modeButtons[3]?.getAttribute('aria-pressed')).toBe('true');
+
+    act(() => root.unmount());
+  });
+
+  it('requests a fit for restored hierarchy data instead of fitting empty overview data', async () => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    await act(async () => {
+      root.render(
+        <OrgGraphSurface
+          viewModel={buildViewModel()}
+          isActive
+          collapsedNodeIds={new Set()}
+          layoutMode="hierarchical"
+          selectedNodeId={null}
+          onLayoutModeChange={vi.fn()}
+          onSelectNode={vi.fn()}
+          onRevealNode={vi.fn()}
+          onToggleNodeCollapse={vi.fn()}
+        />
+      );
+      await Promise.resolve();
+    });
+
+    const overviewButton = host.querySelector<HTMLButtonElement>(
+      'button[data-organization-map-view-mode="overview"]'
+    );
+    await act(async () => {
+      overviewButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+    });
+    expect(host.querySelector('[data-graph-node-count="0"]')).not.toBeNull();
+
+    const resetButton = host.querySelector<HTMLButtonElement>(
+      'button[aria-label="organizations.graph.toolbar.reset"]'
+    );
+    await act(async () => {
+      resetButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(host.querySelector('[data-graph-node-count="1"]')).not.toBeNull();
+    expect(host.querySelector('[data-fit-view-request-id="1"]')).not.toBeNull();
+    expect(graphViewMock.zoomToFit).not.toHaveBeenCalled();
 
     act(() => root.unmount());
   });


### PR DESCRIPTION
## Summary
- replace the synchronous reset fit with a declarative fit request
- process the request in GraphView after simulation data is synchronized
- cover reset from empty overview data and expanded graph fit ordering

Follow-up to #277.

## Validation
- focused Vitest: 18 tests passed
- focused fast ESLint: passed
- TypeScript typecheck: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the graph reset experience so the view fits correctly after hierarchy data is restored.
  - Ensured graph content updates before the automatic zoom-to-fit action runs.
  - Prevented duplicate or premature zoom-to-fit operations during graph transitions.

- **Tests**
  - Added coverage for graph reset behavior and the correct ordering of data updates and view fitting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-router-summary:start -->
## Summary

- update 2 test files
- updates GraphView: changes database query construction
- updates source implementation in OrgGraphSurface, edgeOverlayText
- updates test coverage for processes fit requests after syncing the requested graph da...
- touch 4 files (4 modified) with +137/-4 lines

## Tests

- changed test file: `test/renderer/features/agent-graph/GraphView.test.ts`
- changed test file: `test/renderer/features/organizations/OrgGraphSurface.test.tsx`

<details>
<summary>📒 Files selected for processing (4)</summary>

* `packages/agent-graph/src/ui/GraphView.tsx`
* `src/features/organizations/renderer/ui/OrgGraphSurface.tsx`
* `test/renderer/features/agent-graph/GraphView.test.ts`
* `test/renderer/features/organizations/OrgGraphSurface.test.tsx`

</details>

<details>
<summary>📝 Walkthrough</summary>

## Walkthrough

This PR updates 4 files across 2 source, 2 tests. The generated summary is based on the GitHub pull request file list and diff metadata, and the author's description above is preserved.

## Changes

| Cohort / File(s) | Summary |
|---|---|
| **Source** <br> `packages/agent-graph/src/ui/GraphView.tsx`<br>`src/features/organizations/renderer/ui/OrgGraphSurface.tsx` | Updates GraphView: changes database query construction.<br>Updates source implementation in OrgGraphSurface, edgeOverlayText.<br>Line stats: 2 modified; +16/-1. |
| **Tests** <br> `test/renderer/features/agent-graph/GraphView.test.ts`<br>`test/renderer/features/organizations/OrgGraphSurface.test.tsx` | Updates test coverage for processes fit requests after syncing the requested graph da....<br>Updates test coverage for requests a fit for restored hierarchy data instead of fitti....<br>Line stats: 2 modified; +121/-3. |

</details>
<!-- review-router-summary:end -->