### PR TITLE
fix(team): stabilize OpenCode launch on Windows

### DIFF
--- a/src/features/runtime-provider-management/main/infrastructure/KiroCliCompanionService.test.ts
+++ b/src/features/runtime-provider-management/main/infrastructure/KiroCliCompanionService.test.ts
@@ -2,8 +2,8 @@ import path from 'node:path';
 
 import { describe, expect, it, vi } from 'vitest';
 
-import { KiroCliCompanionService, resolveKiroLinuxArchiveSuffix } from './KiroCliCompanionService';
 import { KIRO_CLI_COMPANION_DEFINITION } from './cli-companion/definitions/KiroCliCompanionDefinition';
+import { KiroCliCompanionService, resolveKiroLinuxArchiveSuffix } from './KiroCliCompanionService';
 
 const VALID_UNIX_INSTALLER = `#!/bin/bash
 # Kiro CLI

--- a/src/features/runtime-provider-management/main/infrastructure/KiroCliCompanionService.test.ts
+++ b/src/features/runtime-provider-management/main/infrastructure/KiroCliCompanionService.test.ts
@@ -1,6 +1,9 @@
+import path from 'node:path';
+
 import { describe, expect, it, vi } from 'vitest';
 
 import { KiroCliCompanionService, resolveKiroLinuxArchiveSuffix } from './KiroCliCompanionService';
+import { KIRO_CLI_COMPANION_DEFINITION } from './cli-companion/definitions/KiroCliCompanionDefinition';
 
 const VALID_UNIX_INSTALLER = `#!/bin/bash
 # Kiro CLI
