### PR TITLE
refactor(teams): extract team configuration

### DIFF
--- a/src/features/team-configuration/README.md
+++ b/src/features/team-configuration/README.md
@@ -1,0 +1,15 @@
+# Team Configuration
+
+Owns the Electron IPC workflows for creating and updating saved team configuration,
+reading a saved provisioning request, and deleting an unconfigured draft team.
+
+Public entrypoints:
+
+- `@features/team-configuration` exposes pure runtime-selection validation reused by legacy provisioning and roster flows.
+- `@features/team-configuration/contracts` exposes browser-safe IPC channel constants.
+- `@features/team-configuration/main` exposes main-process composition and IPC registration.
+
+The input adapter deliberately preserves the existing desktop validation and normalization
+semantics. Browser mode currently reports team configuration mutation as unsupported, and
+the HTTP route parsers have different compatibility rules, so transport unification is out
+of scope for this behavior-preserving extraction.

--- a/src/features/team-configuration/contracts/channels.ts
+++ b/src/features/team-configuration/contracts/channels.ts
@@ -1,0 +1,4 @@
+export const TEAM_CREATE_CONFIG = 'team:createConfig';
+export const TEAM_UPDATE_CONFIG = 'team:updateConfig';
+export const TEAM_GET_SAVED_REQUEST = 'team:getSavedRequest';
+export const TEAM_DELETE_DRAFT = 'team:deleteDraft';

--- a/src/features/team-configuration/contracts/index.ts
+++ b/src/features/team-configuration/contracts/index.ts
@@ -1,0 +1,6 @@
+export {
+  TEAM_CREATE_CONFIG,
+  TEAM_DELETE_DRAFT,
+  TEAM_GET_SAVED_REQUEST,
+  TEAM_UPDATE_CONFIG,
+} from './channels';

--- a/src/features/team-configuration/core/application/ports/TeamConfigurationPorts.ts
+++ b/src/features/team-configuration/core/application/ports/TeamConfigurationPorts.ts
@@ -1,0 +1,49 @@
+import type {
+  TeamConfig,
+  TeamCreateConfigRequest,
+  TeamCreateRequest,
+  TeamUpdateConfigRequest,
+} from '@shared/types';
+
+export interface TeamConfigCreationRepositoryPort {
+  createTeamConfig(request: TeamCreateConfigRequest): Promise<void>;
+}
+
+export interface TeamConfigUpdateRepositoryPort {
+  getTeamDisplayName(teamName: string): Promise<string | null>;
+  updateConfig(teamName: string, updates: TeamUpdateConfigRequest): Promise<TeamConfig | null>;
+}
+
+export interface SavedTeamRequestRepositoryPort {
+  getSavedRequest(teamName: string): Promise<TeamCreateRequest | null>;
+}
+
+export interface DraftTeamDeletionRepositoryPort {
+  permanentlyDeleteTeam(teamName: string): Promise<void>;
+}
+
+export type TeamConfigurationRepositoryPort = TeamConfigCreationRepositoryPort &
+  TeamConfigUpdateRepositoryPort &
+  SavedTeamRequestRepositoryPort &
+  DraftTeamDeletionRepositoryPort;
+
+export interface TeamConfigurationRuntimePort {
+  isTeamAlive(teamName: string): boolean;
+}
+
+export interface TeamConfigurationMessagingPort {
+  sendMessageToTeam(teamName: string, message: string): Promise<void>;
+}
+
+export interface TeamConfigurationCachePort {
+  invalidateTeamConfig(teamName: string): void;
+}
+
+export interface DraftTeamConfigGuardPort {
+  assertDraftCanBeDeleted(teamName: string): Promise<void>;
+}
+
+export interface TeamConfigurationLoggerPort {
+  error(message: string): void;
+  warn(message: string): void;
+}

--- a/src/features/team-configuration/core/application/use-cases/CreateTeamConfigUseCase.ts
+++ b/src/features/team-configuration/core/application/use-cases/CreateTeamConfigUseCase.ts
@@ -1,0 +1,19 @@
+import type {
+  TeamConfigCreationRepositoryPort,
+  TeamConfigurationCachePort,
+} from '../ports/TeamConfigurationPorts';
+import type { TeamCreateConfigRequest } from '@shared/types';
+
+export class CreateTeamConfigUseCase {
+  constructor(
+    private readonly dependencies: {
+      repository: TeamConfigCreationRepositoryPort;
+      cache: TeamConfigurationCachePort;
+    }
+  ) {}
+
+  async execute(request: TeamCreateConfigRequest): Promise<void> {
+    await this.dependencies.repository.createTeamConfig(request);
+    this.dependencies.cache.invalidateTeamConfig(request.teamName);
+  }
+}

--- a/src/features/team-configuration/core/application/use-cases/DeleteDraftTeamUseCase.ts
+++ b/src/features/team-configuration/core/application/use-cases/DeleteDraftTeamUseCase.ts
@@ -1,0 +1,18 @@
+import type {
+  DraftTeamConfigGuardPort,
+  DraftTeamDeletionRepositoryPort,
+} from '../ports/TeamConfigurationPorts';
+
+export class DeleteDraftTeamUseCase {
+  constructor(
+    private readonly dependencies: {
+      repository: DraftTeamDeletionRepositoryPort;
+      draftGuard: DraftTeamConfigGuardPort;
+    }
+  ) {}
+
+  async execute(teamName: string): Promise<void> {
+    await this.dependencies.draftGuard.assertDraftCanBeDeleted(teamName);
+    await this.dependencies.repository.permanentlyDeleteTeam(teamName);
+  }
+}

--- a/src/features/team-configuration/core/application/use-cases/GetSavedTeamRequestUseCase.ts
+++ b/src/features/team-configuration/core/application/use-cases/GetSavedTeamRequestUseCase.ts
@@ -1,0 +1,10 @@
+import type { SavedTeamRequestRepositoryPort } from '../ports/TeamConfigurationPorts';
+import type { TeamCreateRequest } from '@shared/types';
+
+export class GetSavedTeamRequestUseCase {
+  constructor(private readonly repository: SavedTeamRequestRepositoryPort) {}
+
+  execute(teamName: string): Promise<TeamCreateRequest | null> {
+    return this.repository.getSavedRequest(teamName);
+  }
+}

--- a/src/features/team-configuration/core/application/use-cases/UpdateTeamConfigUseCase.ts
+++ b/src/features/team-configuration/core/application/use-cases/UpdateTeamConfigUseCase.ts
@@ -1,0 +1,45 @@
+import type {
+  TeamConfigUpdateRepositoryPort,
+  TeamConfigurationCachePort,
+  TeamConfigurationLoggerPort,
+  TeamConfigurationMessagingPort,
+  TeamConfigurationRuntimePort,
+} from '../ports/TeamConfigurationPorts';
+import type { TeamConfig, TeamUpdateConfigRequest } from '@shared/types';
+
+export class UpdateTeamConfigUseCase {
+  constructor(
+    private readonly dependencies: {
+      repository: TeamConfigUpdateRepositoryPort;
+      runtime: TeamConfigurationRuntimePort;
+      messaging: TeamConfigurationMessagingPort;
+      cache: TeamConfigurationCachePort;
+      logger: TeamConfigurationLoggerPort;
+    }
+  ) {}
+
+  async execute(teamName: string, updates: TeamUpdateConfigRequest): Promise<TeamConfig> {
+    const previousDisplayName = await this.dependencies.repository
+      .getTeamDisplayName(teamName)
+      .catch(() => teamName);
+    const requestedName = typeof updates.name === 'string' ? updates.name.trim() : '';
+    const result = await this.dependencies.repository.updateConfig(teamName, updates);
+    if (!result) {
+      throw new Error('Team config not found');
+    }
+
+    if (requestedName && requestedName !== (previousDisplayName?.trim() || teamName)) {
+      if (this.dependencies.runtime.isTeamAlive(teamName)) {
+        const message = `The team has been renamed to "${requestedName}". Please use this name when referring to the team going forward.`;
+        try {
+          await this.dependencies.messaging.sendMessageToTeam(teamName, message);
+        } catch {
+          this.dependencies.logger.warn(`Failed to notify lead about team rename for ${teamName}`);
+        }
+      }
+    }
+
+    this.dependencies.cache.invalidateTeamConfig(teamName);
+    return result;
+  }
+}

--- a/src/features/team-configuration/core/domain/teamRuntimeSelectionValidation.ts
+++ b/src/features/team-configuration/core/domain/teamRuntimeSelectionValidation.ts
@@ -1,0 +1,164 @@
+import {
+  formatEffortLevelListForProvider,
+  isTeamEffortLevelForProvider,
+} from '@shared/utils/effortLevels';
+import { isTeamProviderBackendId, migrateProviderBackendId } from '@shared/utils/providerBackend';
+import { isTeamProviderId } from '@shared/utils/teamProvider';
+
+import type {
+  EffortLevel,
+  TeamFastMode,
+  TeamProviderBackendId,
+  TeamProviderId,
+} from '@shared/types';
+
+type ValidationResult<T> = { valid: true; value: T } | { valid: false; error: string };
+
+export function isProvisioningTeamName(teamName: string): boolean {
+  if (teamName.length > 64) return false;
+  const parts = teamName.split('-');
+  return parts.every((part) => /^[a-z0-9]+$/.test(part));
+}
+
+function isValidEffort(value: unknown, providerId?: TeamProviderId | null): value is EffortLevel {
+  return isTeamEffortLevelForProvider(value, providerId);
+}
+
+function parseOptionalProviderId(
+  value: unknown,
+  fieldName: string
+): ValidationResult<TeamProviderId | undefined> {
+  if (value === undefined || value === null || value === '') {
+    return { valid: true, value: undefined };
+  }
+  if (isTeamProviderId(value)) {
+    return { valid: true, value };
+  }
+  return { valid: false, error: `${fieldName} must be anthropic, codex, gemini, or opencode` };
+}
+
+export function parseOptionalMemberProviderId(
+  value: unknown
+): ValidationResult<TeamProviderId | undefined> {
+  return parseOptionalProviderId(value, 'member providerId');
+}
+
+export function parseOptionalTeamProviderId(
+  value: unknown
+): ValidationResult<TeamProviderId | undefined> {
+  return parseOptionalProviderId(value, 'providerId');
+}
+
+export function parseOptionalProviderBackendId(
+  value: unknown,
+  providerId?: TeamProviderId
+): ValidationResult<TeamProviderBackendId | undefined> {
+  if (value === undefined || value === null || value === '') {
+    return { valid: true, value: undefined };
+  }
+  if (typeof value !== 'string') {
+    return { valid: false, error: 'providerBackendId must be a string' };
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return { valid: true, value: undefined };
+  }
+  if (trimmed.length > 64) {
+    return { valid: false, error: 'providerBackendId too long (max 64)' };
+  }
+  if (providerId) {
+    const migratedBackendId = migrateProviderBackendId(providerId, trimmed);
+    if (migratedBackendId) {
+      return { valid: true, value: migratedBackendId };
+    }
+  } else if (isTeamProviderBackendId(trimmed)) {
+    return { valid: true, value: trimmed };
+  }
+
+  return {
+    valid: false,
+    error:
+      'providerBackendId must be valid for the selected provider (auto, adapter, api, cli-sdk, codex-native, or opencode-cli)',
+  };
+}
+
+export function parseOptionalLaunchProviderBackendId(
+  value: unknown,
+  providerId?: TeamProviderId
+): ValidationResult<TeamProviderBackendId | undefined> {
+  if (value === undefined || value === null || value === '') {
+    return { valid: true, value: undefined };
+  }
+  if (typeof value !== 'string') {
+    return { valid: false, error: 'providerBackendId must be a string' };
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return { valid: true, value: undefined };
+  }
+  if (trimmed.length > 64) {
+    return { valid: false, error: 'providerBackendId too long (max 64)' };
+  }
+
+  const migratedBackendId = migrateProviderBackendId(providerId, trimmed);
+  if (migratedBackendId) {
+    return { valid: true, value: migratedBackendId };
+  }
+
+  if (isTeamProviderBackendId(trimmed)) {
+    return { valid: true, value: undefined };
+  }
+
+  return {
+    valid: false,
+    error:
+      'providerBackendId must be valid for the selected provider (auto, adapter, api, cli-sdk, codex-native, or opencode-cli)',
+  };
+}
+
+export function parseOptionalMemberEffort(
+  value: unknown,
+  providerId?: TeamProviderId | null
+): ValidationResult<EffortLevel | undefined> {
+  if (value === undefined || value === null || value === '') {
+    return { valid: true, value: undefined };
+  }
+  if (isValidEffort(value, providerId)) {
+    return { valid: true, value };
+  }
+  return {
+    valid: false,
+    error: `member effort must be one of ${formatEffortLevelListForProvider(providerId)}`,
+  };
+}
+
+export function parseOptionalTeamEffort(
+  value: unknown,
+  providerId?: TeamProviderId | null
+): ValidationResult<EffortLevel | undefined> {
+  if (value === undefined || value === null || value === '') {
+    return { valid: true, value: undefined };
+  }
+  if (isValidEffort(value, providerId)) {
+    return { valid: true, value };
+  }
+  return {
+    valid: false,
+    error: `effort must be one of ${formatEffortLevelListForProvider(providerId)}`,
+  };
+}
+
+export function parseOptionalTeamFastMode(
+  value: unknown
+): ValidationResult<TeamFastMode | undefined> {
+  if (value === undefined || value === null || value === '') {
+    return { valid: true, value: undefined };
+  }
+  if (value === 'inherit' || value === 'on' || value === 'off') {
+    return { valid: true, value };
+  }
+  return {
+    valid: false,
+    error: 'fastMode must be one of inherit, on, or off',
+  };
+}

