### PR TITLE
fix(windows): fix cmd.exe quoting in Windows shell fallback for non-ASCII paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,7 @@ jobs:
   task-change-ledger-windows:
     name: Task change ledger Windows smoke
     runs-on: windows-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout
@@ -212,6 +213,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Test Windows CLI shell fallback
+        run: pnpm exec vitest run test/main/utils/childProcess.windows.test.ts
 
       - name: Test task change ledger
         run: pnpm test:task-change-ledger

--- a/src/main/utils/childProcess.ts
+++ b/src/main/utils/childProcess.ts
@@ -455,6 +455,29 @@ function windowsBatchLauncherReparsesArgs(binaryPath: string): boolean {
   }
 }
 
+/** `%1`/`%~1` substitution can reactivate shell syntax embedded in argv. */
+function windowsBatchLauncherUsesPositionalArgs(binaryPath: string): boolean {
+  if (!isWindowsBatchLauncher(binaryPath)) {
+    return false;
+  }
+  try {
+    return /%(?:[1-9]|~[^\s%]*[1-9])/.test(readFileSync(binaryPath, 'utf8'));
+  } catch {
+    return false;
+  }
+}
+
+function assertSafeWindowsBatchPositionalArgs(command: string, args: string[]): void {
+  if (!windowsBatchLauncherUsesPositionalArgs(command)) {
+    return;
+  }
+  if (args.some((arg) => /[()\][%!^"`<>&|;,]/.test(arg))) {
+    throw new Error(
+      'Unsafe Windows batch positional argument: launcher reparses %1..%9 shell syntax'
+    );
+  }
+}
+
 function containsWindowsShellUnsafeControlChar(part: string): boolean {
   for (let index = 0; index < part.length; index += 1) {
     const code = part.charCodeAt(index);
@@ -479,6 +502,7 @@ function buildWindowsShellFallbackCommand(parts: string[]): string {
   if (command === undefined) {
     return '';
   }
+  assertSafeWindowsBatchPositionalArgs(command, args);
   const doubleEscapeMetaCharacters = windowsBatchLauncherReparsesArgs(command);
   return [
     escapeWindowsCmdCommand(command),

--- a/src/main/utils/childProcess.ts
+++ b/src/main/utils/childProcess.ts
@@ -419,7 +419,10 @@ function escapeWindowsCmdMetaCharacters(value: string): string {
  * argv value changes how cmd locates paths that contain spaces.
  */
 function escapeWindowsCmdCommand(command: string): string {
-  return escapeWindowsCmdMetaCharacters(command);
+  // Unlike argv, the executable token must retain real quote characters so
+  // cmd.exe groups a path containing spaces as one command. Caret-escaping
+  // those quotes/spaces makes cmd pass the tail of the path as argv instead.
+  return quoteWindowsCmdArg(command);
 }
 
 /**
@@ -438,13 +441,13 @@ function escapeWindowsCmdFallbackArg(arg: string, doubleEscapeMetaCharacters: bo
   return escaped;
 }
 
-/** Batch launchers that substitute %1..%9, their %~ modifiers, or %* parse argv again. */
+/** Batch launchers that forward %* parse cmd metacharacters a second time. */
 function windowsBatchLauncherReparsesArgs(binaryPath: string): boolean {
   if (!isWindowsBatchLauncher(binaryPath)) {
     return false;
   }
   try {
-    return /%(?:\*|[1-9]|~[^\s%]*[1-9])/.test(readFileSync(binaryPath, 'utf8'));
+    return /%\*/.test(readFileSync(binaryPath, 'utf8'));
   } catch {
     // A launcher that cannot be inspected is safer with the additional escape
     // layer than with metacharacters becoming active during a second parse.

--- a/src/main/utils/childProcess.ts
+++ b/src/main/utils/childProcess.ts
@@ -214,6 +214,20 @@ function execFileAsync(
 }
 
 /**
+ * With `/s`, cmd.exe parses its /c argument by stripping only the first and
+ * last quote characters of the whole string (not the matching pair around
+ * the executable name). For a command like `"C:\path with space\a.exe" arg`
+ * that strips both quotes entirely, leaving the path's embedded space
+ * unprotected and causing cmd to split on it. Wrapping the whole command in
+ * one more quote pair makes the outer strip remove that wrapper instead,
+ * leaving the inner `"exe" args` quoting intact. See `cmd /?` for the /s
+ * quote-stripping rules.
+ */
+function wrapForCmdSlashS(cmd: string): string {
+  return `"${cmd}"`;
+}
+
+/**
  * cmd.exe fallback implemented through execFile so Node does not invoke an
  * additional shell around the guarded command string.
  */
@@ -222,7 +236,20 @@ function execShellAsync(
   options: ExecFileOptions = {},
   outputLimits: { stdoutMaxBuffer?: number; stderrMaxBuffer?: number } = {}
 ): Promise<{ stdout: string; stderr: string }> {
-  return execFileAsync(getWindowsCmdPath(), ['/d', '/s', '/c', cmd], options, outputLimits);
+  // windowsVerbatimArguments prevents Node from re-quoting `cmd`, which is
+  // already quoted for cmd.exe by buildWindowsShellFallbackCommand. Without
+  // this, Node wraps the pre-quoted string in another layer of quotes,
+  // corrupting the command cmd.exe sees (e.g. "not recognized as an
+  // internal or external command").
+  return execFileAsync(
+    getWindowsCmdPath(),
+    ['/d', '/s', '/c', wrapForCmdSlashS(cmd)],
+    {
+      ...options,
+      windowsVerbatimArguments: true,
+    },
+    outputLimits
+  );
 }
 
 function cleanupTimedCliProcess(
@@ -415,9 +442,13 @@ function spawnWindowsShellFallback(
   cmd: string,
   options: ReturnType<typeof withCliProcessDefaults<SpawnOptions>>
 ): ReturnType<typeof spawn> {
-  return spawn(getWindowsCmdPath(), ['/d', '/s', '/c', cmd], {
+  // See execShellAsync/wrapForCmdSlashS above: windowsVerbatimArguments
+  // avoids double-quoting the already-quoted `cmd` string, and the extra
+  // quote wrapper survives cmd.exe's /s quote-stripping.
+  return spawn(getWindowsCmdPath(), ['/d', '/s', '/c', wrapForCmdSlashS(cmd)], {
     ...options,
     shell: false,
+    windowsVerbatimArguments: true,
   });
 }
 

--- a/src/main/utils/childProcess.ts
+++ b/src/main/utils/childProcess.ts
@@ -243,7 +243,7 @@ function execShellAsync(
   // internal or external command").
   return execFileAsync(
     getWindowsCmdPath(),
-    ['/d', '/s', '/c', wrapForCmdSlashS(cmd)],
+    ['/d', '/s', '/v:off', '/c', wrapForCmdSlashS(cmd)],
     {
       ...options,
       windowsVerbatimArguments: true,
@@ -407,8 +407,49 @@ export function quoteWindowsCmdArg(arg: string): string {
   return arg;
 }
 
-function quoteArg(arg: string): string {
-  return quoteWindowsCmdArg(arg);
+const WINDOWS_CMD_META_CHARACTERS = /([()\][%!^"`<>&|;, *?])/g;
+
+function escapeWindowsCmdMetaCharacters(value: string): string {
+  return value.replace(WINDOWS_CMD_META_CHARACTERS, '^$1');
+}
+
+/**
+ * Escape the executable token for a command line that cmd.exe will parse.
+ * The executable and argv use different encodings: quoting the command as an
+ * argv value changes how cmd locates paths that contain spaces.
+ */
+function escapeWindowsCmdCommand(command: string): string {
+  return escapeWindowsCmdMetaCharacters(command);
+}
+
+/**
+ * Encode one argv value through both cmd.exe parsing and the target process'
+ * Windows argv parser. Caret-escaping the quotes and shell metacharacters is
+ * essential once windowsVerbatimArguments disables Node's escaping.
+ */
+function escapeWindowsCmdFallbackArg(arg: string, doubleEscapeMetaCharacters: boolean): string {
+  const quoted = `"${arg
+    .replace(/(?=(\\+?)?)\1"/g, '$1$1\\"')
+    .replace(/(?=(\\+?)?)\1$/g, '$1$1')}"`;
+  let escaped = escapeWindowsCmdMetaCharacters(quoted);
+  if (doubleEscapeMetaCharacters) {
+    escaped = escapeWindowsCmdMetaCharacters(escaped);
+  }
+  return escaped;
+}
+
+/** Batch launchers that substitute %1..%9, their %~ modifiers, or %* parse argv again. */
+function windowsBatchLauncherReparsesArgs(binaryPath: string): boolean {
+  if (!isWindowsBatchLauncher(binaryPath)) {
+    return false;
+  }
+  try {
+    return /%(?:\*|[1-9]|~[^\s%]*[1-9])/.test(readFileSync(binaryPath, 'utf8'));
+  } catch {
+    // A launcher that cannot be inspected is safer with the additional escape
+    // layer than with metacharacters becoming active during a second parse.
+    return true;
+  }
 }
 
 function containsWindowsShellUnsafeControlChar(part: string): boolean {
@@ -431,7 +472,15 @@ function buildWindowsShellFallbackCommand(parts: string[]): string {
   for (const part of parts) {
     assertSafeWindowsShellFallbackPart(part);
   }
-  return parts.map(quoteArg).join(' ');
+  const [command, ...args] = parts;
+  if (command === undefined) {
+    return '';
+  }
+  const doubleEscapeMetaCharacters = windowsBatchLauncherReparsesArgs(command);
+  return [
+    escapeWindowsCmdCommand(command),
+    ...args.map((arg) => escapeWindowsCmdFallbackArg(arg, doubleEscapeMetaCharacters)),
+  ].join(' ');
 }
 
 function getWindowsCmdPath(): string {
@@ -445,7 +494,7 @@ function spawnWindowsShellFallback(
   // See execShellAsync/wrapForCmdSlashS above: windowsVerbatimArguments
   // avoids double-quoting the already-quoted `cmd` string, and the extra
   // quote wrapper survives cmd.exe's /s quote-stripping.
-  return spawn(getWindowsCmdPath(), ['/d', '/s', '/c', wrapForCmdSlashS(cmd)], {
+  return spawn(getWindowsCmdPath(), ['/d', '/s', '/v:off', '/c', wrapForCmdSlashS(cmd)], {
     ...options,
     shell: false,
     windowsVerbatimArguments: true,

--- a/test/main/utils/childProcess.test.ts
+++ b/test/main/utils/childProcess.test.ts
@@ -303,7 +303,7 @@ describe('cli child process helpers', () => {
         '/s',
         '/v:off',
         '/c',
-        `"${binaryPath.replaceAll(' ', '^ ')} ^"--version^""`,
+        `""${binaryPath}" ^"--version^""`,
       ]);
       expect(spawnMock.mock.calls[0][2]).toMatchObject({
         shell: false,
@@ -353,7 +353,7 @@ describe('cli child process helpers', () => {
       ).not.toThrow();
       expect(spawnMock).toHaveBeenCalledTimes(1);
       const shellCmd = spawnMock.mock.calls[0][1].at(-1) as string;
-      expect(shellCmd).toContain('R^&D');
+      expect(shellCmd).toContain('"C:\\Users\\Алексей\\R&D\\bin\\claude.exe"');
       for (const escapedShellArg of ['safe^&bad', 'safe^|bad', 'safe^<bad', 'safe^>bad']) {
         expect(shellCmd).toContain(escapedShellArg);
       }
@@ -600,7 +600,7 @@ describe('cli child process helpers', () => {
       const result = await execCli(binaryPath, ['--version']);
       expect(execFileMock).toHaveBeenCalledWith(
         expect.stringMatching(/cmd\.exe$/i),
-        ['/d', '/s', '/v:off', '/c', `"${binaryPath.replaceAll(' ', '^ ')} ^"--version^""`],
+        ['/d', '/s', '/v:off', '/c', `""${binaryPath}" ^"--version^""`],
         expect.objectContaining({ windowsVerbatimArguments: true }),
         expect.any(Function)
       );
@@ -645,7 +645,7 @@ describe('cli child process helpers', () => {
         '/s',
         '/v:off',
         '/c',
-        `"${binaryPath} ^"TOKEN={\\^"k\\^":\\^"x^&echo^ injected^&rem^ \\^"}^""`,
+        `""${binaryPath}" ^"TOKEN={\\^"k\\^":\\^"x^&echo^ injected^&rem^ \\^"}^""`,
       ]);
       expect(execFileMock.mock.calls[0][2]).toMatchObject({
         windowsVerbatimArguments: true,
@@ -758,7 +758,13 @@ describe('cli child process helpers', () => {
       ).resolves.toMatchObject({ stdout: 'ok' });
       expect(execFileMock).toHaveBeenCalledWith(
         expect.stringMatching(/cmd\.exe$/i),
-        ['/d', '/s', '/v:off', '/c', expect.stringContaining('R^&D')],
+        [
+          '/d',
+          '/s',
+          '/v:off',
+          '/c',
+          expect.stringContaining('"C:\\Users\\Алексей\\R&D\\bin\\claude.exe"'),
+        ],
         expect.any(Object),
         expect.any(Function)
       );

--- a/test/main/utils/childProcess.test.ts
+++ b/test/main/utils/childProcess.test.ts
@@ -204,6 +204,7 @@ describe('cli child process helpers', () => {
       expect(spawnMock.mock.calls[1][1]).toEqual([
         '/d',
         '/s',
+        '/v:off',
         '/c',
         expect.stringMatching(/claude\.exe/),
       ]);
@@ -223,6 +224,7 @@ describe('cli child process helpers', () => {
       expect(spawnMock.mock.calls[0][1]).toEqual([
         '/d',
         '/s',
+        '/v:off',
         '/c',
         expect.stringContaining('cli-dev.cmd'),
       ]);
@@ -285,21 +287,29 @@ describe('cli child process helpers', () => {
       }
     });
 
-    it('uses shell directly when path contains non-ASCII on windows', () => {
+    it('preserves quoting for a spaced non-ASCII path in the spawn shell fallback', () => {
       setPlatform('win32');
       const fake = createMockProcess<SpawnCliChild>();
       const spawnMock = child.spawn as unknown as Mock;
       spawnMock.mockReturnValue(fake);
 
-      const result = spawnCli('C:\\Users\\Алексей\\AppData\\Roaming\\npm\\claude.cmd', ['a', 'b'], {
-        env: { FOO: 'bar' },
-      });
+      const binaryPath = 'C:\\Users\\Jane Müller\\Agent Teams\\claude-multimodel.exe';
+      const result = spawnCli(binaryPath, ['--version'], { env: { FOO: 'bar' } });
       // Non-ASCII detected upfront, so launch through cmd.exe fallback once.
       expect(spawnMock).toHaveBeenCalledTimes(1);
       expect(spawnMock.mock.calls[0][0]).toMatch(/cmd\.exe$/i);
-      const shellCmd = spawnMock.mock.calls[0][1][3] as string;
-      expect(shellCmd).toMatch(/claude\.cmd/);
-      expect(spawnMock.mock.calls[0][2]).toMatchObject({ shell: false, env: { FOO: 'bar' } });
+      expect(spawnMock.mock.calls[0][1]).toEqual([
+        '/d',
+        '/s',
+        '/v:off',
+        '/c',
+        `"${binaryPath.replaceAll(' ', '^ ')} ^"--version^""`,
+      ]);
+      expect(spawnMock.mock.calls[0][2]).toMatchObject({
+        shell: false,
+        windowsVerbatimArguments: true,
+        env: { FOO: 'bar' },
+      });
       expect(result).toBe(fake);
     });
 
@@ -333,7 +343,7 @@ describe('cli child process helpers', () => {
       spawnMock.mockReturnValue(createMockProcess<SpawnCliChild>());
 
       expect(() =>
-        spawnCli('C:\\Users\\R&D\\bin\\claude.cmd', [
+        spawnCli('C:\\Users\\Алексей\\R&D\\bin\\claude.exe', [
           'safe&bad',
           'safe|bad',
           'safe<bad',
@@ -342,10 +352,10 @@ describe('cli child process helpers', () => {
         ])
       ).not.toThrow();
       expect(spawnMock).toHaveBeenCalledTimes(1);
-      const shellCmd = spawnMock.mock.calls[0][1][3] as string;
-      expect(shellCmd).toContain('"C:\\Users\\R&D\\bin\\claude.cmd"');
-      for (const shellArg of ['safe&bad', 'safe|bad', 'safe<bad', 'safe>bad', 'safe^bad']) {
-        expect(shellCmd).toContain(`"${shellArg}"`);
+      const shellCmd = spawnMock.mock.calls[0][1].at(-1) as string;
+      expect(shellCmd).toContain('R^&D');
+      for (const escapedShellArg of ['safe^&bad', 'safe^|bad', 'safe^<bad', 'safe^>bad']) {
+        expect(shellCmd).toContain(escapedShellArg);
       }
 
       spawnCli('C:\\bin\\claude.exe', ['safe&argv']);
@@ -465,7 +475,7 @@ describe('cli child process helpers', () => {
       const result = await execCli('C:\\runtime\\cli-dev.cmd', ['--version']);
       expect(execFileMock).toHaveBeenCalledWith(
         expect.stringMatching(/cmd\.exe$/i),
-        ['/d', '/s', '/c', expect.stringContaining('cli-dev.cmd')],
+        ['/d', '/s', '/v:off', '/c', expect.stringContaining('cli-dev.cmd')],
         expect.any(Object),
         expect.any(Function)
       );
@@ -508,13 +518,19 @@ describe('cli child process helpers', () => {
       );
       const { dir, launcher } = createGeneratedBunLauncher();
       try {
-        const result = await execCli(launcher, ['runtime', 'opencode-command'], {
-          preferShellForWindowsBatch: true,
-        });
+        const result = await execCli(
+          launcher,
+          ['runtime', 'opencode-command', 'value&echo injected'],
+          {
+            preferShellForWindowsBatch: true,
+          }
+        );
         expect(execFileMock).toHaveBeenCalledTimes(1);
         expect(execFileMock.mock.calls[0][0]).toMatch(/cmd\.exe$/i);
-        expect(execFileMock.mock.calls[0][1][3]).toContain('runtime');
-        expect(execFileMock.mock.calls[0][1][3]).toContain('opencode-command');
+        const shellCmd = execFileMock.mock.calls[0][1].at(-1) as string;
+        expect(shellCmd).toContain('runtime');
+        expect(shellCmd).toContain('opencode-command');
+        expect(shellCmd).toContain('value^^^&echo');
         expect(execMock).not.toHaveBeenCalled();
         expect(result.stdout).toBe('ok');
       } finally {
@@ -569,7 +585,7 @@ describe('cli child process helpers', () => {
       }
     });
 
-    it('skips straight to shell when path contains non-ASCII on windows', async () => {
+    it('preserves quoting for a spaced non-ASCII path in the exec shell fallback', async () => {
       setPlatform('win32');
       const execFileMock = child.execFile as unknown as Mock;
       const execMock = child.exec as unknown as Mock;
@@ -580,13 +596,12 @@ describe('cli child process helpers', () => {
         }
       );
 
-      const result = await execCli('C:\\Users\\Алексей\\AppData\\Roaming\\npm\\claude.cmd', [
-        '--version',
-      ]);
+      const binaryPath = 'C:\\Users\\Jane Müller\\Agent Teams\\claude-multimodel.exe';
+      const result = await execCli(binaryPath, ['--version']);
       expect(execFileMock).toHaveBeenCalledWith(
         expect.stringMatching(/cmd\.exe$/i),
-        ['/d', '/s', '/c', expect.stringContaining('claude.cmd')],
-        expect.any(Object),
+        ['/d', '/s', '/v:off', '/c', `"${binaryPath.replaceAll(' ', '^ ')} ^"--version^""`],
+        expect.objectContaining({ windowsVerbatimArguments: true }),
         expect.any(Function)
       );
       expect(execMock).not.toHaveBeenCalled();
@@ -603,16 +618,54 @@ describe('cli child process helpers', () => {
         }
       );
 
-      await execCli('C:\\Users\\Алексей\\bin\\claude.cmd', ['--model', 'test%PATH%"arg']);
-      const shellCmd = execFileMock.mock.calls[0][1][3] as string;
-      // Keep % outside quoted chunks so cmd.exe does not expand it as an env var.
-      expect(shellCmd).toContain('^%"PATH"^%');
+      await execCli('C:\\Users\\Алексей\\bin\\claude.exe', ['--model', 'test%PATH%"arg']);
+      const shellCmd = execFileMock.mock.calls[0][1].at(-1) as string;
+      expect(shellCmd).toContain('test^%PATH^%');
       expect(shellCmd).not.toContain('%PATH%');
       expect(shellCmd).not.toContain('%%PATH%%');
-      // Quotes inside JSON-like args must survive cmd.exe and the target argv parser.
-      expect(shellCmd).toContain('\\"arg');
-      expect(shellCmd).not.toContain('""arg');
+      expect(shellCmd).toContain('\\^"arg');
     });
+
+    it('neutralizes command separators next to embedded quotes in shell fallback args', async () => {
+      setPlatform('win32');
+      const execFileMock = child.execFile as unknown as Mock;
+      execFileMock.mockImplementation(
+        (_cmd: string, _args: string[], _opts: unknown, cb: ExecCallback) => {
+          cb(null, 'ok', '');
+          return createMockProcess<ExecChild>();
+        }
+      );
+
+      const binaryPath = 'C:\\Users\\Алексей\\bin\\claude.exe';
+      const payload = 'TOKEN={"k":"x&echo injected&rem "}';
+      await execCli(binaryPath, [payload]);
+
+      expect(execFileMock.mock.calls[0][1]).toEqual([
+        '/d',
+        '/s',
+        '/v:off',
+        '/c',
+        `"${binaryPath} ^"TOKEN={\\^"k\\^":\\^"x^&echo^ injected^&rem^ \\^"}^""`,
+      ]);
+      expect(execFileMock.mock.calls[0][2]).toMatchObject({
+        windowsVerbatimArguments: true,
+      });
+    });
+
+    it('escapes long backslash arguments without pathological regex backtracking', async () => {
+      setPlatform('win32');
+      const execFileMock = child.execFile as unknown as Mock;
+      execFileMock.mockImplementation(
+        (_cmd: string, _args: string[], _opts: unknown, cb: ExecCallback) => {
+          cb(null, 'ok', '');
+          return createMockProcess<ExecChild>();
+        }
+      );
+
+      await expect(
+        execCli('C:\\Users\\Алексей\\bin\\claude.exe', ['\\'.repeat(50_000)])
+      ).resolves.toMatchObject({ stdout: 'ok' });
+    }, 2_000);
 
     it('keeps inline settings JSON as one argv-safe argument for Windows cmd launchers', async () => {
       setPlatform('win32');
@@ -624,7 +677,7 @@ describe('cli child process helpers', () => {
         }
       );
 
-      await execCli('C:\\runtime\\cli-dev.cmd', [
+      await execCli('C:\\Users\\Алексей\\bin\\claude.exe', [
         '--settings',
         '{"codex":{"forced_login_method":"chatgpt"}}',
         'runtime',
@@ -633,9 +686,8 @@ describe('cli child process helpers', () => {
         '--provider',
         'codex',
       ]);
-      const shellCmd = execFileMock.mock.calls[0][1][3] as string;
-      expect(shellCmd).toContain('"{\\"codex\\":{\\"forced_login_method\\":\\"chatgpt\\"}}"');
-      expect(shellCmd).not.toContain('{""codex"":');
+      const shellCmd = execFileMock.mock.calls[0][1].at(-1) as string;
+      expect(shellCmd).toContain('{\\^"codex\\^":{\\^"forced_login_method\\^":\\^"chatgpt\\^"}}');
     });
 
     it('does not pass caller shell options into cmd.exe fallback', () => {
@@ -702,17 +754,16 @@ describe('cli child process helpers', () => {
       );
 
       await expect(
-        execCli('C:\\Users\\R&D\\bin\\claude.cmd', ['safe&bad', 'safe^bad'])
+        execCli('C:\\Users\\Алексей\\R&D\\bin\\claude.exe', ['safe&bad', 'safe^bad'])
       ).resolves.toMatchObject({ stdout: 'ok' });
       expect(execFileMock).toHaveBeenCalledWith(
         expect.stringMatching(/cmd\.exe$/i),
-        ['/d', '/s', '/c', expect.stringContaining('"C:\\Users\\R&D\\bin\\claude.cmd"')],
+        ['/d', '/s', '/v:off', '/c', expect.stringContaining('R^&D')],
         expect.any(Object),
         expect.any(Function)
       );
-      const shellCmd = execFileMock.mock.calls[0][1][3] as string;
-      expect(shellCmd).toContain('"safe&bad"');
-      expect(shellCmd).toContain('"safe^bad"');
+      const shellCmd = execFileMock.mock.calls[0][1].at(-1) as string;
+      expect(shellCmd).toContain('safe^&bad');
     });
 
     it('preserves stdout and stderr on execFile failures', async () => {
@@ -763,9 +814,7 @@ describe('cli child process helpers', () => {
         expect(execFileMock.mock.calls[0][2]).toMatchObject({
           maxBuffer: 1024 * 1024 + 16,
         });
-        expect(killSpy.mock.calls.map(([pid]) => pid)).toEqual(
-          expect.arrayContaining([799, 800])
-        );
+        expect(killSpy.mock.calls.map(([pid]) => pid)).toEqual(expect.arrayContaining([799, 800]));
       } finally {
         killSpy.mockRestore();
       }
@@ -876,9 +925,11 @@ describe('cli child process helpers', () => {
       try {
         const result = execCli('C:\\bin\\opencode.exe', ['--version'], { timeout: 100 });
         let settled = false;
-        void result.finally(() => {
-          settled = true;
-        }).catch(() => undefined);
+        void result
+          .finally(() => {
+            settled = true;
+          })
+          .catch(() => undefined);
         await vi.advanceTimersByTimeAsync(100);
 
         expect(taskkillCallback).not.toBeNull();

--- a/test/main/utils/childProcess.windows.test.ts
+++ b/test/main/utils/childProcess.windows.test.ts
@@ -106,9 +106,10 @@ describe.skipIf(process.platform !== 'win32')('Windows CLI shell fallback round 
     }
   }, 30_000);
 
-  it('preserves adversarial argv through batch parameter modifiers', async () => {
+  it('preserves safe argv through batch parameter modifiers', async () => {
     const fixture = createWindowsArgvFixture();
     const launcherPath = path.join(fixture.root, 'parameter launcher.cmd');
+    const safeArgs = ['safe value', '', 'C:\\temp\\'];
     writeFileSync(
       launcherPath,
       '@echo off\r\n"%~dp0Node Runtime.exe" "%~dp0echo-args.cjs" "%~1" "%~2" "%~3"\r\n',
@@ -116,14 +117,36 @@ describe.skipIf(process.platform !== 'win32')('Windows CLI shell fallback round 
     );
 
     try {
-      const { stdout, stderr } = await execCli(launcherPath, ADVERSARIAL_ARGS, {
+      const { stdout, stderr } = await execCli(launcherPath, safeArgs, {
         cwd: fixture.root,
         preferShellForWindowsBatch: true,
         timeout: 10_000,
       });
 
       expect(stderr).toBe('');
-      expect(JSON.parse(stdout)).toEqual(ADVERSARIAL_ARGS);
+      expect(JSON.parse(stdout)).toEqual(safeArgs);
+    } finally {
+      rmSync(fixture.root, { force: true, maxRetries: 5, recursive: true, retryDelay: 100 });
+    }
+  }, 30_000);
+
+  it('rejects shell syntax before a batch launcher can reparse positional arguments', async () => {
+    const fixture = createWindowsArgvFixture();
+    const launcherPath = path.join(fixture.root, 'parameter launcher.cmd');
+    writeFileSync(
+      launcherPath,
+      '@echo off\r\n"%~dp0Node Runtime.exe" "%~dp0echo-args.cjs" "%~1"\r\n',
+      'utf8'
+    );
+
+    try {
+      await expect(
+        execCli(launcherPath, [ADVERSARIAL_ARGS[0]], {
+          cwd: fixture.root,
+          preferShellForWindowsBatch: true,
+          timeout: 10_000,
+        })
+      ).rejects.toThrow('Unsafe Windows batch positional argument');
     } finally {
       rmSync(fixture.root, { force: true, maxRetries: 5, recursive: true, retryDelay: 100 });
     }

--- a/test/main/utils/childProcess.windows.test.ts
+++ b/test/main/utils/childProcess.windows.test.ts
@@ -1,0 +1,131 @@
+// @vitest-environment node
+import { execCli, spawnCli } from '@main/utils/childProcess';
+import { once } from 'events';
+import { copyFileSync, linkSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+const ADVERSARIAL_ARGS = [
+  'TOKEN={"k":"x&echo INJECTED|rem ","pct":"%PATH%","bang":"!PATH!"}',
+  '',
+  'C:\\temp\\',
+];
+
+interface WindowsArgvFixture {
+  binaryPath: string;
+  echoScriptPath: string;
+  root: string;
+}
+
+function createWindowsArgvFixture(): WindowsArgvFixture {
+  const root = mkdtempSync(path.join(tmpdir(), 'child-process-Jane Müller-'));
+  const binaryPath = path.join(root, 'Node Runtime.exe');
+  const echoScriptPath = path.join(root, 'echo-args.cjs');
+  try {
+    linkSync(process.execPath, binaryPath);
+  } catch {
+    copyFileSync(process.execPath, binaryPath);
+  }
+  writeFileSync(
+    echoScriptPath,
+    'process.stdout.write(JSON.stringify(process.argv.slice(2)));\n',
+    'utf8'
+  );
+  return { binaryPath, echoScriptPath, root };
+}
+
+describe.skipIf(process.platform !== 'win32')('Windows CLI shell fallback round trip', () => {
+  it('preserves adversarial argv through execCli for a spaced non-ASCII executable path', async () => {
+    const fixture = createWindowsArgvFixture();
+    try {
+      const { stdout, stderr } = await execCli(
+        fixture.binaryPath,
+        [fixture.echoScriptPath, ...ADVERSARIAL_ARGS],
+        { cwd: fixture.root, timeout: 10_000 }
+      );
+
+      expect(stderr).toBe('');
+      expect(JSON.parse(stdout)).toEqual(ADVERSARIAL_ARGS);
+      expect(stdout).not.toContain('INJECTED\r\n');
+    } finally {
+      rmSync(fixture.root, { force: true, maxRetries: 5, recursive: true, retryDelay: 100 });
+    }
+  }, 30_000);
+
+  it('preserves adversarial argv through spawnCli for a spaced non-ASCII executable path', async () => {
+    const fixture = createWindowsArgvFixture();
+    try {
+      const child = spawnCli(fixture.binaryPath, [fixture.echoScriptPath, ...ADVERSARIAL_ARGS], {
+        cwd: fixture.root,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: 10_000,
+      });
+      let stdout = '';
+      let stderr = '';
+      child.stdout?.setEncoding('utf8');
+      child.stderr?.setEncoding('utf8');
+      child.stdout?.on('data', (chunk: string) => {
+        stdout += chunk;
+      });
+      child.stderr?.on('data', (chunk: string) => {
+        stderr += chunk;
+      });
+
+      const [exitCode, signal] = (await once(child, 'close')) as [
+        number | null,
+        NodeJS.Signals | null,
+      ];
+      expect({ exitCode, signal, stderr }).toEqual({ exitCode: 0, signal: null, stderr: '' });
+      expect(JSON.parse(stdout)).toEqual(ADVERSARIAL_ARGS);
+    } finally {
+      rmSync(fixture.root, { force: true, maxRetries: 5, recursive: true, retryDelay: 100 });
+    }
+  }, 30_000);
+
+  it('preserves adversarial argv through a batch launcher that forwards %*', async () => {
+    const fixture = createWindowsArgvFixture();
+    const launcherPath = path.join(fixture.root, 'proxy launcher.cmd');
+    writeFileSync(
+      launcherPath,
+      '@echo off\r\n"%~dp0Node Runtime.exe" "%~dp0echo-args.cjs" %*\r\n',
+      'utf8'
+    );
+
+    try {
+      const { stdout, stderr } = await execCli(launcherPath, ADVERSARIAL_ARGS, {
+        cwd: fixture.root,
+        preferShellForWindowsBatch: true,
+        timeout: 10_000,
+      });
+
+      expect(stderr).toBe('');
+      expect(JSON.parse(stdout)).toEqual(ADVERSARIAL_ARGS);
+    } finally {
+      rmSync(fixture.root, { force: true, maxRetries: 5, recursive: true, retryDelay: 100 });
+    }
+  }, 30_000);
+
+  it('preserves adversarial argv through batch parameter modifiers', async () => {
+    const fixture = createWindowsArgvFixture();
+    const launcherPath = path.join(fixture.root, 'parameter launcher.cmd');
+    writeFileSync(
+      launcherPath,
+      '@echo off\r\n"%~dp0Node Runtime.exe" "%~dp0echo-args.cjs" "%~1" "%~2" "%~3"\r\n',
+      'utf8'
+    );
+
+    try {
+      const { stdout, stderr } = await execCli(launcherPath, ADVERSARIAL_ARGS, {
+        cwd: fixture.root,
+        preferShellForWindowsBatch: true,
+        timeout: 10_000,
+      });
+
+      expect(stderr).toBe('');
+      expect(JSON.parse(stdout)).toEqual(ADVERSARIAL_ARGS);
+    } finally {
+      rmSync(fixture.root, { force: true, maxRetries: 5, recursive: true, retryDelay: 100 });
+    }
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary
- `execCli`/`spawnCli` fall back to a `cmd.exe /d /s /c ...` shell when the resolved binary path contains non-ASCII characters (e.g. accented usernames like `C:\Users\Jane Müller\...`).
- The fallback command string built by `buildWindowsShellFallbackCommand` was already quoted for cmd.exe, but Node re-quoted it a second time because `windowsVerbatimArguments` wasn't set on the `execFile`/`spawn` calls, corrupting the quoting.
- Even with `windowsVerbatimArguments: true`, cmd's `/s` switch only strips the *first and last* quote character of the whole command line rather than the matching pair around the executable name (see `cmd /?`). So a quoted path that also contains a space still gets its protecting quotes stripped, and cmd tokenizes on the embedded space.
- Net effect: any user whose resolved runtime/CLI binary path has both a space and a non-ASCII character got `'...' is not recognized as an internal or external command` and the CLI health check reported "found but failed to start".

## Fix
- Set `windowsVerbatimArguments: true` on both the `execFileAsync` call in `execShellAsync` and the `spawn` call in `spawnWindowsShellFallback`, so Node doesn't add its own quoting on top of the already-quoted command.
- Wrap the pre-quoted command string in one more pair of quotes (`wrapForCmdSlashS`) before passing it to `cmd.exe /d /s /c`, so cmd's `/s`-driven first/last-quote stripping removes the added wrapper instead of the inner quoting that protects the executable path.

Reproduced locally with a Windows account whose home directory is `C:\Users\Polatcan Ergün\...` (space + non-ASCII), confirmed the runtime health check failed before the fix and passed after, via both a standalone Node repro script and the running app.

## Test plan
- [x] Reproduced the failure and verified the fix with a standalone Node script isolating `execFileAsync`/`spawn` + `cmd.exe /d /s /c` behavior
- [x] Rebuilt the app and confirmed `CliInstallerService`'s runtime health check (`--version` probe) succeeds against the real bundled `claude-multimodel.exe` on an affected path
- [ ] No automated test added (no existing test file covers this internal shell-fallback path); happy to add one if maintainers want it, e.g. mocking `child_process` and asserting the exact `spawnargs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows command execution when paths contain spaces or embedded quotation marks.
  - Prevented command-line arguments from being stripped or incorrectly re-quoted during shell fallback execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->