### PR TITLE
fix(release): bootstrap runtime from public binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -465,8 +465,25 @@ jobs:
           echo "Timed out waiting for terminal-platform assets in release $RELEASE_REPO@$RELEASE_TAG" >&2
           exit 1
 
+  verify-public-runtime:
+    needs: prepare-runtime
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .node-version
+
+      - name: Verify anonymous runtime bootstrap before packaging
+        run: node ./scripts/ci/verify-public-runtime-bootstrap.mjs
+
   release-mac:
-    needs: [build, prepare-runtime, prepare-terminal-platform-runtime]
+    needs: [build, prepare-runtime, prepare-terminal-platform-runtime, verify-public-runtime]
     timeout-minutes: 90
     strategy:
       fail-fast: false
@@ -618,7 +635,7 @@ jobs:
           done
 
   release-win:
-    needs: [build, prepare-runtime, prepare-terminal-platform-runtime]
+    needs: [build, prepare-runtime, prepare-terminal-platform-runtime, verify-public-runtime]
     runs-on: windows-latest
     timeout-minutes: 60
 
@@ -761,7 +778,7 @@ jobs:
           done
 
   release-linux:
-    needs: [build, prepare-runtime, prepare-terminal-platform-runtime]
+    needs: [build, prepare-runtime, prepare-terminal-platform-runtime, verify-public-runtime]
     runs-on: ubuntu-latest
     timeout-minutes: 90
 