--- a/src/features/team-configuration/index.ts
+++ b/src/features/team-configuration/index.ts
@@ -1,0 +1,10 @@
+export {
+  isProvisioningTeamName,
+  parseOptionalLaunchProviderBackendId,
+  parseOptionalMemberEffort,
+  parseOptionalMemberProviderId,
+  parseOptionalProviderBackendId,
+  parseOptionalTeamEffort,
+  parseOptionalTeamFastMode,
+  parseOptionalTeamProviderId,
+} from './core/domain/teamRuntimeSelectionValidation';

--- a/src/features/team-configuration/main/adapters/input/ipc/TeamConfigurationIpcDependencies.ts
+++ b/src/features/team-configuration/main/adapters/input/ipc/TeamConfigurationIpcDependencies.ts
@@ -1,0 +1,15 @@
+import type { TeamConfigurationLoggerPort } from '../../../../core/application/ports/TeamConfigurationPorts';
+import type { TeamConfig, TeamCreateConfigRequest, TeamCreateRequest } from '@shared/types';
+
+export interface TeamConfigurationIpcDependencies {
+  createConfig: { execute(request: TeamCreateConfigRequest): Promise<void> };
+  updateConfig: {
+    execute(
+      teamName: string,
+      updates: { name?: string; description?: string; color?: string }
+    ): Promise<TeamConfig>;
+  };
+  getSavedRequest: { execute(teamName: string): Promise<TeamCreateRequest | null> };
+  deleteDraft: { execute(teamName: string): Promise<void> };
+  logger: TeamConfigurationLoggerPort;
+}

--- a/src/features/team-configuration/main/adapters/input/ipc/createTeamConfigurationIpcHandlers.ts
+++ b/src/features/team-configuration/main/adapters/input/ipc/createTeamConfigurationIpcHandlers.ts
@@ -1,0 +1,91 @@
+import { validateTeamName } from '@main/ipc/guards';
+
+import { normalizeCreateTeamConfigRequest } from './normalizeCreateTeamConfigRequest';
+
+import type { TeamConfigurationIpcDependencies } from './TeamConfigurationIpcDependencies';
+import type {
+  IpcResult,
+  TeamConfig,
+  TeamCreateRequest,
+  TeamUpdateConfigRequest,
+} from '@shared/types';
+
+export function createTeamConfigurationIpcHandlers(
+  dependencies: TeamConfigurationIpcDependencies
+): {
+  createConfig: (_event: unknown, request: unknown) => Promise<IpcResult<void>>;
+  updateConfig: (
+    _event: unknown,
+    teamName: unknown,
+    updates: unknown
+  ) => Promise<IpcResult<TeamConfig>>;
+  getSavedRequest: (
+    _event: unknown,
+    teamName: unknown
+  ) => Promise<IpcResult<TeamCreateRequest | null>>;
+  deleteDraft: (_event: unknown, teamName: unknown) => Promise<IpcResult<void>>;
+} {
+  const execute = async <T>(
+    operation: string,
+    handler: () => Promise<T>
+  ): Promise<IpcResult<T>> => {
+    try {
+      return { success: true, data: await handler() };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      dependencies.logger.error(`[teams:${operation}] ${message}`);
+      return { success: false, error: message };
+    }
+  };
+
+  return {
+    createConfig: async (_event, request) => {
+      const normalized = normalizeCreateTeamConfigRequest(request);
+      if (!normalized.valid) {
+        return { success: false, error: normalized.error };
+      }
+      return execute('createConfig', () => dependencies.createConfig.execute(normalized.value));
+    },
+
+    updateConfig: async (_event, teamName, updates) => {
+      const validated = validateTeamName(teamName);
+      if (!validated.valid) {
+        return { success: false, error: validated.error ?? 'Invalid teamName' };
+      }
+      if (!updates || typeof updates !== 'object') {
+        return { success: false, error: 'Invalid updates object' };
+      }
+      const { name, description, color } = updates as TeamUpdateConfigRequest;
+      if (name !== undefined && typeof name !== 'string') {
+        return { success: false, error: 'name must be a string' };
+      }
+      if (description !== undefined && typeof description !== 'string') {
+        return { success: false, error: 'description must be a string' };
+      }
+      if (color !== undefined && typeof color !== 'string') {
+        return { success: false, error: 'color must be a string' };
+      }
+      return execute('updateConfig', () =>
+        dependencies.updateConfig.execute(validated.value!, { name, description, color })
+      );
+    },
+
+    getSavedRequest: async (_event, teamName) => {
+      const validated = validateTeamName(teamName);
+      if (!validated.valid) {
+        return { success: false, error: validated.error ?? 'Invalid teamName' };
+      }
+      return execute('getSavedRequest', () =>
+        dependencies.getSavedRequest.execute(validated.value!)
+      );
+    },
+
+    deleteDraft: async (_event, teamName) => {
+      const validated = validateTeamName(teamName);
+      if (!validated.valid) {
+        return { success: false, error: validated.error ?? 'Invalid teamName' };
+      }
+      return execute('deleteDraft', () => dependencies.deleteDraft.execute(validated.value!));
+    },
+  };
+}

--- a/src/features/team-configuration/main/adapters/input/ipc/normalizeCreateTeamConfigRequest.ts
+++ b/src/features/team-configuration/main/adapters/input/ipc/normalizeCreateTeamConfigRequest.ts
@@ -1,0 +1,223 @@
+import {
+  isProvisioningTeamName,
+  parseOptionalLaunchProviderBackendId,
+  parseOptionalMemberEffort,
+  parseOptionalMemberProviderId,
+  parseOptionalProviderBackendId,
+  parseOptionalTeamEffort,
+  parseOptionalTeamFastMode,
+  parseOptionalTeamProviderId,
+} from '@features/team-configuration';
+import { validateTeammateName } from '@main/ipc/guards';
+import { extractUserFlags, PROTECTED_CLI_FLAGS } from '@shared/utils/cliArgsParser';
+import { normalizeTeamMemberMcpPolicy } from '@shared/utils/teamMemberMcpPolicy';
+import * as path from 'path';
+
+import type { TeamCreateConfigRequest } from '@shared/types';
+
+type NormalizedCreateConfigResult =
+  | { valid: true; value: TeamCreateConfigRequest }
+  | { valid: false; error: string };
+
+export function normalizeCreateTeamConfigRequest(request: unknown): NormalizedCreateConfigResult {
+  if (!request || typeof request !== 'object') {
+    return { valid: false, error: 'Invalid create config request' };
+  }
+
+  const payload = request as Partial<TeamCreateConfigRequest>;
+  if (typeof payload.teamName !== 'string' || payload.teamName.trim().length === 0) {
+    return { valid: false, error: 'teamName is required' };
+  }
+  const teamName = payload.teamName.trim();
+  if (!isProvisioningTeamName(teamName)) {
+    return { valid: false, error: 'teamName must be kebab-case [a-z0-9-], max 64 chars' };
+  }
+
+  if (!Array.isArray(payload.members)) {
+    return { valid: false, error: 'members must be an array' };
+  }
+
+  if (payload.displayName !== undefined && typeof payload.displayName !== 'string') {
+    return { valid: false, error: 'displayName must be a string' };
+  }
+  if (payload.description !== undefined && typeof payload.description !== 'string') {
+    return { valid: false, error: 'description must be a string' };
+  }
+  if (payload.color !== undefined && typeof payload.color !== 'string') {
+    return { valid: false, error: 'color must be a string' };
+  }
+  if (payload.cwd !== undefined) {
+    if (typeof payload.cwd !== 'string' || payload.cwd.trim().length === 0) {
+      return { valid: false, error: 'cwd must be a non-empty string if provided' };
+    }
+    if (!path.isAbsolute(payload.cwd.trim())) {
+      return { valid: false, error: 'cwd must be an absolute path' };
+    }
+  }
+  if (payload.prompt !== undefined && typeof payload.prompt !== 'string') {
+    return { valid: false, error: 'prompt must be a string' };
+  }
+  const teamProviderValidation = parseOptionalTeamProviderId(payload.providerId);
+  if (!teamProviderValidation.valid) {
+    return { valid: false, error: teamProviderValidation.error };
+  }
+  const effectiveTeamProviderId = teamProviderValidation.value ?? 'anthropic';
+  const providerBackendValidation = parseOptionalLaunchProviderBackendId(
+    payload.providerBackendId,
+    effectiveTeamProviderId
+  );
+  if (!providerBackendValidation.valid) {
+    return { valid: false, error: providerBackendValidation.error };
+  }
+  if (payload.model !== undefined && typeof payload.model !== 'string') {
+    return { valid: false, error: 'model must be a string' };
+  }
+  const effortValidation = parseOptionalTeamEffort(payload.effort, effectiveTeamProviderId);
+  if (!effortValidation.valid) {
+    return { valid: false, error: effortValidation.error };
+  }
+  const fastModeValidation = parseOptionalTeamFastMode(payload.fastMode);
+  if (!fastModeValidation.valid) {
+    return { valid: false, error: fastModeValidation.error };
+  }
+  if (payload.limitContext !== undefined && typeof payload.limitContext !== 'boolean') {
+    return { valid: false, error: 'limitContext must be a boolean' };
+  }
+  if (payload.skipPermissions !== undefined && typeof payload.skipPermissions !== 'boolean') {
+    return { valid: false, error: 'skipPermissions must be a boolean' };
+  }
+  if (payload.worktree !== undefined) {
+    if (typeof payload.worktree !== 'string') {
+      return { valid: false, error: 'worktree must be a string' };
+    }
+    const worktree = payload.worktree.trim();
+    if (worktree.length > 128) {
+      return { valid: false, error: 'worktree name too long (max 128)' };
+    }
+    if (worktree && !/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(worktree)) {
+      return {
+        valid: false,
+        error: 'worktree name: start with alphanumeric, use [a-zA-Z0-9._-]',
+      };
+    }
+  }
+  if (payload.extraCliArgs !== undefined) {
+    if (typeof payload.extraCliArgs !== 'string') {
+      return { valid: false, error: 'extraCliArgs must be a string' };
+    }
+    if (payload.extraCliArgs.length > 1024) {
+      return { valid: false, error: 'extraCliArgs too long (max 1024)' };
+    }
+    const protectedFlags = extractUserFlags(payload.extraCliArgs).filter((flag) =>
+      PROTECTED_CLI_FLAGS.has(flag)
+    );
+    if (protectedFlags.length > 0) {
+      return {
+        valid: false,
+        error: `extraCliArgs contains app-managed flags: ${[...new Set(protectedFlags)].join(', ')}`,
+      };
+    }
+  }
+
+  const seenNames = new Set<string>();
+  const members: TeamCreateConfigRequest['members'] = [];
+  for (const member of payload.members) {
+    if (!member || typeof member !== 'object') {
+      return { valid: false, error: 'member must be object' };
+    }
+    const nameValidation = validateTeammateName((member as { name?: unknown }).name);
+    if (!nameValidation.valid) {
+      return { valid: false, error: nameValidation.error ?? 'Invalid member name' };
+    }
+    const memberName = nameValidation.value!;
+    if (seenNames.has(memberName)) {
+      return { valid: false, error: 'member names must be unique' };
+    }
+    seenNames.add(memberName);
+
+    const role = (member as { role?: unknown }).role;
+    if (role !== undefined && typeof role !== 'string') {
+      return { valid: false, error: 'member role must be string' };
+    }
+    const workflow = (member as { workflow?: unknown }).workflow;
+    if (workflow !== undefined && typeof workflow !== 'string') {
+      return { valid: false, error: 'member workflow must be string' };
+    }
+    const isolation = (member as { isolation?: unknown }).isolation;
+    if (isolation !== undefined && isolation !== 'worktree') {
+      return { valid: false, error: 'member isolation must be "worktree" when provided' };
+    }
+    const providerValidation = parseOptionalMemberProviderId(
+      (member as { providerId?: unknown }).providerId
+    );
+    if (!providerValidation.valid) {
+      return { valid: false, error: providerValidation.error };
+    }
+    const effectiveMemberProviderId = providerValidation.value ?? effectiveTeamProviderId;
+    const memberProviderBackendValidation = parseOptionalProviderBackendId(
+      (member as { providerBackendId?: unknown }).providerBackendId,
+      effectiveMemberProviderId
+    );
+    if (!memberProviderBackendValidation.valid) {
+      return { valid: false, error: memberProviderBackendValidation.error };
+    }
+    const model = (member as { model?: unknown }).model;
+    if (model !== undefined && typeof model !== 'string') {
+      return { valid: false, error: 'member model must be string' };
+    }
+    const memberEffortValidation = parseOptionalMemberEffort(
+      (member as { effort?: unknown }).effort,
+      effectiveMemberProviderId
+    );
+    if (!memberEffortValidation.valid) {
+      return { valid: false, error: memberEffortValidation.error };
+    }
+    const memberFastModeValidation = parseOptionalTeamFastMode(
+      (member as { fastMode?: unknown }).fastMode
+    );
+    if (!memberFastModeValidation.valid) {
+      return { valid: false, error: memberFastModeValidation.error };
+    }
+    members.push({
+      name: memberName,
+      role: typeof role === 'string' ? role.trim() : undefined,
+      workflow: typeof workflow === 'string' ? workflow.trim() : undefined,
+      isolation: isolation === 'worktree' ? ('worktree' as const) : undefined,
+      providerId: providerValidation.value,
+      providerBackendId: memberProviderBackendValidation.value,
+      model: typeof model === 'string' ? model.trim() || undefined : undefined,
+      effort: memberEffortValidation.value,
+      fastMode: memberFastModeValidation.value,
+      mcpPolicy: normalizeTeamMemberMcpPolicy((member as { mcpPolicy?: unknown }).mcpPolicy),
+    });
+  }
+
+  return {
+    valid: true,
+    value: {
+      teamName,
+      displayName: payload.displayName?.trim() || undefined,
+      description: payload.description?.trim() || undefined,
+      color: typeof payload.color === 'string' ? payload.color.trim() || undefined : undefined,
+      members,
+      cwd: typeof payload.cwd === 'string' ? payload.cwd.trim() || undefined : undefined,
+      prompt: typeof payload.prompt === 'string' ? payload.prompt.trim() || undefined : undefined,
+      providerId: teamProviderValidation.value,
+      providerBackendId: providerBackendValidation.value,
+      model: typeof payload.model === 'string' ? payload.model.trim() || undefined : undefined,
+      effort: effortValidation.value,
+      fastMode: fastModeValidation.value,
+      limitContext: typeof payload.limitContext === 'boolean' ? payload.limitContext : undefined,
+      skipPermissions:
+        typeof payload.skipPermissions === 'boolean' ? payload.skipPermissions : undefined,
+      worktree:
+        typeof payload.worktree === 'string' && payload.worktree.trim()
+          ? payload.worktree.trim()
+          : undefined,
+      extraCliArgs:
+        typeof payload.extraCliArgs === 'string' && payload.extraCliArgs.trim()
+          ? payload.extraCliArgs.trim()
+          : undefined,
+    },
+  };
+}

