### PR TITLE
fix(ci): review draft pull requests without backlog

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -2,9 +2,9 @@ name: ReviewRouter Codex OAuth
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
   pull_request_target:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
   workflow_dispatch:
   schedule:
     - cron: "17 */6 * * *"
@@ -18,7 +18,6 @@ jobs:
     timeout-minutes: ${{ fromJSON(vars.REVIEW_ROUTER_TIMEOUT_MINUTES || '60') }}
     concurrency:
       group: reviewrouter-codex-oauth-${{ github.repository_id }}-codex-rotating-1163183284
-      queue: max
       cancel-in-progress: false
     if: ${{ ((github.event_name == 'pull_request' && github.event.pull_request.draft == false) || (github.event_name == 'pull_request_target' && github.event.pull_request.draft == true && vars.REVIEW_ROUTER_REVIEW_DRAFTS == 'true')) && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.type != 'Bot' }}
     permissions:
@@ -43,7 +42,6 @@ jobs:
     timeout-minutes: 60
     concurrency:
       group: reviewrouter-codex-oauth-${{ github.repository_id }}-codex-rotating-1163183284
-      queue: max
       cancel-in-progress: false
     if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     permissions:


### PR DESCRIPTION
## Summary
- trigger ReviewRouter when an existing pull request is converted to draft
- preserve REVIEW_ROUTER_REVIEW_DRAFTS as the explicit draft-review switch
- keep the active review and only the latest pending run instead of a 100-run FIFO backlog

## Validation
- PR targets dev and contains exactly one workflow file
- production workflow scanner: valid, no errors
- git diff --check
- current draft PRs #240 and #252 will be rerun after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request review automation to consistently respond when pull requests are converted to draft, across relevant pull request event types.
  * Added manual and scheduled triggers for periodic review refreshes.
  * Improved review execution controls with shared concurrency handling and a configurable review timeout.
  * Enhanced review configuration to better support draft-review behavior and review limits, including passing through updated review parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-router-summary:start -->
## Summary

- updates a GitHub Actions workflow


<details>
<summary>📒 Files selected for processing (1)</summary>

* `.github/workflows/reviewrouter-codex.yml`

</details>

<details>
<summary>📝 Walkthrough</summary>

## Walkthrough

This PR updates 1 file across 1 CI workflow. The generated summary is based on the GitHub pull request file list and diff metadata, and the author's description above is preserved.

## Changes

| Cohort / File(s) | Summary |
|---|---|
| **CI workflow** <br> `.github/workflows/reviewrouter-codex.yml` | Updates a GitHub Actions workflow.<br>Line stats: 1 modified; +2/-4. |

</details>
<!-- review-router-summary:end -->