@@ -110,6 +113,38 @@ describe('KiroCliCompanionService', () => {
     expect(status.error).toContain('changed its installer format');
     expect(status.manualCommand).toContain('https://cli.kiro.dev/install');
     expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it('discovers the current per-user Windows MSI install location', () => {
+    const candidates = KIRO_CLI_COMPANION_DEFINITION.binary.extraCandidates(
+      'win32',
+      'C:\\Users\\test'
+    );
+
+    expect(candidates).toContain(
+      path.join(process.env.LOCALAPPDATA ?? '', 'Kiro-Cli', 'kiro-cli.exe')
+    );
+  });
+
+  it('surfaces installer stderr instead of the last progress line', async () => {
+    const service = new KiroCliCompanionService({
+      platform: 'win32',
+      arch: 'x64',
+      fetchInstallerScript: async () => VALID_WINDOWS_INSTALLER,
+      fetchPackageSize: async () => 100 * 1024 * 1024,
+      getAvailableBytes: async () => 10 * 1024 * 1024 * 1024,
+      resolveBinary: async () => null,
+      runCommand: async () => ({
+        exitCode: 1,
+        stdout: 'Downloaded\nVerifying checksum...\n',
+        stderr: 'Get-FileHash is not available\nFullyQualifiedErrorId: CommandNotFoundException\n',
+      }),
+    });
+
+    const status = await service.installAndConnect();
+
+    expect(status.phase).toBe('needs-manual-step');
+    expect(status.error).toBe('Get-FileHash is not available');
   });
 
   it('fails before downloading the package when free disk space is unsafe', async () => {
@@ -231,6 +266,12 @@ describe('KiroCliCompanionService', () => {
       ([command]) => command === scenario.installCommand
     );
     expect(installCall?.[2].env[scenario.tempEnvKey]).toContain('agent-teams-kiro-');
+    expect(installCall?.[2].isolateFromHost).toBe(scenario.platform === 'win32');
+    if (scenario.platform === 'win32') {
+      expect(
+        Object.keys(installCall?.[2].env ?? {}).some((key) => key.toLowerCase() === 'psmodulepath')
+      ).toBe(false);
+    }
     expect(status.phase).toBe('connected');
     expect(status.binaryPath).toBe(scenario.binary);
     expect(status.manualCommand).toBe(scenario.manualCommand);

--- a/src/features/runtime-provider-management/main/infrastructure/cli-companion/RuntimeProviderCliCompanionService.ts
+++ b/src/features/runtime-provider-management/main/infrastructure/cli-companion/RuntimeProviderCliCompanionService.ts
@@ -27,6 +27,24 @@ const INSTALL_TIMEOUT_MS = 45 * 60 * 1_000;
 const LOGIN_TIMEOUT_MS = 10 * 60 * 1_000;
 const PROBE_TIMEOUT_MS = 10_000;
 const MAX_CAPTURED_OUTPUT_CHARS = 32_000;
+const WINDOWS_ISOLATED_COMMAND_HELPER = String.raw`
+const { spawn } = require('node:child_process');
+const [command, ...args] = process.argv.slice(1);
+if (!command) process.exit(1);
+const child = spawn(command, args, {
+  env: process.env,
+  shell: /\.(?:cmd|bat)$/i.test(command),
+  windowsHide: true,
+  stdio: ['ignore', 'pipe', 'pipe'],
+});
+child.stdout?.pipe(process.stdout);
+child.stderr?.pipe(process.stderr);
+child.once('error', (error) => {
+  process.stderr.write(String(error?.message || error));
+  process.exit(1);
+});
+child.once('close', (code) => process.exit(code ?? 1));
+`;
 
 export interface RuntimeProviderCliCompanionServiceDependencies {
   platform?: NodeJS.Platform;
@@ -59,10 +77,15 @@ async function runCommandDefault(
   options: RuntimeProviderCliCompanionRunCommandOptions
 ): Promise<RuntimeProviderCliCompanionCommandResult> {
   return new Promise((resolve, reject) => {
-    const child = spawn(command, [...args], {
+    const isolateFromHost = process.platform === 'win32' && options.isolateFromHost === true;
+    const launchCommand = isolateFromHost ? process.execPath : command;
+    const launchArgs = isolateFromHost
+      ? ['-e', WINDOWS_ISOLATED_COMMAND_HELPER, command, ...args]
+      : [...args];
+    const child = spawn(launchCommand, launchArgs, {
       detached: process.platform !== 'win32',
-      env: options.env,
-      shell: process.platform === 'win32' && /\.(?:cmd|bat)$/i.test(command),
+      env: isolateFromHost ? { ...options.env, ELECTRON_RUN_AS_NODE: '1' } : options.env,
+      shell: !isolateFromHost && process.platform === 'win32' && /\.(?:cmd|bat)$/i.test(command),
       windowsHide: true,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
@@ -174,11 +197,22 @@ function trimCommandOutput(result: RuntimeProviderCliCompanionCommandResult): st
 
 function summarizeCommandFailure(result: RuntimeProviderCliCompanionCommandResult): string | null {
   const ignored = /^(?:installation failed\. cleaning up\.\.\.|next steps:)$/i;
-  const lines = `${result.stderr}\n${result.stdout}`
-    .split(/\r?\n/)
-    .map((line) => line.replace(/^(?:(?:❌|⚠️|✓|🎉)\s*)+/u, '').trim())
-    .filter((line) => line && !ignored.test(line));
-  return lines.at(-1) ?? trimCommandOutput(result);
+  const toLines = (value: string): string[] =>
+    value
+      .split(/\r?\n/)
+      .map((line) => line.replace(/^(?:(?:❌|⚠️|✓|🎉)\s*)+/u, '').trim())
+      .filter((line) => line && !ignored.test(line));
+  const stderrLines = toLines(result.stderr);
+  const stdoutLines = toLines(result.stdout);
+  return stderrLines[0] ?? stdoutLines.at(-1) ?? trimCommandOutput(result);
+}
+
+function removeInheritedPowerShellModulePath(env: NodeJS.ProcessEnv): void {
+  for (const key of Object.keys(env)) {
+    if (key.toLowerCase() === 'psmodulepath') {
+      delete env[key];
+    }
+  }
 }
 
 async function findLargestInstallerFile(root: string): Promise<number> {
@@ -389,6 +423,12 @@ export class RuntimeProviderCliCompanionService implements RuntimeProviderCompan
       if (this.#platform === 'win32') {
         installerEnv.TEMP = tempDir;
         installerEnv.TMP = tempDir;
+        if (path.basename(installCommand.command).toLowerCase() === 'powershell.exe') {
+          // PowerShell 7 prepends its module directories to PSModulePath. Passing
+          // that value into Windows PowerShell 5.1 breaks built-in commands such
+          // as Get-FileHash, which the signed Kiro installer requires.
+          removeInheritedPowerShellModulePath(installerEnv);
+        }
       } else {
         installerEnv.TMPDIR = tempDir;
       }
@@ -398,6 +438,9 @@ export class RuntimeProviderCliCompanionService implements RuntimeProviderCompan
       const result = await this.#runCommand(installCommand.command, installCommand.args, {
         env: installerEnv,
         timeoutMs: INSTALL_TIMEOUT_MS,
+        isolateFromHost:
+          this.#platform === 'win32' &&
+          this.#definition.installer.isolateFromHostOnWindows === true,
         onOutput: (text) => this.#handleInstallerOutput(text),
       }).finally(stopDownloadMonitor);
       if (result.exitCode !== 0) {

--- a/src/features/runtime-provider-management/main/infrastructure/cli-companion/RuntimeProviderCliCompanionService.ts
+++ b/src/features/runtime-provider-management/main/infrastructure/cli-companion/RuntimeProviderCliCompanionService.ts
@@ -31,8 +31,10 @@ const WINDOWS_ISOLATED_COMMAND_HELPER = String.raw`
 const { spawn } = require('node:child_process');
 const [command, ...args] = process.argv.slice(1);
 if (!command) process.exit(1);
+const childEnv = { ...process.env };
+delete childEnv.ELECTRON_RUN_AS_NODE;
 const child = spawn(command, args, {
-  env: process.env,
+  env: childEnv,
   shell: /\.(?:cmd|bat)$/i.test(command),
   windowsHide: true,
   stdio: ['ignore', 'pipe', 'pipe'],

--- a/src/features/runtime-provider-management/main/infrastructure/cli-companion/definitions/KiroCliCompanionDefinition.ts
+++ b/src/features/runtime-provider-management/main/infrastructure/cli-companion/definitions/KiroCliCompanionDefinition.ts
@@ -116,6 +116,10 @@ export const KIRO_CLI_COMPANION_DEFINITION: RuntimeProviderCliCompanionDefinitio
     manualUrl: KIRO_DOWNLOADS_URL,
     minimumFreeBytes: MINIMUM_INSTALL_FREE_BYTES,
     monitorDownload: true,
+    // The official Windows script launches a signed MSI. Keep that native
+    // installer tree behind a Node helper so a faulty MSI child cannot corrupt
+    // or terminate the Electron host process.
+    isolateFromHostOnWindows: true,
     packageDescription: 'signed Kiro CLI package',
     parseProgress: (text) => {
       const normalized = text.toLowerCase();
@@ -143,6 +147,7 @@ export const KIRO_CLI_COMPANION_DEFINITION: RuntimeProviderCliCompanionDefinitio
     extraCandidates: (platform, homeDir) =>
       platform === 'win32'
         ? [
+            path.join(process.env.LOCALAPPDATA ?? '', 'Kiro-Cli', 'kiro-cli.exe'),
             path.join(process.env.LOCALAPPDATA ?? '', 'Programs', 'Kiro-Cli', 'kiro-cli.exe'),
             path.join(process.env.ProgramFiles ?? 'C:\\Program Files', 'Kiro-Cli', 'kiro-cli.exe'),
           ]

--- a/src/features/runtime-provider-management/main/infrastructure/cli-companion/types.ts
+++ b/src/features/runtime-provider-management/main/infrastructure/cli-companion/types.ts
@@ -13,6 +13,12 @@ export interface RuntimeProviderCliCompanionRunCommandOptions {
   env: NodeJS.ProcessEnv;
   timeoutMs: number;
   onOutput?: (text: string) => void;
+  /**
+   * Run the command behind a short-lived Node helper on Windows. This keeps
+   * third-party installers behind a separate Node process so Electron does
+   * not own their native handles while preserving output and cancellation.
+   */
+  isolateFromHost?: boolean;
 }
 
 export interface RuntimeProviderCliCompanionInstallCommand {
@@ -46,6 +52,7 @@ export interface RuntimeProviderCliCompanionDefinition {
     manualUrl: string;
     minimumFreeBytes: number;
     monitorDownload: boolean;
+    isolateFromHostOnWindows?: boolean;
     packageDescription: string;
     parseProgress(text: string): RuntimeProviderCliCompanionProgressUpdate | null;
     fetchPackageSize?(platform: NodeJS.Platform, arch: string): Promise<number | null>;

--- a/src/features/tmux-installer/main/infrastructure/wsl/TmuxWslService.ts
+++ b/src/features/tmux-installer/main/infrastructure/wsl/TmuxWslService.ts
@@ -34,6 +34,12 @@ interface WindowsOptionalFeatureProbe {
   hasConfiguredWslFeature: boolean;
 }
 
+interface WindowsOptionalFeatureProbeCacheEntry {
+  value: WindowsOptionalFeatureProbe | null;
+  expiresAt: number;
+  request: Promise<WindowsOptionalFeatureProbe | null> | null;
+}
+
 interface WslDistroGroups {
   userDistros: string[];
   serviceDistros: string[];
@@ -69,6 +75,11 @@ const POWERSHELL_FEATURE_QUERY = [
   '$features = Get-WindowsOptionalFeature -Online -FeatureName "Microsoft-Windows-Subsystem-Linux","VirtualMachinePlatform"',
   '$features | Select-Object FeatureName, State, RestartRequired | ConvertTo-Json -Compress',
 ].join('; ');
+const WINDOWS_OPTIONAL_FEATURE_CACHE_TTL_MS = 10_000;
+const windowsOptionalFeatureProbeCache = new WeakMap<
+  ExecFileLike,
+  WindowsOptionalFeatureProbeCacheEntry
+>();
 const SERVICE_WSL_DISTRO_EXACT_NAMES = new Set([
   'docker-desktop',
   'docker-desktop-data',
@@ -600,6 +611,38 @@ export class TmuxWslService {
   }
 
   async #queryWindowsOptionalFeatures(): Promise<WindowsOptionalFeatureProbe | null> {
+    const cached = windowsOptionalFeatureProbeCache.get(this.#execFile);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.value ? { ...cached.value } : null;
+    }
+    if (cached?.request) {
+      const value = await cached.request;
+      return value ? { ...value } : null;
+    }
+
+    const request = this.#queryWindowsOptionalFeaturesUncached();
+    windowsOptionalFeatureProbeCache.set(this.#execFile, {
+      value: cached?.value ?? null,
+      expiresAt: cached?.expiresAt ?? 0,
+      request,
+    });
+    try {
+      const value = await request;
+      windowsOptionalFeatureProbeCache.set(this.#execFile, {
+        value,
+        expiresAt: Date.now() + WINDOWS_OPTIONAL_FEATURE_CACHE_TTL_MS,
+        request: null,
+      });
+      return value ? { ...value } : null;
+    } finally {
+      const active = windowsOptionalFeatureProbeCache.get(this.#execFile);
+      if (active?.request === request) {
+        active.request = null;
+      }
+    }
+  }
+
+  async #queryWindowsOptionalFeaturesUncached(): Promise<WindowsOptionalFeatureProbe | null> {
     const result = await this.#execPowerShell(
       ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command', POWERSHELL_FEATURE_QUERY],
       6_000

--- a/src/features/tmux-installer/main/infrastructure/wsl/__tests__/TmuxWslService.test.ts
+++ b/src/features/tmux-installer/main/infrastructure/wsl/__tests__/TmuxWslService.test.ts
@@ -381,4 +381,41 @@ describe('TmuxWslService', () => {
     expect(result.status.rebootRequired).toBe(true);
     expect(result.status.statusDetail).toContain('restart');
   });
+
+  it('shares the stable Windows feature probe across service instances', async () => {
+    let powershellCalls = 0;
+    const execFileMock = (
+      command: string,
+      _args: string[],
+      _options: {
+        timeout: number;
+        windowsHide: boolean;
+        maxBuffer: number;
+        encoding: 'buffer';
+      },
+      callback: (error: Error | null, stdout: string | Buffer, stderr: string | Buffer) => void
+    ): void => {
+      if (command === 'powershell.exe') {
+        powershellCalls += 1;
+        callback(
+          null,
+          JSON.stringify([
+            { FeatureName: 'Microsoft-Windows-Subsystem-Linux', State: 'Disabled' },
+            { FeatureName: 'VirtualMachinePlatform', State: 'Disabled' },
+          ]),
+          ''
+        );
+        return;
+      }
+      callback(Object.assign(new Error('WSL unavailable'), { code: 1 }), '', '');
+    };
+
+    const first = new TmuxWslService(execFileMock, createPreferenceStore() as never);
+    const second = new TmuxWslService(execFileMock, createPreferenceStore() as never);
+
+    await first.probe();
+    await second.probe();
+
+    expect(powershellCalls).toBe(1);
+  });
 });

--- a/src/main/services/infrastructure/OpenCodeRuntimeInstallerService.ts
+++ b/src/main/services/infrastructure/OpenCodeRuntimeInstallerService.ts
@@ -122,10 +122,40 @@ function collectPathOpenCodeBinaryCandidates(
 ): string[] {
   return collectRuntimePathBinaryCandidates({
     executableNames: getPathExecutableNames(),
-    additionalEnvSources,
+    // Prefer the environment that launched the desktop app over a cached login-shell
+    // snapshot. On Windows, NVM can leave an older OpenCode shim in the cached shell
+    // PATH while the active npm prefix exposes the current installation.
+    additionalEnvSources:
+      process.platform === 'win32' ? [process.env, ...additionalEnvSources] : additionalEnvSources,
     includeFallbackPathEntries: options.includeFallbackPathEntries,
     extraCandidates: collectNvmOpenCodeBinaryCandidates(),
   });
+}
+
+function collectWindowsNativeOpenCodeBinaryCandidates(binaryPath: string): string[] {
+  if (process.platform !== 'win32' || !/\.(?:cmd|bat)$/i.test(binaryPath)) {
+    return [binaryPath];
+  }
+
+  const shimDirectory = path.dirname(binaryPath);
+  const packageRoot = path.join(shimDirectory, 'node_modules', ROOT_PACKAGE_NAME);
+  const platformPackageNames =
+    process.arch === 'x64'
+      ? ['opencode-windows-x64', 'opencode-windows-x64-baseline']
+      : [`opencode-windows-${process.arch}`];
+  const nativeCandidates = [
+    path.join(packageRoot, 'bin', 'opencode.exe'),
+    ...platformPackageNames.map((packageName) =>
+      path.join(packageRoot, 'node_modules', packageName, 'bin', 'opencode.exe')
+    ),
+  ].filter(isAbsoluteExistingFile);
+
+  // The multimodel runtime launches an explicit OpenCode override without a shell.
+  // Passing an npm .cmd shim therefore fails with spawnSync EINVAL on Windows. Only
+  // return native executables that the external runtime can launch without a shell.
+  // An incomplete npm installation must fall through to the managed runtime instead
+  // of being reported as healthy and failing later during team launch.
+  return nativeCandidates;
 }
 
 function collectNvmOpenCodeBinaryCandidates(): string[] {
@@ -260,16 +290,22 @@ async function probeFirstWorkingOpenCodeBinaryCandidate(
 ): Promise<VerifiedOpenCodeBinaryProbe> {
   let nextFirstFailure = firstFailure;
   for (const binaryPath of candidates) {
-    const normalized = normalizeBinaryCandidateForCompare(binaryPath);
-    if (seen.has(normalized)) {
-      continue;
+    for (const launchBinaryPath of collectWindowsNativeOpenCodeBinaryCandidates(binaryPath)) {
+      const normalized = normalizeBinaryCandidateForCompare(launchBinaryPath);
+      if (seen.has(normalized)) {
+        continue;
+      }
+      seen.add(normalized);
+      const version = await probeOpenCodeBinaryVersionCached(launchBinaryPath);
+      if (version.ok) {
+        return {
+          ok: true,
+          binaryPath: launchBinaryPath,
+          version: version.version,
+        };
+      }
+      nextFirstFailure ??= { binaryPath: launchBinaryPath, error: version.error };
     }
-    seen.add(normalized);
-    const version = await probeOpenCodeBinaryVersionCached(binaryPath);
-    if (version.ok) {
-      return { ok: true, binaryPath, version: version.version };
-    }
-    nextFirstFailure ??= { binaryPath, error: version.error };
   }
 
   return { ok: false, firstFailure: nextFirstFailure };

--- a/src/main/services/team/TeamProvisioningService.ts
+++ b/src/main/services/team/TeamProvisioningService.ts
@@ -9940,7 +9940,18 @@ export class TeamProvisioningService {
       });
     }
 
-    return normalizedDefaultModel;
+    if (normalizedDefaultModel) {
+      return normalizedDefaultModel;
+    }
+
+    return this.resolveProviderDefaultModelFromRuntimeStatus(
+      claudePath,
+      cwd,
+      providerId,
+      env,
+      providerArgs,
+      limitContext
+    ).catch(() => null);
   }
 
   private async resolveProviderDefaultModelFromRuntimeStatus(

--- a/src/main/utils/windowsProcessTable.ts
+++ b/src/main/utils/windowsProcessTable.ts
@@ -25,6 +25,10 @@ const PROCESS_TABLE_ARGS = [
   '-Command',
   PROCESS_TABLE_SCRIPT,
 ];
+const PROCESS_TABLE_CACHE_TTL_MS = 1_500;
+
+let cachedProcessTable: { rows: WindowsProcessTableRow[]; expiresAt: number } | null = null;
+let processTableRequest: Promise<WindowsProcessTableRow[]> | null = null;
 
 function parsePositiveInteger(value: unknown): number | null {
   const parsed =
@@ -68,7 +72,17 @@ export function parseWindowsProcessTableJson(stdout: string): WindowsProcessTabl
 export async function listWindowsProcessTable(
   timeoutMs = 4_000
 ): Promise<WindowsProcessTableRow[]> {
-  return new Promise((resolve, reject) => {
+  const cached = cachedProcessTable;
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.rows.map((row) => ({ ...row }));
+  }
+
+  if (processTableRequest) {
+    const rows = await processTableRequest;
+    return rows.map((row) => ({ ...row }));
+  }
+
+  const request = new Promise<WindowsProcessTableRow[]>((resolve, reject) => {
     execFile(
       'powershell.exe',
       PROCESS_TABLE_ARGS,
@@ -91,6 +105,20 @@ export async function listWindowsProcessTable(
       }
     );
   });
+  processTableRequest = request;
+
+  try {
+    const rows = await request;
+    cachedProcessTable = {
+      rows,
+      expiresAt: Date.now() + PROCESS_TABLE_CACHE_TTL_MS,
+    };
+    return rows.map((row) => ({ ...row }));
+  } finally {
+    if (processTableRequest === request) {
+      processTableRequest = null;
+    }
+  }
 }
 
 export function listWindowsProcessTableSync(timeoutMs = 4_000): WindowsProcessTableRow[] {

--- a/src/renderer/components/team/dialogs/providerPrepareDiagnostics.ts
+++ b/src/renderer/components/team/dialogs/providerPrepareDiagnostics.ts
@@ -279,6 +279,23 @@ function decodeQuotedJsonString(value: string): string {
   }
 }
 
+function normalizeProviderAccountFailure(rawReason: string): string | null {
+  if (/not licensed to use copilot/i.test(rawReason)) {
+    return 'GitHub account connected, but this account does not have an active Copilot license';
+  }
+  if (
+    /payment required|used all available credits|monthly spending limit|insufficient credits/i.test(
+      rawReason
+    )
+  ) {
+    return 'Provider account has no available credits or reached its spending limit';
+  }
+  if (/invalid authentication credentials/i.test(rawReason)) {
+    return 'Provider credentials were rejected. Reconnect the account and retry';
+  }
+  return null;
+}
+
 function normalizeModelReason(rawReason: string | null | undefined): string | null {
   const trimmed = rawReason?.trim() ?? '';
   if (!trimmed) {
@@ -292,6 +309,10 @@ function normalizeModelReason(rawReason: string | null | undefined): string | nu
   }
   if (/The requested model is not available for your account\./i.test(trimmed)) {
     return 'Not available for this account';
+  }
+  const accountFailure = normalizeProviderAccountFailure(trimmed);
+  if (accountFailure) {
+    return accountFailure;
   }
   if (/token refresh failed:\s*401/i.test(trimmed)) {
     return 'OpenCode provider authentication failed (token refresh 401)';
@@ -385,6 +406,11 @@ function isAdvisoryOpenCodeDeepVerificationIssue(
     lower.includes('authentication') ||
     lower.includes('credential') ||
     lower.includes('api key') ||
+    lower.includes('not licensed') ||
+    lower.includes('payment required') ||
+    lower.includes('available credits') ||
+    lower.includes('spending limit') ||
+    lower.includes('insufficient credits') ||
     lower.includes('/experimental/tool') ||
     lower.includes('runtime store') ||
     lower.includes('opencode cli') ||
@@ -571,6 +597,11 @@ function normalizeRuntimeFailureDetailLine(
 
   if (/opencode cli (?:not detected on path|not found)/i.test(trimmed)) {
     return 'OpenCode runtime binary is not installed or not reachable by launch preflight.';
+  }
+
+  const accountFailure = normalizeProviderAccountFailure(trimmed);
+  if (accountFailure) {
+    return accountFailure;
   }
 
   const lower = trimmed.toLowerCase();
@@ -958,7 +989,12 @@ function looksLikeSingleModelCredentialFailure(result: TeamProvisioningPrepareRe
     combined.includes('credential') ||
     combined.includes('api key') ||
     combined.includes('apikey') ||
-    combined.includes('not_authenticated');
+    combined.includes('not_authenticated') ||
+    combined.includes('not licensed') ||
+    combined.includes('payment required') ||
+    combined.includes('available credits') ||
+    combined.includes('spending limit') ||
+    combined.includes('insufficient credits');
   const hasAuthStatus =
     combined.includes('unauthorized') ||
     combined.includes('forbidden') ||
@@ -969,6 +1005,11 @@ function looksLikeSingleModelCredentialFailure(result: TeamProvisioningPrepareRe
     combined.includes('token refresh failed') ||
     combined.includes('authentication failed') ||
     combined.includes('not_authenticated') ||
+    combined.includes('not licensed') ||
+    combined.includes('payment required') ||
+    combined.includes('available credits') ||
+    combined.includes('spending limit') ||
+    combined.includes('insufficient credits') ||
     (hasCredentialContext && hasAuthStatus)
   );
 }

--- a/src/renderer/components/team/dialogs/providerPrepareDiagnostics.ts
+++ b/src/renderer/components/team/dialogs/providerPrepareDiagnostics.ts
@@ -989,12 +989,7 @@ function looksLikeSingleModelCredentialFailure(result: TeamProvisioningPrepareRe
     combined.includes('credential') ||
     combined.includes('api key') ||
     combined.includes('apikey') ||
-    combined.includes('not_authenticated') ||
-    combined.includes('not licensed') ||
-    combined.includes('payment required') ||
-    combined.includes('available credits') ||
-    combined.includes('spending limit') ||
-    combined.includes('insufficient credits');
+    combined.includes('not_authenticated');
   const hasAuthStatus =
     combined.includes('unauthorized') ||
     combined.includes('forbidden') ||

--- a/test/main/services/infrastructure/OpenCodeRuntimeInstallerService.test.ts
+++ b/test/main/services/infrastructure/OpenCodeRuntimeInstallerService.test.ts
@@ -41,6 +41,7 @@ import { setAppDataBasePath } from '@main/utils/pathDecoder';
 
 let tempRoot: string | null = null;
 let originalPath: string | undefined;
+let originalAppData: string | undefined;
 
 function deferred<T>(): {
   promise: Promise<T>;
@@ -54,6 +55,12 @@ function deferred<T>(): {
     reject = promiseReject;
   });
   return { promise, resolve, reject };
+}
+
+function getTestNvmOpenCodeBinaryPath(version: string): string {
+  return process.platform === 'win32'
+    ? path.join(tempRoot!, 'nvm', version, 'opencode.exe')
+    : path.join(tempRoot!, '.nvm', 'versions', 'node', version, 'bin', 'opencode');
 }
 
 function writeOctal(header: Buffer, offset: number, length: number, value: number): void {
@@ -98,7 +105,9 @@ describe('OpenCodeRuntimeInstallerService resolver', () => {
     tempRoot = await mkdtemp(path.join(os.tmpdir(), 'opencode-runtime-resolver-'));
     setAppDataBasePath(tempRoot);
     originalPath = process.env.PATH;
+    originalAppData = process.env.APPDATA;
     process.env.PATH = '';
+    process.env.APPDATA = tempRoot;
     clearOpenCodeRuntimeBinaryResolverCache();
     execCliMock.mockReset();
     execCliMock.mockResolvedValue({ stdout: 'opencode 1.0.0\n', stderr: '' });
@@ -120,7 +129,13 @@ describe('OpenCodeRuntimeInstallerService resolver', () => {
     } else {
       process.env.PATH = originalPath;
     }
+    if (originalAppData === undefined) {
+      delete process.env.APPDATA;
+    } else {
+      process.env.APPDATA = originalAppData;
+    }
     originalPath = undefined;
+    originalAppData = undefined;
     if (tempRoot) {
       await rm(tempRoot, { recursive: true, force: true });
       tempRoot = null;
@@ -448,24 +463,8 @@ describe('OpenCodeRuntimeInstallerService resolver', () => {
   });
 
   it('returns a verified OpenCode binary from nvm when desktop PATH misses npm globals', async () => {
-    const olderBinaryPath = path.join(
-      tempRoot!,
-      '.nvm',
-      'versions',
-      'node',
-      'v20.10.0',
-      'bin',
-      'opencode'
-    );
-    const binaryPath = path.join(
-      tempRoot!,
-      '.nvm',
-      'versions',
-      'node',
-      'v22.22.1',
-      'bin',
-      'opencode'
-    );
+    const olderBinaryPath = getTestNvmOpenCodeBinaryPath('v20.10.0');
+    const binaryPath = getTestNvmOpenCodeBinaryPath('v22.22.1');
     await mkdir(path.dirname(olderBinaryPath), { recursive: true });
     await mkdir(path.dirname(binaryPath), { recursive: true });
     await writeFile(olderBinaryPath, 'older binary', { mode: 0o755 });
@@ -483,7 +482,7 @@ describe('OpenCodeRuntimeInstallerService resolver', () => {
     });
   });
 
-  it('returns a verified OpenCode cmd shim from nvm-windows when desktop PATH misses npm globals', async () => {
+  it('returns the native executable behind an nvm-windows cmd shim when desktop PATH misses npm globals', async () => {
     const originalPlatform = process.platform;
     const originalAppData = process.env.APPDATA;
 
@@ -496,10 +495,22 @@ describe('OpenCodeRuntimeInstallerService resolver', () => {
       process.env.APPDATA = tempRoot!;
 
       const olderBinaryPath = path.join(tempRoot!, 'nvm', 'v20.10.0', 'opencode.cmd');
-      const binaryPath = path.join(tempRoot!, 'nvm', 'v22.22.1', 'opencode.cmd');
+      const shimPath = path.join(tempRoot!, 'nvm', 'v22.22.1', 'opencode.cmd');
+      const binaryPath = path.join(
+        tempRoot!,
+        'nvm',
+        'v22.22.1',
+        'node_modules',
+        'opencode-ai',
+        'node_modules',
+        `opencode-windows-${process.arch}`,
+        'bin',
+        'opencode.exe'
+      );
       await mkdir(path.dirname(olderBinaryPath), { recursive: true });
       await mkdir(path.dirname(binaryPath), { recursive: true });
       await writeFile(olderBinaryPath, 'older binary', { mode: 0o755 });
+      await writeFile(shimPath, 'npm shim', { mode: 0o755 });
       await writeFile(binaryPath, 'binary', { mode: 0o755 });
 
       await expect(
@@ -510,6 +521,7 @@ describe('OpenCodeRuntimeInstallerService resolver', () => {
         timeout: 20_000,
         windowsHide: true,
       });
+      expect(execCliMock).not.toHaveBeenCalledWith(shimPath, expect.anything(), expect.anything());
     } finally {
       Object.defineProperty(process, 'platform', {
         value: originalPlatform,
@@ -524,25 +536,103 @@ describe('OpenCodeRuntimeInstallerService resolver', () => {
     }
   });
 
+  it('prefers the active npm OpenCode native executable over a stale nvm-windows cmd shim', async () => {
+    const originalPlatform = process.platform;
+    const originalAppData = process.env.APPDATA;
+
+    try {
+      Object.defineProperty(process, 'platform', {
+        value: 'win32',
+        configurable: true,
+        writable: true,
+      });
+      process.env.APPDATA = tempRoot!;
+
+      const activeNpmDirectory = path.join(tempRoot!, 'npm');
+      const activeShimPath = path.join(activeNpmDirectory, 'opencode.cmd');
+      const activeNativePath = path.join(
+        activeNpmDirectory,
+        'node_modules',
+        'opencode-ai',
+        'bin',
+        'opencode.exe'
+      );
+      const staleNvmDirectory = path.join(tempRoot!, 'nvm', 'v20.20.0');
+      const staleNvmShimPath = path.join(staleNvmDirectory, 'opencode.cmd');
+      await mkdir(path.dirname(activeNativePath), { recursive: true });
+      await mkdir(staleNvmDirectory, { recursive: true });
+      await writeFile(activeShimPath, 'active npm shim', { mode: 0o755 });
+      await writeFile(activeNativePath, 'active native binary', { mode: 0o755 });
+      await writeFile(staleNvmShimPath, 'stale nvm shim', { mode: 0o755 });
+      process.env.PATH = activeNpmDirectory;
+      getCachedShellEnvMock.mockReturnValue({ PATH: staleNvmDirectory });
+      execCliMock.mockImplementation(async (binaryPath: string) => ({
+        stdout: binaryPath === activeNativePath ? '1.15.10\n' : '1.14.29\n',
+        stderr: '',
+      }));
+
+      await expect(
+        resolveVerifiedOpenCodeRuntimeBinaryPath({ shellEnvTimeoutMs: 0 })
+      ).resolves.toBe(activeNativePath);
+      expect(execCliMock).toHaveBeenCalledWith(activeNativePath, ['--version'], {
+        timeout: 20_000,
+        windowsHide: true,
+      });
+      expect(execCliMock).not.toHaveBeenCalledWith(
+        staleNvmShimPath,
+        expect.anything(),
+        expect.anything()
+      );
+    } finally {
+      Object.defineProperty(process, 'platform', {
+        value: originalPlatform,
+        configurable: true,
+        writable: true,
+      });
+      if (originalAppData === undefined) {
+        delete process.env.APPDATA;
+      } else {
+        process.env.APPDATA = originalAppData;
+      }
+    }
+  });
+
+  it('does not report a Windows cmd-only OpenCode installation as runtime-ready', async () => {
+    const originalPlatform = process.platform;
+
+    try {
+      Object.defineProperty(process, 'platform', {
+        value: 'win32',
+        configurable: true,
+        writable: true,
+      });
+
+      const shimDirectory = path.join(tempRoot!, 'npm');
+      const shimPath = path.join(shimDirectory, 'opencode.cmd');
+      await mkdir(shimDirectory, { recursive: true });
+      await writeFile(shimPath, 'incomplete npm shim', { mode: 0o755 });
+      process.env.PATH = shimDirectory;
+      getCachedShellEnvMock.mockReturnValue({ PATH: shimDirectory });
+
+      await expect(
+        resolveVerifiedOpenCodeRuntimeBinaryPath({
+          includeShellEnv: false,
+          shellEnvTimeoutMs: 0,
+        })
+      ).resolves.toBeNull();
+      expect(execCliMock).not.toHaveBeenCalledWith(shimPath, expect.anything(), expect.anything());
+    } finally {
+      Object.defineProperty(process, 'platform', {
+        value: originalPlatform,
+        configurable: true,
+        writable: true,
+      });
+    }
+  });
+
   it('skips a broken newer nvm OpenCode binary and reports the next working install', async () => {
-    const brokenBinaryPath = path.join(
-      tempRoot!,
-      '.nvm',
-      'versions',
-      'node',
-      'v23.0.0',
-      'bin',
-      'opencode'
-    );
-    const workingBinaryPath = path.join(
-      tempRoot!,
-      '.nvm',
-      'versions',
-      'node',
-      'v22.22.1',
-      'bin',
-      'opencode'
-    );
+    const brokenBinaryPath = getTestNvmOpenCodeBinaryPath('v23.0.0');
+    const workingBinaryPath = getTestNvmOpenCodeBinaryPath('v22.22.1');
     await mkdir(path.dirname(brokenBinaryPath), { recursive: true });
     await mkdir(path.dirname(workingBinaryPath), { recursive: true });
     await writeFile(brokenBinaryPath, 'broken binary', { mode: 0o755 });
@@ -569,15 +659,7 @@ describe('OpenCodeRuntimeInstallerService resolver', () => {
   });
 
   it('falls through to shell PATH when all fast nvm candidates are broken', async () => {
-    const brokenBinaryPath = path.join(
-      tempRoot!,
-      '.nvm',
-      'versions',
-      'node',
-      'v23.0.0',
-      'bin',
-      'opencode'
-    );
+    const brokenBinaryPath = getTestNvmOpenCodeBinaryPath('v23.0.0');
     const shellBinaryPath = path.join(tempRoot!, 'custom-npm-prefix', 'bin', 'opencode');
     await mkdir(path.dirname(brokenBinaryPath), { recursive: true });
     await mkdir(path.dirname(shellBinaryPath), { recursive: true });

--- a/test/main/services/infrastructure/OpenCodeRuntimeInstallerService.test.ts
+++ b/test/main/services/infrastructure/OpenCodeRuntimeInstallerService.test.ts
@@ -559,11 +559,19 @@ describe('OpenCodeRuntimeInstallerService resolver', () => {
       );
       const staleNvmDirectory = path.join(tempRoot!, 'nvm', 'v20.20.0');
       const staleNvmShimPath = path.join(staleNvmDirectory, 'opencode.cmd');
+      const staleNvmNativePath = path.join(
+        staleNvmDirectory,
+        'node_modules',
+        'opencode-ai',
+        'bin',
+        'opencode.exe'
+      );
       await mkdir(path.dirname(activeNativePath), { recursive: true });
-      await mkdir(staleNvmDirectory, { recursive: true });
+      await mkdir(path.dirname(staleNvmNativePath), { recursive: true });
       await writeFile(activeShimPath, 'active npm shim', { mode: 0o755 });
       await writeFile(activeNativePath, 'active native binary', { mode: 0o755 });
       await writeFile(staleNvmShimPath, 'stale nvm shim', { mode: 0o755 });
+      await writeFile(staleNvmNativePath, 'stale native binary', { mode: 0o755 });
       process.env.PATH = activeNpmDirectory;
       getCachedShellEnvMock.mockReturnValue({ PATH: staleNvmDirectory });
       execCliMock.mockImplementation(async (binaryPath: string) => ({
@@ -579,7 +587,7 @@ describe('OpenCodeRuntimeInstallerService resolver', () => {
         windowsHide: true,
       });
       expect(execCliMock).not.toHaveBeenCalledWith(
-        staleNvmShimPath,
+        staleNvmNativePath,
         expect.anything(),
         expect.anything()
       );

--- a/test/main/services/runtime/OpenCodeRuntimeNvmResolution.safe-e2e.test.ts
+++ b/test/main/services/runtime/OpenCodeRuntimeNvmResolution.safe-e2e.test.ts
@@ -1,12 +1,13 @@
 // @vitest-environment node
 /* eslint-disable security/detect-non-literal-fs-filename */
-import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { chmod, copyFile, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
+  clearOpenCodeRuntimeBinaryResolverCache,
   OpenCodeRuntimeInstallerService,
   resolveVerifiedOpenCodeRuntimeBinaryPath,
 } from '../../../../src/main/services/infrastructure/OpenCodeRuntimeInstallerService';
@@ -16,6 +17,7 @@ import { setAppDataBasePath } from '../../../../src/main/utils/pathDecoder';
 import { clearShellEnvCache } from '../../../../src/main/utils/shellEnv';
 
 const describePosix = process.platform === 'win32' ? describe.skip : describe;
+const describeWindows = process.platform === 'win32' ? describe : describe.skip;
 
 describePosix('OpenCode nvm runtime resolution safe e2e', () => {
   let tempDir: string | null = null;
@@ -111,6 +113,83 @@ describePosix('OpenCode nvm runtime resolution safe e2e', () => {
     await chmod(binaryPath, 0o755);
     return binaryPath;
   }
+});
+
+describeWindows('OpenCode nvm-windows runtime resolution safe e2e', () => {
+  let tempDir: string | null = null;
+  let originalAppData: string | undefined;
+  let originalPath: string | undefined;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), 'opencode-nvm-windows-resolution-e2e-'));
+    setAppDataBasePath(path.join(tempDir, 'app-data'));
+    clearOpenCodeRuntimeBinaryResolverCache();
+    clearShellEnvCache();
+
+    originalAppData = process.env.APPDATA;
+    originalPath = process.env.PATH;
+    process.env.APPDATA = tempDir;
+    process.env.PATH = '';
+  });
+
+  afterEach(async () => {
+    clearOpenCodeRuntimeBinaryResolverCache();
+    clearShellEnvCache();
+    setAppDataBasePath(null);
+
+    restoreEnvValue('APPDATA', originalAppData);
+    restoreEnvValue('PATH', originalPath);
+
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+      tempDir = null;
+    }
+  });
+
+  it('selects the native OpenCode executable behind an nvm cmd shim', async () => {
+    const versionDir = path.join(tempDir!, 'nvm', 'v20.20.0');
+    const shimPath = path.join(versionDir, 'opencode.cmd');
+    const nativeBinaryPath = path.join(
+      versionDir,
+      'node_modules',
+      'opencode-ai',
+      'node_modules',
+      `opencode-windows-${process.arch}`,
+      'bin',
+      'opencode.exe'
+    );
+    await mkdir(path.dirname(nativeBinaryPath), { recursive: true });
+    await writeFile(shimPath, '@echo off\r\nexit /b 1\r\n', 'utf8');
+    await copyFile(process.execPath, nativeBinaryPath);
+
+    await expect(resolveVerifiedOpenCodeRuntimeBinaryPath({ shellEnvTimeoutMs: 0 })).resolves.toBe(
+      nativeBinaryPath
+    );
+
+    const status = await new OpenCodeRuntimeInstallerService().getStatus();
+    expect(status).toMatchObject({
+      installed: true,
+      source: 'path',
+      state: 'ready',
+      binaryPath: nativeBinaryPath,
+    });
+
+    const bridgeEnv: NodeJS.ProcessEnv = { PATH: '' };
+    await ensureOpenCodeBridgeRuntimeBinaryEnv({
+      targetEnv: bridgeEnv,
+      bridgeEnv,
+      resolveVerifiedOpenCodeRuntimeBinaryPath,
+    });
+    expect(bridgeEnv.CLAUDE_MULTIMODEL_OPENCODE_BIN_PATH).toBe(nativeBinaryPath);
+    expect(bridgeEnv.OPENCODE_BIN_PATH).toBe(nativeBinaryPath);
+
+    const version = await execCli(nativeBinaryPath, ['--version'], {
+      env: bridgeEnv,
+      timeout: 2_000,
+      windowsHide: true,
+    });
+    expect(version.stdout.trim()).toMatch(/^v\d+\./);
+  });
 });
 
 function restoreEnvValue(name: string, value: string | undefined): void {

--- a/test/main/services/team/TeamProvisioningServicePrepare.test.ts
+++ b/test/main/services/team/TeamProvisioningServicePrepare.test.ts
@@ -3368,6 +3368,84 @@ describe('TeamProvisioningService prepare/auth behavior', () => {
     ).resolves.toBe('opencode/big-pickle');
   });
 
+  it('falls back to OpenCode runtime status when the model list has no default model', async () => {
+    execCliMock.mockImplementation(async (_binaryPath: string | null, args: string[]) => {
+      if (args[0] === 'model' && args[1] === 'list' && args.includes('opencode')) {
+        return {
+          stdout: JSON.stringify({
+            schemaVersion: 1,
+            providers: {
+              opencode: {
+                defaultModel: null,
+                models: [
+                  {
+                    id: 'opencode/big-pickle',
+                    label: 'Big Pickle',
+                    description: 'Free OpenCode model',
+                  },
+                ],
+              },
+            },
+          }),
+          stderr: '',
+          exitCode: 0,
+        };
+      }
+      if (args[0] === 'runtime' && args[1] === 'status' && args.includes('opencode')) {
+        return {
+          stdout: JSON.stringify({
+            providers: {
+              opencode: {
+                providerId: 'opencode',
+                modelCatalog: {
+                  schemaVersion: 1,
+                  providerId: 'opencode',
+                  source: 'app-server',
+                  status: 'ready',
+                  fetchedAt: new Date(0).toISOString(),
+                  staleAt: new Date(60_000).toISOString(),
+                  defaultModelId: 'opencode/big-pickle',
+                  defaultLaunchModel: 'opencode/big-pickle',
+                  models: [],
+                  diagnostics: {
+                    configReadState: 'ready',
+                    appServerState: 'healthy',
+                  },
+                },
+              },
+            },
+          }),
+          stderr: '',
+          exitCode: 0,
+        };
+      }
+      return defaultExecCliMockImplementation(_binaryPath, args);
+    });
+
+    const svc = new TeamProvisioningService();
+    const serviceWithDefaultModelResolver = svc as unknown as {
+      resolveProviderDefaultModel: (
+        claudePath: string,
+        cwd: string,
+        providerId: string,
+        env: NodeJS.ProcessEnv,
+        providerArgs: string[],
+        limitContext: boolean
+      ) => Promise<string | null>;
+    };
+
+    await expect(
+      serviceWithDefaultModelResolver.resolveProviderDefaultModel(
+        '/fake/claude',
+        tempRoot,
+        'opencode',
+        { PATH: '/usr/bin' },
+        [],
+        false
+      )
+    ).resolves.toBe('opencode/big-pickle');
+  });
+
   it('materializes pure OpenCode runtime adapter Default selections before launch', async () => {
     execCliMock.mockImplementation(async (_binaryPath: string | null, args: string[]) => {
       if (args[0] === 'model' && args[1] === 'list' && args.includes('opencode')) {

--- a/test/renderer/components/team/dialogs/providerPrepareDiagnostics.test.ts
+++ b/test/renderer/components/team/dialogs/providerPrepareDiagnostics.test.ts
@@ -1032,6 +1032,69 @@ describe('runProviderPrepareDiagnostics', () => {
     expect(prepareProvisioning).toHaveBeenCalledTimes(2);
   });
 
+  it.each([
+    {
+      raw: 'Forbidden: unauthorized: not licensed to use Copilot',
+      normalized:
+        'GitHub account connected, but this account does not have an active Copilot license',
+    },
+    {
+      raw: 'Payment Required: team used all available credits or reached its monthly spending limit',
+      normalized: 'Provider account has no available credits or reached its spending limit',
+    },
+    {
+      raw: 'API Error: 401 authentication_error: Invalid authentication credentials',
+      normalized: 'Provider credentials were rejected. Reconnect the account and retry',
+    },
+  ])('keeps account limitation blocking and actionable: $raw', async ({ raw, normalized }) => {
+    const prepareProvisioning = vi.fn(
+      (
+        _cwd?: string,
+        _providerId?: TeamProviderId,
+        _providerIds?: TeamProviderId[],
+        _selectedModels?: string[],
+        _limitContext?: boolean,
+        modelVerificationMode?: 'compatibility' | 'deep'
+      ): Promise<TeamProvisioningPrepareResult> =>
+        Promise.resolve(
+          modelVerificationMode === 'compatibility'
+            ? {
+                ready: true,
+                message: 'CLI is ready to launch',
+                details: [
+                  'Selected model opencode/big-pickle is compatible. Deep verification pending.',
+                ],
+              }
+            : {
+                ready: false,
+                message: raw,
+                details: [raw],
+                issues: [
+                  {
+                    providerId: 'opencode',
+                    scope: 'provider',
+                    severity: 'blocking',
+                    code: 'unknown_error',
+                    message: raw,
+                  },
+                ],
+              }
+        )
+    );
+
+    const result = await runProviderPrepareDiagnostics({
+      cwd: '/tmp/project',
+      providerId: 'opencode',
+      selectedModelIds: ['opencode/big-pickle'],
+      prepareProvisioning,
+    });
+
+    expect(result.status).toBe('failed');
+    expect(result.details.join('\n')).toContain(normalized);
+    expect(result.warnings).toEqual([]);
+    expect(prepareProvisioning).toHaveBeenCalledTimes(2);
+  });
+
   it('uses structured mcp_unavailable code to explain plain OpenCode connect failures', async () => {
     const prepareProvisioning = vi.fn<
       (


### PR DESCRIPTION
## Что исправлено

- Windows resolver разворачивает npm/NVM `opencode.cmd` в нативный `opencode.exe` перед передачей пути multimodel runtime.
- Неполная установка только с `.cmd` больше не считается готовой и не доходит до позднего `spawnSync EINVAL`.
- При отсутствии default model в model list запуск использует default model из OpenCode runtime status.
- Добавлены Windows regression и safe e2e тесты для реального пути через nvm-windows shim.

## Проверка

- `pnpm exec vitest run test/main/services/infrastructure/OpenCodeRuntimeInstallerService.test.ts test/main/services/runtime/OpenCodeRuntimeNvmResolution.safe-e2e.test.ts test/main/services/team/TeamProvisioningServicePrepare.test.ts test/main/utils/childProcess.test.ts`
- `pnpm lint:fast:files -- src/main/services/infrastructure/OpenCodeRuntimeInstallerService.ts src/main/services/team/TeamProvisioningService.ts test/main/services/runtime/OpenCodeRuntimeNvmResolution.safe-e2e.test.ts`
- `pnpm typecheck`
- Локальный OpenCode 1.14.48 выполнил `npm --version` без видимых окон `cmd.exe`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows OpenCode runtime detection and probing to prefer native executables over `.cmd`/`.bat` shims, handle `.cmd`-only installs correctly, and avoid stale candidates.
  * Made default model resolution more resilient when runtime metadata is missing.
  * Enhanced provider preparation diagnostics to better classify common account/entitlement issues (e.g., not licensed, payment required, credit limits).
  * Improved Windows CLI companion installation reliability by isolating installer execution and cleaning PowerShell module-path settings.
* **Tests**
  * Expanded and updated Windows runtime e2e and resolution tests, including cache isolation and new `.cmd`-vs-`opencode.exe` expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->