--- a/src/features/team-configuration/main/adapters/input/ipc/registerTeamConfigurationIpc.ts
+++ b/src/features/team-configuration/main/adapters/input/ipc/registerTeamConfigurationIpc.ts
@@ -1,0 +1,29 @@
+import {
+  TEAM_CREATE_CONFIG,
+  TEAM_DELETE_DRAFT,
+  TEAM_GET_SAVED_REQUEST,
+  TEAM_UPDATE_CONFIG,
+} from '@features/team-configuration/contracts';
+
+import { createTeamConfigurationIpcHandlers } from './createTeamConfigurationIpcHandlers';
+
+import type { TeamConfigurationIpcDependencies } from './TeamConfigurationIpcDependencies';
+import type { IpcMain } from 'electron';
+
+export function registerTeamConfigurationIpc(
+  ipcMain: IpcMain,
+  dependencies: TeamConfigurationIpcDependencies
+): void {
+  const handlers = createTeamConfigurationIpcHandlers(dependencies);
+  ipcMain.handle(TEAM_CREATE_CONFIG, handlers.createConfig);
+  ipcMain.handle(TEAM_UPDATE_CONFIG, handlers.updateConfig);
+  ipcMain.handle(TEAM_GET_SAVED_REQUEST, handlers.getSavedRequest);
+  ipcMain.handle(TEAM_DELETE_DRAFT, handlers.deleteDraft);
+}
+
+export function removeTeamConfigurationIpc(ipcMain: IpcMain): void {
+  ipcMain.removeHandler(TEAM_CREATE_CONFIG);
+  ipcMain.removeHandler(TEAM_UPDATE_CONFIG);
+  ipcMain.removeHandler(TEAM_GET_SAVED_REQUEST);
+  ipcMain.removeHandler(TEAM_DELETE_DRAFT);
+}

--- a/src/features/team-configuration/main/adapters/output/TeamDataWorkerConfigCache.ts
+++ b/src/features/team-configuration/main/adapters/output/TeamDataWorkerConfigCache.ts
@@ -1,0 +1,9 @@
+import { getTeamDataWorkerClient } from '@main/services/team/TeamDataWorkerClient';
+
+import type { TeamConfigurationCachePort } from '../../../core/application/ports/TeamConfigurationPorts';
+
+export class TeamDataWorkerConfigCache implements TeamConfigurationCachePort {
+  invalidateTeamConfig(teamName: string): void {
+    getTeamDataWorkerClient().invalidateTeamConfig(teamName);
+  }
+}

--- a/src/features/team-configuration/main/composition/createTeamConfigurationFeature.ts
+++ b/src/features/team-configuration/main/composition/createTeamConfigurationFeature.ts
@@ -1,0 +1,47 @@
+import { CreateTeamConfigUseCase } from '../../core/application/use-cases/CreateTeamConfigUseCase';
+import { DeleteDraftTeamUseCase } from '../../core/application/use-cases/DeleteDraftTeamUseCase';
+import { GetSavedTeamRequestUseCase } from '../../core/application/use-cases/GetSavedTeamRequestUseCase';
+import { UpdateTeamConfigUseCase } from '../../core/application/use-cases/UpdateTeamConfigUseCase';
+import { TeamDataWorkerConfigCache } from '../adapters/output/TeamDataWorkerConfigCache';
+import { FileSystemDraftTeamConfigGuard } from '../infrastructure/FileSystemDraftTeamConfigGuard';
+
+import type {
+  DraftTeamConfigGuardPort,
+  TeamConfigurationCachePort,
+  TeamConfigurationLoggerPort,
+  TeamConfigurationMessagingPort,
+  TeamConfigurationRepositoryPort,
+  TeamConfigurationRuntimePort,
+} from '../../core/application/ports/TeamConfigurationPorts';
+import type { TeamConfigurationIpcDependencies } from '../adapters/input/ipc/TeamConfigurationIpcDependencies';
+
+export type TeamConfigurationFeature = TeamConfigurationIpcDependencies;
+
+export function createTeamConfigurationFeature(dependencies: {
+  repository: TeamConfigurationRepositoryPort;
+  runtime: TeamConfigurationRuntimePort;
+  messaging: TeamConfigurationMessagingPort;
+  logger: TeamConfigurationLoggerPort;
+  cache?: TeamConfigurationCachePort;
+  draftGuard?: DraftTeamConfigGuardPort;
+}): TeamConfigurationFeature {
+  const cache = dependencies.cache ?? new TeamDataWorkerConfigCache();
+  const draftGuard = dependencies.draftGuard ?? new FileSystemDraftTeamConfigGuard();
+
+  return {
+    createConfig: new CreateTeamConfigUseCase({ repository: dependencies.repository, cache }),
+    updateConfig: new UpdateTeamConfigUseCase({
+      repository: dependencies.repository,
+      runtime: dependencies.runtime,
+      messaging: dependencies.messaging,
+      cache,
+      logger: dependencies.logger,
+    }),
+    getSavedRequest: new GetSavedTeamRequestUseCase(dependencies.repository),
+    deleteDraft: new DeleteDraftTeamUseCase({
+      repository: dependencies.repository,
+      draftGuard,
+    }),
+    logger: dependencies.logger,
+  };
+}

--- a/src/features/team-configuration/main/index.ts
+++ b/src/features/team-configuration/main/index.ts
@@ -1,0 +1,8 @@
+export {
+  registerTeamConfigurationIpc,
+  removeTeamConfigurationIpc,
+} from './adapters/input/ipc/registerTeamConfigurationIpc';
+export {
+  createTeamConfigurationFeature,
+  type TeamConfigurationFeature,
+} from './composition/createTeamConfigurationFeature';

