### PR TITLE
chore(review): pin revision-aware runtime release

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -30,9 +30,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-reusable.yml@c804fe9b139437a961b6c65e512cacf761b70875
+    uses: 777genius/review-router/.github/workflows/reviewrouter-reusable.yml@ceb4d251389ac5733504b61e08f6085810a0a2f0
     with:
-      runtime_ref: "c804fe9b139437a961b6c65e512cacf761b70875"
+      runtime_ref: "ceb4d251389ac5733504b61e08f6085810a0a2f0"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       review_action_v2_mode: t0
@@ -59,7 +59,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@c804fe9b139437a961b6c65e512cacf761b70875
+        uses: 777genius/review-router@ceb4d251389ac5733504b61e08f6085810a0a2f0
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"

--- a/.github/workflows/reviewrouter-interaction.yml
+++ b/.github/workflows/reviewrouter-interaction.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.event_name == 'workflow_dispatch' || ((github.event_name != 'issue_comment' || github.event.issue.pull_request) && github.event.comment.user.type != 'Bot') }}
     env:
-      RR_RUNTIME_REF: "c804fe9b139437a961b6c65e512cacf761b70875"
+      RR_RUNTIME_REF: "ceb4d251389ac5733504b61e08f6085810a0a2f0"
       REVIEWROUTER_API_URL: "https://api.reviewrouter.site"
       REVIEWROUTER_OIDC_AUDIENCE: "reviewrouter"
       REVIEWROUTER_RUNTIME_CONFIG_MODE: "oidc"


### PR DESCRIPTION
Pins both managed ReviewRouter workflows to the registered immutable Action release `ceb4d251389ac5733504b61e08f6085810a0a2f0`.

The SaaS v2 mutation authority remains inactive until the GitHub App has `actions: write` and the installation permission update is approved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated review and interaction workflows to use the latest ReviewRouter revision.
  * No changes to workflow behavior, permissions, configuration, or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Pins the managed ReviewRouter workflows to one immutable runtime release.
- Updates the reusable Codex review workflow and its `runtime_ref`.
- Updates the Codex OAuth refresh action reference.
- Updates the interaction workflow’s runtime reference.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with all changed ReviewRouter references consistently pinned to the intended immutable revision.

The changes only replace the previous full commit SHA, preserve existing workflow configuration and permissions, and keep the related runtime references synchronized.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/reviewrouter-codex.yml | Consistently updates the reusable workflow, runtime input, and OAuth refresh action to the same immutable ReviewRouter revision. |
| .github/workflows/reviewrouter-interaction.yml | Updates the interaction workflow’s runtime reference to the same immutable ReviewRouter revision. |

<sub>Reviews (1): Last reviewed commit: ["chore(review): pin revision-aware runtim..."](https://github.com/777genius/agent-teams-ai/commit/e5e0013f19dc47e348f8990eb178a22509f9075f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46609688)</sub>

<!-- /greptile_comment -->