### PR TITLE
fix(agent-graph): fit layout transition targets

### DIFF
--- a/packages/agent-graph/src/hooks/useGraphSimulation.ts
+++ b/packages/agent-graph/src/hooks/useGraphSimulation.ts
@@ -9,6 +9,7 @@ import {
   captureGraphNodePositions,
   createGraphLayoutTransition,
   type GraphLayoutTransition,
+  resolveGraphLayoutTargetNodes,
 } from '../layout/layoutTransition';
 import {
   buildStableSlotLayoutSnapshot,
@@ -82,6 +83,8 @@ export interface UseGraphSimulationResult {
   getLogWorldRect: (nodeId: string) => StableRect | null;
   getOwnerColumnGroupRects: () => readonly OwnerColumnGroupRect[];
   getExtraWorldBounds: () => WorldBounds[];
+  /** Returns final layout coordinates for camera fitting while a transition is active. */
+  getLayoutTargetNodes: () => GraphNode[];
 }
 
 export function useGraphSimulation(): UseGraphSimulationResult {
@@ -325,6 +328,11 @@ export function useGraphSimulation(): UseGraphSimulationResult {
     });
   }, []);
 
+  const getLayoutTargetNodes = useCallback(
+    () => resolveGraphLayoutTargetNodes(stateRef.current.nodes, layoutTransitionRef.current),
+    []
+  );
+
   useEffect(() => {
     return () => {
       dragOwnerPositionsRef.current.clear();
@@ -355,6 +363,7 @@ export function useGraphSimulation(): UseGraphSimulationResult {
       getLogWorldRect: (nodeId: string) => logRectByNodeIdRef.current.get(nodeId) ?? null,
       getOwnerColumnGroupRects: () => ownerColumnGroupRectsRef.current,
       getExtraWorldBounds: () => extraWorldBoundsRef.current,
+      getLayoutTargetNodes,
     }),
     [
       updateData,
@@ -364,6 +373,7 @@ export function useGraphSimulation(): UseGraphSimulationResult {
       clearTransientOwnerPositions,
       resolveNearestOwnerSlot,
       resolveNearestOwnerGridTarget,
+      getLayoutTargetNodes,
     ]
   );
 }

--- a/packages/agent-graph/src/layout/layoutTransition.ts
+++ b/packages/agent-graph/src/layout/layoutTransition.ts
@@ -64,6 +64,19 @@ export function createGraphLayoutTransition(args: {
   };
 }
 
+export function resolveGraphLayoutTargetNodes(
+  nodes: GraphNode[],
+  transition: GraphLayoutTransition | null
+): GraphNode[] {
+  if (!transition) return nodes;
+
+  return nodes.map((node) => {
+    const target = transition.toByNodeId.get(node.id);
+    if (!target) return node;
+    return { ...node, x: target.x, y: target.y };
+  });
+}
+
 export function advanceGraphLayoutTransition(
   nodes: GraphNode[],
   transition: GraphLayoutTransition,

--- a/packages/agent-graph/src/ui/GraphView.tsx
+++ b/packages/agent-graph/src/ui/GraphView.tsx
@@ -677,7 +677,7 @@ export function GraphView({
     (animated = false) => {
       const el = containerRef.current;
       if (!el || data.nodes.length === 0) return;
-      const fitNodes = getFitNodes(simulation.stateRef.current.nodes);
+      const fitNodes = getFitNodes(simulation.getLayoutTargetNodes());
       const extraBounds = simulation.getExtraWorldBounds();
       if (animated) {
         camera.animateToFit(fitNodes, el.clientWidth, el.clientHeight, extraBounds);
@@ -1390,14 +1390,7 @@ export function GraphView({
         }
       }
       if (e.key === 'f' || e.key === 'F') {
-        const el = containerRef.current;
-        if (el)
-          camera.zoomToFit(
-            getFitNodes(simulation.stateRef.current.nodes),
-            el.clientWidth,
-            el.clientHeight,
-            simulation.getExtraWorldBounds()
-          );
+        fitGraphToViewport(false);
       }
       if (e.key === ' ') {
         e.preventDefault();
@@ -1406,7 +1399,7 @@ export function GraphView({
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [selectedEdgeId, selectedNodeId, onRequestClose, camera, getFitNodes, simulation]);
+  }, [selectedEdgeId, selectedNodeId, onRequestClose, fitGraphToViewport]);
 
   // ─── Selected node for overlay ──────────────────────────────────────────
   const selectedNode: GraphNode | null =

--- a/test/renderer/features/agent-graph/GraphView.test.ts
+++ b/test/renderer/features/agent-graph/GraphView.test.ts
@@ -33,7 +33,9 @@ const hoisted = vi.hoisted(() => ({
     effects: [],
     time: 0,
   },
+  layoutTargetNodes: [] as GraphNode[],
   updateData: vi.fn(),
+  getLayoutTargetNodes: vi.fn(),
   setNodePosition: vi.fn(),
   clearNodePosition: vi.fn(),
   clearTransientOwnerPositions: vi.fn(),
@@ -92,6 +94,7 @@ vi.mock('../../../../packages/agent-graph/src/hooks/useGraphSimulation', () => (
     updateData: hoisted.updateData,
     tick: vi.fn(),
     getExtraWorldBounds: vi.fn(() => []),
+    getLayoutTargetNodes: hoisted.getLayoutTargetNodes,
     getLaunchAnchorWorldPosition: vi.fn(() => null),
     getActivityWorldRect: vi.fn(() => null),
     getLogWorldRect: vi.fn(() => null),
@@ -132,12 +135,14 @@ describe('GraphView pan interactions', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     hoisted.updateData.mockImplementation(() => undefined);
+    hoisted.getLayoutTargetNodes.mockImplementation(() => hoisted.layoutTargetNodes);
     hoisted.zoomToFit.mockImplementation(() => undefined);
     vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
     hoisted.interaction.hoveredNodeId.current = null;
     hoisted.interaction.dragNodeId.current = null;
     hoisted.interaction.isDragging.current = false;
     hoisted.simulationState.nodes = [];
+    hoisted.layoutTargetNodes = [];
     hoisted.simulationState.edges = [];
     hoisted.interaction.handleMouseDown.mockImplementation(() => undefined);
     hoisted.interaction.handleMouseMove.mockImplementation(() => undefined);
@@ -233,11 +238,12 @@ describe('GraphView pan interactions', () => {
     };
     const events: string[] = [];
     hoisted.updateData.mockImplementation((nodes: GraphNode[]) => {
-      hoisted.simulationState.nodes = nodes;
+      hoisted.simulationState.nodes = nodes.map((node) => ({ ...node, x: -100, y: -100 }));
+      hoisted.layoutTargetNodes = nodes;
       events.push(`update:${nodes.length}`);
     });
     hoisted.zoomToFit.mockImplementation((nodes: GraphNode[]) => {
-      events.push(`fit:${nodes.length}`);
+      events.push(`fit:${nodes.map((node) => node.x).join(',')}`);
     });
 
     await act(async () => {
@@ -271,7 +277,8 @@ describe('GraphView pan interactions', () => {
       );
     });
 
-    expect(events).toEqual(['update:2', 'fit:2']);
+    expect(events).toEqual(['update:2', 'fit:0,200']);
+    expect(hoisted.simulationState.nodes.map((node) => node.x)).toEqual([-100, -100]);
   });
 
   it('preserves an explicit null returned by a custom controls renderer', async () => {

--- a/test/renderer/features/agent-graph/layoutTransition.test.ts
+++ b/test/renderer/features/agent-graph/layoutTransition.test.ts
@@ -4,6 +4,7 @@ import {
   advanceGraphLayoutTransition,
   createGraphLayoutTransition,
   easeGraphLayoutTransition,
+  resolveGraphLayoutTargetNodes,
 } from '../../../../packages/agent-graph/src/layout/layoutTransition';
 
 import type { GraphEdge, GraphNode } from '@claude-teams/agent-graph';
@@ -64,5 +65,21 @@ describe('layout transitions', () => {
     expect(container).toMatchObject({ x: 40, y: 60 });
     expect(organization).toMatchObject({ x: 40, y: 60 });
     expect(team).toMatchObject({ x: 40, y: 60 });
+  });
+
+  it('projects final coordinates for camera fitting without advancing the transition', () => {
+    const team = node('team:alpha', 100, 200, 'team');
+    const transition = createGraphLayoutTransition({
+      nodes: [team],
+      edges: [],
+      previousPositions: new Map([['team:alpha', { x: 0, y: 0 }]]),
+      duration: 1,
+    });
+
+    const targetNodes = resolveGraphLayoutTargetNodes([team], transition);
+
+    expect(team).toMatchObject({ x: 0, y: 0 });
+    expect(targetNodes[0]).not.toBe(team);
+    expect(targetNodes[0]).toMatchObject({ x: 100, y: 200 });
   });
 });

--- a/test/renderer/features/agent-graph/useGraphSimulationIdentity.test.ts
+++ b/test/renderer/features/agent-graph/useGraphSimulationIdentity.test.ts
@@ -1,8 +1,14 @@
 import React, { act } from 'react';
 import { createRoot } from 'react-dom/client';
+
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { useGraphSimulation, type UseGraphSimulationResult } from '../../../../packages/agent-graph/src/hooks/useGraphSimulation';
+import {
+  useGraphSimulation,
+  type UseGraphSimulationResult,
+} from '../../../../packages/agent-graph/src/hooks/useGraphSimulation';
+
+import type { GraphLayoutPort, GraphNode } from '@claude-teams/agent-graph';
 
 let firstSimulation: UseGraphSimulationResult | null = null;
 let secondSimulation: UseGraphSimulationResult | null = null;
@@ -15,6 +21,31 @@ function SimulationHarness({ pass }: { pass: number }): React.JSX.Element | null
     secondSimulation = simulation;
   }
   return null;
+}
+
+function buildNodes(): GraphNode[] {
+  return [
+    {
+      id: 'lead:demo-team',
+      kind: 'lead',
+      label: 'lead',
+      state: 'active',
+      domainRef: { kind: 'lead', teamName: 'demo-team', memberName: 'lead' },
+    },
+    {
+      id: 'member:alice',
+      kind: 'member',
+      label: 'alice',
+      state: 'idle',
+      domainRef: { kind: 'member', teamName: 'demo-team', memberName: 'alice' },
+    },
+  ];
+}
+
+function positionsById(
+  nodes: GraphNode[]
+): Record<string, { x: number | undefined; y: number | undefined }> {
+  return Object.fromEntries(nodes.map((node) => [node.id, { x: node.x, y: node.y }]));
 }
 
 describe('useGraphSimulation', () => {
@@ -42,6 +73,51 @@ describe('useGraphSimulation', () => {
 
     expect(firstSimulation).toBeTruthy();
     expect(secondSimulation).toBe(firstSimulation);
+
+    await act(async () => {
+      root.unmount();
+      await Promise.resolve();
+    });
+  });
+
+  it('exposes final layout coordinates while nodes are transitioning from the previous layout', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    await act(async () => {
+      root.render(React.createElement(SimulationHarness, { pass: 1 }));
+      await Promise.resolve();
+    });
+
+    const simulation = firstSimulation!;
+    const initialNodes = buildNodes();
+    const gridLayout: GraphLayoutPort = {
+      version: 'stable-slots-v1',
+      mode: 'grid-under-lead',
+      ownerOrder: ['member:alice'],
+      slotAssignments: {},
+    };
+    simulation.updateData(initialNodes, [], [], 'demo-team', gridLayout);
+    const initialPositions = positionsById(simulation.stateRef.current.nodes);
+
+    const targetPositions = {
+      'lead:demo-team': { x: 0, y: -800 },
+      'member:alice': { x: 1200, y: 900 },
+    };
+    const hierarchicalLayout: GraphLayoutPort = {
+      version: 'stable-slots-v1',
+      mode: 'hierarchical',
+      ownerOrder: ['member:alice'],
+      slotAssignments: {},
+      nodePositions: targetPositions,
+    };
+    simulation.updateData(buildNodes(), [], [], 'demo-team', hierarchicalLayout);
+
+    expect(positionsById(simulation.stateRef.current.nodes)).toEqual(initialPositions);
+    expect(positionsById(simulation.getLayoutTargetNodes())).toEqual(targetPositions);
+    expect(positionsById(simulation.stateRef.current.nodes)).not.toEqual(targetPositions);
 
     await act(async () => {
       root.unmount();


### PR DESCRIPTION
## Summary
- fit camera against final layout targets while nodes transition
- route keyboard fit through the shared transition-aware helper
- cover target projection, a real grid-under-lead to hierarchical transition, and GraphView wiring

Follow-up to #278.

## Validation
- focused Vitest: 23 tests passed
- pnpm typecheck
- focused fast ESLint
- Prettier check
- independent implementation and test reviews: no findings

<!-- review-router-summary:start -->
## Summary

- update 3 test files
- updates source implementation in useGraphSimulation
- updates createGraphLayoutTransition, advanceGraphLayoutTransition: changes fallback/null handling, return value handling
- updates source implementation in GraphView
- touch 6 files (6 modified) with +130/-14 lines

## Tests

- changed test file: `test/renderer/features/agent-graph/GraphView.test.ts`
- changed test file: `test/renderer/features/agent-graph/layoutTransition.test.ts`
- changed test file: `test/renderer/features/agent-graph/useGraphSimulationIdentity.test.ts`

<details>
<summary>📒 Files selected for processing (6)</summary>

* `packages/agent-graph/src/hooks/useGraphSimulation.ts`
* `packages/agent-graph/src/layout/layoutTransition.ts`
* `packages/agent-graph/src/ui/GraphView.tsx`
* `test/renderer/features/agent-graph/GraphView.test.ts`
* `test/renderer/features/agent-graph/layoutTransition.test.ts`
* `test/renderer/features/agent-graph/useGraphSimulationIdentity.test.ts`

</details>

<details>
<summary>📝 Walkthrough</summary>

## Walkthrough

This PR updates 6 files across 3 source, 3 tests. The generated summary is based on the GitHub pull request file list and diff metadata, and the author's description above is preserved.

## Changes

| Cohort / File(s) | Summary |
|---|---|
| **Source** <br> `packages/agent-graph/src/hooks/useGraphSimulation.ts`<br>`packages/agent-graph/src/layout/layoutTransition.ts`<br>`packages/agent-graph/src/ui/GraphView.tsx` | Updates source implementation in useGraphSimulation.<br>Updates createGraphLayoutTransition, advanceGraphLayoutTransition: changes fallback/null handling, return value handling.<br>Updates source implementation in GraphView.<br>Line stats: 3 modified; +26/-10. |
| **Tests** <br> `test/renderer/features/agent-graph/GraphView.test.ts`<br>`test/renderer/features/agent-graph/layoutTransition.test.ts`<br>`test/renderer/features/agent-graph/useGraphSimulationIdentity.test.ts` | Updates GraphView.test test coverage.<br>Updates test coverage for projects final coordinates for camera fitting without advan....<br>Updates test coverage for buildNodes, positionsById.<br>Line stats: 3 modified; +104/-4. |

</details>
<!-- review-router-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graph viewport fitting during layout transitions so all nodes are fitted using their intended final positions.
  * Updated the `F` keyboard shortcut to perform a consistent, non-animated fit-to-viewport action.
  * Prevented viewport fitting from altering nodes while a layout transition is still in progress.

* **Tests**
  * Added coverage for fitting graphs during transitions and verifying final node positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->