--- a/src/features/team-configuration/main/infrastructure/FileSystemDraftTeamConfigGuard.ts
+++ b/src/features/team-configuration/main/infrastructure/FileSystemDraftTeamConfigGuard.ts
@@ -1,0 +1,19 @@
+import { getTeamsBasePath } from '@main/utils/pathDecoder';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import type { DraftTeamConfigGuardPort } from '../../core/application/ports/TeamConfigurationPorts';
+
+export class FileSystemDraftTeamConfigGuard implements DraftTeamConfigGuardPort {
+  constructor(private readonly getTeamsRoot: () => string = getTeamsBasePath) {}
+
+  async assertDraftCanBeDeleted(teamName: string): Promise<void> {
+    const configPath = path.join(this.getTeamsRoot(), teamName, 'config.json');
+    try {
+      await fs.promises.access(configPath, fs.constants.F_OK);
+      throw new Error('Cannot delete draft: team has config.json (use deleteTeam instead)');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+  }
+}

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -24,6 +24,11 @@ import {
   removeTeamApprovalsIpc,
 } from '@features/team-approvals/main';
 import {
+  createTeamConfigurationFeature,
+  registerTeamConfigurationIpc,
+  removeTeamConfigurationIpc,
+} from '@features/team-configuration/main';
+import {
   createTeamTaskBoardFeature,
   registerTeamTaskBoardIpc,
   removeTeamTaskBoardIpc,
@@ -156,6 +161,7 @@ const taskLogObservabilityLogger = createLogger('IPC:teams');
 const teamApprovalsLogger = createLogger('IPC:teamApprovals');
 const teamTaskBoardLogger = createLogger('IPC:teamTaskBoard');
 const teamViewReadModelLogger = createLogger('IPC:teams');
+const teamConfigurationLogger = createLogger('IPC:teams');
 
 /**
  * Initializes IPC handlers with service registry.
@@ -223,6 +229,12 @@ export function initializeIpcHandlers(
     runtime: teamHandlerApis.runtime,
     messaging: teamHandlerApis.messaging,
     logger: teamViewReadModelLogger,
+  });
+  const teamConfigurationFeature = createTeamConfigurationFeature({
+    repository: teamDataService,
+    runtime: teamHandlerApis.runtime,
+    messaging: teamHandlerApis.messaging,
+    logger: teamConfigurationLogger,
   });
 
   // Initialize domain handlers with registry
@@ -300,6 +312,7 @@ export function initializeIpcHandlers(
   registerSshHandlers(ipcMain);
   registerContextHandlers(ipcMain);
   registerTeamHandlers(ipcMain);
+  registerTeamConfigurationIpc(ipcMain, teamConfigurationFeature);
   registerTeamViewReadModelIpc(ipcMain, teamViewReadModelFeature);
   registerTeamTaskBoardIpc(ipcMain, teamTaskBoardFeature);
   registerTeamApprovalsIpc(ipcMain, {
@@ -364,6 +377,7 @@ export function removeIpcHandlers(): void {
   removeSshHandlers(ipcMain);
   removeContextHandlers(ipcMain);
   removeTeamHandlers(ipcMain);
+  removeTeamConfigurationIpc(ipcMain);
   removeTeamViewReadModelIpc(ipcMain);
   removeTeamTaskBoardIpc(ipcMain);
   removeTeamApprovalsIpc(ipcMain);

--- a/src/main/ipc/teams.ts
+++ b/src/main/ipc/teams.ts
@@ -3,6 +3,16 @@ import {
   MAX_AGENT_ATTACHMENT_SERIALIZED_PAYLOAD_BYTES,
 } from '@features/agent-attachments/contracts';
 import {
+  isProvisioningTeamName,
+  parseOptionalLaunchProviderBackendId,
+  parseOptionalMemberEffort,
+  parseOptionalMemberProviderId,
+  parseOptionalProviderBackendId,
+  parseOptionalTeamEffort,
+  parseOptionalTeamFastMode,
+  parseOptionalTeamProviderId,
+} from '@features/team-configuration';
+import {
   type CanonicalListTeamLifecycleResult,
   TEAM_LIFECYCLE_READ_SCHEMA_VERSION,
   type TeamLifecycleReadFailure,
@@ -24,9 +34,7 @@ import {
   TEAM_ALIVE_LIST,
   TEAM_CANCEL_PROVISIONING,
   TEAM_CREATE,
-  TEAM_CREATE_CONFIG,
   TEAM_CREATE_INITIAL_GIT_COMMIT,
-  TEAM_DELETE_DRAFT,
   TEAM_DELETE_TASK_ATTACHMENT,
   TEAM_DELETE_TEAM,
   TEAM_GET_AGENT_RUNTIME,
@@ -37,7 +45,6 @@ import {
   TEAM_GET_MEMBER_STATS,
   TEAM_GET_OPENCODE_RUNTIME_DELIVERY_STATUS,
   TEAM_GET_PROJECT_BRANCH,
-  TEAM_GET_SAVED_REQUEST,
   TEAM_GET_TASK_ATTACHMENT,
   TEAM_GET_WORKTREE_GIT_STATUS,
   TEAM_INITIALIZE_GIT_REPOSITORY,
@@ -68,7 +75,6 @@ import {
   TEAM_SHOW_MESSAGE_NOTIFICATION,
   TEAM_SKIP_MEMBER_FOR_LAUNCH,
   TEAM_STOP,
-  TEAM_UPDATE_CONFIG,
   TEAM_UPDATE_MEMBER_ROLE,
   TEAM_VALIDATE_CLI_ARGS,
   // eslint-disable-next-line boundaries/element-types -- IPC channel constants are shared between main and preload by design
@@ -80,14 +86,10 @@ import {
   extractUserFlags,
   PROTECTED_CLI_FLAGS,
 } from '@shared/utils/cliArgsParser';
-import {
-  formatEffortLevelListForProvider,
-  isTeamEffortLevelForProvider,
-} from '@shared/utils/effortLevels';
 import { getErrorMessage } from '@shared/utils/errorHandling';
 import { isLeadMember } from '@shared/utils/leadDetection';
 import { createLogger } from '@shared/utils/logger';
-import { isTeamProviderBackendId, migrateProviderBackendId } from '@shared/utils/providerBackend';
+import { migrateProviderBackendId } from '@shared/utils/providerBackend';
 import {
   buildStandaloneSlashCommandMeta,
   parseStandaloneSlashCommand,
@@ -176,8 +178,6 @@ import type {
   TeamAgentRuntimeSnapshot,
   TeamClaudeLogsQuery,
   TeamClaudeLogsResponse,
-  TeamConfig,
-  TeamCreateConfigRequest,
   TeamCreateRequest,
   TeamCreateResponse,
   TeamFastMode,
@@ -192,7 +192,6 @@ import type {
   TeamProvisioningPrepareResult,
   TeamProvisioningProgress,
   TeamSummary,
-  TeamUpdateConfigRequest,
   TeamWorktreeGitStatus,
 } from '@shared/types';
 import type { CliArgsValidationResult } from '@shared/utils/cliArgsParser';
@@ -675,11 +674,9 @@ export function registerTeamHandlers(ipcMain: IpcMain): void {
   ipcMain.handle(TEAM_PROCESS_ALIVE, handleProcessAlive);
   ipcMain.handle(TEAM_ALIVE_LIST, handleAliveList);
   ipcMain.handle(TEAM_STOP, handleStopTeam);
-  ipcMain.handle(TEAM_CREATE_CONFIG, handleCreateConfig);
   ipcMain.handle(TEAM_GET_MEMBER_LOGS, handleGetMemberLogs);
   ipcMain.handle(TEAM_GET_LOGS_FOR_TASK, handleGetLogsForTask);
   ipcMain.handle(TEAM_GET_MEMBER_STATS, handleGetMemberStats);
-  ipcMain.handle(TEAM_UPDATE_CONFIG, handleUpdateConfig);
   ipcMain.handle(TEAM_ADD_MEMBER, handleAddMember);
   ipcMain.handle(TEAM_REPLACE_MEMBERS, handleReplaceMembers);
   ipcMain.handle(TEAM_REMOVE_MEMBER, handleRemoveMember);
@@ -703,8 +700,6 @@ export function registerTeamHandlers(ipcMain: IpcMain): void {
   ipcMain.handle(TEAM_GET_TASK_ATTACHMENT, handleGetTaskAttachment);
   ipcMain.handle(TEAM_DELETE_TASK_ATTACHMENT, handleDeleteTaskAttachment);
   ipcMain.handle(TEAM_VALIDATE_CLI_ARGS, handleValidateCliArgs);
-  ipcMain.handle(TEAM_GET_SAVED_REQUEST, handleGetSavedRequest);
-  ipcMain.handle(TEAM_DELETE_DRAFT, handleDeleteDraft);
   logger.info('Team handlers registered');
 }
 
@@ -732,11 +727,9 @@ export function removeTeamHandlers(ipcMain: IpcMain): void {
   ipcMain.removeHandler(TEAM_PROCESS_ALIVE);
   ipcMain.removeHandler(TEAM_ALIVE_LIST);
   ipcMain.removeHandler(TEAM_STOP);
-  ipcMain.removeHandler(TEAM_CREATE_CONFIG);
   ipcMain.removeHandler(TEAM_GET_MEMBER_LOGS);
   ipcMain.removeHandler(TEAM_GET_LOGS_FOR_TASK);
   ipcMain.removeHandler(TEAM_GET_MEMBER_STATS);
-  ipcMain.removeHandler(TEAM_UPDATE_CONFIG);
   ipcMain.removeHandler(TEAM_ADD_MEMBER);
   ipcMain.removeHandler(TEAM_REPLACE_MEMBERS);
   ipcMain.removeHandler(TEAM_REMOVE_MEMBER);
@@ -757,8 +750,6 @@ export function removeTeamHandlers(ipcMain: IpcMain): void {
   ipcMain.removeHandler(TEAM_GET_TASK_ATTACHMENT);
   ipcMain.removeHandler(TEAM_DELETE_TASK_ATTACHMENT);
   ipcMain.removeHandler(TEAM_VALIDATE_CLI_ARGS);
-  ipcMain.removeHandler(TEAM_GET_SAVED_REQUEST);
-  ipcMain.removeHandler(TEAM_DELETE_DRAFT);
 }
 
 function getTeamDataService(): TeamDataService {
@@ -1073,209 +1064,6 @@ async function handlePermanentlyDeleteTeam(
       await teamBackupService.markDeletedByUser(validated.value!);
     }
   });
-}
-
-async function handleUpdateConfig(
-  _event: IpcMainInvokeEvent,
-  teamName: unknown,
-  updates: unknown
-): Promise<IpcResult<TeamConfig>> {
-  const validated = validateTeamName(teamName);
-  if (!validated.valid) {
-    return { success: false, error: validated.error ?? 'Invalid teamName' };
-  }
-  if (!updates || typeof updates !== 'object') {
-    return { success: false, error: 'Invalid updates object' };
-  }
-  const { name, description, color } = updates as TeamUpdateConfigRequest;
-  if (name !== undefined && typeof name !== 'string') {
-    return { success: false, error: 'name must be a string' };
-  }
-  if (description !== undefined && typeof description !== 'string') {
-    return { success: false, error: 'description must be a string' };
-  }
-  if (color !== undefined && typeof color !== 'string') {
-    return { success: false, error: 'color must be a string' };
-  }
-  return wrapTeamHandler('updateConfig', async () => {
-    const tn = validated.value!;
-    const teamDataService = getTeamDataService();
-    const previousDisplayName = await teamDataService.getTeamDisplayName(tn).catch(() => tn);
-    const requestedName = typeof name === 'string' ? name.trim() : '';
-    const result = await getTeamDataService().updateConfig(tn, {
-      name,
-      description,
-      color,
-    });
-    if (!result) {
-      throw new Error('Team config not found');
-    }
-
-    // Notify running lead about the rename so it stays aware of current team name
-    if (requestedName && requestedName !== (previousDisplayName?.trim() || tn)) {
-      const messaging = getTeamMessagingApi();
-      if (getTeamRuntimeApi().isTeamAlive(tn)) {
-        const msg = `The team has been renamed to "${requestedName}". Please use this name when referring to the team going forward.`;
-        try {
-          await messaging.sendMessageToTeam(tn, msg);
-        } catch {
-          logger.warn(`Failed to notify lead about team rename for ${tn}`);
-        }
-      }
-    }
-
-    getTeamDataWorkerClient().invalidateTeamConfig(tn);
-    return result;
-  });
-}
-
-function isProvisioningTeamName(teamName: string): boolean {
-  if (teamName.length > 64) return false;
-  const parts = teamName.split('-');
-  return parts.every((p) => /^[a-z0-9]+$/.test(p));
-}
-
-function isValidEffort(value: unknown, providerId?: TeamProviderId | null): value is EffortLevel {
-  return isTeamEffortLevelForProvider(value, providerId);
-}
-
-function parseOptionalProviderId(
-  value: unknown,
-  fieldName: string
-): { valid: true; value: TeamProviderId | undefined } | { valid: false; error: string } {
-  if (value === undefined || value === null || value === '') {
-    return { valid: true, value: undefined };
-  }
-  if (isTeamProviderId(value)) {
-    return { valid: true, value };
-  }
-  return { valid: false, error: `${fieldName} must be anthropic, codex, gemini, or opencode` };
-}
-
-function parseOptionalMemberProviderId(
-  value: unknown
-): { valid: true; value: TeamProviderId | undefined } | { valid: false; error: string } {
-  return parseOptionalProviderId(value, 'member providerId');
-}
-
-function parseOptionalTeamProviderId(
-  value: unknown
-): { valid: true; value: TeamProviderId | undefined } | { valid: false; error: string } {
-  return parseOptionalProviderId(value, 'providerId');
-}
-
-function parseOptionalProviderBackendId(
-  value: unknown,
-  providerId?: TeamProviderId
-): { valid: true; value: TeamProviderBackendId | undefined } | { valid: false; error: string } {
-  if (value === undefined || value === null || value === '') {
-    return { valid: true, value: undefined };
-  }
-  if (typeof value !== 'string') {
-    return { valid: false, error: 'providerBackendId must be a string' };
-  }
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return { valid: true, value: undefined };
-  }
-  if (trimmed.length > 64) {
-    return { valid: false, error: 'providerBackendId too long (max 64)' };
-  }
-  if (providerId) {
-    const migratedBackendId = migrateProviderBackendId(providerId, trimmed);
-    if (migratedBackendId) {
-      return { valid: true, value: migratedBackendId };
-    }
-  } else if (isTeamProviderBackendId(trimmed)) {
-    return { valid: true, value: trimmed };
-  }
-
-  return {
-    valid: false,
-    error:
-      'providerBackendId must be valid for the selected provider (auto, adapter, api, cli-sdk, codex-native, or opencode-cli)',
-  };
-}
-
-function parseOptionalLaunchProviderBackendId(
-  value: unknown,
-  providerId?: TeamProviderId
-): { valid: true; value: TeamProviderBackendId | undefined } | { valid: false; error: string } {
-  if (value === undefined || value === null || value === '') {
-    return { valid: true, value: undefined };
-  }
-  if (typeof value !== 'string') {
-    return { valid: false, error: 'providerBackendId must be a string' };
-  }
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return { valid: true, value: undefined };
-  }
-  if (trimmed.length > 64) {
-    return { valid: false, error: 'providerBackendId too long (max 64)' };
-  }
-
-  const migratedBackendId = migrateProviderBackendId(providerId, trimmed);
-  if (migratedBackendId) {
-    return { valid: true, value: migratedBackendId };
-  }
-
-  if (isTeamProviderBackendId(trimmed)) {
-    return { valid: true, value: undefined };
-  }
-
-  return {
-    valid: false,
-    error:
-      'providerBackendId must be valid for the selected provider (auto, adapter, api, cli-sdk, codex-native, or opencode-cli)',
-  };
-}
-
-function parseOptionalMemberEffort(
-  value: unknown,
-  providerId?: TeamProviderId | null
-): { valid: true; value: EffortLevel | undefined } | { valid: false; error: string } {
-  if (value === undefined || value === null || value === '') {
-    return { valid: true, value: undefined };
-  }
-  if (isValidEffort(value, providerId)) {
-    return { valid: true, value };
-  }
-  return {
-    valid: false,
-    error: `member effort must be one of ${formatEffortLevelListForProvider(providerId)}`,
-  };
-}
-
-function parseOptionalTeamEffort(
-  value: unknown,
-  providerId?: TeamProviderId | null
-): { valid: true; value: EffortLevel | undefined } | { valid: false; error: string } {
-  if (value === undefined || value === null || value === '') {
-    return { valid: true, value: undefined };
-  }
-  if (isValidEffort(value, providerId)) {
-    return { valid: true, value };
-  }
-  return {
-    valid: false,
-    error: `effort must be one of ${formatEffortLevelListForProvider(providerId)}`,
-  };
-}
-
-function parseOptionalTeamFastMode(
-  value: unknown
-): { valid: true; value: TeamFastMode | undefined } | { valid: false; error: string } {
-  if (value === undefined || value === null || value === '') {
-    return { valid: true, value: undefined };
-  }
-  if (value === 'inherit' || value === 'on' || value === 'off') {
-    return { valid: true, value };
-  }
-  return {
-    valid: false,
-    error: 'fastMode must be one of inherit, on, or off',
-  };
 }
 
 interface RuntimeRosterMutationMember {
@@ -2923,212 +2711,6 @@ async function handleProcessAlive(
   );
 }
 
-async function handleCreateConfig(
-  _event: IpcMainInvokeEvent,
-  request: unknown
-): Promise<IpcResult<void>> {
-  if (!request || typeof request !== 'object') {
-    return { success: false, error: 'Invalid create config request' };
-  }
-
-  const payload = request as Partial<TeamCreateConfigRequest>;
-  if (typeof payload.teamName !== 'string' || payload.teamName.trim().length === 0) {
-    return { success: false, error: 'teamName is required' };
-  }
-  const teamName = payload.teamName.trim();
-  if (!isProvisioningTeamName(teamName)) {
-    return { success: false, error: 'teamName must be kebab-case [a-z0-9-], max 64 chars' };
-  }
-
-  if (!Array.isArray(payload.members)) {
-    return { success: false, error: 'members must be an array' };
-  }
-
-  if (payload.displayName !== undefined && typeof payload.displayName !== 'string') {
-    return { success: false, error: 'displayName must be a string' };
-  }
-  if (payload.description !== undefined && typeof payload.description !== 'string') {
-    return { success: false, error: 'description must be a string' };
-  }
-  if (payload.color !== undefined && typeof payload.color !== 'string') {
-    return { success: false, error: 'color must be a string' };
-  }
-  if (payload.cwd !== undefined) {
-    if (typeof payload.cwd !== 'string' || payload.cwd.trim().length === 0) {
-      return { success: false, error: 'cwd must be a non-empty string if provided' };
-    }
-    if (!path.isAbsolute(payload.cwd.trim())) {
-      return { success: false, error: 'cwd must be an absolute path' };
-    }
-  }
-  if (payload.prompt !== undefined && typeof payload.prompt !== 'string') {
-    return { success: false, error: 'prompt must be a string' };
-  }
-  const teamProviderValidation = parseOptionalTeamProviderId(payload.providerId);
-  if (!teamProviderValidation.valid) {
-    return { success: false, error: teamProviderValidation.error };
-  }
-  const effectiveTeamProviderId = teamProviderValidation.value ?? 'anthropic';
-  const providerBackendValidation = parseOptionalLaunchProviderBackendId(
-    payload.providerBackendId,
-    effectiveTeamProviderId
-  );
-  if (!providerBackendValidation.valid) {
-    return { success: false, error: providerBackendValidation.error };
-  }
-  if (payload.model !== undefined && typeof payload.model !== 'string') {
-    return { success: false, error: 'model must be a string' };
-  }
-  const effortValidation = parseOptionalTeamEffort(payload.effort, effectiveTeamProviderId);
-  if (!effortValidation.valid) {
-    return { success: false, error: effortValidation.error };
-  }
-  const fastModeValidation = parseOptionalTeamFastMode(payload.fastMode);
-  if (!fastModeValidation.valid) {
-    return { success: false, error: fastModeValidation.error };
-  }
-  if (payload.limitContext !== undefined && typeof payload.limitContext !== 'boolean') {
-    return { success: false, error: 'limitContext must be a boolean' };
-  }
-  if (payload.skipPermissions !== undefined && typeof payload.skipPermissions !== 'boolean') {
-    return { success: false, error: 'skipPermissions must be a boolean' };
-  }
-  if (payload.worktree !== undefined) {
-    if (typeof payload.worktree !== 'string') {
-      return { success: false, error: 'worktree must be a string' };
-    }
-    const worktree = payload.worktree.trim();
-    if (worktree.length > 128) {
-      return { success: false, error: 'worktree name too long (max 128)' };
-    }
-    if (worktree && !/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(worktree)) {
-      return {
-        success: false,
-        error: 'worktree name: start with alphanumeric, use [a-zA-Z0-9._-]',
-      };
-    }
-  }
-  if (payload.extraCliArgs !== undefined) {
-    if (typeof payload.extraCliArgs !== 'string') {
-      return { success: false, error: 'extraCliArgs must be a string' };
-    }
-    if (payload.extraCliArgs.length > 1024) {
-      return { success: false, error: 'extraCliArgs too long (max 1024)' };
-    }
-    const protectedFlags = extractUserFlags(payload.extraCliArgs).filter((flag) =>
-      PROTECTED_CLI_FLAGS.has(flag)
-    );
-    if (protectedFlags.length > 0) {
-      return {
-        success: false,
-        error: `extraCliArgs contains app-managed flags: ${[...new Set(protectedFlags)].join(', ')}`,
-      };
-    }
-  }
-
-  const seenNames = new Set<string>();
-  const members: TeamCreateConfigRequest['members'] = [];
-  for (const member of payload.members) {
-    if (!member || typeof member !== 'object') {
-      return { success: false, error: 'member must be object' };
-    }
-    const nameValidation = validateTeammateName((member as { name?: unknown }).name);
-    if (!nameValidation.valid) {
-      return { success: false, error: nameValidation.error ?? 'Invalid member name' };
-    }
-    const memberName = nameValidation.value!;
-    if (seenNames.has(memberName)) {
-      return { success: false, error: 'member names must be unique' };
-    }
-    seenNames.add(memberName);
-
-    const role = (member as { role?: unknown }).role;
-    if (role !== undefined && typeof role !== 'string') {
-      return { success: false, error: 'member role must be string' };
-    }
-    const workflow = (member as { workflow?: unknown }).workflow;
-    if (workflow !== undefined && typeof workflow !== 'string') {
-      return { success: false, error: 'member workflow must be string' };
-    }
-    const isolation = (member as { isolation?: unknown }).isolation;
-    if (isolation !== undefined && isolation !== 'worktree') {
-      return { success: false, error: 'member isolation must be "worktree" when provided' };
-    }
-    const providerValidation = parseOptionalMemberProviderId(
-      (member as { providerId?: unknown }).providerId
-    );
-    if (!providerValidation.valid) {
-      return { success: false, error: providerValidation.error };
-    }
-    const effectiveMemberProviderId = providerValidation.value ?? effectiveTeamProviderId;
-    const providerBackendValidation = parseOptionalProviderBackendId(
-      (member as { providerBackendId?: unknown }).providerBackendId,
-      effectiveMemberProviderId
-    );
-    if (!providerBackendValidation.valid) {
-      return { success: false, error: providerBackendValidation.error };
-    }
-    const model = (member as { model?: unknown }).model;
-    if (model !== undefined && typeof model !== 'string') {
-      return { success: false, error: 'member model must be string' };
-    }
-    const effortValidation = parseOptionalMemberEffort(
-      (member as { effort?: unknown }).effort,
-      effectiveMemberProviderId
-    );
-    if (!effortValidation.valid) {
-      return { success: false, error: effortValidation.error };
-    }
-    const fastModeValidation = parseOptionalTeamFastMode(
-      (member as { fastMode?: unknown }).fastMode
-    );
-    if (!fastModeValidation.valid) {
-      return { success: false, error: fastModeValidation.error };
-    }
-    members.push({
-      name: memberName,
-      role: typeof role === 'string' ? role.trim() : undefined,
-      workflow: typeof workflow === 'string' ? workflow.trim() : undefined,
-      isolation: isolation === 'worktree' ? ('worktree' as const) : undefined,
-      providerId: providerValidation.value,
-      providerBackendId: providerBackendValidation.value,
-      model: typeof model === 'string' ? model.trim() || undefined : undefined,
-      effort: effortValidation.value,
-      fastMode: fastModeValidation.value,
-      mcpPolicy: normalizeTeamMemberMcpPolicy((member as { mcpPolicy?: unknown }).mcpPolicy),
-    });
-  }
-
-  return wrapTeamHandler('createConfig', async () => {
-    await getTeamDataService().createTeamConfig({
-      teamName,
-      displayName: payload.displayName?.trim() || undefined,
-      description: payload.description?.trim() || undefined,
-      color: typeof payload.color === 'string' ? payload.color.trim() || undefined : undefined,
-      members,
-      cwd: typeof payload.cwd === 'string' ? payload.cwd.trim() || undefined : undefined,
-      prompt: typeof payload.prompt === 'string' ? payload.prompt.trim() || undefined : undefined,
-      providerId: teamProviderValidation.value,
-      providerBackendId: providerBackendValidation.value,
-      model: typeof payload.model === 'string' ? payload.model.trim() || undefined : undefined,
-      effort: effortValidation.value,
-      fastMode: fastModeValidation.value,
-      limitContext: typeof payload.limitContext === 'boolean' ? payload.limitContext : undefined,
-      skipPermissions:
-        typeof payload.skipPermissions === 'boolean' ? payload.skipPermissions : undefined,
-      worktree:
-        typeof payload.worktree === 'string' && payload.worktree.trim()
-          ? payload.worktree.trim()
-          : undefined,
-      extraCliArgs:
-        typeof payload.extraCliArgs === 'string' && payload.extraCliArgs.trim()
-          ? payload.extraCliArgs.trim()
-          : undefined,
-    });
-    getTeamDataWorkerClient().invalidateTeamConfig(teamName);
-  });
-}
-
 function getTeamMemberLogsFinder(): TeamMemberLogsFinder {
   if (!teamMemberLogsFinder) {
     throw new Error('Team member logs finder is not initialized');
@@ -4169,39 +3751,5 @@ async function handleDeleteTaskAttachment(
     );
     // Remove metadata from task JSON
     await getTeamDataService().removeTaskAttachment(vTeam.value!, vTask.value!, safeAttId);
-  });
-}
-
-async function handleGetSavedRequest(
-  _event: IpcMainInvokeEvent,
-  teamName: unknown
-): Promise<IpcResult<TeamCreateRequest | null>> {
-  const validated = validateTeamName(teamName);
-  if (!validated.valid) {
-    return { success: false, error: validated.error ?? 'Invalid teamName' };
-  }
-  return wrapTeamHandler('getSavedRequest', async () => {
-    return getTeamDataService().getSavedRequest(validated.value!);
-  });
-}
-
-async function handleDeleteDraft(
-  _event: IpcMainInvokeEvent,
-  teamName: unknown
-): Promise<IpcResult<void>> {
-  const validated = validateTeamName(teamName);
-  if (!validated.valid) {
-    return { success: false, error: validated.error ?? 'Invalid teamName' };
-  }
-  return wrapTeamHandler('deleteDraft', async () => {
-    // Only allow deleting draft teams (no config.json)
-    const configPath = path.join(getTeamsBasePath(), validated.value!, 'config.json');
-    try {
-      await fs.promises.access(configPath, fs.constants.F_OK);
-      throw new Error('Cannot delete draft: team has config.json (use deleteTeam instead)');
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
-    }
-    await getTeamDataService().permanentlyDeleteTeam(validated.value!);
   });
 }

--- a/src/preload/constants/ipcChannels.ts
+++ b/src/preload/constants/ipcChannels.ts
@@ -227,6 +227,12 @@ export const APP_RELAUNCH = 'app:relaunch';
 export const TEAM_LIST = 'team:list';
 
 export {
+  TEAM_CREATE_CONFIG,
+  TEAM_DELETE_DRAFT,
+  TEAM_GET_SAVED_REQUEST,
+  TEAM_UPDATE_CONFIG,
+} from '@features/team-configuration/contracts';
+export {
   TEAM_GET_DATA,
   TEAM_GET_MEMBER_ACTIVITY_META,
   TEAM_GET_MESSAGES_PAGE,
@@ -299,9 +305,6 @@ export const TEAM_PERMANENTLY_DELETE = 'team:permanentlyDeleteTeam';
 export const TEAM_ALIVE_LIST = 'team:aliveList';
 export const TEAM_STOP = 'team:stop';
 
-/** Create team config without provisioning CLI */
-export const TEAM_CREATE_CONFIG = 'team:createConfig';
-
 /** Get member subagent logs */
 export const TEAM_GET_MEMBER_LOGS = 'team:getMemberLogs';
 
@@ -316,9 +319,6 @@ export {
   TEAM_GET_TASK_LOG_STREAM,
   TEAM_GET_TASK_LOG_STREAM_SUMMARY,
 } from '@features/task-log-observability/contracts';
-
-/** Update team config (name, description) */
-export const TEAM_UPDATE_CONFIG = 'team:updateConfig';
 
 /** Get aggregated member stats */
 export const TEAM_GET_MEMBER_STATS = 'team:getMemberStats';
@@ -417,9 +417,6 @@ export {
 
 /** Validate custom CLI args against `claude --help` output */
 export const TEAM_VALIDATE_CLI_ARGS = 'team:validateCliArgs';
-
-export const TEAM_GET_SAVED_REQUEST = 'team:getSavedRequest';
-export const TEAM_DELETE_DRAFT = 'team:deleteDraft';
 
 // =============================================================================
 // Cross-Team Communication Channels

--- a/test/features/team-configuration/TeamConfigurationIpc.test.ts
+++ b/test/features/team-configuration/TeamConfigurationIpc.test.ts
@@ -1,0 +1,161 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  TEAM_CREATE_CONFIG,
+  TEAM_DELETE_DRAFT,
+  TEAM_GET_SAVED_REQUEST,
+  TEAM_UPDATE_CONFIG,
+} from '../../../src/features/team-configuration/contracts';
+import {
+  registerTeamConfigurationIpc,
+  removeTeamConfigurationIpc,
+} from '../../../src/features/team-configuration/main';
+import { createTeamConfigurationIpcHandlers } from '../../../src/features/team-configuration/main/adapters/input/ipc/createTeamConfigurationIpcHandlers';
+import { FileSystemDraftTeamConfigGuard } from '../../../src/features/team-configuration/main/infrastructure/FileSystemDraftTeamConfigGuard';
+
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryRoots.splice(0).map((root) => rm(root, { recursive: true })));
+});
+
+function createDependencies() {
+  return {
+    createConfig: { execute: vi.fn(() => Promise.resolve()) },
+    updateConfig: {
+      execute: vi.fn(() =>
+        Promise.resolve({
+          name: 'Renamed',
+          members: [],
+        })
+      ),
+    },
+    getSavedRequest: { execute: vi.fn(() => Promise.resolve(null)) },
+    deleteDraft: { execute: vi.fn(() => Promise.resolve()) },
+    logger: { error: vi.fn(), warn: vi.fn() },
+  };
+}
+
+describe('team configuration IPC', () => {
+  it('owns and removes all four channels', () => {
+    const handlers = new Map<string, unknown>();
+    const ipcMain = {
+      handle: vi.fn((channel: string, handler: unknown) => handlers.set(channel, handler)),
+      removeHandler: vi.fn((channel: string) => handlers.delete(channel)),
+    };
+
+    registerTeamConfigurationIpc(ipcMain as never, createDependencies());
+
+    expect(new Set(handlers.keys())).toEqual(
+      new Set([
+        TEAM_CREATE_CONFIG,
+        TEAM_UPDATE_CONFIG,
+        TEAM_GET_SAVED_REQUEST,
+        TEAM_DELETE_DRAFT,
+      ])
+    );
+
+    removeTeamConfigurationIpc(ipcMain as never);
+    expect(handlers.size).toBe(0);
+  });
+
+  it('normalizes create config input before invoking the use case', async () => {
+    const dependencies = createDependencies();
+    const handlers = createTeamConfigurationIpcHandlers(dependencies);
+
+    await expect(
+      handlers.createConfig({}, {
+        teamName: '  demo-team  ',
+        displayName: ' Demo ',
+        members: [{ name: ' Alice ', role: ' Engineer ' }],
+      })
+    ).resolves.toEqual({ success: true, data: undefined });
+    expect(dependencies.createConfig.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamName: 'demo-team',
+        displayName: 'Demo',
+        members: [expect.objectContaining({ name: 'Alice', role: 'Engineer' })],
+      })
+    );
+  });
+
+  it('preserves create validation errors without invoking application code', async () => {
+    const dependencies = createDependencies();
+    const handlers = createTeamConfigurationIpcHandlers(dependencies);
+
+    await expect(
+      handlers.createConfig({}, { teamName: 'demo-team', members: 'alice' })
+    ).resolves.toEqual({ success: false, error: 'members must be an array' });
+    expect(dependencies.createConfig.execute).not.toHaveBeenCalled();
+  });
+
+  it('returns saved request data and validates draft names', async () => {
+    const dependencies = createDependencies();
+    dependencies.getSavedRequest.execute.mockResolvedValueOnce({
+      teamName: 'demo-team',
+      members: [],
+    } as never);
+    const handlers = createTeamConfigurationIpcHandlers(dependencies);
+
+    await expect(handlers.getSavedRequest({}, 'demo-team')).resolves.toMatchObject({
+      success: true,
+      data: { teamName: 'demo-team' },
+    });
+    await expect(handlers.deleteDraft({}, '../demo')).resolves.toMatchObject({ success: false });
+    expect(dependencies.deleteDraft.execute).not.toHaveBeenCalled();
+  });
+
+  it('keeps application failures inside the legacy IPC result envelope', async () => {
+    const dependencies = createDependencies();
+    dependencies.deleteDraft.execute.mockRejectedValueOnce(new Error('draft delete failed'));
+    const handlers = createTeamConfigurationIpcHandlers(dependencies);
+
+    await expect(handlers.deleteDraft({}, 'demo-team')).resolves.toEqual({
+      success: false,
+      error: 'draft delete failed',
+    });
+    expect(dependencies.logger.error).toHaveBeenCalledWith(
+      '[teams:deleteDraft] draft delete failed'
+    );
+  });
+});
+
+describe('FileSystemDraftTeamConfigGuard', () => {
+  it('resolves the teams root lazily and permits a missing config', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'team-config-guard-'));
+    temporaryRoots.push(root);
+    const getTeamsRoot = vi.fn(() => root);
+    const guard = new FileSystemDraftTeamConfigGuard(getTeamsRoot);
+
+    await expect(guard.assertDraftCanBeDeleted('draft-team')).resolves.toBeUndefined();
+    expect(getTeamsRoot).toHaveBeenCalledOnce();
+  });
+
+  it('rejects deletion when config.json exists', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'team-config-guard-'));
+    temporaryRoots.push(root);
+    const teamDir = join(root, 'saved-team');
+    await mkdir(teamDir);
+    await writeFile(join(teamDir, 'config.json'), '{}');
+    const guard = new FileSystemDraftTeamConfigGuard(() => root);
+
+    await expect(guard.assertDraftCanBeDeleted('saved-team')).rejects.toThrow(
+      'Cannot delete draft: team has config.json (use deleteTeam instead)'
+    );
+  });
+
+  it('does not treat non-ENOENT filesystem failures as a draft', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'team-config-guard-'));
+    temporaryRoots.push(root);
+    const blocker = join(root, 'not-a-directory');
+    await writeFile(blocker, 'blocked');
+    const guard = new FileSystemDraftTeamConfigGuard(() => blocker);
+
+    await expect(guard.assertDraftCanBeDeleted('draft-team')).rejects.toMatchObject({
+      code: 'ENOTDIR',
+    });
+  });
+});

