### PR TITLE
refactor(change-review): isolate scope lifecycle

### DIFF
--- a/src/features/change-review/README.md
+++ b/src/features/change-review/README.md
@@ -4,9 +4,11 @@ This is a thin renderer feature extracted incrementally from the legacy
 `ChangeReviewDialog` shell.
 
 - `renderer/view-models` owns pure presentation projections.
+- `renderer/utils` owns pure scope and operation-generation policies.
+- `renderer/hooks` owns scope projection and lifecycle orchestration through narrow ports.
 - `renderer/ui` owns store-free presentation components.
-- The legacy dialog temporarily retains Zustand, IPC, editor, and lifecycle
-  orchestration while later slices move those responsibilities behind focused
-  hooks and use cases.
+- The legacy dialog temporarily retains Zustand, IPC, editor, mutation, persistence,
+  and close-flush orchestration while later slices move those responsibilities behind
+  focused hooks and use cases.
 
 Production callers import through `@features/change-review/renderer`.

--- a/src/features/change-review/renderer/hooks/useChangeReviewLifecycleRegistration.ts
+++ b/src/features/change-review/renderer/hooks/useChangeReviewLifecycleRegistration.ts
@@ -1,0 +1,74 @@
+import { useEffect, useLayoutEffect } from 'react';
+
+import type {
+  RegisterChangeReviewAppCloseParticipant,
+  RegisterChangeReviewLifecycleOwner,
+} from '../ports/changeReviewLifecyclePorts';
+import type { AppCloseParticipant } from '@features/app-close-coordination/renderer';
+
+interface UseChangeReviewLifecycleRegistrationInput {
+  open: boolean;
+  authorized: boolean;
+  hostId: string;
+  sessionId: string;
+  tabId?: string;
+  focus?: () => void;
+  requestClose: () => Promise<boolean>;
+  closeRejectedDialog: () => void;
+  setAuthorized: (authorized: boolean) => void;
+  appCloseParticipantId: string;
+  flushForAppClose: AppCloseParticipant;
+  registerOwner: RegisterChangeReviewLifecycleOwner;
+  registerAppCloseParticipant: RegisterChangeReviewAppCloseParticipant;
+}
+
+export function useChangeReviewLifecycleRegistration({
+  open,
+  authorized,
+  hostId,
+  sessionId,
+  tabId,
+  focus,
+  requestClose,
+  closeRejectedDialog,
+  setAuthorized,
+  appCloseParticipantId,
+  flushForAppClose,
+  registerOwner,
+  registerAppCloseParticipant,
+}: UseChangeReviewLifecycleRegistrationInput): void {
+  useLayoutEffect(() => {
+    if (!open) {
+      setAuthorized(false);
+      return;
+    }
+    const registration = registerOwner({
+      hostId,
+      sessionId,
+      tabId,
+      requestClose,
+      focus,
+    });
+    setAuthorized(registration.accepted);
+    if (!registration.accepted) closeRejectedDialog();
+    return () => {
+      registration.unregister();
+      setAuthorized(false);
+    };
+  }, [
+    closeRejectedDialog,
+    focus,
+    hostId,
+    open,
+    registerOwner,
+    requestClose,
+    sessionId,
+    setAuthorized,
+    tabId,
+  ]);
+
+  useEffect(() => {
+    if (!open || !authorized) return;
+    return registerAppCloseParticipant(appCloseParticipantId, flushForAppClose);
+  }, [appCloseParticipantId, authorized, flushForAppClose, open, registerAppCloseParticipant]);
+}

--- a/src/features/change-review/renderer/hooks/useChangeReviewOperationGeneration.ts
+++ b/src/features/change-review/renderer/hooks/useChangeReviewOperationGeneration.ts
@@ -1,0 +1,58 @@
+import { useCallback, useLayoutEffect, useRef } from 'react';
+
+import {
+  createReviewOperationScopeToken,
+  isReviewOperationScopeCurrent,
+  type ReviewOperationScopeToken,
+} from '../utils/reviewOperationGeneration';
+
+interface UseChangeReviewOperationGenerationInput {
+  active: boolean;
+  decisionHydrationKey: string | null;
+  fallbackScopeKey: string;
+  changeSetEpoch: number;
+  resetGenerationState: () => void;
+}
+
+interface ChangeReviewOperationGeneration {
+  captureReviewOperationScope: () => ReviewOperationScopeToken | null;
+  isCurrentReviewOperationScope: (
+    operationScope: ReviewOperationScopeToken | null
+  ) => operationScope is ReviewOperationScopeToken;
+}
+
+export function useChangeReviewOperationGeneration({
+  active,
+  decisionHydrationKey,
+  fallbackScopeKey,
+  changeSetEpoch,
+  resetGenerationState,
+}: UseChangeReviewOperationGenerationInput): ChangeReviewOperationGeneration {
+  const operationScopeRef = useRef<ReviewOperationScopeToken | null>(null);
+
+  useLayoutEffect(() => {
+    const activeScopeKey = active ? (decisionHydrationKey ?? fallbackScopeKey) : null;
+    const operationScope = activeScopeKey ? createReviewOperationScopeToken(activeScopeKey) : null;
+    operationScopeRef.current = operationScope;
+    resetGenerationState();
+    return () => {
+      if (operationScopeRef.current === operationScope) {
+        operationScopeRef.current = null;
+      }
+    };
+  }, [active, changeSetEpoch, decisionHydrationKey, fallbackScopeKey, resetGenerationState]);
+
+  const captureReviewOperationScope = useCallback((): ReviewOperationScopeToken | null => {
+    return operationScopeRef.current;
+  }, []);
+
+  const isCurrentReviewOperationScope = useCallback(
+    (
+      operationScope: ReviewOperationScopeToken | null
+    ): operationScope is ReviewOperationScopeToken =>
+      isReviewOperationScopeCurrent(operationScopeRef.current, operationScope),
+    []
+  );
+
+  return { captureReviewOperationScope, isCurrentReviewOperationScope };
+}

--- a/src/features/change-review/renderer/hooks/useChangeReviewScopeIdentity.ts
+++ b/src/features/change-review/renderer/hooks/useChangeReviewScopeIdentity.ts
@@ -1,0 +1,45 @@
+import { useMemo } from 'react';
+
+import {
+  buildChangeReviewScopeProjection,
+  type BuildChangeReviewScopeProjectionInput,
+  type ChangeReviewScopeProjection,
+} from '../utils/changeReviewScope';
+
+export function useChangeReviewScopeIdentity({
+  activeChangeSet,
+  decisionHydrationScopeKey,
+  decisionHydrationStatus,
+  draftHistoryHydration,
+  memberName,
+  mode,
+  taskChangeRequestOptions,
+  taskId,
+  teamName,
+}: BuildChangeReviewScopeProjectionInput): ChangeReviewScopeProjection {
+  return useMemo(
+    () =>
+      buildChangeReviewScopeProjection({
+        activeChangeSet,
+        decisionHydrationScopeKey,
+        decisionHydrationStatus,
+        draftHistoryHydration,
+        memberName,
+        mode,
+        taskChangeRequestOptions,
+        taskId,
+        teamName,
+      }),
+    [
+      activeChangeSet,
+      decisionHydrationScopeKey,
+      decisionHydrationStatus,
+      draftHistoryHydration,
+      memberName,
+      mode,
+      taskChangeRequestOptions,
+      taskId,
+      teamName,
+    ]
+  );
+}

--- a/src/features/change-review/renderer/index.ts
+++ b/src/features/change-review/renderer/index.ts
@@ -1,5 +1,28 @@
+export { useChangeReviewLifecycleRegistration } from './hooks/useChangeReviewLifecycleRegistration';
+export { useChangeReviewOperationGeneration } from './hooks/useChangeReviewOperationGeneration';
+export { useChangeReviewScopeIdentity } from './hooks/useChangeReviewScopeIdentity';
+export type {
+  RegisterChangeReviewAppCloseParticipant,
+  RegisterChangeReviewLifecycleOwner,
+} from './ports/changeReviewLifecyclePorts';
 export type { TaskChangesEmptyStateProps } from './ui/TaskChangesEmptyState';
 export { TaskChangesEmptyState } from './ui/TaskChangesEmptyState';