--- a/.github/workflows/runtime-bootstrap-smoke.yml
+++ b/.github/workflows/runtime-bootstrap-smoke.yml
@@ -1,0 +1,54 @@
+name: Public Runtime Bootstrap Smoke
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main, dev]
+    paths:
+      - 'runtime.lock.json'
+      - 'scripts/dev-with-runtime.mjs'
+      - 'scripts/ci/verify-public-runtime-bootstrap.mjs'
+      - 'scripts/ci/verify-runtime-lock.mjs'
+      - 'scripts/lib/github-release-download-error.mjs'
+      - '.github/workflows/runtime-bootstrap-smoke.yml'
+  pull_request:
+    paths:
+      - 'runtime.lock.json'
+      - 'scripts/dev-with-runtime.mjs'
+      - 'scripts/ci/verify-public-runtime-bootstrap.mjs'
+      - 'scripts/ci/verify-runtime-lock.mjs'
+      - 'scripts/lib/github-release-download-error.mjs'
+      - '.github/workflows/runtime-bootstrap-smoke.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  bootstrap:
+    name: anonymous bootstrap (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux-x64
+            runner: ubuntu-24.04
+          - platform: win32-x64
+            runner: windows-2022
+          - platform: darwin-arm64
+            runner: macos-14
+          - platform: darwin-x64
+            runner: macos-15-intel
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .node-version
+
+      - name: Download, extract, and execute pinned runtime anonymously
+        run: node ./scripts/ci/verify-public-runtime-bootstrap.mjs

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -505,8 +505,8 @@ gh workflow run release-runtime.yml \
   --ref "v$RUNTIME_VERSION" \
   -f source_ref="v$RUNTIME_VERSION" \
   -f runtime_version="$RUNTIME_VERSION" \
-  -f target_release_repo=777genius/agent_teams_orchestrator \
-  -f target_release_tag="v$RUNTIME_VERSION"
+  -f target_release_repo=777genius/agent_teams_orchestrator_binaries \
+  -f target_release_tag="runtime-v$RUNTIME_VERSION"
 
 gh run list \
   --repo 777genius/agent_teams_orchestrator \
@@ -524,9 +524,9 @@ After the runtime workflow succeeds, update this repo's `runtime.lock.json`:
 
 - `version`: the new runtime version, for example `0.0.52`
 - `sourceRef`: the matching runtime tag, for example `v0.0.52`
-- `releaseRepository`: the runtime repository that hosts runtime assets, normally
-  `777genius/agent_teams_orchestrator`
-- `releaseTag`: the matching runtime release tag, for example `v0.0.52`
+- `releaseRepository`: the public repository that hosts runtime assets,
+  `777genius/agent_teams_orchestrator_binaries`
+- `releaseTag`: the namespaced public runtime release tag, for example `runtime-v0.0.52`
 - each `assets.*.file`: replace the old runtime version suffix with the new one
 
 Then verify the lock points at real uploaded assets:
@@ -547,14 +547,14 @@ done
 node scripts/stage-runtime.mjs
 ```
 
-Do not create standalone runtime releases in the frontend repository. The
-canonical runtime release is in `777genius/agent_teams_orchestrator`, for example
-`v0.0.52`. The frontend release workflow stages those archives into packaged app
-installers.
+Do not create standalone runtime releases in the frontend repository. The source tag is in the
+private `777genius/agent_teams_orchestrator` repository, while the downloadable release is in
+public `777genius/agent_teams_orchestrator_binaries`. The frontend release workflow stages those
+archives into packaged app installers.
 
-If the orchestrator repository is private, local `pnpm dev` needs GitHub CLI
-authentication with access to `777genius/agent_teams_orchestrator`, or a local
-runtime override through `CLAUDE_AGENT_TEAMS_ORCHESTRATOR_CLI_PATH`.
+Local `pnpm dev` downloads the pinned runtime anonymously from the public binary repository. GitHub
+CLI authentication is not required. A local runtime override remains available through
+`CLAUDE_AGENT_TEAMS_ORCHESTRATOR_CLI_PATH`.
 
 ### 3. Create tag and build the draft
 

--- a/runtime.lock.json
+++ b/runtime.lock.json
@@ -1,27 +1,27 @@
 {
-  "version": "0.0.65",
-  "sourceRef": "v0.0.65",
+  "version": "0.0.66",
+  "sourceRef": "v0.0.66",
   "sourceRepository": "777genius/agent_teams_orchestrator",
-  "releaseRepository": "777genius/agent_teams_orchestrator",
-  "releaseTag": "v0.0.65",
+  "releaseRepository": "777genius/agent_teams_orchestrator_binaries",
+  "releaseTag": "runtime-v0.0.66",
   "assets": {
     "darwin-arm64": {
-      "file": "agent-teams-runtime-darwin-arm64-v0.0.65.tar.gz",
+      "file": "agent-teams-runtime-darwin-arm64-v0.0.66.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel"
     },
     "darwin-x64": {
-      "file": "agent-teams-runtime-darwin-x64-v0.0.65.tar.gz",
+      "file": "agent-teams-runtime-darwin-x64-v0.0.66.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel"
     },
     "linux-x64": {
-      "file": "agent-teams-runtime-linux-x64-v0.0.65.tar.gz",
+      "file": "agent-teams-runtime-linux-x64-v0.0.66.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel"
     },
     "win32-x64": {
-      "file": "agent-teams-runtime-win32-x64-v0.0.65.zip",
+      "file": "agent-teams-runtime-win32-x64-v0.0.66.zip",
       "archiveKind": "zip",
       "binaryName": "claude-multimodel.exe"
     }

--- a/scripts/ci/verify-public-runtime-bootstrap.mjs
+++ b/scripts/ci/verify-public-runtime-bootstrap.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, '..', '..');
+const runtimeLock = JSON.parse(fs.readFileSync(path.join(repoRoot, 'runtime.lock.json'), 'utf8'));
+const cacheRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-teams-public-runtime-e2e-'));
+const platformKey = `${process.platform}-${process.arch}`;
+
+function fail(message, result) {
+  if (result?.stdout) {
+    process.stderr.write(result.stdout);
+  }
+  if (result?.stderr) {
+    process.stderr.write(result.stderr);
+  }
+  throw new Error(`[public-runtime-bootstrap-e2e] ${message}`);
+}
+
+try {
+  const env = {
+    ...process.env,
+    CLAUDE_DEV_RUNTIME_CACHE_ROOT: cacheRoot,
+    CLAUDE_DEV_RUNTIME_DISABLE_GH: '1',
+    GH_CONFIG_DIR: path.join(cacheRoot, 'gh-config'),
+  };
+  delete env.CLAUDE_AGENT_TEAMS_ORCHESTRATOR_CLI_PATH;
+  delete env.CLAUDE_DEV_RUNTIME_ROOT;
+  delete env.GH_TOKEN;
+  delete env.GITHUB_TOKEN;
+  delete env.GH_ENTERPRISE_TOKEN;
+
+  const bootstrap = spawnSync(
+    process.execPath,
+    [path.join(repoRoot, 'scripts', 'dev-with-runtime.mjs'), '--print-runtime-path'],
+    {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      env,
+      maxBuffer: 16 * 1024 * 1024,
+    }
+  );
+  if (bootstrap.error || bootstrap.status !== 0) {
+    fail(
+      `anonymous bootstrap failed: ${bootstrap.error?.message ?? `exit ${bootstrap.status}`}`,
+      bootstrap
+    );
+  }
+
+  const outputLines = bootstrap.stdout
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const runtimePath = outputLines.at(-1) ?? '';
+  if (!runtimePath || !fs.statSync(runtimePath, { throwIfNoEntry: false })?.isFile()) {
+    fail(
+      `bootstrap did not return an existing runtime path: ${runtimePath || '<empty>'}`,
+      bootstrap
+    );
+  }
+
+  const asset = runtimeLock.assets?.[platformKey];
+  if (!asset) {
+    fail(`runtime lock has no asset for ${platformKey}`);
+  }
+  const expectedRuntimePath = path.join(
+    cacheRoot,
+    runtimeLock.version,
+    platformKey,
+    asset.binaryName
+  );
+  if (path.resolve(runtimePath) !== path.resolve(expectedRuntimePath)) {
+    fail(`expected runtime path ${expectedRuntimePath}, got ${runtimePath}`, bootstrap);
+  }
+
+  const version = spawnSync(runtimePath, ['--version'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    env,
+    maxBuffer: 1024 * 1024,
+  });
+  const versionText = `${version.stdout ?? ''}\n${version.stderr ?? ''}`.trim();
+  if (version.error || version.status !== 0 || !versionText.includes(runtimeLock.version)) {
+    fail(
+      `expected executable runtime ${runtimeLock.version}, got ${versionText || version.error?.message || `exit ${version.status}`}`,
+      version
+    );
+  }
+
+  const cachedBootstrap = spawnSync(
+    process.execPath,
+    [path.join(repoRoot, 'scripts', 'dev-with-runtime.mjs'), '--print-runtime-path'],
+    {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      env,
+      maxBuffer: 1024 * 1024,
+    }
+  );
+  if (cachedBootstrap.error || cachedBootstrap.status !== 0) {
+    fail(
+      `cached bootstrap failed: ${cachedBootstrap.error?.message ?? `exit ${cachedBootstrap.status}`}`,
+      cachedBootstrap
+    );
+  }
+  if (cachedBootstrap.stdout.includes('Downloading runtime')) {
+    fail('second bootstrap downloaded the already cached runtime again', cachedBootstrap);
+  }
+  const cachedOutputLines = cachedBootstrap.stdout
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (path.resolve(cachedOutputLines.at(-1) ?? '') !== path.resolve(runtimePath)) {
+    fail('second bootstrap did not return the same cached runtime path', cachedBootstrap);
+  }
+
+  const cacheDirEntries = fs.readdirSync(path.dirname(runtimePath));
+  const staleBootstrapEntry = cacheDirEntries.find(
+    (entry) => entry === '.bootstrap.lock' || entry.startsWith('.bootstrap-')
+  );
+  if (staleBootstrapEntry) {
+    fail(`bootstrap left stale cache state: ${staleBootstrapEntry}`, cachedBootstrap);
+  }
+
+  process.stdout.write(
+    `[public-runtime-bootstrap-e2e] anonymous ${process.platform}/${process.arch} bootstrap succeeded: ${versionText}\n`
+  );
+} finally {
+  fs.rmSync(cacheRoot, { recursive: true, force: true });
+}

--- a/scripts/ci/verify-runtime-lock.mjs
+++ b/scripts/ci/verify-runtime-lock.mjs
@@ -25,6 +25,8 @@ const sourceRepository =
 const releaseRepository =
   typeof lock.releaseRepository === 'string' ? lock.releaseRepository.trim() : '';
 const releaseTag = typeof lock.releaseTag === 'string' ? lock.releaseTag.trim() : '';
+const runtimeSourceRepository = '777genius/agent_teams_orchestrator';
+const publicRuntimeReleaseRepository = '777genius/agent_teams_orchestrator_binaries';
 
 if (!version) {
   fail('version is required');
@@ -34,19 +36,21 @@ if (!sourceRef || sourceRef !== `v${version}`) {
   fail(`sourceRef must match version. Expected v${version}, got ${sourceRef || '<empty>'}`);
 }
 
-if (!sourceRepository) {
-  fail('sourceRepository is required');
-}
-
-if (releaseRepository !== sourceRepository) {
+if (sourceRepository !== runtimeSourceRepository) {
   fail(
-    `releaseRepository must point at the runtime source repository (${sourceRepository}), got ${releaseRepository || '<empty>'}.`
+    `sourceRepository must point at the canonical runtime source repository (${runtimeSourceRepository}), got ${sourceRepository || '<empty>'}.`
   );
 }
 
-if (releaseTag !== sourceRef) {
+if (releaseRepository !== publicRuntimeReleaseRepository) {
   fail(
-    `releaseTag must point at the runtime release tag (${sourceRef}), got ${releaseTag || '<empty>'}.`
+    `releaseRepository must point at the public runtime binary repository (${publicRuntimeReleaseRepository}), got ${releaseRepository || '<empty>'}.`
+  );
+}
+
+if (releaseTag !== `runtime-${sourceRef}`) {
+  fail(
+    `releaseTag must point at the namespaced public runtime release tag (runtime-${sourceRef}), got ${releaseTag || '<empty>'}.`
   );
 }
 

--- a/scripts/dev-with-runtime.mjs
+++ b/scripts/dev-with-runtime.mjs
@@ -18,6 +18,8 @@ const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const uiRepoRoot = path.resolve(scriptDir, '..');
 const runtimeRepoRoot = process.env.CLAUDE_DEV_RUNTIME_ROOT?.trim() ?? '';
 const explicitRuntimeCliPath = process.env.CLAUDE_AGENT_TEAMS_ORCHESTRATOR_CLI_PATH?.trim() ?? '';
+const disableAuthenticatedRuntimeDownload =
+  process.env.CLAUDE_DEV_RUNTIME_DISABLE_GH?.trim() === '1';
 const runtimeLockPath = path.join(uiRepoRoot, 'runtime.lock.json');
 const defaultRuntimeCacheRoot = path.join(os.homedir(), '.agent-teams', 'runtime-cache');
 const runtimeCacheRoot = process.env.CLAUDE_DEV_RUNTIME_CACHE_ROOT?.trim()
@@ -426,7 +428,7 @@ async function downloadWithProgress(download, destinationPath) {
         response,
         lockPath: runtimeLockPath,
         notFoundHint:
-          '404 usually means the runtime release or asset is missing, private, or inaccessible. If the orchestrator repository is private, run gh auth login with access to it or set CLAUDE_AGENT_TEAMS_ORCHESTRATOR_CLI_PATH to a local runtime.',
+          'The pinned public runtime asset is unavailable. Please update the checkout and retry. Do not substitute an older runtime build; report the release and asset names above if the problem persists. For local runtime development, set CLAUDE_AGENT_TEAMS_ORCHESTRATOR_CLI_PATH.',
         ...download,
       })
     );
@@ -509,6 +511,10 @@ async function downloadWithProgress(download, destinationPath) {
 }
 
 function downloadReleaseAssetWithGh(download, destinationPath) {
+  if (disableAuthenticatedRuntimeDownload) {
+    return false;
+  }
+
   fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
   const result = spawnSync(
     'gh',
@@ -783,5 +789,5 @@ async function main() {
 
 main().catch((error) => {
   console.error(error instanceof Error ? error.message : String(error));
-  process.exit(1);
+  process.exitCode = 1;
 });


### PR DESCRIPTION
## Summary
- pin the desktop source bootstrap to public runtime v0.0.66 assets
- fail cleanly when a pinned public asset is unavailable
- add anonymous download, extraction, execution, and cache E2E coverage across Windows, Linux, and both macOS architectures
- block application packaging until the public runtime bootstrap succeeds

## Verification
- runtime lock invariants
- anonymous local bootstrap and cached second run
- downloaded runtime reports v0.0.66
- syntax, focused lint, typecheck, workflow validation, and diff checks