### PR TITLE
refactor(change-review): isolate draft history

### DIFF
--- a/src/features/change-review/renderer/adapters/createChangeReviewDraftHistoryPort.ts
+++ b/src/features/change-review/renderer/adapters/createChangeReviewDraftHistoryPort.ts
@@ -1,0 +1,61 @@
+import type { ChangeReviewDraftHistoryPort } from '../ports/changeReviewDraftHistoryPort';
+import type { ReviewAPI } from '@shared/types/api';
+
+type ReviewDraftHistoryApi = Pick<
+  ReviewAPI,
+  | 'loadDraftHistory'
+  | 'saveDraftHistoryEntry'
+  | 'clearDraftHistory'
+  | 'checkConflict'
+  | 'replaceDraftHistoryConflictCandidate'
+  | 'resolveDraftHistoryConflictCandidate'
+>;
+
+export function createChangeReviewDraftHistoryPort(
+  getReviewApi: () => ReviewDraftHistoryApi
+): ChangeReviewDraftHistoryPort {
+  return {
+    load: ({ teamName, scopeKey, scopeToken }) =>
+      getReviewApi().loadDraftHistory(teamName, scopeKey, scopeToken),
+    saveEntry: ({ scope, entry, expectedVersion }) =>
+      getReviewApi().saveDraftHistoryEntry(
+        scope.teamName,
+        scope.scopeKey,
+        scope.scopeToken,
+        entry,
+        expectedVersion.revision,
+        expectedVersion.generation
+      ),
+    clear: ({ scope, filePath, expectedVersion }) =>
+      getReviewApi().clearDraftHistory(
+        scope.teamName,
+        scope.scopeKey,
+        scope.scopeToken,
+        filePath,
+        expectedVersion?.revision,
+        expectedVersion?.generation
+      ),
+    checkConflict: ({ reviewScope, filePath, expectedModified }) =>
+      getReviewApi().checkConflict(reviewScope, filePath, expectedModified),
+    replaceConflictCandidate: ({ scope, expectedEntry, replacementEntry, observedVersion }) =>
+      getReviewApi().replaceDraftHistoryConflictCandidate(
+        scope.teamName,
+        scope.scopeKey,
+        scope.scopeToken,
+        expectedEntry,
+        replacementEntry,
+        observedVersion.revision,
+        observedVersion.generation
+      ),
+    resolveConflictCandidate: ({ scope, candidateId, resolution, observedVersion }) =>
+      getReviewApi().resolveDraftHistoryConflictCandidate(
+        scope.teamName,
+        scope.scopeKey,
+        scope.scopeToken,
+        candidateId,
+        resolution,
+        observedVersion.revision,
+        observedVersion.generation
+      ),
+  };
+}