--- a/test/features/team-configuration/core/TeamConfigurationUseCases.test.ts
+++ b/test/features/team-configuration/core/TeamConfigurationUseCases.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { CreateTeamConfigUseCase } from '../../../../src/features/team-configuration/core/application/use-cases/CreateTeamConfigUseCase';
+import { DeleteDraftTeamUseCase } from '../../../../src/features/team-configuration/core/application/use-cases/DeleteDraftTeamUseCase';
+import { GetSavedTeamRequestUseCase } from '../../../../src/features/team-configuration/core/application/use-cases/GetSavedTeamRequestUseCase';
+import { UpdateTeamConfigUseCase } from '../../../../src/features/team-configuration/core/application/use-cases/UpdateTeamConfigUseCase';
+
+function createRepository() {
+  return {
+    createTeamConfig: vi.fn(() => Promise.resolve()),
+    getSavedRequest: vi.fn(() => Promise.resolve(null)),
+    getTeamDisplayName: vi.fn(() => Promise.resolve('Old Name')),
+    permanentlyDeleteTeam: vi.fn(() => Promise.resolve()),
+    updateConfig: vi.fn(() =>
+      Promise.resolve({
+        name: 'New Name',
+        members: [],
+      })
+    ),
+  };
+}
+
+describe('team configuration use cases', () => {
+  it('invalidates the worker cache only after config creation succeeds', async () => {
+    const repository = createRepository();
+    const cache = { invalidateTeamConfig: vi.fn() };
+    const useCase = new CreateTeamConfigUseCase({ repository, cache });
+
+    await useCase.execute({ teamName: 'demo-team', members: [] });
+    expect(cache.invalidateTeamConfig).toHaveBeenCalledWith('demo-team');
+
+    repository.createTeamConfig.mockRejectedValueOnce(new Error('write failed'));
+    cache.invalidateTeamConfig.mockClear();
+    await expect(useCase.execute({ teamName: 'demo-team', members: [] })).rejects.toThrow(
+      'write failed'
+    );
+    expect(cache.invalidateTeamConfig).not.toHaveBeenCalled();
+  });
+
+  it('notifies a live lead after a rename and then invalidates the cache', async () => {
+    const order: string[] = [];
+    const repository = createRepository();
+    repository.updateConfig.mockImplementationOnce(async () => {
+      order.push('update');
+      return { name: 'New Name', members: [] };
+    });
+    const runtime = { isTeamAlive: vi.fn(() => true) };
+    const messaging = {
+      sendMessageToTeam: vi.fn(async () => {
+        order.push('notify');
+      }),
+    };
+    const cache = {
+      invalidateTeamConfig: vi.fn(() => {
+        order.push('invalidate');
+      }),
+    };
+    const logger = { error: vi.fn(), warn: vi.fn() };
+    const useCase = new UpdateTeamConfigUseCase({
+      repository,
+      runtime,
+      messaging,
+      cache,
+      logger,
+    });
+
+    await useCase.execute('demo-team', { name: ' New Name ' });
+
+    expect(messaging.sendMessageToTeam).toHaveBeenCalledWith(
+      'demo-team',
+      'The team has been renamed to "New Name". Please use this name when referring to the team going forward.'
+    );
+    expect(order).toEqual(['update', 'notify', 'invalidate']);
+  });
+
+  it('keeps rename notification best-effort and returns the updated config', async () => {
+    const repository = createRepository();
+    const runtime = { isTeamAlive: vi.fn(() => true) };
+    const messaging = {
+      sendMessageToTeam: vi.fn(() => Promise.reject(new Error('offline'))),
+    };
+    const cache = { invalidateTeamConfig: vi.fn() };
+    const logger = { error: vi.fn(), warn: vi.fn() };
+    const useCase = new UpdateTeamConfigUseCase({
+      repository,
+      runtime,
+      messaging,
+      cache,
+      logger,
+    });
+
+    await expect(useCase.execute('demo-team', { name: 'New Name' })).resolves.toMatchObject({
+      name: 'New Name',
+    });
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Failed to notify lead about team rename for demo-team'
+    );
+    expect(cache.invalidateTeamConfig).toHaveBeenCalledWith('demo-team');
+  });
+
+  it('does not notify an offline lead when display-name lookup falls back', async () => {
+    const repository = createRepository();
+    repository.getTeamDisplayName.mockRejectedValueOnce(new Error('display read failed'));
+    const runtime = { isTeamAlive: vi.fn(() => false) };
+    const messaging = { sendMessageToTeam: vi.fn(() => Promise.resolve()) };
+    const cache = { invalidateTeamConfig: vi.fn() };
+    const useCase = new UpdateTeamConfigUseCase({
+      repository,
+      runtime,
+      messaging,
+      cache,
+      logger: { error: vi.fn(), warn: vi.fn() },
+    });
+
+    await useCase.execute('demo-team', { name: 'Renamed Team' });
+
+    expect(runtime.isTeamAlive).toHaveBeenCalledWith('demo-team');
+    expect(messaging.sendMessageToTeam).not.toHaveBeenCalled();
+    expect(cache.invalidateTeamConfig).toHaveBeenCalledWith('demo-team');
+  });
+
+  it('does not invalidate when the config is missing', async () => {
+    const repository = createRepository();
+    repository.updateConfig.mockResolvedValueOnce(null as never);
+    const cache = { invalidateTeamConfig: vi.fn() };
+    const useCase = new UpdateTeamConfigUseCase({
+      repository,
+      runtime: { isTeamAlive: vi.fn(() => true) },
+      messaging: { sendMessageToTeam: vi.fn(() => Promise.resolve()) },
+      cache,
+      logger: { error: vi.fn(), warn: vi.fn() },
+    });
+
+    await expect(useCase.execute('demo-team', { name: 'New Name' })).rejects.toThrow(
+      'Team config not found'
+    );
+    expect(cache.invalidateTeamConfig).not.toHaveBeenCalled();
+  });
+
+  it('checks draft eligibility before permanent deletion', async () => {
+    const order: string[] = [];
+    const repository = createRepository();
+    repository.permanentlyDeleteTeam.mockImplementationOnce(async () => {
+      order.push('delete');
+    });
+    const draftGuard = {
+      assertDraftCanBeDeleted: vi.fn(async () => {
+        order.push('guard');
+      }),
+    };
+    const useCase = new DeleteDraftTeamUseCase({ repository, draftGuard });
+
+    await useCase.execute('draft-team');
+    expect(order).toEqual(['guard', 'delete']);
+  });
+
+  it('does not delete when the draft guard rejects', async () => {
+    const repository = createRepository();
+    const draftGuard = {
+      assertDraftCanBeDeleted: vi.fn(() => Promise.reject(new Error('config exists'))),
+    };
+    const useCase = new DeleteDraftTeamUseCase({ repository, draftGuard });
+
+    await expect(useCase.execute('saved-team')).rejects.toThrow('config exists');
+    expect(repository.permanentlyDeleteTeam).not.toHaveBeenCalled();
+  });
+
+  it('returns the saved request through the repository capability', async () => {
+    const repository = createRepository();
+    repository.getSavedRequest.mockResolvedValueOnce({
+      teamName: 'draft-team',
+      members: [],
+    } as never);
+    const useCase = new GetSavedTeamRequestUseCase(repository);
+
+    await expect(useCase.execute('draft-team')).resolves.toMatchObject({
+      teamName: 'draft-team',
+    });
+    expect(repository.getSavedRequest).toHaveBeenCalledWith('draft-team');
+  });
+});