+export type {
+  BuildChangeReviewScopeProjectionInput,
+  ChangeReviewScopeProjection,
+  ReviewDecisionHydrationGuard,
+  ReviewDecisionHydrationStatus,
+  ReviewDraftHistoryHydrationState,
+} from './utils/changeReviewScope';
+export {
+  buildChangeReviewScopeProjection,
+  getReviewDecisionHydrationGuard,
+} from './utils/changeReviewScope';
+export type { ReviewOperationScopeToken } from './utils/reviewOperationGeneration';
+export {
+  createReviewOperationScopeToken,
+  isReviewOperationScopeCurrent,
+} from './utils/reviewOperationGeneration';
 export type {
   ChangeReviewChangeSet,
   GlobalDiffLoadingState,

--- a/src/features/change-review/renderer/ports/changeReviewLifecyclePorts.ts
+++ b/src/features/change-review/renderer/ports/changeReviewLifecyclePorts.ts
@@ -1,0 +1,22 @@
+export interface ChangeReviewLifecycleOwnerRegistration {
+  hostId: string;
+  sessionId: string;
+  tabId?: string;
+  requestClose: () => Promise<boolean>;
+  focus?: () => void;
+}
+
+export interface ChangeReviewLifecycleOwnerRegistrationResult {
+  accepted: boolean;
+  unregister: () => void;
+}
+
+export type RegisterChangeReviewLifecycleOwner = (
+  owner: ChangeReviewLifecycleOwnerRegistration
+) => ChangeReviewLifecycleOwnerRegistrationResult;
+
+export type RegisterChangeReviewAppCloseParticipant = (
+  participantId: string,
+  flush: AppCloseParticipant
+) => () => void;
+import type { AppCloseParticipant } from '@features/app-close-coordination/renderer';

--- a/src/features/change-review/renderer/utils/changeReviewScope.ts
+++ b/src/features/change-review/renderer/utils/changeReviewScope.ts
@@ -1,0 +1,121 @@
+import {
+  buildReviewDecisionScopeToken,
+  reviewChangeSetMatchesScope,
+} from '@renderer/utils/reviewDecisionScope';
+import { buildTaskChangeSignature } from '@renderer/utils/taskChangeRequest';
+
+import type { ReviewChangeSetLike } from '@renderer/utils/reviewDecisionScope';
+import type { TaskChangeRequestOptions } from '@renderer/utils/taskChangeRequest';
+import type { ReviewFileScope } from '@shared/types';
+
+export type ReviewDecisionHydrationStatus = 'idle' | 'loading' | 'loaded' | 'error';
+export type ReviewDecisionHydrationGuard = 'not-required' | 'pending' | 'ready' | 'error';
+
+export interface ReviewDraftHistoryHydrationState {
+  key: string | null;
+  status: ReviewDecisionHydrationStatus;
+}
+
+export interface ChangeReviewScopeProjection {
+  scopeKey: string;
+  decisionScopeKey: string;
+  decisionScopeToken: string | null;
+  decisionHydrationKey: string | null;
+  decisionHydrationReady: boolean;
+  decisionHydrationFailed: boolean;
+  decisionHydrationPending: boolean;
+  draftHistoryHydrationReady: boolean;
+  draftHistoryHydrationPending: boolean;
+  draftHistoryHydrationFailed: boolean;
+  reviewScope: ReviewFileScope;
+  collapseStorageKey: string;
+}
+
+export interface BuildChangeReviewScopeProjectionInput {
+  teamName: string;
+  mode: 'agent' | 'task';
+  memberName?: string;
+  taskId?: string;
+  taskChangeRequestOptions?: TaskChangeRequestOptions;
+  activeChangeSet: ReviewChangeSetLike | null | undefined;
+  decisionHydrationScopeKey: string | null;
+  decisionHydrationStatus: ReviewDecisionHydrationStatus;
+  draftHistoryHydration: ReviewDraftHistoryHydrationState;
+}
+
+export function getReviewDecisionHydrationGuard(input: {
+  expectedScopeKey: string | null;
+  hydratedScopeKey: string | null;
+  status: ReviewDecisionHydrationStatus;
+}): ReviewDecisionHydrationGuard {
+  if (input.expectedScopeKey === null) return 'not-required';
+  if (input.hydratedScopeKey !== input.expectedScopeKey) return 'pending';
+  if (input.status === 'loaded') return 'ready';
+  if (input.status === 'error') return 'error';
+  return 'pending';
+}
+
+export function buildChangeReviewScopeProjection(
+  input: BuildChangeReviewScopeProjectionInput
+): ChangeReviewScopeProjection {
+  const scopeTarget = input.mode === 'task' ? (input.taskId ?? '') : (input.memberName ?? '');
+  const scopeKey = `${input.mode}:${scopeTarget}`;
+  const decisionScopeKey = `${input.mode}-${scopeTarget}`;
+  const changeSetMatchesScope = reviewChangeSetMatchesScope(input.activeChangeSet, {
+    teamName: input.teamName,
+    taskId: input.mode === 'task' ? input.taskId : undefined,
+    memberName: input.mode === 'agent' ? input.memberName : undefined,
+  });
+  const decisionScopeToken = changeSetMatchesScope
+    ? buildReviewDecisionScopeToken({
+        mode: input.mode,
+        taskId: input.taskId,
+        memberName: input.memberName,
+        requestSignature:
+          input.mode === 'task'
+            ? buildTaskChangeSignature(input.taskChangeRequestOptions ?? {})
+            : undefined,
+        changeSet: input.activeChangeSet,
+      })
+    : null;
+  const decisionHydrationKey = decisionScopeToken
+    ? `${input.teamName}:${decisionScopeKey}:${decisionScopeToken}`
+    : null;
+  const decisionHydrationGuard = getReviewDecisionHydrationGuard({
+    expectedScopeKey: decisionHydrationKey,
+    hydratedScopeKey: input.decisionHydrationScopeKey,
+    status: input.decisionHydrationStatus,
+  });
+  const draftHistoryHydrationReady =
+    decisionHydrationKey === null ||
+    (input.draftHistoryHydration.key === decisionHydrationKey &&
+      input.draftHistoryHydration.status === 'loaded');
+  const draftHistoryHydrationPending =
+    decisionHydrationKey !== null &&
+    (input.draftHistoryHydration.key !== decisionHydrationKey ||
+      input.draftHistoryHydration.status === 'idle' ||
+      input.draftHistoryHydration.status === 'loading');
+  const draftHistoryHydrationFailed =
+    decisionHydrationKey !== null &&
+    input.draftHistoryHydration.key === decisionHydrationKey &&
+    input.draftHistoryHydration.status === 'error';
+
+  return {
+    scopeKey,
+    decisionScopeKey,
+    decisionScopeToken,
+    decisionHydrationKey,
+    decisionHydrationReady: decisionHydrationGuard === 'ready',
+    decisionHydrationFailed: decisionHydrationGuard === 'error',
+    decisionHydrationPending: decisionHydrationGuard === 'pending',
+    draftHistoryHydrationReady,
+    draftHistoryHydrationPending,
+    draftHistoryHydrationFailed,
+    reviewScope: {
+      teamName: input.teamName,
+      taskId: input.taskId,
+      memberName: input.memberName,
+    },
+    collapseStorageKey: `review:collapsed:${input.teamName}:${decisionScopeKey}`,
+  };
+}

--- a/src/features/change-review/renderer/utils/reviewOperationGeneration.ts
+++ b/src/features/change-review/renderer/utils/reviewOperationGeneration.ts
@@ -1,0 +1,16 @@
+export interface ReviewOperationScopeToken {
+  readonly hydrationKey: string;
+  readonly generation: symbol;
+}
+
+/** Object identity prevents an A -> B -> A scope transition from reviving stale work. */
+export function createReviewOperationScopeToken(hydrationKey: string): ReviewOperationScopeToken {
+  return Object.freeze({ hydrationKey, generation: Symbol(hydrationKey) });
+}
+
+export function isReviewOperationScopeCurrent(
+  current: ReviewOperationScopeToken | null,
+  operation: ReviewOperationScopeToken | null
+): operation is ReviewOperationScopeToken {
+  return current !== null && current === operation;
+}

--- a/src/renderer/components/team/review/ChangeReviewDialog.tsx
+++ b/src/renderer/components/team/review/ChangeReviewDialog.tsx
@@ -24,6 +24,9 @@ import {
   sortChangeReviewFiles,
   TaskChangesEmptyState,
   toTaskChangeSetV2,
+  useChangeReviewLifecycleRegistration,
+  useChangeReviewOperationGeneration,
+  useChangeReviewScopeIdentity,
 } from '@features/change-review/renderer';
 import {
   ReviewDraftHistoryWriteBuffer,
@@ -58,15 +61,7 @@ import {
   registerChangeReviewLifecycleOwner,
 } from '@renderer/utils/changeReviewLifecycleCoordinator';
 import { buildSelectionInfo, SELECTION_DEBOUNCE_MS } from '@renderer/utils/codemirrorSelectionInfo';
-import {
-  buildReviewDecisionScopeToken,
-  reviewChangeSetMatchesScope,
-} from '@renderer/utils/reviewDecisionScope';
 import { buildHunkDecisionKey, getFileReviewKey } from '@renderer/utils/reviewKey';
-import {
-  buildTaskChangeSignature,
-  type TaskChangeRequestOptions,
-} from '@renderer/utils/taskChangeRequest';
 import { normalizePathForComparison } from '@shared/utils/platformPath';
 import { threeWayTextMerge } from '@shared/utils/threeWayTextMerge';
 import { AlertTriangle, ChevronDown, Clock, X } from 'lucide-react';
@@ -87,9 +82,7 @@ import { buildPathChangeLabels } from './pathChangeLabels';
 import { getReviewActionFilePath } from './reviewActionPresentation';
 import {
   appendOrderedReviewAction,
-  createReviewOperationScopeToken,
   getReviewCloseBlockReason,
-  getReviewDecisionHydrationGuard,
   getReviewRenameRecoveryExpectation,
   hasReviewFileRejections,
   hasUnresolvedReviewExternalChange,
@@ -97,7 +90,6 @@ import {
   isReviewActionLocked,
   isReviewActionPersistenceBlocking,
   isReviewFileFullyRejected,
-  isReviewOperationScopeCurrent,
   popOrderedReviewAction,
   reconcileReviewDecisionRecordsAfterApply,
   replaceLatestReviewAction,
@@ -141,14 +133,15 @@ import type {
   ReviewActionPersistenceStatus,
   ReviewConflictCandidateSelection,
   ReviewDecisionRecords,
-  ReviewOperationScopeToken,
 } from './reviewActionState';
 import type { EditorView } from '@codemirror/view';
+import type { ReviewDraftHistoryHydrationState } from '@features/change-review/renderer';
 import type {
   ReviewDraftHistoryConflictCandidateSummary,
   ReviewDraftHistoryEntry,
   ReviewSerializedEditorState,
 } from '@features/change-review-history/contracts';
+import type { TaskChangeRequestOptions } from '@renderer/utils/taskChangeRequest';
 import type {
   FileChangeSummary,
   HunkDecision,
@@ -157,7 +150,6 @@ import type {
   ReviewDecisionSnapshot,
   ReviewDiskUndoAction,
   ReviewDiskUndoSnapshot,
-  ReviewFileScope,
   ReviewHistoryRestoreTarget,
   ReviewMutationDiskPostimage,
   ReviewPersistedStateSnapshot,
@@ -177,11 +169,6 @@ type ReviewUndoActionInput =
 interface RecentReviewWrite {
   at: number;
   expectedContent: string | null;
-}
-
-interface DraftHistoryHydrationState {
-  key: string | null;
-  status: 'idle' | 'loading' | 'loaded' | 'error';
 }
 
 interface PendingDraftHistoryWrite {
@@ -382,37 +369,11 @@ export const ChangeReviewDialog = ({
     globalTasks,
   } = useStore();
 
-  // Build scope keys (pure values - safe to compute before hooks that depend on them)
-  const scopeKey = mode === 'task' ? `task:${taskId ?? ''}` : `agent:${memberName ?? ''}`;
-  // Filesystem-safe: use `-` instead of `:` for decision persistence key
-  const decisionScopeKey = mode === 'task' ? `task-${taskId ?? ''}` : `agent-${memberName ?? ''}`;
-  const decisionScopeToken = useMemo(() => {
-    if (
-      !reviewChangeSetMatchesScope(activeChangeSet, {
-        teamName,
-        taskId: mode === 'task' ? taskId : undefined,
-        memberName: mode === 'agent' ? memberName : undefined,
-      })
-    ) {
-      return null;
-    }
-
-    return buildReviewDecisionScopeToken({
-      mode,
-      taskId,
-      memberName,
-      requestSignature:
-        mode === 'task' ? buildTaskChangeSignature(taskChangeRequestOptions ?? {}) : undefined,
-      changeSet: activeChangeSet,
-    });
-  }, [activeChangeSet, memberName, mode, taskChangeRequestOptions, taskId, teamName]);
   const [draftHistoryEntries, setDraftHistoryEntries] = useState<
     Record<string, ReviewDraftHistoryEntry>
   >({});
-  const [draftHistoryHydration, setDraftHistoryHydration] = useState<DraftHistoryHydrationState>({
-    key: null,
-    status: 'idle',
-  });
+  const [draftHistoryHydration, setDraftHistoryHydration] =
+    useState<ReviewDraftHistoryHydrationState>({ key: null, status: 'idle' });
   const [draftHistoryRetryNonce, setDraftHistoryRetryNonce] = useState(0);
   const [draftConflictPromotionNonce, setDraftConflictPromotionNonce] = useState(0);
   const [decisionConflictCandidates, setDecisionConflictCandidates] = useState<
@@ -426,30 +387,30 @@ export const ChangeReviewDialog = ({
   const [resolvingConflictCandidateId, setResolvingConflictCandidateId] = useState<string | null>(
     null
   );
-  const decisionHydrationKey = decisionScopeToken
-    ? `${teamName}:${decisionScopeKey}:${decisionScopeToken}`
-    : null;
-  const decisionHydrationGuard = getReviewDecisionHydrationGuard({
-    expectedScopeKey: decisionHydrationKey,
-    hydratedScopeKey: decisionHydrationScopeKey,
-    status: decisionHydrationStatus,
+  const {
+    scopeKey,
+    decisionScopeKey,
+    decisionScopeToken,
+    decisionHydrationKey,
+    decisionHydrationReady,
+    decisionHydrationFailed,
+    decisionHydrationPending,
+    draftHistoryHydrationReady,
+    draftHistoryHydrationPending,
+    draftHistoryHydrationFailed,
+    reviewScope,
+    collapseStorageKey,
+  } = useChangeReviewScopeIdentity({
+    teamName,
+    mode,
+    memberName,
+    taskId,
+    taskChangeRequestOptions,
+    activeChangeSet,
+    decisionHydrationScopeKey,
+    decisionHydrationStatus,
+    draftHistoryHydration,
   });
-  const decisionHydrationReady = decisionHydrationGuard === 'ready';
-  const decisionHydrationFailed = decisionHydrationGuard === 'error';
-  const decisionHydrationPending = decisionHydrationGuard === 'pending';
-  const draftHistoryHydrationReady =
-    decisionHydrationKey === null ||
-    (draftHistoryHydration.key === decisionHydrationKey &&
-      draftHistoryHydration.status === 'loaded');
-  const draftHistoryHydrationPending =
-    decisionHydrationKey !== null &&
-    (draftHistoryHydration.key !== decisionHydrationKey ||
-      draftHistoryHydration.status === 'idle' ||
-      draftHistoryHydration.status === 'loading');
-  const draftHistoryHydrationFailed =
-    decisionHydrationKey !== null &&
-    draftHistoryHydration.key === decisionHydrationKey &&
-    draftHistoryHydration.status === 'error';
 
   // Active file from scroll-spy (replaces selectedReviewFilePath for continuous scroll)
   const [activeFilePath, setActiveFilePath] = useState<string | null>(null);
@@ -463,14 +424,6 @@ export const ChangeReviewDialog = ({
   const [closing, setClosing] = useState(false);
   const [reviewActionPersistenceStatus, setReviewActionPersistenceStatus] =
     useState<ReviewActionPersistenceStatus>('saved');
-  const reviewScope = useMemo<ReviewFileScope>(
-    () => ({ teamName, taskId, memberName }),
-    [memberName, taskId, teamName]
-  );
-  const collapseStorageKey = useMemo(
-    () => `review:collapsed:${teamName}:${decisionScopeKey}`,
-    [teamName, decisionScopeKey]
-  );
   const [collapsedFiles, setCollapsedFiles] = useState<Set<string>>(() => {
     if (typeof window === 'undefined') return new Set<string>();
     try {
@@ -528,7 +481,6 @@ export const ChangeReviewDialog = ({
   const draftHistoryWriteErrorsRef = useRef(new Map<string, unknown>());
   const draftHistoryPersistedVersionsRef = useRef(new Map<string, DraftHistoryVersion>());
   const expectedDraftHistoryKeyRef = useRef<string | null>(null);
-  const reviewOperationScopeRef = useRef<ReviewOperationScopeToken | null>(null);
   const reviewConflictRefreshGenerationRef = useRef(0);
   const conflictResolutionOperationRef = useRef<object | null>(null);
   const suppressedDraftHistoryFilesRef = useRef(new Set<string>());
@@ -668,13 +620,7 @@ export const ChangeReviewDialog = ({
     };
   }, [decisionHydrationKey, lifecycleAuthorized, open]);
 
-  useLayoutEffect(() => {
-    const activeScopeKey =
-      open && lifecycleAuthorized
-        ? (decisionHydrationKey ?? `unscoped:${teamName}:${scopeKey}`)
-        : null;
-    const operationScope = activeScopeKey ? createReviewOperationScopeToken(activeScopeKey) : null;
-    reviewOperationScopeRef.current = operationScope;
+  const resetReviewOperationGenerationState = useCallback((): void => {
     // Busy state belongs to one operation generation. Never carry it into a
     // reopened or re-hydrated scope, but preserve recent-write evidence so late
     // filesystem events from our own committed mutation remain suppressible.
@@ -685,24 +631,16 @@ export const ChangeReviewDialog = ({
     setFilesApplying(new Set());
     setUndoing(false);
     setClosing(false);
-    return () => {
-      if (reviewOperationScopeRef.current === operationScope) {
-        reviewOperationScopeRef.current = null;
-      }
-    };
-  }, [changeSetEpoch, decisionHydrationKey, lifecycleAuthorized, open, scopeKey, teamName]);
-
-  const captureReviewOperationScope = useCallback((): ReviewOperationScopeToken | null => {
-    return reviewOperationScopeRef.current;
   }, []);
 
-  const isCurrentReviewOperationScope = useCallback(
-    (
-      operationScope: ReviewOperationScopeToken | null
-    ): operationScope is ReviewOperationScopeToken =>
-      isReviewOperationScopeCurrent(reviewOperationScopeRef.current, operationScope),
-    []
-  );
+  const { captureReviewOperationScope, isCurrentReviewOperationScope } =
+    useChangeReviewOperationGeneration({
+      active: open && lifecycleAuthorized,
+      decisionHydrationKey,
+      fallbackScopeKey: `unscoped:${teamName}:${scopeKey}`,
+      changeSetEpoch,
+      resetGenerationState: resetReviewOperationGenerationState,
+    });
 
   useEffect(() => {
     if (!open || !lifecycleAuthorized || !decisionHydrationKey) {
@@ -4297,46 +4235,22 @@ export const ChangeReviewDialog = ({
     await requestLifecycleClose();
   }, [requestLifecycleClose]);
 
-  useLayoutEffect(() => {
-    if (!open) {
-      setLifecycleAuthorized(false);
-      return;
-    }
-    const registration = registerChangeReviewLifecycleOwner({
-      hostId: resolvedLifecycleHostId,
-      sessionId: reviewLifecycleSessionId,
-      tabId: lifecycleTabId,
-      requestClose: requestLifecycleClose,
-      focus: onLifecycleFocus,
-    });
-    setLifecycleAuthorized(registration.accepted);
-    if (!registration.accepted) onOpenChange(false);
-    return () => {
-      registration.unregister();
-      setLifecycleAuthorized(false);
-    };
-  }, [
-    lifecycleTabId,
-    onLifecycleFocus,
-    onOpenChange,
+  const closeRejectedDialog = useCallback((): void => onOpenChange(false), [onOpenChange]);
+  useChangeReviewLifecycleRegistration({
     open,
-    requestLifecycleClose,
-    resolvedLifecycleHostId,
-    reviewLifecycleSessionId,
-  ]);
-
-  useEffect(() => {
-    if (!open || !lifecycleAuthorized) return;
-    const participantId = `changes:${teamName}:${decisionHydrationKey ?? scopeKey}`;
-    return registerAppCloseParticipant(participantId, async () => flushReviewStateForClose());
-  }, [
-    decisionHydrationKey,
-    flushReviewStateForClose,
-    lifecycleAuthorized,
-    open,
-    scopeKey,
-    teamName,
-  ]);
+    authorized: lifecycleAuthorized,
+    hostId: resolvedLifecycleHostId,
+    sessionId: reviewLifecycleSessionId,
+    tabId: lifecycleTabId,
+    focus: onLifecycleFocus,
+    requestClose: requestLifecycleClose,
+    closeRejectedDialog,
+    setAuthorized: setLifecycleAuthorized,
+    appCloseParticipantId: `changes:${teamName}:${decisionHydrationKey ?? scopeKey}`,
+    flushForAppClose: flushReviewStateForClose,
+    registerOwner: registerChangeReviewLifecycleOwner,
+    registerAppCloseParticipant,
+  });
 
   const handleRetrySavedReviewState = useCallback(async (): Promise<void> => {
     if (!decisionScopeToken || !decisionHydrationKey || reviewMutationBusy) return;

--- a/src/renderer/components/team/review/reviewActionState.ts
+++ b/src/renderer/components/team/review/reviewActionState.ts
@@ -21,29 +21,16 @@ import type {
   ReviewUndoAction,
 } from '@shared/types';
 
+export type { ReviewOperationScopeToken } from '@features/change-review/renderer';
+export {
+  createReviewOperationScopeToken,
+  getReviewDecisionHydrationGuard,
+  isReviewOperationScopeCurrent,
+} from '@features/change-review/renderer';
+
 export interface ReviewDecisionRecords {
   hunkDecisions: Record<string, HunkDecision>;
   fileDecisions: Record<string, HunkDecision>;
-}
-
-export interface ReviewOperationScopeToken {
-  readonly hydrationKey: string;
-  readonly generation: symbol;
-}
-
-/**
- * Object identity intentionally distinguishes closing and reopening the same
- * durable scope. A string key alone is vulnerable to an A -> B -> A race.
- */
-export function createReviewOperationScopeToken(hydrationKey: string): ReviewOperationScopeToken {
-  return Object.freeze({ hydrationKey, generation: Symbol(hydrationKey) });
-}
-
-export function isReviewOperationScopeCurrent(
-  current: ReviewOperationScopeToken | null,
-  operation: ReviewOperationScopeToken | null
-): operation is ReviewOperationScopeToken {
-  return current !== null && current === operation;
 }
 
 export function shouldRequestReviewCloseForEscape(input: {
@@ -177,18 +164,6 @@ export function hasUnscopedLocalReviewState(input: {
     input.pendingDecisionClear ||
     input.persistenceStatus !== 'saved'
   );
-}
-
-export function getReviewDecisionHydrationGuard(input: {
-  expectedScopeKey: string | null;
-  hydratedScopeKey: string | null;
-  status: 'idle' | 'loading' | 'loaded' | 'error';
-}): 'not-required' | 'pending' | 'ready' | 'error' {
-  if (input.expectedScopeKey === null) return 'not-required';
-  if (input.hydratedScopeKey !== input.expectedScopeKey) return 'pending';
-  if (input.status === 'loaded') return 'ready';
-  if (input.status === 'error') return 'error';
-  return 'pending';
 }
 
 /** A draft that survives an async Save must rebase onto the bytes that Save published. */

--- a/test/features/change-review/renderer/changeReviewScope.test.ts
+++ b/test/features/change-review/renderer/changeReviewScope.test.ts
@@ -1,0 +1,200 @@
+import {
+  buildChangeReviewScopeProjection,
+  getReviewDecisionHydrationGuard,
+} from '@features/change-review/renderer';
+import { describe, expect, it } from 'vitest';
+
+import type { AgentChangeSet, TaskChangeSetV2 } from '@shared/types';
+
+function makeTaskChangeSet(overrides: Partial<TaskChangeSetV2> = {}): TaskChangeSetV2 {
+  return {
+    teamName: 'team-a',
+    taskId: 'task-a',
+    files: [],
+    totalFiles: 0,
+    totalLinesAdded: 0,
+    totalLinesRemoved: 0,
+    confidence: 'high',
+    computedAt: '2026-07-23T07:00:00.000Z',
+    scope: {
+      taskId: 'task-a',
+      memberName: 'alice',
+      startLine: 1,
+      endLine: 2,
+      startTimestamp: '2026-07-23T06:00:00.000Z',
+      endTimestamp: '2026-07-23T06:30:00.000Z',
+      toolUseIds: [],
+      filePaths: [],
+      confidence: { tier: 1, label: 'high', reason: 'test' },
+    },
+    warnings: [],
+    ...overrides,
+  };
+}
+
+function buildTaskProjection(
+  overrides: Partial<Parameters<typeof buildChangeReviewScopeProjection>[0]> = {}
+) {
+  return buildChangeReviewScopeProjection({
+    teamName: 'team-a',
+    mode: 'task',
+    taskId: 'task-a',
+    taskChangeRequestOptions: {
+      owner: 'alice',
+      status: 'in_progress',
+      since: '2026-07-23T06:00:00.000Z',
+    },
+    activeChangeSet: makeTaskChangeSet(),
+    decisionHydrationScopeKey: null,
+    decisionHydrationStatus: 'idle',
+    draftHistoryHydration: { key: null, status: 'idle' },
+    ...overrides,
+  });
+}
+
+describe('changeReviewScope', () => {
+  it('builds the exact logical, persistence, and storage identities', () => {
+    const projection = buildTaskProjection();
+
+    expect(projection.scopeKey).toBe('task:task-a');
+    expect(projection.decisionScopeKey).toBe('task-task-a');
+    expect(projection.decisionScopeToken).toContain('task:task-a:');
+    expect(projection.decisionScopeToken).toContain('"owner":"alice"');
+    expect(projection.decisionHydrationKey).toBe(
+      `team-a:task-task-a:${projection.decisionScopeToken}`
+    );
+    expect(projection.reviewScope).toEqual({
+      teamName: 'team-a',
+      taskId: 'task-a',
+      memberName: undefined,
+    });
+    expect(projection.collapseStorageKey).toBe('review:collapsed:team-a:task-task-a');
+  });
+
+  it('refuses to bind a stale change set from another team or task', () => {
+    const projection = buildTaskProjection({
+      activeChangeSet: makeTaskChangeSet({ teamName: 'team-b', taskId: 'task-b' }),
+      decisionHydrationScopeKey: 'stale-loaded-scope',
+      decisionHydrationStatus: 'loaded',
+      draftHistoryHydration: { key: 'stale-loaded-scope', status: 'loaded' },
+    });
+
+    expect(projection.decisionScopeToken).toBeNull();
+    expect(projection.decisionHydrationKey).toBeNull();
+    expect(projection.decisionHydrationReady).toBe(false);
+    expect(projection.decisionHydrationPending).toBe(false);
+    expect(projection.draftHistoryHydrationReady).toBe(true);
+  });
+
+  it('builds agent scope identities without task-only fields', () => {
+    const activeChangeSet: AgentChangeSet = {
+      teamName: 'team-a',
+      memberName: 'alice',
+      files: [],
+      totalFiles: 0,
+      totalLinesAdded: 0,
+      totalLinesRemoved: 0,
+      computedAt: '2026-07-23T07:00:00.000Z',
+    };
+    const projection = buildChangeReviewScopeProjection({
+      teamName: 'team-a',
+      mode: 'agent',
+      memberName: 'alice',
+      activeChangeSet,
+      decisionHydrationScopeKey: null,
+      decisionHydrationStatus: 'idle',
+      draftHistoryHydration: { key: null, status: 'idle' },
+    });
+
+    expect(projection).toMatchObject({
+      scopeKey: 'agent:alice',
+      decisionScopeKey: 'agent-alice',
+      reviewScope: { teamName: 'team-a', memberName: 'alice', taskId: undefined },
+      collapseStorageKey: 'review:collapsed:team-a:agent-alice',
+    });
+    expect(projection.decisionScopeToken).toContain('agent:alice:');
+  });
+
+  it('changes the durable token when request intent or change-set provenance changes', () => {
+    const baseline = buildTaskProjection();
+    const changedRequest = buildTaskProjection({
+      taskChangeRequestOptions: {
+        owner: 'alice',
+        status: 'completed',
+        since: '2026-07-23T06:00:00.000Z',
+      },
+    });
+    const changedChangeSet = buildTaskProjection({
+      activeChangeSet: makeTaskChangeSet({
+        provenance: {
+          sourceKind: 'ledger',
+          sourceFingerprint: 'different-fingerprint',
+          integrity: 'ok',
+        },
+      }),
+    });
+
+    expect(changedRequest.decisionScopeToken).not.toBe(baseline.decisionScopeToken);
+    expect(changedChangeSet.decisionScopeToken).not.toBe(baseline.decisionScopeToken);
+  });
+
+  it('requires exact hydration identity before exposing persisted state', () => {
+    const unhydrated = buildTaskProjection();
+    const hydrationKey = unhydrated.decisionHydrationKey!;
+
+    expect(
+      buildTaskProjection({
+        decisionHydrationScopeKey: 'another-scope',
+        decisionHydrationStatus: 'loaded',
+      })
+    ).toMatchObject({
+      decisionHydrationReady: false,
+      decisionHydrationPending: true,
+      decisionHydrationFailed: false,
+    });
+    expect(
+      buildTaskProjection({
+        decisionHydrationScopeKey: hydrationKey,
+        decisionHydrationStatus: 'loaded',
+        draftHistoryHydration: { key: hydrationKey, status: 'loaded' },
+      })
+    ).toMatchObject({
+      decisionHydrationReady: true,
+      decisionHydrationPending: false,
+      decisionHydrationFailed: false,
+      draftHistoryHydrationReady: true,
+      draftHistoryHydrationPending: false,
+      draftHistoryHydrationFailed: false,
+    });
+    expect(
+      buildTaskProjection({
+        decisionHydrationScopeKey: hydrationKey,
+        decisionHydrationStatus: 'error',
+        draftHistoryHydration: { key: hydrationKey, status: 'error' },
+      })
+    ).toMatchObject({
+      decisionHydrationReady: false,
+      decisionHydrationPending: false,
+      decisionHydrationFailed: true,
+      draftHistoryHydrationReady: false,
+      draftHistoryHydrationPending: false,
+      draftHistoryHydrationFailed: true,
+    });
+  });
+
+  it.each([
+    [null, null, 'loaded', 'not-required'],
+    ['scope-a', 'scope-b', 'loaded', 'pending'],
+    ['scope-a', 'scope-a', 'idle', 'pending'],
+    ['scope-a', 'scope-a', 'loading', 'pending'],
+    ['scope-a', 'scope-a', 'loaded', 'ready'],
+    ['scope-a', 'scope-a', 'error', 'error'],
+  ] as const)(
+    'keeps the hydration guard truth table for %s / %s / %s',
+    (expectedScopeKey, hydratedScopeKey, status, expected) => {
+      expect(getReviewDecisionHydrationGuard({ expectedScopeKey, hydratedScopeKey, status })).toBe(
+        expected
+      );
+    }
+  );
+});

--- a/test/features/change-review/renderer/useChangeReviewLifecycleRegistration.test.tsx
+++ b/test/features/change-review/renderer/useChangeReviewLifecycleRegistration.test.tsx
@@ -1,0 +1,195 @@
+import React, { act, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { useChangeReviewLifecycleRegistration } from '@features/change-review/renderer';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { AppCloseParticipant } from '@features/app-close-coordination/renderer';
+import type {
+  RegisterChangeReviewAppCloseParticipant,
+  RegisterChangeReviewLifecycleOwner,
+} from '@features/change-review/renderer';
+
+interface LifecycleProbeProps {
+  open: boolean;
+  hostId?: string;
+  sessionId?: string;
+  requestClose: () => Promise<boolean>;
+  closeRejectedDialog: () => void;
+  flushForAppClose: AppCloseParticipant;
+  registerOwner: RegisterChangeReviewLifecycleOwner;
+  registerAppCloseParticipant: RegisterChangeReviewAppCloseParticipant;
+}
+
+function LifecycleProbe({
+  open,
+  hostId = 'host-a',
+  sessionId = 'session-a',
+  requestClose,
+  closeRejectedDialog,
+  flushForAppClose,
+  registerOwner,
+  registerAppCloseParticipant,
+}: LifecycleProbeProps): React.JSX.Element {
+  const [authorized, setAuthorized] = useState(false);
+  useChangeReviewLifecycleRegistration({
+    open,
+    authorized,
+    hostId,
+    sessionId,
+    tabId: 'tab-a',
+    requestClose,
+    closeRejectedDialog,
+    setAuthorized,
+    appCloseParticipantId: 'changes:team-a:scope-a',
+    flushForAppClose,
+    registerOwner,
+    registerAppCloseParticipant,
+  });
+  return <div data-authorized={String(authorized)} />;
+}
+
+describe('useChangeReviewLifecycleRegistration', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.unstubAllGlobals();
+  });
+
+  it('claims ownership in layout and registers app-close only after authorization', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    const unregisterOwner = vi.fn();
+    const unregisterAppClose = vi.fn();
+    const registerOwner = vi.fn<RegisterChangeReviewLifecycleOwner>(() => ({
+      accepted: true,
+      unregister: unregisterOwner,
+    }));
+    let appCloseParticipant: AppCloseParticipant | null = null;
+    const registerAppCloseParticipant = vi.fn<RegisterChangeReviewAppCloseParticipant>(
+      (_id, participant) => {
+        appCloseParticipant = participant;
+        return unregisterAppClose;
+      }
+    );
+    const requestClose = vi.fn(async () => true);
+    const closeRejectedDialog = vi.fn();
+    const flushForAppClose = vi.fn<AppCloseParticipant>(async () => ({ ok: true }));
+
+    await act(async () => {
+      root.render(
+        <LifecycleProbe
+          open
+          requestClose={requestClose}
+          closeRejectedDialog={closeRejectedDialog}
+          flushForAppClose={flushForAppClose}
+          registerOwner={registerOwner}
+          registerAppCloseParticipant={registerAppCloseParticipant}
+        />
+      );
+    });
+
+    expect(host.firstElementChild?.getAttribute('data-authorized')).toBe('true');
+    expect(registerOwner).toHaveBeenCalledOnce();
+    expect(registerOwner).toHaveBeenCalledWith({
+      hostId: 'host-a',
+      sessionId: 'session-a',
+      tabId: 'tab-a',
+      requestClose,
+      focus: undefined,
+    });
+    expect(closeRejectedDialog).not.toHaveBeenCalled();
+    expect(registerAppCloseParticipant).toHaveBeenCalledWith(
+      'changes:team-a:scope-a',
+      flushForAppClose
+    );
+
+    await appCloseParticipant!({
+      requestId: 'close-a',
+      reason: 'window-close',
+      deadlineAt: Date.now() + 1_000,
+    });
+    expect(flushForAppClose).toHaveBeenCalledOnce();
+    expect(closeRejectedDialog).not.toHaveBeenCalled();
+
+    await act(async () => root.unmount());
+    expect(unregisterOwner).toHaveBeenCalledOnce();
+    expect(unregisterAppClose).toHaveBeenCalledOnce();
+  });
+
+  it('closes a rejected duplicate without registering an app-close participant', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    const unregisterOwner = vi.fn();
+    const registerOwner = vi.fn<RegisterChangeReviewLifecycleOwner>(() => ({
+      accepted: false,
+      unregister: unregisterOwner,
+    }));
+    const registerAppCloseParticipant = vi.fn<RegisterChangeReviewAppCloseParticipant>();
+    const closeRejectedDialog = vi.fn();
+
+    await act(async () => {
+      root.render(
+        <LifecycleProbe
+          open
+          requestClose={async () => true}
+          closeRejectedDialog={closeRejectedDialog}
+          flushForAppClose={async () => ({ ok: true })}
+          registerOwner={registerOwner}
+          registerAppCloseParticipant={registerAppCloseParticipant}
+        />
+      );
+    });
+
+    expect(host.firstElementChild?.getAttribute('data-authorized')).toBe('false');
+    expect(closeRejectedDialog).toHaveBeenCalledOnce();
+    expect(registerAppCloseParticipant).not.toHaveBeenCalled();
+
+    await act(async () => root.unmount());
+    expect(unregisterOwner).toHaveBeenCalledOnce();
+  });
+
+  it('unregisters the previous owner before claiming a new host and session', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    const firstUnregister = vi.fn();
+    const secondUnregister = vi.fn();
+    const registerOwner = vi
+      .fn<RegisterChangeReviewLifecycleOwner>()
+      .mockReturnValueOnce({ accepted: true, unregister: firstUnregister })
+      .mockReturnValueOnce({ accepted: true, unregister: secondUnregister });
+    const registerAppCloseParticipant = vi.fn<RegisterChangeReviewAppCloseParticipant>(() =>
+      vi.fn()
+    );
+    const sharedProps = {
+      open: true,
+      requestClose: async () => true,
+      closeRejectedDialog: vi.fn(),
+      flushForAppClose: async () => ({ ok: true }),
+      registerOwner,
+      registerAppCloseParticipant,
+    };
+
+    await act(async () => {
+      root.render(<LifecycleProbe {...sharedProps} hostId="host-a" sessionId="session-a" />);
+    });
+    await act(async () => {
+      root.render(<LifecycleProbe {...sharedProps} hostId="host-b" sessionId="session-b" />);
+    });
+
+    expect(firstUnregister).toHaveBeenCalledOnce();
+    expect(registerOwner).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ hostId: 'host-b', sessionId: 'session-b' })
+    );
+    expect(host.firstElementChild?.getAttribute('data-authorized')).toBe('true');
+
+    await act(async () => root.unmount());
+    expect(secondUnregister).toHaveBeenCalledOnce();
+  });
+});

--- a/test/features/change-review/renderer/useChangeReviewLifecycleRegistration.test.tsx
+++ b/test/features/change-review/renderer/useChangeReviewLifecycleRegistration.test.tsx
@@ -21,6 +21,13 @@ interface LifecycleProbeProps {
   registerAppCloseParticipant: RegisterChangeReviewAppCloseParticipant;
 }
 
+async function flushReact(action: () => void): Promise<void> {
+  await act(async () => {
+    action();
+    await Promise.resolve();
+  });
+}
+
 function LifecycleProbe({
   open,
   hostId = 'host-a',
@@ -30,7 +37,7 @@ function LifecycleProbe({
   flushForAppClose,
   registerOwner,
   registerAppCloseParticipant,
-}: LifecycleProbeProps): React.JSX.Element {
+}: Readonly<LifecycleProbeProps>): React.JSX.Element {
   const [authorized, setAuthorized] = useState(false);
   useChangeReviewLifecycleRegistration({
     open,
@@ -73,11 +80,11 @@ describe('useChangeReviewLifecycleRegistration', () => {
         return unregisterAppClose;
       }
     );
-    const requestClose = vi.fn(async () => true);
+    const requestClose = vi.fn(() => Promise.resolve(true));
     const closeRejectedDialog = vi.fn();
-    const flushForAppClose = vi.fn<AppCloseParticipant>(async () => ({ ok: true }));
+    const flushForAppClose = vi.fn<AppCloseParticipant>(() => Promise.resolve({ ok: true }));
 
-    await act(async () => {
+    await flushReact(() => {
       root.render(
         <LifecycleProbe
           open
@@ -113,7 +120,7 @@ describe('useChangeReviewLifecycleRegistration', () => {
     expect(flushForAppClose).toHaveBeenCalledOnce();
     expect(closeRejectedDialog).not.toHaveBeenCalled();
 
-    await act(async () => root.unmount());
+    await flushReact(() => root.unmount());
     expect(unregisterOwner).toHaveBeenCalledOnce();
     expect(unregisterAppClose).toHaveBeenCalledOnce();
   });
@@ -131,13 +138,13 @@ describe('useChangeReviewLifecycleRegistration', () => {
     const registerAppCloseParticipant = vi.fn<RegisterChangeReviewAppCloseParticipant>();
     const closeRejectedDialog = vi.fn();
 
-    await act(async () => {
+    await flushReact(() => {
       root.render(
         <LifecycleProbe
           open
-          requestClose={async () => true}
+          requestClose={() => Promise.resolve(true)}
           closeRejectedDialog={closeRejectedDialog}
-          flushForAppClose={async () => ({ ok: true })}
+          flushForAppClose={() => Promise.resolve({ ok: true })}
           registerOwner={registerOwner}
           registerAppCloseParticipant={registerAppCloseParticipant}
         />
@@ -148,7 +155,7 @@ describe('useChangeReviewLifecycleRegistration', () => {
     expect(closeRejectedDialog).toHaveBeenCalledOnce();
     expect(registerAppCloseParticipant).not.toHaveBeenCalled();
 
-    await act(async () => root.unmount());
+    await flushReact(() => root.unmount());
     expect(unregisterOwner).toHaveBeenCalledOnce();
   });
 
@@ -168,17 +175,17 @@ describe('useChangeReviewLifecycleRegistration', () => {
     );
     const sharedProps = {
       open: true,
-      requestClose: async () => true,
+      requestClose: () => Promise.resolve(true),
       closeRejectedDialog: vi.fn(),
-      flushForAppClose: async () => ({ ok: true }),
+      flushForAppClose: () => Promise.resolve({ ok: true }),
       registerOwner,
       registerAppCloseParticipant,
     };
 
-    await act(async () => {
+    await flushReact(() => {
       root.render(<LifecycleProbe {...sharedProps} hostId="host-a" sessionId="session-a" />);
     });
-    await act(async () => {
+    await flushReact(() => {
       root.render(<LifecycleProbe {...sharedProps} hostId="host-b" sessionId="session-b" />);
     });
 
@@ -189,7 +196,7 @@ describe('useChangeReviewLifecycleRegistration', () => {
     );
     expect(host.firstElementChild?.getAttribute('data-authorized')).toBe('true');
 
-    await act(async () => root.unmount());
+    await flushReact(() => root.unmount());
     expect(secondUnregister).toHaveBeenCalledOnce();
   });
 });

--- a/test/features/change-review/renderer/useChangeReviewOperationGeneration.test.tsx
+++ b/test/features/change-review/renderer/useChangeReviewOperationGeneration.test.tsx
@@ -21,9 +21,16 @@ interface ProbeValue {
   ) => operationScope is ReviewOperationScopeToken;
 }
 
+async function flushReact(action: () => void): Promise<void> {
+  await act(async () => {
+    action();
+    await Promise.resolve();
+  });
+}
+
 let latest: ProbeValue | null = null;
 
-function OperationProbe(props: ProbeProps): React.JSX.Element {
+function OperationProbe(props: Readonly<ProbeProps>): React.JSX.Element {
   latest = useChangeReviewOperationGeneration(props);
   return <div />;
 }
@@ -42,7 +49,7 @@ describe('useChangeReviewOperationGeneration', () => {
     const root = createRoot(host);
     const resetGenerationState = vi.fn();
 
-    await act(async () => {
+    await flushReact(() => {
       root.render(
         <OperationProbe
           active={false}
@@ -55,7 +62,7 @@ describe('useChangeReviewOperationGeneration', () => {
     });
     expect(latest!.captureReviewOperationScope()).toBeNull();
 
-    await act(async () => {
+    await flushReact(() => {
       root.render(
         <OperationProbe
           active
@@ -69,7 +76,7 @@ describe('useChangeReviewOperationGeneration', () => {
     expect(latest!.captureReviewOperationScope()).toMatchObject({ hydrationKey: 'scope-a' });
     expect(resetGenerationState).toHaveBeenCalledTimes(2);
 
-    await act(async () => root.unmount());
+    await flushReact(() => root.unmount());
   });
 
   it('invalidates stale work across A -> B -> A and same-scope epoch changes', async () => {
@@ -79,7 +86,7 @@ describe('useChangeReviewOperationGeneration', () => {
     const root = createRoot(host);
     const resetGenerationState = vi.fn();
     const renderProbe = async (decisionHydrationKey: string, changeSetEpoch: number) => {
-      await act(async () => {
+      await flushReact(() => {
         root.render(
           <OperationProbe
             active
@@ -105,7 +112,7 @@ describe('useChangeReviewOperationGeneration', () => {
     expect(new Set([firstA, scopeB, reopenedA, refreshedA]).size).toBe(4);
     expect(resetGenerationState).toHaveBeenCalledTimes(4);
 
-    await act(async () => root.unmount());
+    await flushReact(() => root.unmount());
     expect(latest!.captureReviewOperationScope()).toBeNull();
     expect(latest!.isCurrentReviewOperationScope(refreshedA)).toBe(false);
   });

--- a/test/features/change-review/renderer/useChangeReviewOperationGeneration.test.tsx
+++ b/test/features/change-review/renderer/useChangeReviewOperationGeneration.test.tsx
@@ -1,0 +1,112 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { useChangeReviewOperationGeneration } from '@features/change-review/renderer';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { ReviewOperationScopeToken } from '@features/change-review/renderer';
+
+interface ProbeProps {
+  active: boolean;
+  decisionHydrationKey: string | null;
+  fallbackScopeKey: string;
+  changeSetEpoch: number;
+  resetGenerationState: () => void;
+}
+
+interface ProbeValue {
+  captureReviewOperationScope: () => ReviewOperationScopeToken | null;
+  isCurrentReviewOperationScope: (
+    operationScope: ReviewOperationScopeToken | null
+  ) => operationScope is ReviewOperationScopeToken;
+}
+
+let latest: ProbeValue | null = null;
+
+function OperationProbe(props: ProbeProps): React.JSX.Element {
+  latest = useChangeReviewOperationGeneration(props);
+  return <div />;
+}
+
+describe('useChangeReviewOperationGeneration', () => {
+  afterEach(() => {
+    latest = null;
+    document.body.innerHTML = '';
+    vi.unstubAllGlobals();
+  });
+
+  it('exposes no token until the dialog owns an active scope', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    const resetGenerationState = vi.fn();
+
+    await act(async () => {
+      root.render(
+        <OperationProbe
+          active={false}
+          decisionHydrationKey="scope-a"
+          fallbackScopeKey="unscoped:team-a:task:task-a"
+          changeSetEpoch={1}
+          resetGenerationState={resetGenerationState}
+        />
+      );
+    });
+    expect(latest!.captureReviewOperationScope()).toBeNull();
+
+    await act(async () => {
+      root.render(
+        <OperationProbe
+          active
+          decisionHydrationKey="scope-a"
+          fallbackScopeKey="unscoped:team-a:task:task-a"
+          changeSetEpoch={1}
+          resetGenerationState={resetGenerationState}
+        />
+      );
+    });
+    expect(latest!.captureReviewOperationScope()).toMatchObject({ hydrationKey: 'scope-a' });
+    expect(resetGenerationState).toHaveBeenCalledTimes(2);
+
+    await act(async () => root.unmount());
+  });
+
+  it('invalidates stale work across A -> B -> A and same-scope epoch changes', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    const resetGenerationState = vi.fn();
+    const renderProbe = async (decisionHydrationKey: string, changeSetEpoch: number) => {
+      await act(async () => {
+        root.render(
+          <OperationProbe
+            active
+            decisionHydrationKey={decisionHydrationKey}
+            fallbackScopeKey="unscoped:team-a:task:task-a"
+            changeSetEpoch={changeSetEpoch}
+            resetGenerationState={resetGenerationState}
+          />
+        );
+      });
+      return latest!.captureReviewOperationScope()!;
+    };
+
+    const firstA = await renderProbe('scope-a', 1);
+    const scopeB = await renderProbe('scope-b', 1);
+    const reopenedA = await renderProbe('scope-a', 1);
+    const refreshedA = await renderProbe('scope-a', 2);
+
+    expect(latest!.isCurrentReviewOperationScope(firstA)).toBe(false);
+    expect(latest!.isCurrentReviewOperationScope(scopeB)).toBe(false);
+    expect(latest!.isCurrentReviewOperationScope(reopenedA)).toBe(false);
+    expect(latest!.isCurrentReviewOperationScope(refreshedA)).toBe(true);
+    expect(new Set([firstA, scopeB, reopenedA, refreshedA]).size).toBe(4);
+    expect(resetGenerationState).toHaveBeenCalledTimes(4);
+
+    await act(async () => root.unmount());
+    expect(latest!.captureReviewOperationScope()).toBeNull();
+    expect(latest!.isCurrentReviewOperationScope(refreshedA)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- reduce `ChangeReviewDialog.tsx` from 5,326 to 5,240 physical lines
- extract scope identity projection, operation generation, and lifecycle registration into the change-review feature
- keep Electron/app-close and renderer ownership APIs behind narrow injected ports
- preserve A -> B -> A scope invalidation through object-identity operation tokens

## Architecture
- the dialog remains the composition root for renderer-specific lifecycle adapters
- feature hooks depend only on explicit values and narrow ports
- no store or Electron imports were added to the extracted feature hooks
- all new production files are below 121 lines

## Verification
- `pnpm typecheck`
- focused Vitest: 16/16 passed
- `pnpm lint:fast:files` passed
- type-aware lint for the new feature boundaries and tests passed with 0 errors
- `git diff --check`
- independent P0-P2 architecture review found no unresolved findings

## E2E evidence
This is a behavior-preserving structural slice. Full desktop Electron change-review E2E, including close/reopen and restart recovery, remains the completion gate after `ChangeReviewDialog.tsx` is below 800 lines. No agent, terminal, provisioning, or real-project flow was used.

## Remaining work
Continue sequential extraction of draft-history, decision persistence, mutation orchestration, and presentation until the legacy dialog is below 800 lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved change review state handling across reopening, hydration, and operation updates.
  * Added coordinated close handling, including app-close flushing and rejected-close feedback.
  * Improved protection against stale review data being applied to the active review.
  * Added support for consistent task- and agent-based review scopes.

* **Documentation**
  * Updated Change Review documentation to describe its modular architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR preserves change-review behavior while extracting scope projection and lifecycle orchestration.
- Moves scope identity, hydration guards, and operation-generation tokens into focused feature utilities and hooks.
- Injects lifecycle-owner and app-close registration through narrow renderer ports.
- Replaces the dialog’s inline implementations with the extracted hooks.
- Adds focused tests for scope projection, lifecycle registration, and operation-generation invalidation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code regression identified.

The extracted scope projections match the previous inline calculations, lifecycle registration retains authorization and cleanup semantics, and identity-based operation tokens continue to invalidate stale asynchronous work across scope transitions.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/features/change-review/renderer/hooks/useChangeReviewLifecycleRegistration.ts | Extracts owner and app-close registration with equivalent authorization and cleanup behavior. |
| src/features/change-review/renderer/hooks/useChangeReviewOperationGeneration.ts | Encapsulates identity-based operation generations while retaining scope and epoch invalidation. |
| src/features/change-review/renderer/utils/changeReviewScope.ts | Centralizes scope keys, durable identity, hydration guards, and renderer scope projection without identified semantic drift. |
| src/renderer/components/team/review/ChangeReviewDialog.tsx | Replaces inline scope and lifecycle logic with the extracted feature APIs while preserving existing inputs and behavior. |
| src/renderer/components/team/review/reviewActionState.ts | Re-exports relocated scope-generation and hydration helpers for compatibility. |
| test/features/change-review/renderer/changeReviewScope.test.ts | Covers exact identities, scope mismatch handling, provenance changes, and hydration states. |
| test/features/change-review/renderer/useChangeReviewLifecycleRegistration.test.tsx | Covers authorization, duplicate rejection, app-close registration, and owner replacement cleanup. |
| test/features/change-review/renderer/useChangeReviewOperationGeneration.test.tsx | Exercises operation-token generation and stale-scope invalidation behavior. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dialog as ChangeReviewDialog
    participant Scope as Scope Identity Hook
    participant Generation as Operation Generation Hook
    participant Lifecycle as Lifecycle Registration Hook
    participant Owner as Lifecycle Coordinator
    participant Close as App-Close Registry

    Dialog->>Scope: project current review scope
    Scope-->>Dialog: keys, token, hydration guards
    Dialog->>Lifecycle: register owner with injected port
    Lifecycle->>Owner: registerOwner(...)
    Owner-->>Lifecycle: accepted + unregister
    alt owner accepted
        Lifecycle->>Close: register participant
        Dialog->>Generation: activate scope generation
        Generation-->>Dialog: capture/check token functions
    else duplicate rejected
        Lifecycle-->>Dialog: close rejected dialog
    end
    Note over Generation: Scope or epoch changes replace the identity token and invalidate stale async work
```

<sub>Reviews (1): Last reviewed commit: ["test(change-review): satisfy boundary li..."](https://github.com/777genius/agent-teams-ai/commit/12f92e06e83fa9c8724d96bdb6db650d7cde549b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46598415)</sub>

<!-- /greptile_comment -->