--- a/src/features/change-review/renderer/hooks/useChangeReviewDraftHistoryController.ts
+++ b/src/features/change-review/renderer/hooks/useChangeReviewDraftHistoryController.ts
@@ -1,0 +1,668 @@
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+
+import { ReviewDraftHistoryWriteBuffer } from '@features/change-review-history/renderer';
+import { normalizePathForComparison } from '@shared/utils/platformPath';
+
+import type {
+  ChangeReviewDraftHistoryPort,
+  ChangeReviewDraftHistoryScope,
+} from '../ports/changeReviewDraftHistoryPort';
+import type { ReviewDraftHistoryHydrationState } from '../utils/changeReviewScope';
+import type { ReviewOperationScopeToken } from '../utils/reviewOperationGeneration';
+import type { ReviewDraftHistoryConflictCandidateSummary } from '@features/change-review-history/contracts';
+import type {
+  ReviewDraftHistoryEntry,
+  ReviewSerializedEditorState,
+} from '@features/change-review-history/contracts';
+import type { ReviewChangeSetLike } from '@renderer/utils/reviewDecisionScope';
+import type { ReviewConflictResolution, ReviewFileScope } from '@shared/types';
+
+interface PendingDraftHistoryWrite {
+  hydrationKey: string;
+  scope: ChangeReviewDraftHistoryScope;
+  entry: Omit<ReviewDraftHistoryEntry, 'updatedAt' | 'generation'>;
+}
+
+interface DraftHistoryVersion {
+  revision: number;
+  generation: string;
+}
+
+interface HydratedDraftState {
+  scopeFilePaths: string[];
+  recoveredDrafts: Record<string, string>;
+  externalChanges: Record<string, { type: 'change' }>;
+  errorMessage?: string;
+}
+
+interface UseChangeReviewDraftHistoryControllerInput {
+  open: boolean;
+  changeSetEpoch: number;
+  scopeKey: string;
+  teamName: string;
+  activeChangeSet: ReviewChangeSetLike | null | undefined;
+  decisionScopeKey: string;
+  decisionScopeToken: string | null;
+  decisionHydrationKey: string | null;
+  draftHistoryHydrationReady: boolean;
+  reviewScope: ReviewFileScope;
+  draftHistoryConflictCandidates: readonly ReviewDraftHistoryConflictCandidateSummary[];
+  setHydration: (state: ReviewDraftHistoryHydrationState) => void;
+  isExpectedHydrationKey: (hydrationKey: string) => boolean;
+  refreshConflictCandidates: () => Promise<void>;
+  captureOperationScope: () => ReviewOperationScopeToken | null;
+  isCurrentOperationScope: (
+    operationScope: ReviewOperationScopeToken | null
+  ) => operationScope is ReviewOperationScopeToken;
+  commitHydratedDrafts: (state: HydratedDraftState) => void;
+  reportError: (message: string | null) => void;
+  port: ChangeReviewDraftHistoryPort;
+}
+
+export interface ChangeReviewDraftHistoryDiagnostics {
+  pendingWriteCount: number;
+  writeChainCount: number;
+  writeErrorCount: number;
+}
+
+export interface ChangeReviewDraftHistoryController {
+  entries: Record<string, ReviewDraftHistoryEntry>;
+  getEntry: (filePath: string) => ReviewDraftHistoryEntry | undefined;
+  hasBaseline: (filePath: string) => boolean;
+  getBaseline: (filePath: string) => string | null | undefined;
+  setBaseline: (filePath: string, baseline: string | null) => void;
+  deleteBaseline: (filePath: string) => void;
+  unsuppressFile: (filePath: string) => void;
+  publishCheckpoint: (
+    filePath: string,
+    editorState: ReviewSerializedEditorState,
+    diskBaseline: string | null
+  ) => void;
+  handleSerializedStateChanged: (
+    filePath: string,
+    editorState: ReviewSerializedEditorState
+  ) => void;
+  handleSerializedStateRestoreError: (filePath: string, error: unknown) => void;
+  flushWrites: () => Promise<boolean>;
+  clearFile: (filePath: string) => Promise<void>;
+  resolveConflictCandidate: (
+    candidate: ReviewDraftHistoryConflictCandidateSummary,
+    resolution: ReviewConflictResolution,
+    operationScope: ReviewOperationScopeToken
+  ) => Promise<boolean>;
+  retryHydration: () => void;
+  discardUnreadableScope: (operationScope: ReviewOperationScopeToken) => Promise<boolean>;
+  getDiagnostics: (hydrationKey?: string | null) => ChangeReviewDraftHistoryDiagnostics;
+}
+
+export function useChangeReviewDraftHistoryController({
+  open,
+  changeSetEpoch,
+  scopeKey,
+  teamName,
+  activeChangeSet,
+  decisionScopeKey,
+  decisionScopeToken,
+  decisionHydrationKey,
+  draftHistoryHydrationReady,
+  reviewScope,
+  draftHistoryConflictCandidates,
+  setHydration,
+  isExpectedHydrationKey,
+  refreshConflictCandidates,
+  captureOperationScope,
+  isCurrentOperationScope,
+  commitHydratedDrafts,
+  reportError,
+  port,
+}: UseChangeReviewDraftHistoryControllerInput): ChangeReviewDraftHistoryController {
+  const [entries, setEntries] = useState<Record<string, ReviewDraftHistoryEntry>>({});
+  const [retryNonce, setRetryNonce] = useState(0);
+  const [promotionNonce, setPromotionNonce] = useState(0);
+  const entriesRef = useRef<Record<string, ReviewDraftHistoryEntry>>({});
+  const baselinesRef = useRef(new Map<string, string | null>());
+  const writeChainsRef = useRef(new Map<string, Promise<void>>());
+  const promotionChainsRef = useRef(new Map<string, Promise<void>>());
+  const writeBufferRef = useRef(new ReviewDraftHistoryWriteBuffer<PendingDraftHistoryWrite>());
+  const writeErrorsRef = useRef(new Map<string, unknown>());
+  const persistedVersionsRef = useRef(new Map<string, DraftHistoryVersion>());
+  const suppressedFilesRef = useRef(new Set<string>());
+  const persistenceScope = useMemo(
+    () =>
+      decisionScopeToken
+        ? { teamName, scopeKey: decisionScopeKey, scopeToken: decisionScopeToken }
+        : null,
+    [decisionScopeKey, decisionScopeToken, teamName]
+  );
+
+  const replaceEntries = useCallback((next: Record<string, ReviewDraftHistoryEntry>): void => {
+    entriesRef.current = next;
+    setEntries(next);
+  }, []);
+
+  const startDrain = useCallback(
+    (writeKey: string): Promise<void> => {
+      const active = writeChainsRef.current.get(writeKey);
+      if (active) return active;
+
+      const drain = (async () => {
+        while (true) {
+          const pending = writeBufferRef.current.takeNext(writeKey);
+          if (!pending) return;
+          try {
+            const expectedVersion = persistedVersionsRef.current.get(writeKey);
+            const saved = await port.saveEntry({
+              scope: pending.scope,
+              entry: pending.entry,
+              expectedVersion: {
+                revision: expectedVersion?.revision ?? 0,
+                generation: expectedVersion?.generation ?? null,
+              },
+            });
+            persistedVersionsRef.current.set(writeKey, {
+              revision: saved.revision,
+              generation: saved.generation,
+            });
+            writeErrorsRef.current.delete(writeKey);
+            const current = entriesRef.current[pending.entry.filePath];
+            if (
+              isExpectedHydrationKey(pending.hydrationKey) &&
+              current?.revision === saved.revision
+            ) {
+              replaceEntries({ ...entriesRef.current, [pending.entry.filePath]: saved });
+            }
+          } catch (error) {
+            writeBufferRef.current.markFailed(writeKey, pending);
+            writeErrorsRef.current.set(writeKey, error);
+            setPromotionNonce((nonce) => nonce + 1);
+            if (isExpectedHydrationKey(pending.hydrationKey)) {
+              reportError('Unable to save manual edit history. Retry Save or keep Changes open.');
+              void refreshConflictCandidates();
+            }
+            throw error;
+          }
+        }
+      })();
+      writeChainsRef.current.set(writeKey, drain);
+      void drain
+        .catch(() => undefined)
+        .finally(() => {
+          if (writeChainsRef.current.get(writeKey) === drain) {
+            writeChainsRef.current.delete(writeKey);
+          }
+        });
+      return drain;
+    },
+    [isExpectedHydrationKey, port, refreshConflictCandidates, replaceEntries, reportError]
+  );
+
+  const enqueueWrite = useCallback(
+    (entry: Omit<ReviewDraftHistoryEntry, 'updatedAt' | 'generation'>): void => {
+      if (!decisionHydrationKey || !persistenceScope) return;
+      const writeKey = `${decisionHydrationKey}\0${entry.filePath}`;
+      writeBufferRef.current.enqueue(writeKey, {
+        hydrationKey: decisionHydrationKey,
+        scope: persistenceScope,
+        entry,
+      });
+      if (writeBufferRef.current.peekFailed(writeKey)) {
+        setPromotionNonce((nonce) => nonce + 1);
+      }
+      void startDrain(writeKey);
+    },
+    [decisionHydrationKey, persistenceScope, startDrain]
+  );
+
+  useLayoutEffect(() => {
+    suppressedFilesRef.current.clear();
+  }, [changeSetEpoch, decisionHydrationKey, open, scopeKey, teamName]);
+
+  useEffect(() => {
+    baselinesRef.current.clear();
+    replaceEntries({});
+    setHydration({ key: null, status: 'idle' });
+  }, [changeSetEpoch, replaceEntries, scopeKey, setHydration, teamName]);
+
+  useEffect(() => {
+    if (!open || !decisionHydrationKey || !persistenceScope || !activeChangeSet) {
+      if (!decisionHydrationKey) setHydration({ key: null, status: 'idle' });
+      return;
+    }
+    let cancelled = false;
+    const hydrationKey = decisionHydrationKey;
+    setHydration({ key: hydrationKey, status: 'loading' });
+
+    void (async () => {
+      try {
+        const snapshot = await port.load(persistenceScope);
+        if (cancelled || !isExpectedHydrationKey(hydrationKey)) return;
+        const writeKeyPrefix = `${hydrationKey}\0`;
+        for (const writeKey of persistedVersionsRef.current.keys()) {
+          if (writeKey.startsWith(writeKeyPrefix)) persistedVersionsRef.current.delete(writeKey);
+        }
+
+        const allowedFiles = new Map(
+          activeChangeSet.files.map((file) => [normalizePathForComparison(file.filePath), file])
+        );
+        const recoveredEntries: Record<string, ReviewDraftHistoryEntry> = {};
+        const recoveredDrafts: Record<string, string> = {};
+        const externalChanges: Record<string, { type: 'change' }> = {};
+
+        for (const entry of Object.values(snapshot?.entries ?? {})) {
+          const file = allowedFiles.get(normalizePathForComparison(entry.filePath));
+          if (file?.filePath !== entry.filePath) continue;
+          const baselineKey = normalizePathForComparison(file.filePath);
+          const conflict = await port.checkConflict({
+            reviewScope,
+            filePath: file.filePath,
+            expectedModified: entry.diskBaseline ?? '',
+          });
+          if (cancelled || !isExpectedHydrationKey(hydrationKey)) return;
+          const diskMatchesBaseline =
+            entry.diskBaseline === null
+              ? conflict.hasConflict && conflict.conflictContent === null
+              : !conflict.hasConflict;
+
+          recoveredEntries[file.filePath] = entry;
+          persistedVersionsRef.current.set(`${hydrationKey}\0${file.filePath}`, {
+            revision: entry.revision,
+            generation: entry.generation,
+          });
+          baselinesRef.current.set(baselineKey, entry.diskBaseline);
+          if (!diskMatchesBaseline || entry.editorState.doc !== entry.diskBaseline) {
+            recoveredDrafts[file.filePath] = entry.editorState.doc;
+          }
+          if (!diskMatchesBaseline) externalChanges[file.filePath] = { type: 'change' };
+        }
+
+        replaceEntries(recoveredEntries);
+        commitHydratedDrafts({
+          scopeFilePaths: [...allowedFiles.keys()],
+          recoveredDrafts,
+          externalChanges,
+          ...(Object.keys(externalChanges).length > 0
+            ? {
+                errorMessage:
+                  'Recovered manual edits are based on files that changed on disk. Review each conflict before saving.',
+              }
+            : {}),
+        });
+        setHydration({ key: hydrationKey, status: 'loaded' });
+      } catch (error) {
+        if (cancelled || !isExpectedHydrationKey(hydrationKey)) return;
+        setHydration({ key: hydrationKey, status: 'error' });
+        reportError(`Unable to load saved manual edit history: ${String(error)}`);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    activeChangeSet,
+    changeSetEpoch,
+    commitHydratedDrafts,
+    decisionHydrationKey,
+    isExpectedHydrationKey,
+    open,
+    persistenceScope,
+    port,
+    replaceEntries,
+    reportError,
+    retryNonce,
+    reviewScope,
+    setHydration,
+  ]);
+
+  useEffect(() => {
+    if (!decisionHydrationKey || !persistenceScope) return;
+    const hydrationKey = decisionHydrationKey;
+    for (const candidate of draftHistoryConflictCandidates) {
+      const writeKey = `${hydrationKey}\0${candidate.filePath}`;
+      if (promotionChainsRef.current.has(writeKey)) continue;
+      const failed = writeBufferRef.current.peekFailed(writeKey);
+      const pending = writeBufferRef.current.peekPending(writeKey);
+      if (!failed || !pending || failed.hydrationKey !== hydrationKey) continue;
+      const promotion = (async () => {
+        try {
+          await port.replaceConflictCandidate({
+            scope: persistenceScope,
+            expectedEntry: failed.entry,
+            replacementEntry: pending.entry,
+            observedVersion: {
+              revision: candidate.observedCurrentRevision,
+              generation: candidate.observedCurrentGeneration,
+            },
+          });
+          if (!isExpectedHydrationKey(hydrationKey)) return;
+          writeBufferRef.current.promotePendingToFailed(writeKey, failed, pending);
+          await refreshConflictCandidates();
+        } catch (error) {
+          if (!isExpectedHydrationKey(hydrationKey)) return;
+          reportError(`Unable to preserve the latest manual edit recovery copy: ${String(error)}`);
+          await refreshConflictCandidates();
+        }
+      })();
+      promotionChainsRef.current.set(writeKey, promotion);
+      void promotion.finally(() => {
+        if (promotionChainsRef.current.get(writeKey) === promotion) {
+          promotionChainsRef.current.delete(writeKey);
+        }
+        if (
+          isExpectedHydrationKey(hydrationKey) &&
+          writeBufferRef.current.peekFailed(writeKey) &&
+          writeBufferRef.current.peekPending(writeKey)
+        ) {
+          setPromotionNonce((nonce) => nonce + 1);
+        }
+      });
+    }
+  }, [
+    decisionHydrationKey,
+    draftHistoryConflictCandidates,
+    isExpectedHydrationKey,
+    persistenceScope,
+    port,
+    promotionNonce,
+    refreshConflictCandidates,
+    reportError,
+  ]);
+
+  const flushWrites = useCallback(async (): Promise<boolean> => {
+    if (!decisionHydrationKey) return true;
+    const prefix = `${decisionHydrationKey}\0`;
+    for (const key of writeBufferRef.current.keys(prefix)) void startDrain(key);
+    while (true) {
+      const writes = [...writeChainsRef.current.entries()]
+        .filter(([key]) => key.startsWith(prefix))
+        .map(([, write]) => write);
+      if (writes.length === 0) break;
+      await Promise.allSettled(writes);
+    }
+    return (
+      !writeBufferRef.current.hasPendingWithPrefix(prefix) &&
+      !writeBufferRef.current.hasFailedWithPrefix(prefix) &&
+      ![...writeErrorsRef.current.keys()].some((key) => key.startsWith(prefix))
+    );
+  }, [decisionHydrationKey, startDrain]);
+
+  const clearFile = useCallback(
+    (filePath: string): Promise<void> => {
+      const operationScope = captureOperationScope();
+      if (!operationScope) {
+        return Promise.reject(new Error('Review scope changed before Undo history could clear.'));
+      }
+      const normalizedPath = normalizePathForComparison(filePath);
+      suppressedFilesRef.current.add(normalizedPath);
+      if (!decisionHydrationKey || !persistenceScope) {
+        if (isCurrentOperationScope(operationScope))
+          suppressedFilesRef.current.delete(normalizedPath);
+        return Promise.reject(
+          new Error('Durable review scope is unavailable; refusing to discard Undo history.')
+        );
+      }
+
+      const writeKey = `${decisionHydrationKey}\0${filePath}`;
+      const previous = startDrain(writeKey);
+      let clearedVersion: DraftHistoryVersion | undefined;
+      const clear = previous
+        .then(() => {
+          if (!isCurrentOperationScope(operationScope)) {
+            throw new Error('Review scope changed before Undo history could clear.');
+          }
+          clearedVersion = persistedVersionsRef.current.get(writeKey);
+          return port.clear({
+            scope: persistenceScope,
+            filePath,
+            expectedVersion: {
+              revision: clearedVersion?.revision ?? 0,
+              generation: clearedVersion?.generation ?? null,
+            },
+          });
+        })
+        .then(() => {
+          if (!isCurrentOperationScope(operationScope)) return;
+          const next = { ...entriesRef.current };
+          const current = next[filePath];
+          if (!current || current.revision <= (clearedVersion?.revision ?? 0))
+            delete next[filePath];
+          replaceEntries(next);
+          persistedVersionsRef.current.delete(writeKey);
+          writeErrorsRef.current.delete(writeKey);
+        });
+      writeChainsRef.current.set(writeKey, clear);
+      void clear
+        .catch((error) => {
+          if (!isCurrentOperationScope(operationScope)) return;
+          suppressedFilesRef.current.delete(normalizedPath);
+          writeErrorsRef.current.set(writeKey, error);
+          if (isExpectedHydrationKey(decisionHydrationKey)) {
+            reportError(`Unable to discard saved manual edit history: ${String(error)}`);
+          }
+        })
+        .finally(() => {
+          if (writeChainsRef.current.get(writeKey) === clear)
+            writeChainsRef.current.delete(writeKey);
+          if (
+            isCurrentOperationScope(operationScope) &&
+            writeBufferRef.current.hasPending(writeKey)
+          ) {
+            void startDrain(writeKey);
+          }
+        });
+      return clear;
+    },
+    [
+      captureOperationScope,
+      decisionHydrationKey,
+      isCurrentOperationScope,
+      isExpectedHydrationKey,
+      persistenceScope,
+      port,
+      replaceEntries,
+      reportError,
+      startDrain,
+    ]
+  );
+
+  const publishCheckpoint = useCallback(
+    (
+      filePath: string,
+      editorState: ReviewSerializedEditorState,
+      diskBaseline: string | null
+    ): void => {
+      if (!decisionHydrationKey || !draftHistoryHydrationReady) return;
+      const current = entriesRef.current[filePath];
+      if (
+        current?.diskBaseline === diskBaseline &&
+        JSON.stringify(current.editorState) === JSON.stringify(editorState)
+      ) {
+        return;
+      }
+      const entry: ReviewDraftHistoryEntry = {
+        filePath,
+        codec: 'codemirror-history-v1',
+        revision: (current?.revision ?? 0) + 1,
+        generation: current?.generation ?? 'pending',
+        diskBaseline,
+        editorState,
+        updatedAt: new Date().toISOString(),
+      };
+      replaceEntries({ ...entriesRef.current, [filePath]: entry });
+      enqueueWrite({
+        filePath,
+        codec: entry.codec,
+        revision: entry.revision,
+        diskBaseline,
+        editorState,
+      });
+    },
+    [decisionHydrationKey, draftHistoryHydrationReady, enqueueWrite, replaceEntries]
+  );
+
+  const handleSerializedStateChanged = useCallback(
+    (filePath: string, editorState: ReviewSerializedEditorState): void => {
+      const baselineKey = normalizePathForComparison(filePath);
+      if (suppressedFilesRef.current.has(baselineKey)) return;
+      const existing = entriesRef.current[filePath];
+      if (!baselinesRef.current.has(baselineKey)) {
+        if (!existing) return;
+        baselinesRef.current.set(baselineKey, existing.diskBaseline);
+      }
+      publishCheckpoint(filePath, editorState, baselinesRef.current.get(baselineKey) ?? null);
+    },
+    [publishCheckpoint]
+  );
+
+  const handleSerializedStateRestoreError = useCallback(
+    (filePath: string, error: unknown): void => {
+      reportError(
+        `Saved manual edit history for ${filePath} is incompatible and was not applied: ${String(error)}`
+      );
+    },
+    [reportError]
+  );
+
+  const resolveConflictCandidate = useCallback(
+    async (
+      candidate: ReviewDraftHistoryConflictCandidateSummary,
+      resolution: ReviewConflictResolution,
+      operationScope: ReviewOperationScopeToken
+    ): Promise<boolean> => {
+      if (!decisionHydrationKey || !persistenceScope) return false;
+      const hydrationKey = decisionHydrationKey;
+      const writeKey = `${hydrationKey}\0${candidate.filePath}`;
+      await writeChainsRef.current.get(writeKey)?.catch(() => undefined);
+      if (!isCurrentOperationScope(operationScope) || !isExpectedHydrationKey(hydrationKey)) {
+        return false;
+      }
+      const resolved = await port.resolveConflictCandidate({
+        scope: persistenceScope,
+        candidateId: candidate.id,
+        resolution,
+        observedVersion: {
+          revision: candidate.observedCurrentRevision,
+          generation: candidate.observedCurrentGeneration,
+        },
+      });
+      if (!isCurrentOperationScope(operationScope) || !isExpectedHydrationKey(hydrationKey)) {
+        return false;
+      }
+      const pendingDescendant = writeBufferRef.current.resolveConflict(
+        writeKey,
+        resolution === 'recover-candidate'
+      );
+      writeErrorsRef.current.delete(writeKey);
+      if (resolved) {
+        persistedVersionsRef.current.set(writeKey, {
+          revision: resolved.revision,
+          generation: resolved.generation,
+        });
+      } else {
+        persistedVersionsRef.current.delete(writeKey);
+      }
+      if (pendingDescendant && resolved) {
+        const rebasedEntry = {
+          ...pendingDescendant,
+          entry: { ...pendingDescendant.entry, revision: resolved.revision + 1 },
+        };
+        replaceEntries({
+          ...entriesRef.current,
+          [candidate.filePath]: {
+            ...rebasedEntry.entry,
+            generation: resolved.generation,
+            updatedAt: new Date().toISOString(),
+          },
+        });
+        writeBufferRef.current.enqueue(writeKey, rebasedEntry);
+        void startDrain(writeKey);
+      } else {
+        setRetryNonce((nonce) => nonce + 1);
+      }
+      return true;
+    },
+    [
+      decisionHydrationKey,
+      isCurrentOperationScope,
+      isExpectedHydrationKey,
+      persistenceScope,
+      port,
+      replaceEntries,
+      startDrain,
+    ]
+  );
+
+  const retryHydration = useCallback((): void => setRetryNonce((nonce) => nonce + 1), []);
+
+  const discardUnreadableScope = useCallback(
+    async (operationScope: ReviewOperationScopeToken): Promise<boolean> => {
+      if (!decisionHydrationKey || !persistenceScope) return false;
+      await port.clear({ scope: persistenceScope });
+      if (!isCurrentOperationScope(operationScope)) return false;
+      baselinesRef.current.clear();
+      replaceEntries({});
+      setHydration({ key: decisionHydrationKey, status: 'loaded' });
+      return true;
+    },
+    [
+      decisionHydrationKey,
+      isCurrentOperationScope,
+      persistenceScope,
+      port,
+      replaceEntries,
+      setHydration,
+    ]
+  );
+
+  const getEntry = useCallback((filePath: string) => entriesRef.current[filePath], []);
+  const hasBaseline = useCallback(
+    (filePath: string): boolean => baselinesRef.current.has(normalizePathForComparison(filePath)),
+    []
+  );
+  const getBaseline = useCallback(
+    (filePath: string): string | null | undefined =>
+      baselinesRef.current.get(normalizePathForComparison(filePath)),
+    []
+  );
+  const setBaseline = useCallback((filePath: string, baseline: string | null): void => {
+    baselinesRef.current.set(normalizePathForComparison(filePath), baseline);
+  }, []);
+  const deleteBaseline = useCallback((filePath: string): void => {
+    baselinesRef.current.delete(normalizePathForComparison(filePath));
+  }, []);
+  const unsuppressFile = useCallback((filePath: string): void => {
+    suppressedFilesRef.current.delete(normalizePathForComparison(filePath));
+  }, []);
+  const getDiagnostics = useCallback(
+    (hydrationKey?: string | null): ChangeReviewDraftHistoryDiagnostics => {
+      const prefix = hydrationKey ? `${hydrationKey}\0` : '';
+      return {
+        pendingWriteCount: writeBufferRef.current.keys(prefix).length,
+        writeChainCount: [...writeChainsRef.current.keys()].filter((key) => key.startsWith(prefix))
+          .length,
+        writeErrorCount: [...writeErrorsRef.current.keys()].filter((key) => key.startsWith(prefix))
+          .length,
+      };
+    },
+    []
+  );
+
+  return {
+    entries,
+    getEntry,
+    hasBaseline,
+    getBaseline,
+    setBaseline,
+    deleteBaseline,
+    unsuppressFile,
+    publishCheckpoint,
+    handleSerializedStateChanged,
+    handleSerializedStateRestoreError,
+    flushWrites,
+    clearFile,
+    resolveConflictCandidate,
+    retryHydration,
+    discardUnreadableScope,
+    getDiagnostics,
+  };
+}

--- a/src/features/change-review/renderer/index.ts
+++ b/src/features/change-review/renderer/index.ts
@@ -1,6 +1,18 @@
+export { createChangeReviewDraftHistoryPort } from './adapters/createChangeReviewDraftHistoryPort';
+export type {
+  ChangeReviewDraftHistoryController,
+  ChangeReviewDraftHistoryDiagnostics,
+} from './hooks/useChangeReviewDraftHistoryController';
+export { useChangeReviewDraftHistoryController } from './hooks/useChangeReviewDraftHistoryController';
 export { useChangeReviewLifecycleRegistration } from './hooks/useChangeReviewLifecycleRegistration';
 export { useChangeReviewOperationGeneration } from './hooks/useChangeReviewOperationGeneration';
 export { useChangeReviewScopeIdentity } from './hooks/useChangeReviewScopeIdentity';
+export type {
+  ChangeReviewDraftHistoryEntryInput,
+  ChangeReviewDraftHistoryPort,
+  ChangeReviewDraftHistoryScope,
+  ChangeReviewDraftHistoryVersion,
+} from './ports/changeReviewDraftHistoryPort';
 export type {
   RegisterChangeReviewAppCloseParticipant,
   RegisterChangeReviewLifecycleOwner,

--- a/src/features/change-review/renderer/ports/changeReviewDraftHistoryPort.ts
+++ b/src/features/change-review/renderer/ports/changeReviewDraftHistoryPort.ts
@@ -1,0 +1,53 @@
+import type {
+  ReviewDraftHistoryConflictCandidateSummary,
+  ReviewDraftHistoryEntry,
+  ReviewDraftHistorySnapshot,
+} from '@features/change-review-history/contracts';
+import type { ConflictCheckResult, ReviewConflictResolution, ReviewFileScope } from '@shared/types';
+
+export interface ChangeReviewDraftHistoryScope {
+  teamName: string;
+  scopeKey: string;
+  scopeToken: string;
+}
+
+export interface ChangeReviewDraftHistoryVersion {
+  revision: number;
+  generation: string | null;
+}
+
+export type ChangeReviewDraftHistoryEntryInput = Omit<
+  ReviewDraftHistoryEntry,
+  'updatedAt' | 'generation'
+>;
+
+export interface ChangeReviewDraftHistoryPort {
+  load(scope: ChangeReviewDraftHistoryScope): Promise<ReviewDraftHistorySnapshot | null>;
+  saveEntry(input: {
+    scope: ChangeReviewDraftHistoryScope;
+    entry: ChangeReviewDraftHistoryEntryInput;
+    expectedVersion: ChangeReviewDraftHistoryVersion;
+  }): Promise<ReviewDraftHistoryEntry>;
+  clear(input: {
+    scope: ChangeReviewDraftHistoryScope;
+    filePath?: string;
+    expectedVersion?: ChangeReviewDraftHistoryVersion;
+  }): Promise<void>;
+  checkConflict(input: {
+    reviewScope: ReviewFileScope;
+    filePath: string;
+    expectedModified: string;
+  }): Promise<ConflictCheckResult>;
+  replaceConflictCandidate(input: {
+    scope: ChangeReviewDraftHistoryScope;
+    expectedEntry: ChangeReviewDraftHistoryEntryInput;
+    replacementEntry: ChangeReviewDraftHistoryEntryInput;
+    observedVersion: ChangeReviewDraftHistoryVersion;
+  }): Promise<ReviewDraftHistoryConflictCandidateSummary>;
+  resolveConflictCandidate(input: {
+    scope: ChangeReviewDraftHistoryScope;
+    candidateId: string;
+    resolution: ReviewConflictResolution;
+    observedVersion: ChangeReviewDraftHistoryVersion;
+  }): Promise<ReviewDraftHistoryEntry | null>;
+}

--- a/src/renderer/components/team/review/ChangeReviewDialog.tsx
+++ b/src/renderer/components/team/review/ChangeReviewDialog.tsx
@@ -18,20 +18,19 @@ import {
   buildReviewFileLabels,
   buildReviewStats,
   buildWatchedReviewFilePathsKey,
+  createChangeReviewDraftHistoryPort,
   findActiveReviewFile,
   resolveReviewFileLabel as resolveReviewFileLabelFromMap,
   shouldShowTaskScopeBanner,
   sortChangeReviewFiles,
   TaskChangesEmptyState,
   toTaskChangeSetV2,
+  useChangeReviewDraftHistoryController,
   useChangeReviewLifecycleRegistration,
   useChangeReviewOperationGeneration,
   useChangeReviewScopeIdentity,
 } from '@features/change-review/renderer';
-import {
-  ReviewDraftHistoryWriteBuffer,
-  serializeReviewDraftEditorState,
-} from '@features/change-review-history/renderer';
+import { serializeReviewDraftEditorState } from '@features/change-review-history/renderer';
 import { useAppTranslation } from '@features/localization/renderer';
 import {
   buildReviewExternalReloadState,
@@ -136,11 +135,7 @@ import type {
 } from './reviewActionState';
 import type { EditorView } from '@codemirror/view';
 import type { ReviewDraftHistoryHydrationState } from '@features/change-review/renderer';
-import type {
-  ReviewDraftHistoryConflictCandidateSummary,
-  ReviewDraftHistoryEntry,
-  ReviewSerializedEditorState,
-} from '@features/change-review-history/contracts';
+import type { ReviewDraftHistoryConflictCandidateSummary } from '@features/change-review-history/contracts';
 import type { TaskChangeRequestOptions } from '@renderer/utils/taskChangeRequest';
 import type {
   FileChangeSummary,
@@ -171,19 +166,6 @@ interface RecentReviewWrite {
   expectedContent: string | null;
 }
 
-interface PendingDraftHistoryWrite {
-  hydrationKey: string;
-  teamName: string;
-  scopeKey: string;
-  scopeToken: string;
-  entry: Omit<ReviewDraftHistoryEntry, 'updatedAt' | 'generation'>;
-}
-
-interface DraftHistoryVersion {
-  revision: number;
-  generation: string;
-}
-
 interface ReviewCloseFlushResult {
   ok: boolean;
   blocker?: string;
@@ -202,6 +184,7 @@ interface ReviewPersistenceSnapshotIdentity {
 const REVIEW_PERSISTENCE_ERROR =
   'Latest review action is not saved. Retry from History before continuing.';
 const REVIEW_CONFLICT_LOAD_ERROR_PREFIX = 'Unable to load durable recovery copies:';
+const changeReviewDraftHistoryPort = createChangeReviewDraftHistoryPort(() => api.review);
 
 function captureReviewPersistenceSnapshotIdentity(
   scopeToken: string,
@@ -369,13 +352,8 @@ export const ChangeReviewDialog = ({
     globalTasks,
   } = useStore();
 
-  const [draftHistoryEntries, setDraftHistoryEntries] = useState<
-    Record<string, ReviewDraftHistoryEntry>
-  >({});
   const [draftHistoryHydration, setDraftHistoryHydration] =
     useState<ReviewDraftHistoryHydrationState>({ key: null, status: 'idle' });
-  const [draftHistoryRetryNonce, setDraftHistoryRetryNonce] = useState(0);
-  const [draftConflictPromotionNonce, setDraftConflictPromotionNonce] = useState(0);
   const [decisionConflictCandidates, setDecisionConflictCandidates] = useState<
     ReviewDecisionConflictCandidateSummary[]
   >([]);
@@ -471,19 +449,9 @@ export const ChangeReviewDialog = ({
   const recentReviewWritesRef = useRef(new Map<string, RecentReviewWrite>());
   // Exact disk state on which each manual draft started. Map.has() distinguishes
   // a genuinely missing file (null baseline) from an uncaptured baseline.
-  const draftDiskBaselineRef = useRef(new Map<string, string | null>());
-  const draftHistoryEntriesRef = useRef<Record<string, ReviewDraftHistoryEntry>>({});
-  const draftHistoryWriteChainsRef = useRef(new Map<string, Promise<void>>());
-  const draftConflictPromotionChainsRef = useRef(new Map<string, Promise<void>>());
-  const draftHistoryWriteBufferRef = useRef(
-    new ReviewDraftHistoryWriteBuffer<PendingDraftHistoryWrite>()
-  );
-  const draftHistoryWriteErrorsRef = useRef(new Map<string, unknown>());
-  const draftHistoryPersistedVersionsRef = useRef(new Map<string, DraftHistoryVersion>());
   const expectedDraftHistoryKeyRef = useRef<string | null>(null);
   const reviewConflictRefreshGenerationRef = useRef(0);
   const conflictResolutionOperationRef = useRef<object | null>(null);
-  const suppressedDraftHistoryFilesRef = useRef(new Set<string>());
 
   const hydrateDecisionsFromDisk = useCallback(
     async (
@@ -627,7 +595,6 @@ export const ChangeReviewDialog = ({
     fileApplyInFlightRef.current.clear();
     undoInFlightRef.current = false;
     closingRef.current = false;
-    suppressedDraftHistoryFilesRef.current.clear();
     setFilesApplying(new Set());
     setUndoing(false);
     setClosing(false);
@@ -641,6 +608,81 @@ export const ChangeReviewDialog = ({
       changeSetEpoch,
       resetGenerationState: resetReviewOperationGenerationState,
     });
+
+  const isExpectedDraftHistoryKey = useCallback(
+    (hydrationKey: string): boolean => expectedDraftHistoryKeyRef.current === hydrationKey,
+    []
+  );
+  const commitHydratedDrafts = useCallback(
+    ({
+      scopeFilePaths,
+      recoveredDrafts,
+      externalChanges,
+      errorMessage,
+    }: {
+      scopeFilePaths: string[];
+      recoveredDrafts: Record<string, string>;
+      externalChanges: Record<string, { type: 'change' }>;
+      errorMessage?: string;
+    }): void => {
+      useStore.setState((state) => ({
+        editedContents: replaceReviewScopedRecord(
+          state.editedContents,
+          scopeFilePaths,
+          recoveredDrafts
+        ),
+        reviewExternalChangesByFile: replaceReviewScopedRecord(
+          state.reviewExternalChangesByFile,
+          scopeFilePaths,
+          externalChanges
+        ),
+        applyError: errorMessage ?? state.applyError,
+      }));
+    },
+    []
+  );
+  const reportDraftHistoryError = useCallback((message: string | null): void => {
+    useStore.setState({ applyError: message });
+  }, []);
+  const draftHistory = useChangeReviewDraftHistoryController({
+    open,
+    changeSetEpoch,
+    scopeKey,
+    teamName,
+    activeChangeSet,
+    decisionScopeKey,
+    decisionScopeToken,
+    decisionHydrationKey,
+    draftHistoryHydrationReady,
+    reviewScope,
+    draftHistoryConflictCandidates,
+    setHydration: setDraftHistoryHydration,
+    isExpectedHydrationKey: isExpectedDraftHistoryKey,
+    refreshConflictCandidates: refreshReviewConflictCandidates,
+    captureOperationScope: captureReviewOperationScope,
+    isCurrentOperationScope: isCurrentReviewOperationScope,
+    commitHydratedDrafts,
+    reportError: reportDraftHistoryError,
+    port: changeReviewDraftHistoryPort,
+  });
+  const {
+    entries: draftHistoryEntries,
+    getEntry: getDraftHistoryEntry,
+    hasBaseline: hasDraftHistoryBaseline,
+    getBaseline: getDraftHistoryBaseline,
+    setBaseline: setDraftHistoryBaseline,
+    deleteBaseline: deleteDraftHistoryBaseline,
+    unsuppressFile: unsuppressDraftHistoryFile,
+    publishCheckpoint: publishDraftHistoryCheckpoint,
+    handleSerializedStateChanged,
+    handleSerializedStateRestoreError,
+    flushWrites: flushDraftHistoryWrites,
+    clearFile: clearDraftHistoryForFile,
+    resolveConflictCandidate: resolveDraftHistoryConflictCandidate,
+    retryHydration: retryDraftHistoryHydration,
+    discardUnreadableScope: discardUnreadableDraftHistoryScope,
+    getDiagnostics: getDraftHistoryDiagnostics,
+  } = draftHistory;
 
   useEffect(() => {
     if (!open || !lifecycleAuthorized || !decisionHydrationKey) {
@@ -672,316 +714,6 @@ export const ChangeReviewDialog = ({
     }
     publishReviewActionPersistenceStatus('saved');
   }, [decisionHydrationKey, publishReviewActionPersistenceStatus]);
-
-  const startDraftHistoryDrain = useCallback(
-    (writeKey: string): Promise<void> => {
-      const active = draftHistoryWriteChainsRef.current.get(writeKey);
-      if (active) return active;
-
-      const drain = (async () => {
-        while (true) {
-          const pending = draftHistoryWriteBufferRef.current.takeNext(writeKey);
-          if (!pending) return;
-          try {
-            const expectedVersion = draftHistoryPersistedVersionsRef.current.get(writeKey);
-            const saved = await api.review.saveDraftHistoryEntry(
-              pending.teamName,
-              pending.scopeKey,
-              pending.scopeToken,
-              pending.entry,
-              expectedVersion?.revision ?? 0,
-              expectedVersion?.generation ?? null
-            );
-            draftHistoryPersistedVersionsRef.current.set(writeKey, {
-              revision: saved.revision,
-              generation: saved.generation,
-            });
-            draftHistoryWriteErrorsRef.current.delete(writeKey);
-            const current = draftHistoryEntriesRef.current[pending.entry.filePath];
-            if (
-              expectedDraftHistoryKeyRef.current === pending.hydrationKey &&
-              current?.revision === saved.revision
-            ) {
-              const updatedEntries = {
-                ...draftHistoryEntriesRef.current,
-                [pending.entry.filePath]: saved,
-              };
-              draftHistoryEntriesRef.current = updatedEntries;
-              setDraftHistoryEntries(updatedEntries);
-            }
-          } catch (error) {
-            // A reply can be lost after the main process durably commits the write. Keep that
-            // exact predecessor separate from the coalesced latest draft so it can be retried
-            // idempotently before any newer revision is sent.
-            draftHistoryWriteBufferRef.current.markFailed(writeKey, pending);
-            draftHistoryWriteErrorsRef.current.set(writeKey, error);
-            setDraftConflictPromotionNonce((nonce) => nonce + 1);
-            if (expectedDraftHistoryKeyRef.current === pending.hydrationKey) {
-              useStore.setState({
-                applyError: 'Unable to save manual edit history. Retry Save or keep Changes open.',
-              });
-              void refreshReviewConflictCandidates();
-            }
-            throw error;
-          }
-        }
-      })();
-      draftHistoryWriteChainsRef.current.set(writeKey, drain);
-      void drain
-        .catch(() => undefined)
-        .finally(() => {
-          if (draftHistoryWriteChainsRef.current.get(writeKey) === drain) {
-            draftHistoryWriteChainsRef.current.delete(writeKey);
-          }
-        });
-      return drain;
-    },
-    [refreshReviewConflictCandidates]
-  );
-
-  const enqueueDraftHistoryWrite = useCallback(
-    (entry: Omit<ReviewDraftHistoryEntry, 'updatedAt' | 'generation'>): void => {
-      if (!decisionHydrationKey || !decisionScopeToken) return;
-      const writeKey = `${decisionHydrationKey}\0${entry.filePath}`;
-      draftHistoryWriteBufferRef.current.enqueue(writeKey, {
-        hydrationKey: decisionHydrationKey,
-        teamName,
-        scopeKey: decisionScopeKey,
-        scopeToken: decisionScopeToken,
-        entry,
-      });
-      if (draftHistoryWriteBufferRef.current.peekFailed(writeKey)) {
-        setDraftConflictPromotionNonce((nonce) => nonce + 1);
-      }
-      void startDraftHistoryDrain(writeKey);
-    },
-    [decisionHydrationKey, decisionScopeKey, decisionScopeToken, startDraftHistoryDrain, teamName]
-  );
-
-  useEffect(() => {
-    if (!decisionHydrationKey || !decisionScopeToken) return;
-    const hydrationKey = decisionHydrationKey;
-    for (const candidate of draftHistoryConflictCandidates) {
-      const writeKey = `${hydrationKey}\0${candidate.filePath}`;
-      if (draftConflictPromotionChainsRef.current.has(writeKey)) continue;
-      const failed = draftHistoryWriteBufferRef.current.peekFailed(writeKey);
-      const pending = draftHistoryWriteBufferRef.current.peekPending(writeKey);
-      if (!failed || !pending || failed.hydrationKey !== hydrationKey) {
-        continue;
-      }
-      const promotion = (async () => {
-        try {
-          await api.review.replaceDraftHistoryConflictCandidate(
-            teamName,
-            decisionScopeKey,
-            decisionScopeToken,
-            failed.entry,
-            pending.entry,
-            candidate.observedCurrentRevision,
-            candidate.observedCurrentGeneration
-          );
-          if (expectedDraftHistoryKeyRef.current !== hydrationKey) return;
-          draftHistoryWriteBufferRef.current.promotePendingToFailed(writeKey, failed, pending);
-          await refreshReviewConflictCandidates();
-        } catch (error) {
-          if (expectedDraftHistoryKeyRef.current !== hydrationKey) return;
-          useStore.setState({
-            applyError: `Unable to preserve the latest manual edit recovery copy: ${String(error)}`,
-          });
-          await refreshReviewConflictCandidates();
-        }
-      })();
-      draftConflictPromotionChainsRef.current.set(writeKey, promotion);
-      void promotion.finally(() => {
-        if (draftConflictPromotionChainsRef.current.get(writeKey) === promotion) {
-          draftConflictPromotionChainsRef.current.delete(writeKey);
-        }
-        if (
-          expectedDraftHistoryKeyRef.current === hydrationKey &&
-          draftHistoryWriteBufferRef.current.peekFailed(writeKey) &&
-          draftHistoryWriteBufferRef.current.peekPending(writeKey)
-        ) {
-          setDraftConflictPromotionNonce((nonce) => nonce + 1);
-        }
-      });
-    }
-  }, [
-    decisionHydrationKey,
-    decisionScopeKey,
-    decisionScopeToken,
-    draftConflictPromotionNonce,
-    draftHistoryConflictCandidates,
-    refreshReviewConflictCandidates,
-    teamName,
-  ]);
-
-  const flushDraftHistoryWrites = useCallback(async (): Promise<boolean> => {
-    if (!decisionHydrationKey) return true;
-    const prefix = `${decisionHydrationKey}\0`;
-    const pendingKeys = draftHistoryWriteBufferRef.current.keys(prefix);
-    for (const key of pendingKeys) void startDraftHistoryDrain(key);
-
-    while (true) {
-      const writes = [...draftHistoryWriteChainsRef.current.entries()]
-        .filter(([key]) => key.startsWith(prefix))
-        .map(([, write]) => write);
-      if (writes.length === 0) break;
-      await Promise.allSettled(writes);
-    }
-    const hasPending = draftHistoryWriteBufferRef.current.hasPendingWithPrefix(prefix);
-    const hasFailed = draftHistoryWriteBufferRef.current.hasFailedWithPrefix(prefix);
-    const hasErrors = [...draftHistoryWriteErrorsRef.current.keys()].some((key) =>
-      key.startsWith(prefix)
-    );
-    return !hasPending && !hasFailed && !hasErrors;
-  }, [decisionHydrationKey, startDraftHistoryDrain]);
-
-  const clearDraftHistoryForFile = useCallback(
-    (filePath: string): Promise<void> => {
-      const operationScope = captureReviewOperationScope();
-      if (!operationScope) {
-        return Promise.reject(new Error('Review scope changed before Undo history could clear.'));
-      }
-      const normalizedPath = normalizePathForComparison(filePath);
-      suppressedDraftHistoryFilesRef.current.add(normalizedPath);
-      if (!decisionHydrationKey || !decisionScopeToken) {
-        if (isCurrentReviewOperationScope(operationScope)) {
-          suppressedDraftHistoryFilesRef.current.delete(normalizedPath);
-        }
-        return Promise.reject(
-          new Error('Durable review scope is unavailable; refusing to discard Undo history.')
-        );
-      }
-
-      const writeKey = `${decisionHydrationKey}\0${filePath}`;
-      const previous = startDraftHistoryDrain(writeKey);
-      let clearedVersion: DraftHistoryVersion | undefined;
-      const clear = previous
-        .then(() => {
-          if (!isCurrentReviewOperationScope(operationScope)) {
-            throw new Error('Review scope changed before Undo history could clear.');
-          }
-          clearedVersion = draftHistoryPersistedVersionsRef.current.get(writeKey);
-          return api.review.clearDraftHistory(
-            teamName,
-            decisionScopeKey,
-            decisionScopeToken,
-            filePath,
-            clearedVersion?.revision ?? 0,
-            clearedVersion?.generation ?? null
-          );
-        })
-        .then(() => {
-          if (!isCurrentReviewOperationScope(operationScope)) return;
-          const entries = { ...draftHistoryEntriesRef.current };
-          const current = entries[filePath];
-          if (!current || current.revision <= (clearedVersion?.revision ?? 0)) {
-            delete entries[filePath];
-          }
-          draftHistoryEntriesRef.current = entries;
-          setDraftHistoryEntries(entries);
-          draftHistoryPersistedVersionsRef.current.delete(writeKey);
-          draftHistoryWriteErrorsRef.current.delete(writeKey);
-        });
-      draftHistoryWriteChainsRef.current.set(writeKey, clear);
-      void clear
-        .catch((error) => {
-          if (!isCurrentReviewOperationScope(operationScope)) return;
-          suppressedDraftHistoryFilesRef.current.delete(normalizedPath);
-          draftHistoryWriteErrorsRef.current.set(writeKey, error);
-          if (expectedDraftHistoryKeyRef.current === decisionHydrationKey) {
-            useStore.setState({
-              applyError: `Unable to discard saved manual edit history: ${String(error)}`,
-            });
-          }
-        })
-        .finally(() => {
-          if (draftHistoryWriteChainsRef.current.get(writeKey) === clear) {
-            draftHistoryWriteChainsRef.current.delete(writeKey);
-          }
-          if (
-            isCurrentReviewOperationScope(operationScope) &&
-            draftHistoryWriteBufferRef.current.hasPending(writeKey)
-          ) {
-            void startDraftHistoryDrain(writeKey);
-          }
-        });
-      return clear;
-    },
-    [
-      captureReviewOperationScope,
-      decisionHydrationKey,
-      decisionScopeKey,
-      decisionScopeToken,
-      isCurrentReviewOperationScope,
-      startDraftHistoryDrain,
-      teamName,
-    ]
-  );
-
-  const publishDraftHistoryCheckpoint = useCallback(
-    (
-      filePath: string,
-      editorState: ReviewSerializedEditorState,
-      diskBaseline: string | null
-    ): void => {
-      if (!decisionHydrationKey || !draftHistoryHydrationReady) return;
-      const current = draftHistoryEntriesRef.current[filePath];
-      if (
-        current?.diskBaseline === diskBaseline &&
-        JSON.stringify(current.editorState) === JSON.stringify(editorState)
-      ) {
-        return;
-      }
-      const entry: ReviewDraftHistoryEntry = {
-        filePath,
-        codec: 'codemirror-history-v1',
-        revision: (current?.revision ?? 0) + 1,
-        generation: current?.generation ?? 'pending',
-        diskBaseline,
-        editorState,
-        updatedAt: new Date().toISOString(),
-      };
-      const entries = { ...draftHistoryEntriesRef.current, [filePath]: entry };
-      draftHistoryEntriesRef.current = entries;
-      setDraftHistoryEntries(entries);
-      enqueueDraftHistoryWrite({
-        filePath,
-        codec: entry.codec,
-        revision: entry.revision,
-        diskBaseline,
-        editorState,
-      });
-    },
-    [decisionHydrationKey, draftHistoryHydrationReady, enqueueDraftHistoryWrite]
-  );
-
-  const handleSerializedStateChanged = useCallback(
-    (filePath: string, editorState: ReviewSerializedEditorState): void => {
-      const baselineKey = normalizePathForComparison(filePath);
-      if (suppressedDraftHistoryFilesRef.current.has(baselineKey)) return;
-      const existing = draftHistoryEntriesRef.current[filePath];
-      if (!draftDiskBaselineRef.current.has(baselineKey)) {
-        if (!existing) return;
-        draftDiskBaselineRef.current.set(baselineKey, existing.diskBaseline);
-      }
-      publishDraftHistoryCheckpoint(
-        filePath,
-        editorState,
-        draftDiskBaselineRef.current.get(baselineKey) ?? null
-      );
-    },
-    [publishDraftHistoryCheckpoint]
-  );
-
-  const handleSerializedStateRestoreError = useCallback(
-    (filePath: string, error: unknown): void => {
-      useStore.setState({
-        applyError: `Saved manual edit history for ${filePath} is incompatible and was not applied: ${String(error)}`,
-      });
-    },
-    []
-  );
 
   const setFileApplying = useCallback((filePath: string, value: boolean): void => {
     setFilesApplying((previous) => {
@@ -1039,11 +771,6 @@ export const ChangeReviewDialog = ({
     redoHistoryBeforePreparedActionRef.current = null;
     lastFocusedEditorRef.current = null;
     recentReviewWritesRef.current.clear();
-    draftDiskBaselineRef.current.clear();
-    draftHistoryEntriesRef.current = {};
-    suppressedDraftHistoryFilesRef.current.clear();
-    setDraftHistoryEntries({});
-    setDraftHistoryHydration({ key: null, status: 'idle' });
     undoInFlightRef.current = false;
     closingRef.current = false;
     setUndoing(false);
@@ -1060,111 +787,6 @@ export const ChangeReviewDialog = ({
     setReviewUndoDepth(reviewActionHistory.length);
     setReviewRedoDepth(reviewRedoHistory.length);
   }, [decisionHydrationReady, reviewActionHistory, reviewRedoHistory]);
-
-  useEffect(() => {
-    if (!open || !decisionHydrationKey || !decisionScopeToken || !activeChangeSet) {
-      if (!decisionHydrationKey) {
-        setDraftHistoryHydration({ key: null, status: 'idle' });
-      }
-      return;
-    }
-    let cancelled = false;
-    const hydrationKey = decisionHydrationKey;
-    setDraftHistoryHydration({ key: hydrationKey, status: 'loading' });
-
-    void (async () => {
-      try {
-        const snapshot = await api.review.loadDraftHistory(
-          teamName,
-          decisionScopeKey,
-          decisionScopeToken
-        );
-        if (cancelled || expectedDraftHistoryKeyRef.current !== hydrationKey) return;
-        const writeKeyPrefix = `${hydrationKey}\0`;
-        for (const writeKey of draftHistoryPersistedVersionsRef.current.keys()) {
-          if (writeKey.startsWith(writeKeyPrefix)) {
-            draftHistoryPersistedVersionsRef.current.delete(writeKey);
-          }
-        }
-
-        const allowedFiles = new Map(
-          activeChangeSet.files.map((file) => [normalizePathForComparison(file.filePath), file])
-        );
-        const recoveredEntries: Record<string, ReviewDraftHistoryEntry> = {};
-        const recoveredDrafts: Record<string, string> = {};
-        const externalChanges: Record<string, { type: 'change' }> = {};
-
-        for (const entry of Object.values(snapshot?.entries ?? {})) {
-          const file = allowedFiles.get(normalizePathForComparison(entry.filePath));
-          if (file?.filePath !== entry.filePath) continue;
-          const baselineKey = normalizePathForComparison(file.filePath);
-          const conflict = await api.review.checkConflict(
-            reviewScope,
-            file.filePath,
-            entry.diskBaseline ?? ''
-          );
-          if (cancelled || expectedDraftHistoryKeyRef.current !== hydrationKey) return;
-          const diskMatchesBaseline =
-            entry.diskBaseline === null
-              ? conflict.hasConflict && conflict.conflictContent === null
-              : !conflict.hasConflict;
-
-          recoveredEntries[file.filePath] = entry;
-          draftHistoryPersistedVersionsRef.current.set(`${hydrationKey}\0${file.filePath}`, {
-            revision: entry.revision,
-            generation: entry.generation,
-          });
-          draftDiskBaselineRef.current.set(baselineKey, entry.diskBaseline);
-          if (!diskMatchesBaseline || entry.editorState.doc !== entry.diskBaseline) {
-            recoveredDrafts[file.filePath] = entry.editorState.doc;
-          }
-          if (!diskMatchesBaseline) externalChanges[file.filePath] = { type: 'change' };
-        }
-
-        draftHistoryEntriesRef.current = recoveredEntries;
-        setDraftHistoryEntries(recoveredEntries);
-        useStore.setState((state) => {
-          return {
-            editedContents: replaceReviewScopedRecord(
-              state.editedContents,
-              allowedFiles.keys(),
-              recoveredDrafts
-            ),
-            reviewExternalChangesByFile: replaceReviewScopedRecord(
-              state.reviewExternalChangesByFile,
-              allowedFiles.keys(),
-              externalChanges
-            ),
-            applyError:
-              Object.keys(externalChanges).length > 0
-                ? 'Recovered manual edits are based on files that changed on disk. Review each conflict before saving.'
-                : state.applyError,
-          };
-        });
-        setDraftHistoryHydration({ key: hydrationKey, status: 'loaded' });
-      } catch (error) {
-        if (cancelled || expectedDraftHistoryKeyRef.current !== hydrationKey) return;
-        setDraftHistoryHydration({ key: hydrationKey, status: 'error' });
-        useStore.setState({
-          applyError: `Unable to load saved manual edit history: ${String(error)}`,
-        });
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [
-    activeChangeSet,
-    changeSetEpoch,
-    decisionHydrationKey,
-    decisionScopeKey,
-    decisionScopeToken,
-    open,
-    reviewScope,
-    teamName,
-    draftHistoryRetryNonce,
-  ]);
 
   const pushReviewUndoAction = useCallback(
     (input: ReviewUndoActionInput): ReviewUndoAction => {
@@ -1486,65 +1108,12 @@ export const ChangeReviewDialog = ({
           }
           publishReviewActionPersistenceStatus('saved');
         } else {
-          const writeKey = `${resolutionHydrationKey}\0${selected.value.filePath}`;
-          await draftHistoryWriteChainsRef.current.get(writeKey)?.catch(() => undefined);
-          if (
-            !isCurrentReviewOperationScope(operationScope) ||
-            expectedDraftHistoryKeyRef.current !== resolutionHydrationKey
-          ) {
-            return;
-          }
-          const resolved = await api.review.resolveDraftHistoryConflictCandidate(
-            teamName,
-            decisionScopeKey,
-            decisionScopeToken,
-            selected.value.id,
+          const resolved = await resolveDraftHistoryConflictCandidate(
+            selected.value,
             resolution,
-            selected.value.observedCurrentRevision,
-            selected.value.observedCurrentGeneration
+            operationScope
           );
-          if (
-            !isCurrentReviewOperationScope(operationScope) ||
-            expectedDraftHistoryKeyRef.current !== resolutionHydrationKey
-          ) {
-            return;
-          }
-          const pendingDescendant = draftHistoryWriteBufferRef.current.resolveConflict(
-            writeKey,
-            resolution === 'recover-candidate'
-          );
-          draftHistoryWriteErrorsRef.current.delete(writeKey);
-          if (resolved) {
-            draftHistoryPersistedVersionsRef.current.set(writeKey, {
-              revision: resolved.revision,
-              generation: resolved.generation,
-            });
-          } else {
-            draftHistoryPersistedVersionsRef.current.delete(writeKey);
-          }
-          if (pendingDescendant && resolved) {
-            const rebasedEntry = {
-              ...pendingDescendant,
-              entry: {
-                ...pendingDescendant.entry,
-                revision: resolved.revision + 1,
-              },
-            };
-            const optimisticEntry: ReviewDraftHistoryEntry = {
-              ...rebasedEntry.entry,
-              generation: resolved.generation,
-              updatedAt: new Date().toISOString(),
-            };
-            draftHistoryEntriesRef.current = {
-              ...draftHistoryEntriesRef.current,
-              [selected.value.filePath]: optimisticEntry,
-            };
-            setDraftHistoryEntries(draftHistoryEntriesRef.current);
-            draftHistoryWriteBufferRef.current.enqueue(writeKey, rebasedEntry);
-            void startDraftHistoryDrain(writeKey);
-          } else {
-            setDraftHistoryRetryNonce((nonce) => nonce + 1);
-          }
+          if (!resolved) return;
         }
         if (
           !isCurrentReviewOperationScope(operationScope) ||
@@ -1586,8 +1155,8 @@ export const ChangeReviewDialog = ({
       isCurrentReviewOperationScope,
       publishReviewActionPersistenceStatus,
       refreshReviewConflictCandidates,
+      resolveDraftHistoryConflictCandidate,
       resolvingConflictCandidateId,
-      startDraftHistoryDrain,
       teamName,
     ]
   );
@@ -1754,7 +1323,7 @@ export const ChangeReviewDialog = ({
         if (!file) return;
         const changeType =
           event.type === 'create' ? 'add' : event.type === 'delete' ? 'unlink' : 'change';
-        const durableDraftHistory = draftHistoryEntriesRef.current[file.filePath];
+        const durableDraftHistory = getDraftHistoryEntry(file.filePath);
         if (file.filePath in state.editedContents || durableDraftHistory) {
           if (!(file.filePath in state.editedContents) && durableDraftHistory) {
             state.updateEditedContent(file.filePath, durableDraftHistory.editorState.doc);
@@ -1817,7 +1386,7 @@ export const ChangeReviewDialog = ({
       unsubscribe();
       void api.review.unwatchFiles();
     };
-  }, [open, projectPath, reviewScope]);
+  }, [getDraftHistoryEntry, open, projectPath, reviewScope]);
 
   useEffect(() => {
     if (!open || !projectPath || !isElectronMode()) return;
@@ -2897,11 +2466,11 @@ export const ChangeReviewDialog = ({
   const handleContentChanged = useCallback(
     (filePath: string, content: string, previousContent?: string) => {
       const baselineKey = normalizePathForComparison(filePath);
-      suppressedDraftHistoryFilesRef.current.delete(baselineKey);
-      if (!draftDiskBaselineRef.current.has(baselineKey)) {
+      unsuppressDraftHistoryFile(baselineKey);
+      if (!hasDraftHistoryBaseline(baselineKey)) {
         const fileContent = fileContents[filePath] ?? null;
         if (isReviewFileMissingOnDisk(fileContent)) {
-          draftDiskBaselineRef.current.set(baselineKey, null);
+          setDraftHistoryBaseline(baselineKey, null);
         } else {
           const baseline =
             previousContent ??
@@ -2916,17 +2485,26 @@ export const ChangeReviewDialog = ({
               },
               fileContent
             );
-          if (baseline != null) draftDiskBaselineRef.current.set(baselineKey, baseline);
+          if (baseline != null) setDraftHistoryBaseline(baselineKey, baseline);
         }
       }
-      const diskBaseline = draftDiskBaselineRef.current.get(baselineKey);
+      const diskBaseline = getDraftHistoryBaseline(baselineKey);
       if (diskBaseline !== null && diskBaseline !== undefined && content === diskBaseline) {
         discardFileEdits(filePath);
       } else {
         updateEditedContent(filePath, content);
       }
     },
-    [activeChangeSet, discardFileEdits, fileContents, updateEditedContent]
+    [
+      activeChangeSet,
+      discardFileEdits,
+      fileContents,
+      getDraftHistoryBaseline,
+      hasDraftHistoryBaseline,
+      setDraftHistoryBaseline,
+      unsuppressDraftHistoryFile,
+      updateEditedContent,
+    ]
   );
 
   const handleFullyViewed = useCallback(
@@ -2954,13 +2532,13 @@ export const ChangeReviewDialog = ({
         return;
       }
       const baselineKey = normalizePathForComparison(filePath);
-      if (!draftDiskBaselineRef.current.has(baselineKey)) {
+      if (!hasDraftHistoryBaseline(baselineKey)) {
         useStore.setState({
           applyError: 'The draft disk baseline is unavailable. Reload the file before saving.',
         });
         return;
       }
-      const expectedCurrentContent = draftDiskBaselineRef.current.get(baselineKey) ?? null;
+      const expectedCurrentContent = getDraftHistoryBaseline(baselineKey) ?? null;
       const contentToSave = initialState.editedContents[filePath];
       if (contentToSave === undefined) return;
       const operationEpoch = initialState.changeSetEpoch;
@@ -2973,8 +2551,8 @@ export const ChangeReviewDialog = ({
       if (state.changeSetEpoch === operationEpoch && !state.applyError) {
         // Keep the exact saved baseline even when the buffer is clean. Native history is
         // still valuable: Undo after Save (or restart) should produce a dirty draft.
-        draftDiskBaselineRef.current.set(baselineKey, contentToSave);
-        const serializedState = draftHistoryEntriesRef.current[filePath]?.editorState;
+        setDraftHistoryBaseline(baselineKey, contentToSave);
+        const serializedState = getDraftHistoryEntry(filePath)?.editorState;
         if (serializedState) {
           publishDraftHistoryCheckpoint(filePath, serializedState, contentToSave);
           const flushed = await flushDraftHistoryWrites();
@@ -2999,6 +2577,10 @@ export const ChangeReviewDialog = ({
       markRecentReviewWrite,
       publishDraftHistoryCheckpoint,
       flushDraftHistoryWrites,
+      getDraftHistoryBaseline,
+      getDraftHistoryEntry,
+      hasDraftHistoryBaseline,
+      setDraftHistoryBaseline,
     ]
   );
 
@@ -3009,7 +2591,7 @@ export const ChangeReviewDialog = ({
       const operationScope = captureReviewOperationScope();
       if (!operationScope) return;
       const baselineKey = normalizePathForComparison(filePath);
-      draftDiskBaselineRef.current.set(baselineKey, null);
+      setDraftHistoryBaseline(baselineKey, null);
       markRecentReviewWrite(filePath, content);
       updateEditedContent(filePath, content);
       // Ensure editedContents is set before saveEditedFile reads it.
@@ -3019,8 +2601,8 @@ export const ChangeReviewDialog = ({
         if (!isCurrentReviewOperationScope(operationScope)) return;
         const state = useStore.getState();
         if (state.changeSetEpoch === operationEpoch && !state.applyError) {
-          draftDiskBaselineRef.current.set(baselineKey, content);
-          const serializedState = draftHistoryEntriesRef.current[filePath]?.editorState;
+          setDraftHistoryBaseline(baselineKey, content);
+          const serializedState = getDraftHistoryEntry(filePath)?.editorState;
           if (serializedState) {
             publishDraftHistoryCheckpoint(filePath, serializedState, content);
             const flushed = await flushDraftHistoryWrites();
@@ -3048,6 +2630,8 @@ export const ChangeReviewDialog = ({
       markRecentReviewWrite,
       publishDraftHistoryCheckpoint,
       flushDraftHistoryWrites,
+      getDraftHistoryEntry,
+      setDraftHistoryBaseline,
     ]
   );
 
@@ -3118,7 +2702,7 @@ export const ChangeReviewDialog = ({
             decisionScopeToken,
             committed.decisionRevision
           );
-          draftDiskBaselineRef.current.delete(normalizePathForComparison(filePath));
+          deleteDraftHistoryBaseline(filePath);
           useStore.setState({
             hunkDecisions: next.hunkDecisions,
             fileDecisions: next.fileDecisions,
@@ -3162,6 +2746,7 @@ export const ChangeReviewDialog = ({
     [
       captureReviewOperationScope,
       clearDraftHistoryForFile,
+      deleteDraftHistoryBaseline,
       decisionScopeKey,
       decisionScopeToken,
       fetchFileContent,
@@ -3183,13 +2768,13 @@ export const ChangeReviewDialog = ({
     (filePath: string) => {
       if (hasReviewActionInFlight()) return;
       const baselineKey = normalizePathForComparison(filePath);
-      if (!draftDiskBaselineRef.current.has(baselineKey)) {
+      if (!hasDraftHistoryBaseline(baselineKey)) {
         useStore.setState({
           applyError: 'The draft disk baseline is unavailable. Reload the file before continuing.',
         });
         return;
       }
-      const expected = draftDiskBaselineRef.current.get(baselineKey) ?? '';
+      const expected = getDraftHistoryBaseline(baselineKey) ?? '';
       const operationEpoch = useStore.getState().changeSetEpoch;
       const operationScope = captureReviewOperationScope();
       if (!operationScope) return;
@@ -3206,8 +2791,8 @@ export const ChangeReviewDialog = ({
           }
           const nextBaseline =
             current.hasConflict && current.conflictContent === null ? null : current.currentContent;
-          draftDiskBaselineRef.current.set(baselineKey, nextBaseline);
-          const serializedState = draftHistoryEntriesRef.current[filePath]?.editorState;
+          setDraftHistoryBaseline(baselineKey, nextBaseline);
+          const serializedState = getDraftHistoryEntry(filePath)?.editorState;
           if (serializedState) {
             publishDraftHistoryCheckpoint(filePath, serializedState, nextBaseline);
             const flushed = await flushDraftHistoryWrites();
@@ -3240,11 +2825,15 @@ export const ChangeReviewDialog = ({
       captureReviewOperationScope,
       clearReviewFileExternalChange,
       flushDraftHistoryWrites,
+      getDraftHistoryBaseline,
+      getDraftHistoryEntry,
+      hasDraftHistoryBaseline,
       hasReviewActionInFlight,
       isCurrentReviewOperationScope,
       publishDraftHistoryCheckpoint,
       reviewScope,
       setFileApplying,
+      setDraftHistoryBaseline,
     ]
   );
 
@@ -3270,7 +2859,7 @@ export const ChangeReviewDialog = ({
           ) {
             return;
           }
-          draftDiskBaselineRef.current.delete(normalizePathForComparison(filePath));
+          deleteDraftHistoryBaseline(filePath);
           discardFileEdits(filePath);
           setDiscardCounters((prev) => ({ ...prev, [filePath]: (prev[filePath] ?? 0) + 1 }));
         } catch {
@@ -3290,6 +2879,7 @@ export const ChangeReviewDialog = ({
     [
       captureReviewOperationScope,
       clearDraftHistoryForFile,
+      deleteDraftHistoryBaseline,
       discardFileEdits,
       handleReloadFromDisk,
       hasReviewActionInFlight,
@@ -4059,15 +3649,16 @@ export const ChangeReviewDialog = ({
       blocker: 'Review scope changed while Changes was closing.',
     };
     const state = useStore.getState();
+    const draftHistoryDiagnostics = getDraftHistoryDiagnostics();
     const localStateRequiresScope = hasUnscopedLocalReviewState({
       editedContentCount: Object.keys(state.editedContents).length,
       hunkDecisionCount: Object.keys(state.hunkDecisions).length,
       fileDecisionCount: Object.keys(state.fileDecisions).length,
       undoHistoryCount: state.reviewActionHistory.length,
       redoHistoryCount: state.reviewRedoHistory.length,
-      pendingDraftWriteCount: draftHistoryWriteBufferRef.current.keys('').length,
-      draftWriteChainCount: draftHistoryWriteChainsRef.current.size,
-      draftWriteErrorCount: draftHistoryWriteErrorsRef.current.size,
+      pendingDraftWriteCount: draftHistoryDiagnostics.pendingWriteCount,
+      draftWriteChainCount: draftHistoryDiagnostics.writeChainCount,
+      draftWriteErrorCount: draftHistoryDiagnostics.writeErrorCount,
       pendingApplyCleanup: pendingApplyCleanupKeyRef.current !== null,
       pendingDecisionClear: pendingAutoDecisionClearKeyRef.current !== null,
       persistenceStatus: reviewActionPersistenceStatusRef.current,
@@ -4085,20 +3676,16 @@ export const ChangeReviewDialog = ({
         (matchesCurrentHydration && state.decisionHydrationStatus === 'error') ||
         (matchesDraftHydration && draftHistoryHydration.status === 'error')
       ) {
-        const draftPrefix = `${decisionHydrationKey}\0`;
+        const scopedDraftHistoryDiagnostics = getDraftHistoryDiagnostics(decisionHydrationKey);
         const hasLocalState =
           Object.keys(state.editedContents).length > 0 ||
           Object.keys(state.hunkDecisions).length > 0 ||
           Object.keys(state.fileDecisions).length > 0 ||
           state.reviewActionHistory.length > 0 ||
           state.reviewRedoHistory.length > 0 ||
-          draftHistoryWriteBufferRef.current.keys(draftPrefix).length > 0 ||
-          [...draftHistoryWriteChainsRef.current.keys()].some((key) =>
-            key.startsWith(draftPrefix)
-          ) ||
-          [...draftHistoryWriteErrorsRef.current.keys()].some((key) =>
-            key.startsWith(draftPrefix)
-          ) ||
+          scopedDraftHistoryDiagnostics.pendingWriteCount > 0 ||
+          scopedDraftHistoryDiagnostics.writeChainCount > 0 ||
+          scopedDraftHistoryDiagnostics.writeErrorCount > 0 ||
           pendingApplyCleanupKeyRef.current === decisionHydrationKey ||
           pendingAutoDecisionClearKeyRef.current === decisionHydrationKey ||
           reviewActionPersistenceStatusRef.current !== 'saved';
@@ -4140,13 +3727,13 @@ export const ChangeReviewDialog = ({
     setClosing(true);
     try {
       for (const [filePath, view] of editorViewMapRef.current.entries()) {
-        if (filePath in state.editedContents || draftHistoryEntriesRef.current[filePath]) {
+        if (filePath in state.editedContents || getDraftHistoryEntry(filePath)) {
           handleSerializedStateChanged(filePath, serializeReviewDraftEditorState(view.state));
         }
       }
       const currentState = useStore.getState();
       for (const filePath of Object.keys(currentState.editedContents)) {
-        if (!draftHistoryEntriesRef.current[filePath]) {
+        if (!getDraftHistoryEntry(filePath)) {
           const blocker = `Manual edits for ${filePath} are not durable yet. Keep Changes open and retry.`;
           useStore.setState({ applyError: blocker });
           return { ok: false, blocker };
@@ -4211,6 +3798,8 @@ export const ChangeReviewDialog = ({
     draftHistoryHydration.key,
     draftHistoryHydration.status,
     flushDraftHistoryWrites,
+    getDraftHistoryDiagnostics,
+    getDraftHistoryEntry,
     handleSerializedStateChanged,
     isCurrentReviewOperationScope,
     persistLatestAcceptedReviewAction,
@@ -4277,7 +3866,7 @@ export const ChangeReviewDialog = ({
         if (!isCurrentReviewOperationScope(operationScope)) return;
       }
       if (draftHistoryHydrationFailed) {
-        setDraftHistoryRetryNonce((value) => value + 1);
+        retryDraftHistoryHydration();
       }
     } catch (error) {
       if (!isCurrentReviewOperationScope(operationScope)) return;
@@ -4293,6 +3882,7 @@ export const ChangeReviewDialog = ({
     decisionScopeKey,
     decisionScopeToken,
     draftHistoryHydrationFailed,
+    retryDraftHistoryHydration,
     decisionHydrationKey,
     hydrateDecisionsFromDisk,
     isCurrentReviewOperationScope,
@@ -4328,18 +3918,14 @@ export const ChangeReviewDialog = ({
       }
       if (draftHistoryHydrationFailed) {
         try {
-          await api.review.clearDraftHistory(teamName, decisionScopeKey, decisionScopeToken);
-          if (!isCurrentReviewOperationScope(operationScope)) return;
+          const discarded = await discardUnreadableDraftHistoryScope(operationScope);
+          if (!discarded) return;
         } catch (error) {
           if (!isCurrentReviewOperationScope(operationScope)) return;
           const message = `Unable to discard the unreadable manual edit history: ${String(error)}`;
           useStore.setState({ applyError: message });
           throw new Error(message, { cause: error });
         }
-        draftDiskBaselineRef.current.clear();
-        draftHistoryEntriesRef.current = {};
-        setDraftHistoryEntries({});
-        setDraftHistoryHydration({ key: decisionHydrationKey, status: 'loaded' });
       }
       const state = useStore.getState();
       if (decisionHydrationFailed && state.decisionHydrationScopeKey !== decisionHydrationKey) {
@@ -4364,6 +3950,7 @@ export const ChangeReviewDialog = ({
     decisionHydrationKey,
     decisionScopeKey,
     decisionScopeToken,
+    discardUnreadableDraftHistoryScope,
     draftHistoryHydrationFailed,
     isCurrentReviewOperationScope,
     reviewMutationBusy,

--- a/test/features/change-review/renderer/createChangeReviewDraftHistoryPort.test.ts
+++ b/test/features/change-review/renderer/createChangeReviewDraftHistoryPort.test.ts
@@ -1,0 +1,45 @@
+import { createChangeReviewDraftHistoryPort } from '@features/change-review/renderer';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ReviewAPI } from '@shared/types/api';
+
+type DraftHistoryReviewApi = Pick<
+  ReviewAPI,
+  | 'loadDraftHistory'
+  | 'saveDraftHistoryEntry'
+  | 'clearDraftHistory'
+  | 'checkConflict'
+  | 'replaceDraftHistoryConflictCandidate'
+  | 'resolveDraftHistoryConflictCandidate'
+>;
+
+function reviewApi(loadDraftHistory: ReviewAPI['loadDraftHistory']): DraftHistoryReviewApi {
+  return {
+    loadDraftHistory,
+    saveDraftHistoryEntry: vi.fn(),
+    clearDraftHistory: vi.fn(),
+    checkConflict: vi.fn(),
+    replaceDraftHistoryConflictCandidate: vi.fn(),
+    resolveDraftHistoryConflictCandidate: vi.fn(),
+  };
+}
+
+describe('createChangeReviewDraftHistoryPort', () => {
+  it('resolves the review API lazily for every operation', async () => {
+    const firstLoad = vi.fn<ReviewAPI['loadDraftHistory']>(() => Promise.resolve(null));
+    const secondLoad = vi.fn<ReviewAPI['loadDraftHistory']>(() => Promise.resolve({ entries: {} }));
+    let currentApi = reviewApi(firstLoad);
+    const getReviewApi = vi.fn(() => currentApi);
+    const port = createChangeReviewDraftHistoryPort(getReviewApi);
+    const scope = { teamName: 'team-a', scopeKey: 'task-task-a', scopeToken: 'scope-token' };
+
+    expect(getReviewApi).not.toHaveBeenCalled();
+    await expect(port.load(scope)).resolves.toBeNull();
+    expect(firstLoad).toHaveBeenCalledWith('team-a', 'task-task-a', 'scope-token');
+
+    currentApi = reviewApi(secondLoad);
+    await expect(port.load(scope)).resolves.toEqual({ entries: {} });
+    expect(getReviewApi).toHaveBeenCalledTimes(2);
+    expect(secondLoad).toHaveBeenCalledWith('team-a', 'task-task-a', 'scope-token');
+  });
+});

--- a/test/features/change-review/renderer/useChangeReviewDraftHistoryController.test.tsx
+++ b/test/features/change-review/renderer/useChangeReviewDraftHistoryController.test.tsx
@@ -12,6 +12,7 @@ import type {
   ChangeReviewDraftHistoryPort,
   ReviewOperationScopeToken,
 } from '@features/change-review/renderer';
+import type { ReviewDraftHistoryHydrationState } from '@features/change-review/renderer';
 import type {
   ReviewDraftHistoryEntry,
   ReviewDraftHistorySnapshot,
@@ -19,7 +20,6 @@ import type {
 } from '@features/change-review-history/contracts';
 import type { ReviewChangeSetLike } from '@renderer/utils/reviewDecisionScope';
 import type { ReviewFileScope } from '@shared/types';
-import type { ReviewDraftHistoryHydrationState } from '@features/change-review/renderer';
 
 interface Deferred<T> {
   promise: Promise<T>;

--- a/test/features/change-review/renderer/useChangeReviewDraftHistoryController.test.tsx
+++ b/test/features/change-review/renderer/useChangeReviewDraftHistoryController.test.tsx
@@ -1,0 +1,525 @@
+import React, { act, useCallback } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import {
+  createReviewOperationScopeToken,
+  useChangeReviewDraftHistoryController,
+} from '@features/change-review/renderer';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  ChangeReviewDraftHistoryController,
+  ChangeReviewDraftHistoryPort,
+  ReviewOperationScopeToken,
+} from '@features/change-review/renderer';
+import type {
+  ReviewDraftHistoryEntry,
+  ReviewDraftHistorySnapshot,
+  ReviewSerializedEditorState,
+} from '@features/change-review-history/contracts';
+import type { ReviewChangeSetLike } from '@renderer/utils/reviewDecisionScope';
+import type { ReviewFileScope } from '@shared/types';
+import type { ReviewDraftHistoryHydrationState } from '@features/change-review/renderer';
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function editorState(doc: string): ReviewSerializedEditorState {
+  return { doc, history: { done: [], undone: [] } };
+}
+
+function entry(
+  filePath: string,
+  doc: string,
+  revision = 1,
+  generation = `generation-${revision}`,
+  diskBaseline = 'disk'
+): ReviewDraftHistoryEntry {
+  return {
+    filePath,
+    codec: 'codemirror-history-v1',
+    revision,
+    generation,
+    diskBaseline,
+    editorState: editorState(doc),
+    updatedAt: '2026-07-23T00:00:00.000Z',
+  };
+}
+
+const activeChangeSet: ReviewChangeSetLike = {
+  teamName: 'team-a',
+  taskId: 'task-a',
+  files: [
+    {
+      filePath: '/Project/Case.ts',
+      relativePath: 'Case.ts',
+      snippets: [],
+      linesAdded: 1,
+      linesRemoved: 0,
+      isNewFile: false,
+    },
+  ],
+  totalLinesAdded: 1,
+  totalLinesRemoved: 0,
+  totalFiles: 1,
+  confidence: 'high',
+  computedAt: '2026-07-23T00:00:00.000Z',
+};
+const reviewScope: ReviewFileScope = { teamName: 'team-a', taskId: 'task-a' };
+
+function createPortHarness() {
+  const load = vi.fn<ChangeReviewDraftHistoryPort['load']>(() => Promise.resolve(null));
+  const saveEntry = vi.fn<ChangeReviewDraftHistoryPort['saveEntry']>(({ entry: draftEntry }) =>
+    Promise.resolve({
+      ...draftEntry,
+      generation: `generation-${draftEntry.revision}`,
+      updatedAt: '2026-07-23T00:00:00.000Z',
+    })
+  );
+  const clear = vi.fn<ChangeReviewDraftHistoryPort['clear']>(() => Promise.resolve());
+  const checkConflict = vi.fn<ChangeReviewDraftHistoryPort['checkConflict']>(
+    ({ expectedModified }) =>
+      Promise.resolve({
+        hasConflict: false,
+        conflictContent: null,
+        currentContent: expectedModified,
+        originalContent: expectedModified,
+      })
+  );
+  const replaceConflictCandidate = vi.fn<ChangeReviewDraftHistoryPort['replaceConflictCandidate']>(
+    ({ replacementEntry }) =>
+      Promise.resolve({
+        id: 'promoted-candidate',
+        capturedAt: '2026-07-23T00:00:00.000Z',
+        origin: 'current-snapshot',
+        recoverability: 'recoverable',
+        filePath: replacementEntry.filePath,
+        expectedRevision: replacementEntry.revision - 1,
+        expectedGeneration: null,
+        observedCurrentRevision: replacementEntry.revision,
+        observedCurrentGeneration: null,
+        entryRevision: replacementEntry.revision,
+      })
+  );
+  const resolveConflictCandidate = vi.fn<ChangeReviewDraftHistoryPort['resolveConflictCandidate']>(
+    () => Promise.resolve(null)
+  );
+  const port: ChangeReviewDraftHistoryPort = {
+    load,
+    saveEntry,
+    clear,
+    checkConflict,
+    replaceConflictCandidate,
+    resolveConflictCandidate,
+  };
+  return {
+    port,
+    load,
+    saveEntry,
+    clear,
+    checkConflict,
+    replaceConflictCandidate,
+    resolveConflictCandidate,
+  };
+}
+
+interface ProbeProps {
+  hydrationKey: string;
+  scopeToken: string;
+  changeSetEpoch: number;
+  expectedHydrationKey: () => string;
+  operationScope: () => ReviewOperationScopeToken;
+  port: ChangeReviewDraftHistoryPort;
+  commitHydratedDrafts: (state: {
+    scopeFilePaths: string[];
+    recoveredDrafts: Record<string, string>;
+    externalChanges: Record<string, { type: 'change' }>;
+    errorMessage?: string;
+  }) => void;
+  setHydration: (state: ReviewDraftHistoryHydrationState) => void;
+  reportError: (message: string | null) => void;
+  refreshConflictCandidates: () => Promise<void>;
+}
+
+let latestController: ChangeReviewDraftHistoryController | null = null;
+
+function DraftHistoryProbe(props: Readonly<ProbeProps>): React.JSX.Element {
+  const isExpectedHydrationKey = useCallback(
+    (key: string): boolean => key === props.expectedHydrationKey(),
+    [props.expectedHydrationKey]
+  );
+  const captureOperationScope = useCallback(
+    (): ReviewOperationScopeToken => props.operationScope(),
+    [props.operationScope]
+  );
+  const isCurrentOperationScope = useCallback(
+    (scope: ReviewOperationScopeToken | null): scope is ReviewOperationScopeToken =>
+      scope === props.operationScope(),
+    [props.operationScope]
+  );
+  latestController = useChangeReviewDraftHistoryController({
+    open: true,
+    changeSetEpoch: props.changeSetEpoch,
+    scopeKey: 'task:task-a',
+    teamName: 'team-a',
+    activeChangeSet,
+    decisionScopeKey: 'task-task-a',
+    decisionScopeToken: props.scopeToken,
+    decisionHydrationKey: props.hydrationKey,
+    draftHistoryHydrationReady: true,
+    reviewScope,
+    draftHistoryConflictCandidates: [],
+    setHydration: props.setHydration,
+    isExpectedHydrationKey,
+    refreshConflictCandidates: props.refreshConflictCandidates,
+    captureOperationScope,
+    isCurrentOperationScope,
+    commitHydratedDrafts: props.commitHydratedDrafts,
+    reportError: props.reportError,
+    port: props.port,
+  });
+  return <div data-entry-count={Object.keys(latestController.entries).length} />;
+}
+
+function createHarness(port = createPortHarness().port) {
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+  const root = createRoot(host);
+  const commitHydratedDrafts = vi.fn();
+  const setHydration = vi.fn();
+  const reportError = vi.fn();
+  const refreshConflictCandidates = vi.fn(() => Promise.resolve());
+  let expectedHydrationKey = 'scope-a';
+  let operationScope = createReviewOperationScopeToken('scope-a');
+  const getExpectedHydrationKey = (): string => expectedHydrationKey;
+  const getOperationScope = (): ReviewOperationScopeToken => operationScope;
+
+  const render = async (
+    hydrationKey = expectedHydrationKey,
+    scopeToken = `token-${hydrationKey}`,
+    changeSetEpoch = 1
+  ) => {
+    await act(async () => {
+      root.render(
+        <DraftHistoryProbe
+          hydrationKey={hydrationKey}
+          scopeToken={scopeToken}
+          changeSetEpoch={changeSetEpoch}
+          expectedHydrationKey={getExpectedHydrationKey}
+          operationScope={getOperationScope}
+          port={port}
+          commitHydratedDrafts={commitHydratedDrafts}
+          setHydration={setHydration}
+          reportError={reportError}
+          refreshConflictCandidates={refreshConflictCandidates}
+        />
+      );
+      await Promise.resolve();
+    });
+  };
+
+  return {
+    root,
+    port,
+    commitHydratedDrafts,
+    setHydration,
+    reportError,
+    refreshConflictCandidates,
+    render,
+    setScope(key: string) {
+      expectedHydrationKey = key;
+      operationScope = createReviewOperationScopeToken(key);
+    },
+    currentOperationScope: getOperationScope,
+  };
+}
+
+async function settle(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function flushReact(action: () => void): Promise<void> {
+  await act(async () => {
+    action();
+    await Promise.resolve();
+  });
+}
+
+describe('useChangeReviewDraftHistoryController', () => {
+  afterEach(() => {
+    latestController = null;
+    document.body.innerHTML = '';
+    vi.unstubAllGlobals();
+  });
+
+  it('ignores stale A -> B -> A hydration and rejects case-only path aliases', async () => {
+    const { port, load, checkConflict } = createPortHarness();
+    const firstA = deferred<ReviewDraftHistorySnapshot | null>();
+    const scopeB = deferred<ReviewDraftHistorySnapshot | null>();
+    const reopenedA = deferred<ReviewDraftHistorySnapshot | null>();
+    load.mockImplementation(({ scopeToken }) => {
+      if (scopeToken === 'token-a-first') return firstA.promise;
+      if (scopeToken === 'token-b') return scopeB.promise;
+      return reopenedA.promise;
+    });
+    const harness = createHarness(port);
+
+    await harness.render('scope-a', 'token-a-first');
+    harness.setScope('scope-b');
+    await harness.render('scope-b', 'token-b');
+    harness.setScope('scope-a');
+    await harness.render('scope-a', 'token-a-reopened');
+
+    reopenedA.resolve({
+      entries: {
+        exact: entry('/Project/Case.ts', 'current draft'),
+        alias: entry('/Project/case.ts', 'wrong-case draft'),
+      },
+    });
+    await settle();
+
+    expect(latestController!.getEntry('/Project/Case.ts')?.editorState.doc).toBe('current draft');
+    expect(latestController!.getEntry('/Project/case.ts')).toBeUndefined();
+    expect(checkConflict).toHaveBeenCalledOnce();
+    expect(harness.commitHydratedDrafts).toHaveBeenCalledOnce();
+    expect(harness.commitHydratedDrafts).toHaveBeenLastCalledWith(
+      expect.objectContaining({ recoveredDrafts: { '/Project/Case.ts': 'current draft' } })
+    );
+
+    firstA.resolve({ entries: { stale: entry('/Project/Case.ts', 'stale draft') } });
+    scopeB.resolve(null);
+    await settle();
+
+    expect(harness.commitHydratedDrafts).toHaveBeenCalledOnce();
+    expect(latestController!.getEntry('/Project/Case.ts')?.editorState.doc).toBe('current draft');
+    await flushReact(() => harness.root.unmount());
+  });
+
+  it('does not commit stale A hydration after a deferred per-file conflict check', async () => {
+    const { port, load, checkConflict } = createPortHarness();
+    const oldConflict =
+      deferred<Awaited<ReturnType<ChangeReviewDraftHistoryPort['checkConflict']>>>();
+    load.mockImplementation(({ scopeToken }) =>
+      Promise.resolve(
+        scopeToken === 'token-a-first'
+          ? { entries: { stale: entry('/Project/Case.ts', 'stale draft') } }
+          : null
+      )
+    );
+    checkConflict.mockReturnValueOnce(oldConflict.promise);
+    const harness = createHarness(port);
+
+    await harness.render('scope-a', 'token-a-first');
+    await settle();
+    expect(checkConflict).toHaveBeenCalledOnce();
+    harness.setScope('scope-b');
+    await harness.render('scope-b', 'token-b');
+    harness.setScope('scope-a');
+    await harness.render('scope-a', 'token-a-reopened');
+    await settle();
+    const commitsBeforeOldConflict = harness.commitHydratedDrafts.mock.calls.length;
+
+    oldConflict.resolve({
+      hasConflict: false,
+      conflictContent: null,
+      currentContent: 'disk',
+      originalContent: 'disk',
+    });
+    await settle();
+
+    expect(harness.commitHydratedDrafts).toHaveBeenCalledTimes(commitsBeforeOldConflict);
+    expect(latestController!.getEntry('/Project/Case.ts')).toBeUndefined();
+    await flushReact(() => harness.root.unmount());
+  });
+
+  it('retries a failed predecessor before its coalesced descendant', async () => {
+    const { port, saveEntry } = createPortHarness();
+    saveEntry
+      .mockRejectedValueOnce(new Error('reply lost after commit'))
+      .mockImplementation(({ entry: draftEntry }) =>
+        Promise.resolve({
+          ...draftEntry,
+          generation: `generation-${draftEntry.revision}`,
+          updatedAt: '2026-07-23T00:00:00.000Z',
+        })
+      );
+    const harness = createHarness(port);
+    await harness.render();
+    await settle();
+
+    act(() =>
+      latestController!.publishCheckpoint('/Project/Case.ts', editorState('draft-1'), 'disk')
+    );
+    await settle();
+    act(() =>
+      latestController!.publishCheckpoint('/Project/Case.ts', editorState('draft-2'), 'disk')
+    );
+    let flushed = false;
+    await act(async () => {
+      flushed = await latestController!.flushWrites();
+    });
+
+    expect(flushed).toBe(true);
+    expect(saveEntry).toHaveBeenCalledTimes(3);
+    expect(saveEntry.mock.calls.map(([call]) => call.entry.editorState.doc)).toEqual([
+      'draft-1',
+      'draft-1',
+      'draft-2',
+    ]);
+    expect(saveEntry.mock.calls[1]?.[0].expectedVersion).toEqual({
+      revision: 0,
+      generation: null,
+    });
+    expect(saveEntry.mock.calls[2]?.[0].expectedVersion).toEqual({
+      revision: 1,
+      generation: 'generation-1',
+    });
+    expect(latestController!.getEntry('/Project/Case.ts')?.editorState.doc).toBe('draft-2');
+    await flushReact(() => harness.root.unmount());
+  });
+
+  it('keeps an in-flight write bound to its captured scope and isolates the new scope flush', async () => {
+    const { port, saveEntry } = createPortHarness();
+    const firstSave = deferred<ReviewDraftHistoryEntry>();
+    saveEntry.mockReturnValueOnce(firstSave.promise);
+    const harness = createHarness(port);
+    await harness.render('scope-a', 'token-a');
+    await settle();
+
+    act(() =>
+      latestController!.publishCheckpoint('/Project/Case.ts', editorState('scope-a draft'), 'disk')
+    );
+    expect(saveEntry).toHaveBeenCalledOnce();
+    harness.setScope('scope-b');
+    await harness.render('scope-b', 'token-b');
+    await settle();
+
+    let flushed = false;
+    await act(async () => {
+      flushed = await latestController!.flushWrites();
+    });
+    expect(flushed).toBe(true);
+    expect(saveEntry.mock.calls[0]?.[0].scope).toEqual({
+      teamName: 'team-a',
+      scopeKey: 'task-task-a',
+      scopeToken: 'token-a',
+    });
+
+    firstSave.resolve(entry('/Project/Case.ts', 'scope-a draft'));
+    await settle();
+    expect(latestController!.getEntry('/Project/Case.ts')).toBeUndefined();
+    await flushReact(() => harness.root.unmount());
+  });
+
+  it('serializes clear after the active write and restarts a newer pending checkpoint', async () => {
+    const { port, saveEntry, clear: clearHistory } = createPortHarness();
+    const firstSave = deferred<ReviewDraftHistoryEntry>();
+    const clear = deferred<void>();
+    saveEntry
+      .mockReturnValueOnce(firstSave.promise)
+      .mockImplementationOnce(({ entry: draftEntry }) =>
+        Promise.resolve({
+          ...draftEntry,
+          generation: 'generation-after-clear',
+          updatedAt: '2026-07-23T00:00:00.000Z',
+        })
+      );
+    clearHistory.mockReturnValueOnce(clear.promise);
+    const harness = createHarness(port);
+    await harness.render();
+    await settle();
+
+    act(() =>
+      latestController!.publishCheckpoint('/Project/Case.ts', editorState('draft-1'), 'disk')
+    );
+    let clearPromise!: Promise<void>;
+    act(() => {
+      clearPromise = latestController!.clearFile('/Project/Case.ts');
+    });
+    expect(clearHistory).not.toHaveBeenCalled();
+
+    firstSave.resolve(entry('/Project/Case.ts', 'draft-1'));
+    await settle();
+    expect(clearHistory).toHaveBeenCalledWith({
+      scope: { teamName: 'team-a', scopeKey: 'task-task-a', scopeToken: 'token-scope-a' },
+      filePath: '/Project/Case.ts',
+      expectedVersion: { revision: 1, generation: 'generation-1' },
+    });
+    expect(saveEntry).toHaveBeenCalledOnce();
+
+    act(() => {
+      latestController!.publishCheckpoint('/Project/Case.ts', editorState('draft-2'), 'disk');
+    });
+    expect(saveEntry).toHaveBeenCalledOnce();
+
+    clear.resolve();
+    await act(async () => {
+      await clearPromise;
+    });
+    await act(async () => {
+      expect(await latestController!.flushWrites()).toBe(true);
+    });
+
+    expect(saveEntry).toHaveBeenCalledTimes(2);
+    expect(saveEntry.mock.calls[1]?.[0]).toMatchObject({
+      entry: { revision: 2, editorState: { doc: 'draft-2' } },
+      expectedVersion: { revision: 0, generation: null },
+    });
+    await flushReact(() => harness.root.unmount());
+  });
+
+  it('does not restart a deferred clear after the operation scope changes', async () => {
+    const { port, saveEntry, clear: clearHistory } = createPortHarness();
+    const clear = deferred<void>();
+    clearHistory.mockReturnValueOnce(clear.promise);
+    const harness = createHarness(port);
+    await harness.render();
+    await settle();
+
+    act(() =>
+      latestController!.publishCheckpoint('/Project/Case.ts', editorState('draft-1'), 'disk')
+    );
+    await act(async () => {
+      expect(await latestController!.flushWrites()).toBe(true);
+    });
+    let clearPromise!: Promise<void>;
+    act(() => {
+      clearPromise = latestController!.clearFile('/Project/Case.ts');
+    });
+    await settle();
+    expect(clearHistory).toHaveBeenCalledOnce();
+    act(() =>
+      latestController!.publishCheckpoint('/Project/Case.ts', editorState('draft-2'), 'disk')
+    );
+
+    harness.setScope('scope-b');
+    await harness.render('scope-b', 'token-b');
+    clear.resolve();
+    await act(async () => {
+      await clearPromise;
+    });
+    await settle();
+
+    expect(saveEntry).toHaveBeenCalledOnce();
+    expect(latestController!.getEntry('/Project/Case.ts')).toBeUndefined();
+    expect(harness.reportError).not.toHaveBeenCalled();
+    await flushReact(() => harness.root.unmount());
+  });
+});


### PR DESCRIPTION
## Summary

- extract draft history persistence into a feature-owned controller
- access review IPC through a narrow lazy-resolved port
- preserve scope isolation, serialized writes, promotion, retry, clear, and conflict recovery behavior
- reduce ChangeReviewDialog.tsx from 5,240 to 4,827 lines

## Verification

- pnpm typecheck
- pnpm lint:fast:files on changed files
- type-aware ESLint on changed files: 0 errors
- focused change-review and legacy review tests: 112/112
- direct electron-vite production build and Radix bundle verification
- git diff --check
- architecture suite: 22/23; the only failure is the pre-existing recovery-events catalog omission for five ReviewAPI conflict members