--- a/test/features/team-configuration/core/teamRuntimeSelectionValidation.test.ts
+++ b/test/features/team-configuration/core/teamRuntimeSelectionValidation.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isProvisioningTeamName,
+  parseOptionalLaunchProviderBackendId,
+  parseOptionalMemberEffort,
+  parseOptionalMemberProviderId,
+  parseOptionalProviderBackendId,
+  parseOptionalTeamEffort,
+  parseOptionalTeamFastMode,
+  parseOptionalTeamProviderId,
+} from '../../../../src/features/team-configuration';
+
+describe('team runtime selection validation', () => {
+  it.each([
+    ['demo-team', true],
+    ['team1', true],
+    ['', false],
+    ['Uppercase', false],
+    ['bad_team', false],
+    ['-leading', false],
+    [`a${'b'.repeat(64)}`, false],
+  ])('validates provisioning team name %j', (teamName, expected) => {
+    expect(isProvisioningTeamName(teamName)).toBe(expected);
+  });
+
+  it.each([undefined, null, ''])('normalizes empty provider value %j', (value) => {
+    expect(parseOptionalTeamProviderId(value)).toEqual({ valid: true, value: undefined });
+    expect(parseOptionalMemberProviderId(value)).toEqual({ valid: true, value: undefined });
+  });
+
+  it('preserves exact provider validation errors', () => {
+    expect(parseOptionalTeamProviderId('unknown')).toEqual({
+      valid: false,
+      error: 'providerId must be anthropic, codex, gemini, or opencode',
+    });
+    expect(parseOptionalMemberProviderId('unknown')).toEqual({
+      valid: false,
+      error: 'member providerId must be anthropic, codex, gemini, or opencode',
+    });
+    expect(parseOptionalTeamProviderId('codex')).toEqual({ valid: true, value: 'codex' });
+  });
+
+  it('validates and migrates provider-specific backend values', () => {
+    expect(parseOptionalProviderBackendId(' codex-native ', 'codex')).toEqual({
+      valid: true,
+      value: 'codex-native',
+    });
+    expect(parseOptionalProviderBackendId('auto')).toEqual({ valid: true, value: 'auto' });
+    expect(parseOptionalProviderBackendId('opencode-cli', 'codex')).toEqual({
+      valid: false,
+      error:
+        'providerBackendId must be valid for the selected provider (auto, adapter, api, cli-sdk, codex-native, or opencode-cli)',
+    });
+    expect(parseOptionalProviderBackendId(42, 'codex')).toEqual({
+      valid: false,
+      error: 'providerBackendId must be a string',
+    });
+  });
+
+  it('drops a known stale launch backend while rejecting unknown values', () => {
+    expect(parseOptionalLaunchProviderBackendId('codex-native', 'anthropic')).toEqual({
+      valid: true,
+      value: undefined,
+    });
+    expect(parseOptionalLaunchProviderBackendId('unknown', 'anthropic')).toEqual({
+      valid: false,
+      error:
+        'providerBackendId must be valid for the selected provider (auto, adapter, api, cli-sdk, codex-native, or opencode-cli)',
+    });
+  });
+
+  it('validates effort against the selected provider', () => {
+    expect(parseOptionalMemberEffort('xhigh', 'codex')).toEqual({ valid: true, value: 'xhigh' });
+    expect(parseOptionalTeamEffort('max', 'anthropic')).toEqual({ valid: true, value: 'max' });
+    expect(parseOptionalMemberEffort('none', 'codex')).toMatchObject({
+      valid: false,
+      error: expect.stringContaining('member effort must be one of'),
+    });
+    expect(parseOptionalTeamEffort('invalid', 'anthropic')).toMatchObject({
+      valid: false,
+      error: expect.stringContaining('effort must be one of'),
+    });
+  });
+
+  it.each(['inherit', 'on', 'off'] as const)('accepts fast mode %s', (value) => {
+    expect(parseOptionalTeamFastMode(value)).toEqual({ valid: true, value });
+  });
+
+  it('normalizes empty fast mode and preserves its exact error', () => {
+    expect(parseOptionalTeamFastMode('')).toEqual({ valid: true, value: undefined });
+    expect(parseOptionalTeamFastMode('fast')).toEqual({
+      valid: false,
+      error: 'fastMode must be one of inherit, on, or off',
+    });
+  });
+});

--- a/test/features/team-configuration/core/teamRuntimeSelectionValidation.test.ts
+++ b/test/features/team-configuration/core/teamRuntimeSelectionValidation.test.ts
@@ -19,6 +19,7 @@ describe('team runtime selection validation', () => {
     ['Uppercase', false],
     ['bad_team', false],
     ['-leading', false],
+    [`a${'b'.repeat(63)}`, true],
     [`a${'b'.repeat(64)}`, false],
   ])('validates provisioning team name %j', (teamName, expected) => {
     expect(isProvisioningTeamName(teamName)).toBe(expected);
@@ -59,6 +60,10 @@ describe('team runtime selection validation', () => {
   });
 
   it('drops a known stale launch backend while rejecting unknown values', () => {
+    expect(parseOptionalLaunchProviderBackendId('codex-native', 'codex')).toEqual({
+      valid: true,
+      value: 'codex-native',
+    });
     expect(parseOptionalLaunchProviderBackendId('codex-native', 'anthropic')).toEqual({
       valid: true,
       value: undefined,

--- a/test/main/ipc/teams.test.ts
+++ b/test/main/ipc/teams.test.ts
@@ -134,6 +134,11 @@ vi.mock('@main/services/team/AutoResumeService', async (importOriginal) => {
 });
 
 import {
+  createTeamConfigurationFeature,
+  registerTeamConfigurationIpc,
+  removeTeamConfigurationIpc,
+} from '../../../src/features/team-configuration/main';
+import {
   type CanonicalListTeamLifecycleResult,
   TEAM_LIFECYCLE_READ_SCHEMA_VERSION,
 } from '../../../src/features/team-lifecycle';
@@ -352,10 +357,18 @@ const TEAM_VIEW_READ_MODEL_HANDLER_KEYS = [
   TEAM_GET_MEMBER_ACTIVITY_META,
 ] as const;
 const TEAM_VIEW_READ_MODEL_HANDLER_KEY_SET = new Set<string>(TEAM_VIEW_READ_MODEL_HANDLER_KEYS);
+const TEAM_CONFIGURATION_HANDLER_KEYS = [
+  TEAM_CREATE_CONFIG,
+  TEAM_UPDATE_CONFIG,
+  TEAM_GET_SAVED_REQUEST,
+  TEAM_DELETE_DRAFT,
+] as const;
+const TEAM_CONFIGURATION_HANDLER_KEY_SET = new Set<string>(TEAM_CONFIGURATION_HANDLER_KEYS);
 const TEAM_HANDLER_KEYS = ALL_TEAM_HANDLER_KEYS.filter(
   (channel) =>
     !TEAM_TASK_BOARD_HANDLER_KEY_SET.has(channel) &&
-    !TEAM_VIEW_READ_MODEL_HANDLER_KEY_SET.has(channel)
+    !TEAM_VIEW_READ_MODEL_HANDLER_KEY_SET.has(channel) &&
+    !TEAM_CONFIGURATION_HANDLER_KEY_SET.has(channel)
 );
 
 describe('ipc teams handlers', () => {
@@ -373,6 +386,7 @@ describe('ipc teams handlers', () => {
     warn: vi.fn(),
   };
   const teamViewReadModelLogger = createLogger('IPC:teams');
+  const teamConfigurationLogger = createLogger('IPC:teams');
   let launchIoGovernor: LaunchIoGovernor;
 
   const service = {
@@ -747,6 +761,13 @@ describe('ipc teams handlers', () => {
       launchIoGovernor
     );
     registerTeamHandlers(ipcMain as never);
+    const teamConfigurationFeature = createTeamConfigurationFeature({
+      repository: service as never,
+      runtime: teamHandlerApis.runtime,
+      messaging: teamHandlerApis.messaging,
+      logger: teamConfigurationLogger,
+    });
+    registerTeamConfigurationIpc(ipcMain as never, teamConfigurationFeature);
     const teamViewReadModelFeature = createTeamViewReadModelFeature({
       data: service as never,
       provisioningRuns: teamHandlerApis.provisioningRun,
@@ -790,6 +811,9 @@ describe('ipc teams handlers', () => {
       expect(legacyChannels.has(channel)).toBe(false);
     }
     for (const channel of TEAM_VIEW_READ_MODEL_HANDLER_KEYS) {
+      expect(legacyChannels.has(channel)).toBe(false);
+    }
+    for (const channel of TEAM_CONFIGURATION_HANDLER_KEYS) {
       expect(legacyChannels.has(channel)).toBe(false);
     }
   });
@@ -5327,6 +5351,7 @@ describe('ipc teams handlers', () => {
 
   it('removes all expected handlers', () => {
     removeTeamHandlers(ipcMain as never);
+    removeTeamConfigurationIpc(ipcMain as never);
     removeTeamViewReadModelIpc(ipcMain as never);
     removeTeamTaskBoardIpc(ipcMain as never);
     expect(ipcMain.removeHandler).toHaveBeenCalledTimes(ALL_TEAM_HANDLER_KEYS.length);

--- a/test/preload/electronApiTeamConfiguration.test.ts
+++ b/test/preload/electronApiTeamConfiguration.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ElectronAPI } from '@shared/types/api';
+
+const mocks = vi.hoisted(() => ({
+  contextBridge: { exposeInMainWorld: vi.fn() },
+  ipcRenderer: { invoke: vi.fn(), on: vi.fn(), send: vi.fn() },
+  webUtils: { getPathForFile: vi.fn() },
+}));
+
+vi.mock('electron', () => ({
+  contextBridge: mocks.contextBridge,
+  ipcRenderer: mocks.ipcRenderer,
+  webUtils: mocks.webUtils,
+}));
+
+function getElectronApi(): ElectronAPI {
+  const call = mocks.contextBridge.exposeInMainWorld.mock.calls.find(
+    ([name]) => name === 'electronAPI'
+  );
+  if (!call) throw new Error('Expected electronAPI to be exposed in preload');
+  return call[1] as ElectronAPI;
+}
+
+describe('preload team configuration wiring', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    delete (window as Window & { __SENTRY_IPC__?: unknown }).__SENTRY_IPC__;
+    mocks.contextBridge.exposeInMainWorld.mockClear();
+    mocks.ipcRenderer.invoke.mockReset();
+    mocks.ipcRenderer.invoke.mockResolvedValue({ success: true, data: null });
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('keeps channel names and argument order stable', async () => {
+    await import('../../src/preload/index');
+    const teams = getElectronApi().teams;
+    const createRequest = { teamName: 'demo-team', members: [] };
+    const updates = { name: 'Demo Team', description: 'Updated' };
+
+    await teams.createConfig(createRequest);
+    await teams.updateConfig('demo-team', updates);
+    await teams.getSavedRequest('demo-team');
+    await teams.deleteDraft('demo-team');
+
+    expect(mocks.ipcRenderer.invoke.mock.calls).toEqual([
+      ['team:createConfig', createRequest],
+      ['team:updateConfig', 'demo-team', updates],
+      ['team:getSavedRequest', 'demo-team'],
+      ['team:deleteDraft', 'demo-team'],
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- extract team configuration IPC into a dedicated feature boundary
- split create, update, saved-request, and draft-deletion capabilities behind narrow ports
- keep legacy IPC channels, argument order, validation order, defaults, notifications, and cache timing unchanged
- reduce src/main/ipc/teams.ts from 4207 to 3755 physical lines

## Architecture

- browser-safe contracts and pure runtime selection policy
- application use cases depend on capability-specific ports
- filesystem draft safety stays in main infrastructure
- explicit main-process composition and preload contract coverage
- HTTP behavior remains unchanged because its route normalization is intentionally not equivalent to desktop IPC

## Verification

- pnpm typecheck
- pnpm lint:fast:files on the full PR scope
- full type-aware ESLint on changed source
- pnpm build
- renderer bundle guard
- 240 focused tests
- 348 architecture tests passed, 10 platform-specific tests skipped

No agent launch, provisioning, terminal runtime, or task smoke was run in this slice. The required desktop E2E gate will run on a fresh sandbox project after the complete teams.ts target is below 800 lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added team configuration support for creating and updating configurations, retrieving saved requests, and deleting eligible drafts.
  * Added validation and normalization for team names, providers, effort levels, fast mode, members, and related settings.
  * Added cache invalidation after successful configuration changes.
  * Added live-team rename notifications when applicable.
* **Documentation**
  * Added documentation covering team configuration capabilities and supported entry points.
* **Bug Fixes**
  * Prevented deletion of configured teams and improved failure handling for invalid requests.
* **Tests**
  * Added IPC, use-case, and validation/guard test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-router-summary:start -->
## Summary

- update 5 test files
- adds source implementation in TEAM_CREATE_CONFIG, TEAM_UPDATE_CONFIG
- adds source implementation in index
- adds TeamConfigurationPorts: changes fallback/null handling, external request handling
- touch 26 files (22 added, 4 modified) with +1341/-473 lines

## Tests

- changed test file: `test/features/team-configuration/TeamConfigurationIpc.test.ts`
- changed test file: `test/features/team-configuration/core/TeamConfigurationUseCases.test.ts`
- changed test file: `test/features/team-configuration/core/teamRuntimeSelectionValidation.test.ts`
- changed test file: `test/main/ipc/teams.test.ts`
- changed test file: `test/preload/electronApiTeamConfiguration.test.ts`

<details>
<summary>📒 Files selected for processing (26)</summary>

* `src/features/team-configuration/README.md`
* `src/features/team-configuration/contracts/channels.ts`
* `src/features/team-configuration/contracts/index.ts`
* `src/features/team-configuration/core/application/ports/TeamConfigurationPorts.ts`
* `src/features/team-configuration/core/application/use-cases/CreateTeamConfigUseCase.ts`
* `src/features/team-configuration/core/application/use-cases/DeleteDraftTeamUseCase.ts`
* `src/features/team-configuration/core/application/use-cases/GetSavedTeamRequestUseCase.ts`
* `src/features/team-configuration/core/application/use-cases/UpdateTeamConfigUseCase.ts`
* `src/features/team-configuration/core/domain/teamRuntimeSelectionValidation.ts`
* `src/features/team-configuration/index.ts`
* `src/features/team-configuration/main/adapters/input/ipc/TeamConfigurationIpcDependencies.ts`
* `src/features/team-configuration/main/adapters/input/ipc/createTeamConfigurationIpcHandlers.ts`
* `src/features/team-configuration/main/adapters/input/ipc/normalizeCreateTeamConfigRequest.ts`
* `src/features/team-configuration/main/adapters/input/ipc/registerTeamConfigurationIpc.ts`
* `src/features/team-configuration/main/adapters/output/TeamDataWorkerConfigCache.ts`
* `src/features/team-configuration/main/composition/createTeamConfigurationFeature.ts`
* `src/features/team-configuration/main/index.ts`
* `src/features/team-configuration/main/infrastructure/FileSystemDraftTeamConfigGuard.ts`
* `src/main/ipc/handlers.ts`
* `src/main/ipc/teams.ts`
* `src/preload/constants/ipcChannels.ts`
* `test/features/team-configuration/TeamConfigurationIpc.test.ts`
* `test/features/team-configuration/core/TeamConfigurationUseCases.test.ts`
* `test/features/team-configuration/core/teamRuntimeSelectionValidation.test.ts`
* `test/main/ipc/teams.test.ts`
* `test/preload/electronApiTeamConfiguration.test.ts`

</details>

<details>
<summary>📝 Walkthrough</summary>

## Walkthrough

This PR updates 26 files across 20 source, 5 tests, 1 documentation. The generated summary is based on the GitHub pull request file list and diff metadata, and the author's description above is preserved.

## Changes

| Cohort / File(s) | Summary |
|---|---|
| **Source** <br> `src/features/team-configuration/contracts/channels.ts`<br>`src/features/team-configuration/contracts/index.ts`<br>`src/features/team-configuration/core/application/ports/TeamConfigurationPorts.ts`<br>`src/features/team-configuration/core/application/use-cases/CreateTeamConfigUseCase.ts`<br>`src/features/team-configuration/core/application/use-cases/DeleteDraftTeamUseCase.ts`<br>and 15 more | Adds source implementation in TEAM_CREATE_CONFIG, TEAM_UPDATE_CONFIG.<br>Adds source implementation in index.<br>Adds TeamConfigurationPorts: changes fallback/null handling, external request handling.<br>Also updates 17 more files.<br>Line stats: 17 added, 3 modified; +797/-472. |
| **Tests** <br> `test/features/team-configuration/TeamConfigurationIpc.test.ts`<br>`test/features/team-configuration/core/TeamConfigurationUseCases.test.ts`<br>`test/features/team-configuration/core/teamRuntimeSelectionValidation.test.ts`<br>`test/main/ipc/teams.test.ts`<br>`test/preload/electronApiTeamConfiguration.test.ts` | Adds test coverage for createDependencies, team configuration IPC.<br>Adds test coverage for createRepository, team configuration use cases.<br>Adds test coverage for team runtime selection validation, preserves exact provider validation errors.<br>Also updates 2 more files.<br>Line stats: 4 added, 1 modified; +529/-1. |
| **Documentation** <br> `src/features/team-configuration/README.md` | Adds documentation for Team Configuration.<br>Line stats: 1 added; +15/-0. |

</details>
<!-- review-router-summary:end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts the four team-configuration IPC handlers (`TEAM_CREATE_CONFIG`, `TEAM_UPDATE_CONFIG`, `TEAM_GET_SAVED_REQUEST`, `TEAM_DELETE_DRAFT`) from the monolithic `src/main/ipc/teams.ts` into a dedicated `src/features/team-configuration` feature boundary following the same hexagonal-architecture pattern already used by team-approvals and team-task-board.

- All validation, normalization, rename-notify ordering, and cache-invalidation logic are faithfully ported; the old handler code and the new equivalents produce identical behaviour on all inputs covered by the 240+ tests.
- The domain module (`teamRuntimeSelectionValidation.ts`) and input adapter (`normalizeCreateTeamConfigRequest.ts`) are now independently testable browser-safe code; `FileSystemDraftTeamConfigGuard` keeps the filesystem concern in main infrastructure.
- `src/main/ipc/teams.ts` drops ~450 lines with no functional change to the remaining handlers.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a pure structural extraction with no behavioural changes to any handler.

Every changed path is a direct port of existing code with matching validation order, error shapes, cache timing, and rename-notify logic. The four channels are registered in exactly one place after the change, with no double-registration window. The pre-existing silent discard of TeamUpdateConfigRequest.language does not affect runtime correctness for the three fields that are actually handled.

No files require special attention — the most important paths (normalizeCreateTeamConfigRequest, UpdateTeamConfigUseCase, FileSystemDraftTeamConfigGuard) all have focused tests that exercise their critical branches.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/features/team-configuration/core/domain/teamRuntimeSelectionValidation.ts | New domain module extracting provider/effort/fast-mode validation helpers from teams.ts; all logic faithfully ported with matching return shapes. |
| src/features/team-configuration/main/adapters/input/ipc/normalizeCreateTeamConfigRequest.ts | Extracted create-config normalization into its own file; logic is a line-for-line match to the deleted handleCreateConfig body including provider defaulting and member iteration. |
| src/features/team-configuration/main/adapters/input/ipc/createTeamConfigurationIpcHandlers.ts | New IPC handler factory covering create, update, getSavedRequest, and deleteDraft; validation order and error shape match the removed handlers. |
| src/features/team-configuration/core/application/use-cases/UpdateTeamConfigUseCase.ts | Ports the rename-notify + cache-invalidate logic from the old handler; ordering (update → notify → invalidate) is preserved and tested. |
| src/features/team-configuration/main/infrastructure/FileSystemDraftTeamConfigGuard.ts | Guards draft deletion by checking for config.json; error-routing logic (ENOENT → allow, other → rethrow, success → block) is correct and tested against real temp dirs. |
| src/features/team-configuration/main/composition/createTeamConfigurationFeature.ts | Factory wires four use-cases with optional cache and draftGuard overrides for testing; clean DI composition. |
| src/main/ipc/handlers.ts | Adds feature construction and register/remove calls for the new boundary; the four channels are no longer registered by registerTeamHandlers so there is no double-registration risk. |
| src/main/ipc/teams.ts | Removes 452 lines (handleCreateConfig, handleUpdateConfig, handleGetSavedRequest, handleDeleteDraft and their local helpers), imports validation from the new feature boundary. |
| src/features/team-configuration/core/application/use-cases/DeleteDraftTeamUseCase.ts | Delegates draft-deletion eligibility to the guard port before calling permanentlyDeleteTeam, enforcing the correct check → delete ordering. |
| test/features/team-configuration/TeamConfigurationIpc.test.ts | Integration tests covering channel registration, input normalization, guard behavior via temp dirs, and error propagation; solid coverage. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant R as Renderer
    participant IPC as registerTeamConfigurationIpc
    participant H as createTeamConfigurationIpcHandlers
    participant N as normalizeCreateTeamConfigRequest
    participant UC as Use Cases
    participant Repo as TeamDataService
    participant Cache as TeamDataWorkerConfigCache
    participant Guard as FileSystemDraftTeamConfigGuard

    R->>IPC: TEAM_CREATE_CONFIG(payload)
    IPC->>H: handlers.createConfig
    H->>N: normalizeCreateTeamConfigRequest(payload)
    N-->>H: "{valid, value}"
    H->>UC: CreateTeamConfigUseCase.execute(request)
    UC->>Repo: createTeamConfig(request)
    UC->>Cache: invalidateTeamConfig(teamName)
    UC-->>H: void
    H-->>R: "{success:true}"

    R->>IPC: TEAM_UPDATE_CONFIG(teamName, updates)
    IPC->>H: handlers.updateConfig
    H->>UC: "UpdateTeamConfigUseCase.execute(teamName, {name,description,color})"
    UC->>Repo: getTeamDisplayName(teamName)
    UC->>Repo: updateConfig(teamName, updates)
    opt team is alive and name changed
        UC->>Repo: sendMessageToTeam(teamName, renameMsg)
    end
    UC->>Cache: invalidateTeamConfig(teamName)
    UC-->>H: TeamConfig
    H-->>R: "{success:true, data:TeamConfig}"

    R->>IPC: TEAM_DELETE_DRAFT(teamName)
    IPC->>H: handlers.deleteDraft
    H->>UC: DeleteDraftTeamUseCase.execute(teamName)
    UC->>Guard: assertDraftCanBeDeleted(teamName)
    Guard->>Guard: "fs.access(config.json) — ENOENT=safe"
    Guard-->>UC: void or throws
    UC->>Repo: permanentlyDeleteTeam(teamName)
    H-->>R: "{success:true}"
```

<sub>Reviews (2): Last reviewed commit: ["test(team-configuration): cover validati..."](https://github.com/777genius/agent-teams-ai/commit/87919f18e3bd72e621268ef64bce0e05c2a7f7d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46534475)</sub>

<!-- /greptile_comment -->