### PR TITLE
refactor(change-review): isolate recovery conflicts

### DIFF
--- a/docs/research/hosted-web/phase-0/recovery-events/mutation-census.json
+++ b/docs/research/hosted-web/phase-0/recovery-events/mutation-census.json
@@ -1,20 +1,20 @@
 {
   "schemaVersion": 1,
   "artifactId": "P0.W5.SUPPORTING.MUTATION_CENSUS",
-  "observedAtSha": "a32f509e6d9bd31ba2135940e336729bf90c3d93",
+  "observedAtSha": "668e7d4f2277b727125770960a4d826bf44be6fa",
   "derivation": "TypeScript AST extraction compared bidirectionally with the independently maintained mutation-surface-manifest.json and command descriptors",
   "sourceFiles": [
     "src/shared/types/api.ts",
     "src/main/services/team/runtime-control/application/OpenCodeRuntimeControlApi.ts"
   ],
-  "rowCount": 123,
+  "rowCount": 128,
   "dispositionCounts": {
-    "extracted": 123,
-    "dispositions": 123,
+    "extracted": 128,
+    "dispositions": 128,
     "required": 53,
-    "query": 46,
+    "query": 48,
     "ephemeral": 15,
-    "deferred": 9
+    "deferred": 12
   },
   "rows": [
     {
@@ -1090,6 +1090,25 @@
       "sourceObserved": true
     },
     {
+      "id": "ReviewAPI.loadDecisionConflictCandidates",
+      "interfaceName": "ReviewAPI",
+      "sourceMethod": "loadDecisionConflictCandidates",
+      "sourceFile": "src/shared/types/api.ts",
+      "disposition": "query",
+      "owner": "team-review",
+      "sourceObserved": true
+    },
+    {
+      "id": "ReviewAPI.resolveDecisionConflictCandidate",
+      "interfaceName": "ReviewAPI",
+      "sourceMethod": "resolveDecisionConflictCandidate",
+      "sourceFile": "src/shared/types/api.ts",
+      "disposition": "deferred",
+      "owner": "team-review",
+      "reason": "hosted HTTP explicitly rejects this mutation and no admitted command descriptor exists",
+      "sourceObserved": true
+    },
+    {
       "id": "ReviewAPI.loadDraftHistory",
       "interfaceName": "ReviewAPI",
       "sourceMethod": "loadDraftHistory",
@@ -1112,6 +1131,35 @@
       "id": "ReviewAPI.clearDraftHistory",
       "interfaceName": "ReviewAPI",
       "sourceMethod": "clearDraftHistory",
+      "sourceFile": "src/shared/types/api.ts",
+      "disposition": "deferred",
+      "owner": "team-review",
+      "reason": "hosted HTTP explicitly rejects this mutation and no admitted command descriptor exists",
+      "sourceObserved": true
+    },
+    {
+      "id": "ReviewAPI.loadDraftHistoryConflictCandidates",
+      "interfaceName": "ReviewAPI",
+      "sourceMethod": "loadDraftHistoryConflictCandidates",
+      "sourceFile": "src/shared/types/api.ts",
+      "disposition": "query",
+      "owner": "team-review",
+      "sourceObserved": true
+    },
+    {
+      "id": "ReviewAPI.resolveDraftHistoryConflictCandidate",
+      "interfaceName": "ReviewAPI",
+      "sourceMethod": "resolveDraftHistoryConflictCandidate",
+      "sourceFile": "src/shared/types/api.ts",
+      "disposition": "deferred",
+      "owner": "team-review",
+      "reason": "hosted HTTP explicitly rejects this mutation and no admitted command descriptor exists",
+      "sourceObserved": true
+    },
+    {
+      "id": "ReviewAPI.replaceDraftHistoryConflictCandidate",
+      "interfaceName": "ReviewAPI",
+      "sourceMethod": "replaceDraftHistoryConflictCandidate",
       "sourceFile": "src/shared/types/api.ts",
       "disposition": "deferred",
       "owner": "team-review",

--- a/docs/research/hosted-web/phase-0/recovery-events/mutation-surface-manifest.json
+++ b/docs/research/hosted-web/phase-0/recovery-events/mutation-surface-manifest.json
@@ -985,6 +985,23 @@
       "commandKind": "review.clear_decisions"
     },
     {
+      "id": "ReviewAPI.loadDecisionConflictCandidates",
+      "interfaceName": "ReviewAPI",
+      "sourceMethod": "loadDecisionConflictCandidates",
+      "sourceFile": "src/shared/types/api.ts",
+      "disposition": "query",
+      "owner": "team-review"
+    },
+    {
+      "id": "ReviewAPI.resolveDecisionConflictCandidate",
+      "interfaceName": "ReviewAPI",
+      "sourceMethod": "resolveDecisionConflictCandidate",
+      "sourceFile": "src/shared/types/api.ts",
+      "disposition": "deferred",
+      "owner": "team-review",
+      "reason": "hosted HTTP explicitly rejects this mutation and no admitted command descriptor exists"
+    },
+    {
       "id": "ReviewAPI.loadDraftHistory",
       "interfaceName": "ReviewAPI",
       "sourceMethod": "loadDraftHistory",
@@ -1005,6 +1022,32 @@
       "id": "ReviewAPI.clearDraftHistory",
       "interfaceName": "ReviewAPI",
       "sourceMethod": "clearDraftHistory",
+      "sourceFile": "src/shared/types/api.ts",
+      "disposition": "deferred",
+      "owner": "team-review",
+      "reason": "hosted HTTP explicitly rejects this mutation and no admitted command descriptor exists"
+    },
+    {
+      "id": "ReviewAPI.loadDraftHistoryConflictCandidates",
+      "interfaceName": "ReviewAPI",
+      "sourceMethod": "loadDraftHistoryConflictCandidates",
+      "sourceFile": "src/shared/types/api.ts",
+      "disposition": "query",
+      "owner": "team-review"
+    },
+    {
+      "id": "ReviewAPI.resolveDraftHistoryConflictCandidate",
+      "interfaceName": "ReviewAPI",
+      "sourceMethod": "resolveDraftHistoryConflictCandidate",
+      "sourceFile": "src/shared/types/api.ts",
+      "disposition": "deferred",
+      "owner": "team-review",
+      "reason": "hosted HTTP explicitly rejects this mutation and no admitted command descriptor exists"
+    },
+    {
+      "id": "ReviewAPI.replaceDraftHistoryConflictCandidate",
+      "interfaceName": "ReviewAPI",
+      "sourceMethod": "replaceDraftHistoryConflictCandidate",
       "sourceFile": "src/shared/types/api.ts",
       "disposition": "deferred",
       "owner": "team-review",

--- a/src/features/change-review/renderer/adapters/createChangeReviewConflictPorts.ts
+++ b/src/features/change-review/renderer/adapters/createChangeReviewConflictPorts.ts
@@ -1,0 +1,39 @@
+import type {
+  ChangeReviewConflictCommandPort,
+  ChangeReviewConflictQueryPort,
+} from '../ports/changeReviewConflictPorts';
+import type { ReviewAPI } from '@shared/types/api';
+
+type ReviewConflictQueryApi = Pick<
+  ReviewAPI,
+  'loadDecisionConflictCandidates' | 'loadDraftHistoryConflictCandidates'
+>;
+
+type ReviewConflictCommandApi = Pick<ReviewAPI, 'resolveDecisionConflictCandidate'>;
+
+export function createChangeReviewConflictQueryPort(
+  getReviewApi: () => ReviewConflictQueryApi
+): ChangeReviewConflictQueryPort {
+  return {
+    loadDecisionCandidates: ({ teamName, scopeKey, scopeToken }) =>
+      getReviewApi().loadDecisionConflictCandidates(teamName, scopeKey, scopeToken),
+    loadDraftHistoryCandidates: ({ teamName, scopeKey, scopeToken }) =>
+      getReviewApi().loadDraftHistoryConflictCandidates(teamName, scopeKey, scopeToken),
+  };
+}
+
+export function createChangeReviewConflictCommandPort(
+  getReviewApi: () => ReviewConflictCommandApi
+): ChangeReviewConflictCommandPort {
+  return {
+    resolveDecisionCandidate: ({ scope, candidateId, resolution, observedCurrentRevision }) =>
+      getReviewApi().resolveDecisionConflictCandidate(
+        scope.teamName,
+        scope.scopeKey,
+        scope.scopeToken,
+        candidateId,
+        resolution,
+        observedCurrentRevision
+      ),
+  };
+}

--- a/src/features/change-review/renderer/adapters/createChangeReviewConflictStateBridge.ts
+++ b/src/features/change-review/renderer/adapters/createChangeReviewConflictStateBridge.ts
@@ -1,0 +1,41 @@
+import { CHANGE_REVIEW_CONFLICT_LOAD_ERROR_PREFIX } from '../utils/changeReviewConflicts';
+
+interface ChangeReviewConflictStateSnapshot {
+  applyError: string | null;
+  decisionHydrationScopeKey: string | null;
+  decisionHydrationStatus: string;
+}
+
+interface CreateChangeReviewConflictStateBridgeInput {
+  getSnapshot: () => ChangeReviewConflictStateSnapshot;
+  setApplyError: (message: string | null) => void;
+}
+
+export interface ChangeReviewConflictStateBridge {
+  clearReportedLoadError: () => void;
+  reportError: (message: string) => void;
+  clearResolutionError: () => void;
+  isDecisionHydrationLoaded: (hydrationKey: string) => boolean;
+}
+
+export function createChangeReviewConflictStateBridge({
+  getSnapshot,
+  setApplyError,
+}: CreateChangeReviewConflictStateBridgeInput): ChangeReviewConflictStateBridge {
+  return {
+    clearReportedLoadError: () => {
+      if (getSnapshot().applyError?.startsWith(CHANGE_REVIEW_CONFLICT_LOAD_ERROR_PREFIX)) {
+        setApplyError(null);
+      }
+    },
+    reportError: (message) => setApplyError(message),
+    clearResolutionError: () => setApplyError(null),
+    isDecisionHydrationLoaded: (hydrationKey) => {
+      const snapshot = getSnapshot();
+      return (
+        snapshot.decisionHydrationScopeKey === hydrationKey &&
+        snapshot.decisionHydrationStatus === 'loaded'
+      );
+    },
+  };
+}

--- a/src/features/change-review/renderer/hooks/useChangeReviewConflictDiscoveryController.ts
+++ b/src/features/change-review/renderer/hooks/useChangeReviewConflictDiscoveryController.ts
@@ -1,0 +1,123 @@
+import { useCallback, useLayoutEffect, useRef, useState } from 'react';
+
+import { CHANGE_REVIEW_CONFLICT_LOAD_ERROR_PREFIX } from '../utils/changeReviewConflicts';
+
+import type { ChangeReviewConflictQueryPort } from '../ports/changeReviewConflictPorts';
+import type { ChangeReviewConflictScope } from '../ports/changeReviewConflictPorts';
+import type { ReviewDraftHistoryConflictCandidateSummary } from '@features/change-review-history/contracts';
+import type { ReviewDecisionConflictCandidateSummary } from '@shared/types';
+
+interface UseChangeReviewConflictDiscoveryControllerInput {
+  active: boolean;
+  hydrationKey: string | null;
+  scope: ChangeReviewConflictScope | null;
+  isExpectedHydrationKey: (hydrationKey: string) => boolean;
+  hydrateDecisions: (scope: ChangeReviewConflictScope, hydrationKey: string) => Promise<void>;
+  clearReportedLoadError: () => void;
+  reportLoadError: (message: string) => void;
+  port: ChangeReviewConflictQueryPort;
+}
+
+export interface ChangeReviewConflictDiscoveryController {
+  decisionCandidates: ReviewDecisionConflictCandidateSummary[];
+  draftHistoryCandidates: ReviewDraftHistoryConflictCandidateSummary[];
+  candidateCount: number;
+  refreshPending: boolean;
+  loadError: string | null;
+  refresh: () => Promise<void>;
+  reset: () => void;
+}
+
+export function useChangeReviewConflictDiscoveryController({
+  active,
+  hydrationKey,
+  scope,
+  isExpectedHydrationKey,
+  hydrateDecisions,
+  clearReportedLoadError,
+  reportLoadError,
+  port,
+}: UseChangeReviewConflictDiscoveryControllerInput): ChangeReviewConflictDiscoveryController {
+  const [decisionCandidates, setDecisionCandidates] = useState<
+    ReviewDecisionConflictCandidateSummary[]
+  >([]);
+  const [draftHistoryCandidates, setDraftHistoryCandidates] = useState<
+    ReviewDraftHistoryConflictCandidateSummary[]
+  >([]);
+  const [refreshPending, setRefreshPending] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const refreshGenerationRef = useRef(0);
+
+  useLayoutEffect(() => {
+    refreshGenerationRef.current += 1;
+    return () => {
+      refreshGenerationRef.current += 1;
+    };
+  }, [active, hydrationKey]);
+
+  const reset = useCallback((): void => {
+    refreshGenerationRef.current += 1;
+    setDecisionCandidates([]);
+    setDraftHistoryCandidates([]);
+    setRefreshPending(false);
+    setLoadError(null);
+  }, []);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    const refreshGeneration = ++refreshGenerationRef.current;
+    if (!active || !hydrationKey || !scope) {
+      setDecisionCandidates([]);
+      setDraftHistoryCandidates([]);
+      setRefreshPending(false);
+      setLoadError(null);
+      return;
+    }
+    const requestHydrationKey = hydrationKey;
+    const isCurrentRequest = (): boolean =>
+      isExpectedHydrationKey(requestHydrationKey) &&
+      refreshGenerationRef.current === refreshGeneration;
+
+    setRefreshPending(true);
+    try {
+      const [nextDecisionCandidates, nextDraftHistoryCandidates] = await Promise.all([
+        port.loadDecisionCandidates(scope),
+        port.loadDraftHistoryCandidates(scope),
+      ]);
+      if (!isCurrentRequest()) return;
+      if (nextDecisionCandidates.length > 0) {
+        await hydrateDecisions(scope, requestHydrationKey);
+        if (!isCurrentRequest()) return;
+      }
+      setDecisionCandidates(nextDecisionCandidates);
+      setDraftHistoryCandidates(nextDraftHistoryCandidates);
+      setLoadError(null);
+      clearReportedLoadError();
+    } catch (error) {
+      if (!isCurrentRequest()) return;
+      const message = `${CHANGE_REVIEW_CONFLICT_LOAD_ERROR_PREFIX} ${String(error)}`;
+      setLoadError(message);
+      reportLoadError(message);
+    } finally {
+      if (isCurrentRequest()) setRefreshPending(false);
+    }
+  }, [
+    active,
+    clearReportedLoadError,
+    hydrateDecisions,
+    hydrationKey,
+    isExpectedHydrationKey,
+    port,
+    reportLoadError,
+    scope,
+  ]);
+
+  return {
+    decisionCandidates,
+    draftHistoryCandidates,
+    candidateCount: decisionCandidates.length + draftHistoryCandidates.length,
+    refreshPending,
+    loadError,
+    refresh,
+    reset,
+  };
+}

--- a/src/features/change-review/renderer/hooks/useChangeReviewConflictInteractionController.ts
+++ b/src/features/change-review/renderer/hooks/useChangeReviewConflictInteractionController.ts
@@ -1,0 +1,210 @@
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+
+import { selectLatestReviewConflictCandidate } from '../utils/changeReviewConflicts';
+
+import type { ChangeReviewConflictCommandPort } from '../ports/changeReviewConflictPorts';
+import type { ChangeReviewConflictScope } from '../ports/changeReviewConflictPorts';
+import type { ReviewConflictCandidateSelection } from '../utils/changeReviewConflicts';
+import type { ReviewOperationScopeToken } from '../utils/reviewOperationGeneration';
+import type { ReviewDraftHistoryConflictCandidateSummary } from '@features/change-review-history/contracts';
+import type {
+  ReviewConflictResolution,
+  ReviewDecisionConflictCandidateSummary,
+} from '@shared/types';
+
+interface UseChangeReviewConflictInteractionControllerInput {
+  active: boolean;
+  hydrationKey: string | null;
+  scope: ChangeReviewConflictScope | null;
+  decisionCandidates: readonly ReviewDecisionConflictCandidateSummary[];
+  draftHistoryCandidates: readonly ReviewDraftHistoryConflictCandidateSummary[];
+  captureOperationScope: () => ReviewOperationScopeToken | null;
+  isCurrentOperationScope: (
+    operationScope: ReviewOperationScopeToken | null
+  ) => operationScope is ReviewOperationScopeToken;
+  isExpectedHydrationKey: (hydrationKey: string) => boolean;
+  hydrateDecisions: (scope: ChangeReviewConflictScope, hydrationKey: string) => Promise<void>;
+  isDecisionHydrationLoaded: (hydrationKey: string) => boolean;
+  publishDecisionPersistenceSaved: () => void;
+  resolveDraftHistoryCandidate: (
+    candidate: ReviewDraftHistoryConflictCandidateSummary,
+    resolution: ReviewConflictResolution,
+    operationScope: ReviewOperationScopeToken
+  ) => Promise<boolean>;
+  clearResolutionError: () => void;
+  reportResolutionError: (message: string) => void;
+  refreshCandidates: () => Promise<void>;
+  port: ChangeReviewConflictCommandPort;
+}
+
+export interface ChangeReviewConflictInteractionController {
+  activeCandidate: ReviewConflictCandidateSelection | null;
+  activeCandidateRecoverable: boolean;
+  resolvingCandidateId: string | null;
+  pendingDiscard: ReviewConflictCandidateSelection | null;
+  requestDiscard: (candidate: ReviewConflictCandidateSelection) => void;
+  onDiscardOpenChange: (open: boolean) => void;
+  confirmPendingDiscard: () => Promise<void>;
+  resolveActiveCandidate: (
+    resolution: ReviewConflictResolution,
+    expectedCandidateId?: string
+  ) => Promise<void>;
+}
+
+export function useChangeReviewConflictInteractionController({
+  active,
+  hydrationKey,
+  scope,
+  decisionCandidates,
+  draftHistoryCandidates,
+  captureOperationScope,
+  isCurrentOperationScope,
+  isExpectedHydrationKey,
+  hydrateDecisions,
+  isDecisionHydrationLoaded,
+  publishDecisionPersistenceSaved,
+  resolveDraftHistoryCandidate,
+  clearResolutionError,
+  reportResolutionError,
+  refreshCandidates,
+  port,
+}: UseChangeReviewConflictInteractionControllerInput): ChangeReviewConflictInteractionController {
+  const [resolvingCandidateId, setResolvingCandidateId] = useState<string | null>(null);
+  const [pendingDiscard, setPendingDiscard] = useState<ReviewConflictCandidateSelection | null>(
+    null
+  );
+  const resolutionOperationRef = useRef<object | null>(null);
+  const activeCandidate = useMemo(
+    () => selectLatestReviewConflictCandidate(decisionCandidates, draftHistoryCandidates),
+    [decisionCandidates, draftHistoryCandidates]
+  );
+  const activeCandidateRecoverable = activeCandidate?.value.recoverability === 'recoverable';
+
+  useLayoutEffect(() => {
+    resolutionOperationRef.current = null;
+    setResolvingCandidateId(null);
+    return () => {
+      resolutionOperationRef.current = null;
+    };
+  }, [active, hydrationKey]);
+
+  useEffect(() => {
+    setPendingDiscard(null);
+  }, [hydrationKey]);
+
+  const resolveActiveCandidate = useCallback(
+    async (resolution: ReviewConflictResolution, expectedCandidateId?: string): Promise<void> => {
+      if (
+        !activeCandidate ||
+        (resolution === 'recover-candidate' && !activeCandidateRecoverable) ||
+        (expectedCandidateId !== undefined && activeCandidate.value.id !== expectedCandidateId) ||
+        !hydrationKey ||
+        !scope ||
+        resolutionOperationRef.current !== null
+      ) {
+        return;
+      }
+      const selected = activeCandidate;
+      const resolutionHydrationKey = hydrationKey;
+      const operationScope = captureOperationScope();
+      if (!operationScope) return;
+      const resolutionOperation = {};
+      resolutionOperationRef.current = resolutionOperation;
+      setResolvingCandidateId(selected.value.id);
+      const isCurrentResolution = (): boolean =>
+        isCurrentOperationScope(operationScope) &&
+        isExpectedHydrationKey(resolutionHydrationKey) &&
+        resolutionOperationRef.current === resolutionOperation;
+
+      try {
+        if (selected.kind === 'decision') {
+          await port.resolveDecisionCandidate({
+            scope,
+            candidateId: selected.value.id,
+            resolution,
+            observedCurrentRevision: selected.value.observedCurrentRevision,
+          });
+          if (!isCurrentResolution()) return;
+          await hydrateDecisions(scope, resolutionHydrationKey);
+          if (!isCurrentResolution()) return;
+          if (!isDecisionHydrationLoaded(resolutionHydrationKey)) {
+            throw new Error('Resolved decisions could not be reloaded');
+          }
+          publishDecisionPersistenceSaved();
+        } else {
+          const resolved = await resolveDraftHistoryCandidate(
+            selected.value,
+            resolution,
+            operationScope
+          );
+          if (!resolved) return;
+        }
+        if (!isCurrentResolution()) return;
+        clearResolutionError();
+        await refreshCandidates();
+      } catch (error) {
+        if (!isCurrentResolution()) return;
+        reportResolutionError(`Unable to resolve the durable recovery copy: ${String(error)}`);
+        await refreshCandidates();
+      } finally {
+        if (isCurrentResolution()) {
+          resolutionOperationRef.current = null;
+          setResolvingCandidateId(null);
+        }
+      }
+    },
+    [
+      activeCandidate,
+      activeCandidateRecoverable,
+      captureOperationScope,
+      clearResolutionError,
+      hydrateDecisions,
+      hydrationKey,
+      isCurrentOperationScope,
+      isDecisionHydrationLoaded,
+      isExpectedHydrationKey,
+      port,
+      publishDecisionPersistenceSaved,
+      refreshCandidates,
+      reportResolutionError,
+      resolveDraftHistoryCandidate,
+      scope,
+    ]
+  );
+
+  const requestDiscard = useCallback((candidate: ReviewConflictCandidateSelection): void => {
+    setPendingDiscard(candidate);
+  }, []);
+
+  const onDiscardOpenChange = useCallback(
+    (open: boolean): void => {
+      if (!open && resolvingCandidateId === null) setPendingDiscard(null);
+    },
+    [resolvingCandidateId]
+  );
+
+  const confirmPendingDiscard = useCallback(async (): Promise<void> => {
+    if (!pendingDiscard) return;
+    const operationScope = captureOperationScope();
+    if (!operationScope) return;
+    const candidateId = pendingDiscard.value.id;
+    try {
+      await resolveActiveCandidate('keep-current', candidateId);
+    } finally {
+      if (isCurrentOperationScope(operationScope)) {
+        setPendingDiscard((current) => (current?.value.id === candidateId ? null : current));
+      }
+    }
+  }, [captureOperationScope, isCurrentOperationScope, pendingDiscard, resolveActiveCandidate]);
+
+  return {
+    activeCandidate,
+    activeCandidateRecoverable,
+    resolvingCandidateId,
+    pendingDiscard,
+    requestDiscard,
+    onDiscardOpenChange,
+    confirmPendingDiscard,
+    resolveActiveCandidate,
+  };
+}

--- a/src/features/change-review/renderer/hooks/useChangeReviewConflictInteractionController.ts
+++ b/src/features/change-review/renderer/hooks/useChangeReviewConflictInteractionController.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import { selectLatestReviewConflictCandidate } from '../utils/changeReviewConflicts';
 
@@ -83,14 +83,11 @@ export function useChangeReviewConflictInteractionController({
   useLayoutEffect(() => {
     resolutionOperationRef.current = null;
     setResolvingCandidateId(null);
+    setPendingDiscard(null);
     return () => {
       resolutionOperationRef.current = null;
     };
   }, [active, hydrationKey]);
-
-  useEffect(() => {
-    setPendingDiscard(null);
-  }, [hydrationKey]);
 
   const resolveActiveCandidate = useCallback(
     async (resolution: ReviewConflictResolution, expectedCandidateId?: string): Promise<void> => {

--- a/src/features/change-review/renderer/index.ts
+++ b/src/features/change-review/renderer/index.ts
@@ -1,4 +1,14 @@
+export {
+  createChangeReviewConflictCommandPort,
+  createChangeReviewConflictQueryPort,
+} from './adapters/createChangeReviewConflictPorts';
+export type { ChangeReviewConflictStateBridge } from './adapters/createChangeReviewConflictStateBridge';
+export { createChangeReviewConflictStateBridge } from './adapters/createChangeReviewConflictStateBridge';
 export { createChangeReviewDraftHistoryPort } from './adapters/createChangeReviewDraftHistoryPort';
+export type { ChangeReviewConflictDiscoveryController } from './hooks/useChangeReviewConflictDiscoveryController';
+export { useChangeReviewConflictDiscoveryController } from './hooks/useChangeReviewConflictDiscoveryController';
+export type { ChangeReviewConflictInteractionController } from './hooks/useChangeReviewConflictInteractionController';
+export { useChangeReviewConflictInteractionController } from './hooks/useChangeReviewConflictInteractionController';
 export type {
   ChangeReviewDraftHistoryController,
   ChangeReviewDraftHistoryDiagnostics,
@@ -7,6 +17,11 @@ export { useChangeReviewDraftHistoryController } from './hooks/useChangeReviewDr
 export { useChangeReviewLifecycleRegistration } from './hooks/useChangeReviewLifecycleRegistration';
 export { useChangeReviewOperationGeneration } from './hooks/useChangeReviewOperationGeneration';
 export { useChangeReviewScopeIdentity } from './hooks/useChangeReviewScopeIdentity';
+export type {
+  ChangeReviewConflictCommandPort,
+  ChangeReviewConflictQueryPort,
+  ChangeReviewConflictScope,
+} from './ports/changeReviewConflictPorts';
 export type {
   ChangeReviewDraftHistoryEntryInput,
   ChangeReviewDraftHistoryPort,
@@ -17,8 +32,19 @@ export type {
   RegisterChangeReviewAppCloseParticipant,
   RegisterChangeReviewLifecycleOwner,
 } from './ports/changeReviewLifecyclePorts';
+export {
+  ChangeReviewConflictDiscardDialog,
+  ChangeReviewConflictNotices,
+} from './ui/ChangeReviewConflictNotices';
 export type { TaskChangesEmptyStateProps } from './ui/TaskChangesEmptyState';
 export { TaskChangesEmptyState } from './ui/TaskChangesEmptyState';
+export type { ReviewConflictCandidateSelection } from './utils/changeReviewConflicts';
+export {
+  CHANGE_REVIEW_CONFLICT_LOAD_ERROR_PREFIX,
+  describeReviewConflictCandidate,
+  describeReviewConflictDiscard,
+  selectLatestReviewConflictCandidate,
+} from './utils/changeReviewConflicts';
 export type {
   BuildChangeReviewScopeProjectionInput,
   ChangeReviewScopeProjection,

--- a/src/features/change-review/renderer/ports/changeReviewConflictPorts.ts
+++ b/src/features/change-review/renderer/ports/changeReviewConflictPorts.ts
@@ -1,0 +1,29 @@
+import type { ReviewDraftHistoryConflictCandidateSummary } from '@features/change-review-history/contracts';
+import type {
+  ReviewConflictResolution,
+  ReviewDecisionConflictCandidateSummary,
+} from '@shared/types';
+
+export interface ChangeReviewConflictScope {
+  teamName: string;
+  scopeKey: string;
+  scopeToken: string;
+}
+
+export interface ChangeReviewConflictQueryPort {
+  loadDecisionCandidates(
+    scope: ChangeReviewConflictScope
+  ): Promise<ReviewDecisionConflictCandidateSummary[]>;
+  loadDraftHistoryCandidates(
+    scope: ChangeReviewConflictScope
+  ): Promise<ReviewDraftHistoryConflictCandidateSummary[]>;
+}
+
+export interface ChangeReviewConflictCommandPort {
+  resolveDecisionCandidate(input: {
+    scope: ChangeReviewConflictScope;
+    candidateId: string;
+    resolution: ReviewConflictResolution;
+    observedCurrentRevision: number;
+  }): Promise<{ revision: number }>;
+}

--- a/src/features/change-review/renderer/ui/ChangeReviewConflictNotices.tsx
+++ b/src/features/change-review/renderer/ui/ChangeReviewConflictNotices.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@renderer/components/ui/alert-dialog';
+import { AlertTriangle } from 'lucide-react';
+
+import {
+  describeReviewConflictCandidate,
+  describeReviewConflictDiscard,
+} from '../utils/changeReviewConflicts';
+
+import type { ReviewConflictCandidateSelection } from '../utils/changeReviewConflicts';
+
+interface ChangeReviewConflictDiscardDialogProps {
+  pendingDiscard: ReviewConflictCandidateSelection | null;
+  resolvingCandidateId: string | null;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => Promise<void>;
+}
+
+export const ChangeReviewConflictDiscardDialog = ({
+  pendingDiscard,
+  resolvingCandidateId,
+  onOpenChange,
+  onConfirm,
+}: ChangeReviewConflictDiscardDialogProps): React.JSX.Element => (
+  <AlertDialog open={pendingDiscard !== null} onOpenChange={onOpenChange}>
+    <AlertDialogContent>
+      <AlertDialogHeader>
+        <AlertDialogTitle>Discard this recovery branch?</AlertDialogTitle>
+        <AlertDialogDescription>
+          {describeReviewConflictDiscard(pendingDiscard)} Your current branch stays saved. The
+          selected recovery copy will be permanently deleted and cannot be restored later.
+        </AlertDialogDescription>
+      </AlertDialogHeader>
+      <AlertDialogFooter>
+        <AlertDialogCancel disabled={resolvingCandidateId !== null}>Cancel</AlertDialogCancel>
+        <AlertDialogAction
+          disabled={!pendingDiscard || resolvingCandidateId !== null}
+          className="bg-red-600 text-white hover:bg-red-500"
+          onClick={() => void onConfirm()}
+        >
+          Discard recovery branch
+        </AlertDialogAction>
+      </AlertDialogFooter>
+    </AlertDialogContent>
+  </AlertDialog>
+);
+
+interface ChangeReviewConflictNoticesProps {
+  loadError: string | null;
+  refreshPending: boolean;
+  activeCandidate: ReviewConflictCandidateSelection | null;
+  activeCandidateRecoverable: boolean;
+  candidateCount: number;
+  resolvingCandidateId: string | null;
+  onRetry: () => Promise<void>;
+  onRequestDiscard: (candidate: ReviewConflictCandidateSelection) => void;
+  onRecover: () => Promise<void>;
+}
+
+export const ChangeReviewConflictNotices = ({
+  loadError,
+  refreshPending,
+  activeCandidate,
+  activeCandidateRecoverable,
+  candidateCount,
+  resolvingCandidateId,
+  onRetry,
+  onRequestDiscard,
+  onRecover,
+}: ChangeReviewConflictNoticesProps): React.JSX.Element => (
+  <>
+    {loadError && (
+      <div
+        role="alert"
+        className="flex items-center gap-3 border-b border-red-500/25 bg-red-500/10 px-4 py-2.5 text-xs text-red-200"
+      >
+        <AlertTriangle className="size-4 shrink-0 text-red-400" />
+        <div className="min-w-0 flex-1">
+          Recovery copies could not be verified. Review actions stay locked to prevent data loss.
+        </div>
+        <button
+          type="button"
+          onClick={() => void onRetry()}
+          disabled={refreshPending}
+          className="shrink-0 rounded border border-red-400/30 px-2.5 py-1.5 hover:bg-red-400/10 disabled:opacity-50"
+        >
+          Retry recovery check
+        </button>
+      </div>
+    )}
+
+    {activeCandidate && (
+      <div
+        role="status"
+        aria-live="polite"
+        className="flex items-center gap-3 border-b border-amber-500/25 bg-amber-500/10 px-4 py-2.5 text-xs text-amber-100"
+      >
+        <AlertTriangle className="size-4 shrink-0 text-amber-400" />
+        <div className="min-w-0 flex-1">
+          <div className="font-medium">A conflicting recovery branch is safe on disk</div>
+          <div className="mt-0.5 text-amber-100/70">
+            {describeReviewConflictCandidate(activeCandidate)}
+            {candidateCount > 1
+              ? ` ${candidateCount - 1} more recovery ${candidateCount === 2 ? 'copy is' : 'copies are'} queued.`
+              : ''}
+            {activeCandidateRecoverable
+              ? ' Switching branches first preserves the current branch as another recovery copy.'
+              : ' Review actions remain locked until this incompatible copy is explicitly discarded.'}
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={() => onRequestDiscard(activeCandidate)}
+          disabled={resolvingCandidateId !== null || refreshPending || loadError !== null}
+          className="shrink-0 rounded border border-amber-400/30 px-2.5 py-1.5 text-amber-100 hover:bg-amber-400/10 disabled:opacity-50"
+        >
+          Discard recovery branch
+        </button>
+        <button
+          type="button"
+          onClick={() => void onRecover()}
+          disabled={
+            !activeCandidateRecoverable ||
+            resolvingCandidateId !== null ||
+            refreshPending ||
+            loadError !== null
+          }
+          className="shrink-0 rounded bg-amber-400 px-2.5 py-1.5 font-medium text-amber-950 hover:bg-amber-300 disabled:opacity-50"
+        >
+          Switch to recovery
+        </button>
+      </div>
+    )}
+  </>
+);

--- a/src/features/change-review/renderer/utils/changeReviewConflicts.ts
+++ b/src/features/change-review/renderer/utils/changeReviewConflicts.ts
@@ -1,0 +1,46 @@
+import type { ReviewDraftHistoryConflictCandidateSummary } from '@features/change-review-history/contracts';
+import type { ReviewDecisionConflictCandidateSummary } from '@shared/types';
+
+export const CHANGE_REVIEW_CONFLICT_LOAD_ERROR_PREFIX = 'Unable to load durable recovery copies:';
+
+export type ReviewConflictCandidateSelection =
+  | { kind: 'decision'; value: ReviewDecisionConflictCandidateSummary }
+  | { kind: 'draft'; value: ReviewDraftHistoryConflictCandidateSummary };
+
+export function selectLatestReviewConflictCandidate(
+  decisions: readonly ReviewDecisionConflictCandidateSummary[],
+  drafts: readonly ReviewDraftHistoryConflictCandidateSummary[]
+): ReviewConflictCandidateSelection | null {
+  const decision = decisions[0];
+  const draft = drafts[0];
+  if (!decision) return draft ? { kind: 'draft', value: draft } : null;
+  if (!draft) return { kind: 'decision', value: decision };
+  return Date.parse(decision.capturedAt) >= Date.parse(draft.capturedAt)
+    ? { kind: 'decision', value: decision }
+    : { kind: 'draft', value: draft };
+}
+
+export function describeReviewConflictCandidate(
+  selected: ReviewConflictCandidateSelection
+): string {
+  if (selected.kind === 'decision') {
+    return selected.value.origin === 'prior-snapshot'
+      ? `An earlier review snapshot has a saved branch with ${selected.value.undoDepth} Undo and ${selected.value.redoDepth} Redo actions. It cannot be applied to this changed diff.`
+      : `Another window saved a different review branch. Local copy: ${selected.value.undoDepth} Undo and ${selected.value.redoDepth} Redo actions.`;
+  }
+  if (selected.value.recoverability === 'file-not-in-current-review') {
+    return `An earlier manual-edit branch targets ${selected.value.filePath}, which is not part of the current review.`;
+  }
+  return selected.value.entryRevision === null
+    ? `The recovery branch has no saved manual edits for ${selected.value.filePath}.`
+    : `Another window saved different manual edit history for ${selected.value.filePath}.`;
+}
+
+export function describeReviewConflictDiscard(
+  selected: ReviewConflictCandidateSelection | null
+): string {
+  if (!selected) return '';
+  return selected.kind === 'decision'
+    ? `Captured ${new Date(selected.value.capturedAt).toLocaleString()} with ${selected.value.undoDepth} Undo and ${selected.value.redoDepth} Redo actions.`
+    : `Captured ${new Date(selected.value.capturedAt).toLocaleString()} for ${selected.value.filePath}.`;
+}

--- a/src/renderer/components/team/review/ChangeReviewDialog.tsx
+++ b/src/renderer/components/team/review/ChangeReviewDialog.tsx
@@ -18,6 +18,11 @@ import {
   buildReviewFileLabels,
   buildReviewStats,
   buildWatchedReviewFilePathsKey,
+  ChangeReviewConflictDiscardDialog,
+  ChangeReviewConflictNotices,
+  createChangeReviewConflictCommandPort,
+  createChangeReviewConflictQueryPort,
+  createChangeReviewConflictStateBridge,
   createChangeReviewDraftHistoryPort,
   findActiveReviewFile,
   resolveReviewFileLabel as resolveReviewFileLabelFromMap,
@@ -25,6 +30,8 @@ import {
   sortChangeReviewFiles,
   TaskChangesEmptyState,
   toTaskChangeSetV2,
+  useChangeReviewConflictDiscoveryController,
+  useChangeReviewConflictInteractionController,
   useChangeReviewDraftHistoryController,
   useChangeReviewLifecycleRegistration,
   useChangeReviewOperationGeneration,
@@ -38,16 +45,6 @@ import {
 } from '@features/review-mutations';
 import { api, isElectronMode } from '@renderer/api';
 import { EditorSelectionMenu } from '@renderer/components/team/editor/EditorSelectionMenu';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@renderer/components/ui/alert-dialog';
 import { useContinuousScrollNav } from '@renderer/hooks/useContinuousScrollNav';
 import { useDiffNavigation } from '@renderer/hooks/useDiffNavigation';
 import { useViewedFiles } from '@renderer/hooks/useViewedFiles';
@@ -63,7 +60,7 @@ import { buildSelectionInfo, SELECTION_DEBOUNCE_MS } from '@renderer/utils/codem
 import { buildHunkDecisionKey, getFileReviewKey } from '@renderer/utils/reviewKey';
 import { normalizePathForComparison } from '@shared/utils/platformPath';
 import { threeWayTextMerge } from '@shared/utils/threeWayTextMerge';
-import { AlertTriangle, ChevronDown, Clock, X } from 'lucide-react';
+import { ChevronDown, Clock, X } from 'lucide-react';
 
 import { ChangesLoadingAnimation } from './ChangesLoadingAnimation';
 import {
@@ -95,7 +92,6 @@ import {
   replaceReviewScopedRecord,
   resolveReviewFileIsNew,
   restoreReviewDecisionRecordsForFile,
-  selectLatestReviewConflictCandidate,
   shouldCreateFileWhenUndoingReject,
   shouldDeleteFileWhenUndoingReject,
   shouldRequestReviewCloseForEscape,
@@ -128,20 +124,13 @@ import { SavedReviewStateRecoveryGate } from './SavedReviewStateRecoveryGate';
 import { ScopeWarningBanner } from './ScopeWarningBanner';
 import { ViewedProgressBar } from './ViewedProgressBar';
 
-import type {
-  ReviewActionPersistenceStatus,
-  ReviewConflictCandidateSelection,
-  ReviewDecisionRecords,
-} from './reviewActionState';
+import type { ReviewActionPersistenceStatus, ReviewDecisionRecords } from './reviewActionState';
 import type { EditorView } from '@codemirror/view';
 import type { ReviewDraftHistoryHydrationState } from '@features/change-review/renderer';
-import type { ReviewDraftHistoryConflictCandidateSummary } from '@features/change-review-history/contracts';
 import type { TaskChangeRequestOptions } from '@renderer/utils/taskChangeRequest';
 import type {
   FileChangeSummary,
   HunkDecision,
-  ReviewConflictResolution,
-  ReviewDecisionConflictCandidateSummary,
   ReviewDecisionSnapshot,
   ReviewDiskUndoAction,
   ReviewDiskUndoSnapshot,
@@ -183,7 +172,12 @@ interface ReviewPersistenceSnapshotIdentity {
 
 const REVIEW_PERSISTENCE_ERROR =
   'Latest review action is not saved. Retry from History before continuing.';
-const REVIEW_CONFLICT_LOAD_ERROR_PREFIX = 'Unable to load durable recovery copies:';
+const changeReviewConflictQueryPort = createChangeReviewConflictQueryPort(() => api.review);
+const changeReviewConflictCommandPort = createChangeReviewConflictCommandPort(() => api.review);
+const changeReviewConflictStateBridge = createChangeReviewConflictStateBridge({
+  getSnapshot: useStore.getState,
+  setApplyError: (applyError) => useStore.setState({ applyError }),
+});
 const changeReviewDraftHistoryPort = createChangeReviewDraftHistoryPort(() => api.review);
 
 function captureReviewPersistenceSnapshotIdentity(
@@ -354,17 +348,6 @@ export const ChangeReviewDialog = ({
 
   const [draftHistoryHydration, setDraftHistoryHydration] =
     useState<ReviewDraftHistoryHydrationState>({ key: null, status: 'idle' });
-  const [decisionConflictCandidates, setDecisionConflictCandidates] = useState<
-    ReviewDecisionConflictCandidateSummary[]
-  >([]);
-  const [draftHistoryConflictCandidates, setDraftHistoryConflictCandidates] = useState<
-    ReviewDraftHistoryConflictCandidateSummary[]
-  >([]);
-  const [reviewConflictRefreshPending, setReviewConflictRefreshPending] = useState(false);
-  const [reviewConflictLoadError, setReviewConflictLoadError] = useState<string | null>(null);
-  const [resolvingConflictCandidateId, setResolvingConflictCandidateId] = useState<string | null>(
-    null
-  );
   const {
     scopeKey,
     decisionScopeKey,
@@ -450,8 +433,6 @@ export const ChangeReviewDialog = ({
   // Exact disk state on which each manual draft started. Map.has() distinguishes
   // a genuinely missing file (null baseline) from an uncaptured baseline.
   const expectedDraftHistoryKeyRef = useRef<string | null>(null);
-  const reviewConflictRefreshGenerationRef = useRef(0);
-  const conflictResolutionOperationRef = useRef<object | null>(null);
 
   const hydrateDecisionsFromDisk = useCallback(
     async (
@@ -478,80 +459,6 @@ export const ChangeReviewDialog = ({
     [loadDecisionsFromDisk]
   );
 
-  const refreshReviewConflictCandidates = useCallback(async (): Promise<void> => {
-    const refreshGeneration = ++reviewConflictRefreshGenerationRef.current;
-    if (!decisionHydrationKey || !decisionScopeToken) {
-      setDecisionConflictCandidates([]);
-      setDraftHistoryConflictCandidates([]);
-      setReviewConflictRefreshPending(false);
-      setReviewConflictLoadError(null);
-      return;
-    }
-    const hydrationKey = decisionHydrationKey;
-    setReviewConflictRefreshPending(true);
-    try {
-      const [decisionCandidates, draftCandidates] = await Promise.all([
-        api.review.loadDecisionConflictCandidates(teamName, decisionScopeKey, decisionScopeToken),
-        api.review.loadDraftHistoryConflictCandidates(
-          teamName,
-          decisionScopeKey,
-          decisionScopeToken
-        ),
-      ]);
-      if (
-        expectedDraftHistoryKeyRef.current !== hydrationKey ||
-        reviewConflictRefreshGenerationRef.current !== refreshGeneration
-      ) {
-        return;
-      }
-      if (decisionCandidates.length > 0) {
-        await hydrateDecisionsFromDisk(
-          teamName,
-          decisionScopeKey,
-          decisionScopeToken,
-          hydrationKey
-        );
-        if (
-          expectedDraftHistoryKeyRef.current !== hydrationKey ||
-          reviewConflictRefreshGenerationRef.current !== refreshGeneration
-        ) {
-          return;
-        }
-      }
-      setDecisionConflictCandidates(decisionCandidates);
-      setDraftHistoryConflictCandidates(draftCandidates);
-      setReviewConflictLoadError(null);
-      useStore.setState((state) =>
-        state.applyError?.startsWith(REVIEW_CONFLICT_LOAD_ERROR_PREFIX) ? { applyError: null } : {}
-      );
-    } catch (error) {
-      if (
-        expectedDraftHistoryKeyRef.current !== hydrationKey ||
-        reviewConflictRefreshGenerationRef.current !== refreshGeneration
-      ) {
-        return;
-      }
-      const message = `${REVIEW_CONFLICT_LOAD_ERROR_PREFIX} ${String(error)}`;
-      setReviewConflictLoadError(message);
-      useStore.setState({
-        applyError: message,
-      });
-    } finally {
-      if (
-        expectedDraftHistoryKeyRef.current === hydrationKey &&
-        reviewConflictRefreshGenerationRef.current === refreshGeneration
-      ) {
-        setReviewConflictRefreshPending(false);
-      }
-    }
-  }, [
-    decisionHydrationKey,
-    decisionScopeKey,
-    decisionScopeToken,
-    hydrateDecisionsFromDisk,
-    teamName,
-  ]);
-
   // Proxy ref for useDiffNavigation (points to active file's editor)
   const activeEditorViewRef = useRef<EditorView | null>(null);
   const activeFilePathRef = useRef<string | null>(null);
@@ -576,15 +483,10 @@ export const ChangeReviewDialog = ({
   useLayoutEffect(() => {
     const activeHydrationKey = open && lifecycleAuthorized ? decisionHydrationKey : null;
     expectedDraftHistoryKeyRef.current = activeHydrationKey;
-    reviewConflictRefreshGenerationRef.current += 1;
-    conflictResolutionOperationRef.current = null;
-    setResolvingConflictCandidateId(null);
     return () => {
       if (expectedDraftHistoryKeyRef.current === activeHydrationKey) {
         expectedDraftHistoryKeyRef.current = null;
       }
-      reviewConflictRefreshGenerationRef.current += 1;
-      conflictResolutionOperationRef.current = null;
     };
   }, [decisionHydrationKey, lifecycleAuthorized, open]);
 
@@ -611,6 +513,49 @@ export const ChangeReviewDialog = ({
 
   const isExpectedDraftHistoryKey = useCallback(
     (hydrationKey: string): boolean => expectedDraftHistoryKeyRef.current === hydrationKey,
+    []
+  );
+  const conflictScope = useMemo(
+    () =>
+      decisionScopeToken
+        ? { teamName, scopeKey: decisionScopeKey, scopeToken: decisionScopeToken }
+        : null,
+    [decisionScopeKey, decisionScopeToken, teamName]
+  );
+  const hydrateConflictDecisions = useCallback(
+    async (scope: NonNullable<typeof conflictScope>, hydrationKey: string): Promise<void> => {
+      await hydrateDecisionsFromDisk(
+        scope.teamName,
+        scope.scopeKey,
+        scope.scopeToken,
+        hydrationKey
+      );
+    },
+    [hydrateDecisionsFromDisk]
+  );
+  const {
+    decisionCandidates: decisionConflictCandidates,
+    draftHistoryCandidates: draftHistoryConflictCandidates,
+    candidateCount: reviewConflictCandidateCount,
+    refreshPending: reviewConflictRefreshPending,
+    loadError: reviewConflictLoadError,
+    refresh: refreshReviewConflictCandidates,
+    reset: resetReviewConflictCandidates,
+  } = useChangeReviewConflictDiscoveryController({
+    active: open && lifecycleAuthorized,
+    hydrationKey: decisionHydrationKey,
+    scope: conflictScope,
+    isExpectedHydrationKey: isExpectedDraftHistoryKey,
+    hydrateDecisions: hydrateConflictDecisions,
+    clearReportedLoadError: changeReviewConflictStateBridge.clearReportedLoadError,
+    reportLoadError: changeReviewConflictStateBridge.reportError,
+    port: changeReviewConflictQueryPort,
+  });
+  const publishReviewActionPersistenceStatus = useCallback(
+    (status: ReviewActionPersistenceStatus): void => {
+      reviewActionPersistenceStatusRef.current = status;
+      setReviewActionPersistenceStatus(status);
+    },
     []
   );
   const commitHydratedDrafts = useCallback(
@@ -684,24 +629,47 @@ export const ChangeReviewDialog = ({
     getDiagnostics: getDraftHistoryDiagnostics,
   } = draftHistory;
 
+  const {
+    activeCandidate: activeReviewConflictCandidate,
+    activeCandidateRecoverable: activeReviewConflictRecoverable,
+    resolvingCandidateId: resolvingConflictCandidateId,
+    pendingDiscard: pendingRecoveryDiscard,
+    requestDiscard: requestRecoveryDiscard,
+    onDiscardOpenChange: handleRecoveryDiscardOpenChange,
+    confirmPendingDiscard: confirmRecoveryDiscard,
+    resolveActiveCandidate: handleResolveReviewConflictCandidate,
+  } = useChangeReviewConflictInteractionController({
+    active: open && lifecycleAuthorized,
+    hydrationKey: decisionHydrationKey,
+    scope: conflictScope,
+    decisionCandidates: decisionConflictCandidates,
+    draftHistoryCandidates: draftHistoryConflictCandidates,
+    captureOperationScope: captureReviewOperationScope,
+    isCurrentOperationScope: isCurrentReviewOperationScope,
+    isExpectedHydrationKey: isExpectedDraftHistoryKey,
+    hydrateDecisions: hydrateConflictDecisions,
+    isDecisionHydrationLoaded: changeReviewConflictStateBridge.isDecisionHydrationLoaded,
+    publishDecisionPersistenceSaved: () => publishReviewActionPersistenceStatus('saved'),
+    resolveDraftHistoryCandidate: resolveDraftHistoryConflictCandidate,
+    clearResolutionError: changeReviewConflictStateBridge.clearResolutionError,
+    reportResolutionError: changeReviewConflictStateBridge.reportError,
+    refreshCandidates: refreshReviewConflictCandidates,
+    port: changeReviewConflictCommandPort,
+  });
+
   useEffect(() => {
     if (!open || !lifecycleAuthorized || !decisionHydrationKey) {
-      setDecisionConflictCandidates([]);
-      setDraftHistoryConflictCandidates([]);
-      setReviewConflictRefreshPending(false);
-      setReviewConflictLoadError(null);
+      resetReviewConflictCandidates();
       return;
     }
     void refreshReviewConflictCandidates();
-  }, [decisionHydrationKey, lifecycleAuthorized, open, refreshReviewConflictCandidates]);
-
-  const publishReviewActionPersistenceStatus = useCallback(
-    (status: ReviewActionPersistenceStatus): void => {
-      reviewActionPersistenceStatusRef.current = status;
-      setReviewActionPersistenceStatus(status);
-    },
-    []
-  );
+  }, [
+    decisionHydrationKey,
+    lifecycleAuthorized,
+    open,
+    refreshReviewConflictCandidates,
+    resetReviewConflictCandidates,
+  ]);
 
   useEffect(() => {
     reviewActionPersistenceGenerationRef.current += 1;
@@ -988,8 +956,6 @@ export const ChangeReviewDialog = ({
     undoing,
     closing,
   });
-  const reviewConflictCandidateCount =
-    decisionConflictCandidates.length + draftHistoryConflictCandidates.length;
   const reviewActionsBusy =
     reviewMutationBusy ||
     reviewConflictRefreshPending ||
@@ -1033,133 +999,6 @@ export const ChangeReviewDialog = ({
     resolvingConflictCandidateId,
     reviewConflictCandidateCount,
   ]);
-
-  const activeReviewConflictCandidate = useMemo(
-    () =>
-      selectLatestReviewConflictCandidate(
-        decisionConflictCandidates,
-        draftHistoryConflictCandidates
-      ),
-    [decisionConflictCandidates, draftHistoryConflictCandidates]
-  );
-  const activeReviewConflictRecoverable =
-    activeReviewConflictCandidate?.value.recoverability === 'recoverable';
-  const [pendingRecoveryDiscard, setPendingRecoveryDiscard] =
-    useState<ReviewConflictCandidateSelection | null>(null);
-
-  useEffect(() => {
-    setPendingRecoveryDiscard(null);
-  }, [decisionHydrationKey]);
-
-  const handleResolveReviewConflictCandidate = useCallback(
-    async (resolution: ReviewConflictResolution, expectedCandidateId?: string): Promise<void> => {
-      if (
-        !activeReviewConflictCandidate ||
-        (resolution === 'recover-candidate' && !activeReviewConflictRecoverable) ||
-        (expectedCandidateId !== undefined &&
-          activeReviewConflictCandidate.value.id !== expectedCandidateId) ||
-        !decisionHydrationKey ||
-        !decisionScopeToken ||
-        resolvingConflictCandidateId !== null
-      ) {
-        return;
-      }
-      const selected = activeReviewConflictCandidate;
-      const resolutionHydrationKey = decisionHydrationKey;
-      const operationScope = captureReviewOperationScope();
-      if (!operationScope) return;
-      const resolutionOperation = {};
-      conflictResolutionOperationRef.current = resolutionOperation;
-      setResolvingConflictCandidateId(selected.value.id);
-      try {
-        if (selected.kind === 'decision') {
-          await api.review.resolveDecisionConflictCandidate(
-            teamName,
-            decisionScopeKey,
-            decisionScopeToken,
-            selected.value.id,
-            resolution,
-            selected.value.observedCurrentRevision
-          );
-          if (
-            !isCurrentReviewOperationScope(operationScope) ||
-            expectedDraftHistoryKeyRef.current !== resolutionHydrationKey
-          ) {
-            return;
-          }
-          await hydrateDecisionsFromDisk(
-            teamName,
-            decisionScopeKey,
-            decisionScopeToken,
-            resolutionHydrationKey
-          );
-          if (
-            !isCurrentReviewOperationScope(operationScope) ||
-            expectedDraftHistoryKeyRef.current !== resolutionHydrationKey
-          ) {
-            return;
-          }
-          const hydrated = useStore.getState();
-          if (
-            hydrated.decisionHydrationScopeKey !== resolutionHydrationKey ||
-            hydrated.decisionHydrationStatus !== 'loaded'
-          ) {
-            throw new Error('Resolved decisions could not be reloaded');
-          }
-          publishReviewActionPersistenceStatus('saved');
-        } else {
-          const resolved = await resolveDraftHistoryConflictCandidate(
-            selected.value,
-            resolution,
-            operationScope
-          );
-          if (!resolved) return;
-        }
-        if (
-          !isCurrentReviewOperationScope(operationScope) ||
-          expectedDraftHistoryKeyRef.current !== resolutionHydrationKey
-        ) {
-          return;
-        }
-        useStore.setState({ applyError: null });
-        await refreshReviewConflictCandidates();
-      } catch (error) {
-        if (
-          !isCurrentReviewOperationScope(operationScope) ||
-          expectedDraftHistoryKeyRef.current !== resolutionHydrationKey
-        ) {
-          return;
-        }
-        useStore.setState({
-          applyError: `Unable to resolve the durable recovery copy: ${String(error)}`,
-        });
-        await refreshReviewConflictCandidates();
-      } finally {
-        if (
-          isCurrentReviewOperationScope(operationScope) &&
-          conflictResolutionOperationRef.current === resolutionOperation
-        ) {
-          conflictResolutionOperationRef.current = null;
-          setResolvingConflictCandidateId(null);
-        }
-      }
-    },
-    [
-      activeReviewConflictCandidate,
-      activeReviewConflictRecoverable,
-      captureReviewOperationScope,
-      decisionHydrationKey,
-      decisionScopeKey,
-      decisionScopeToken,
-      hydrateDecisionsFromDisk,
-      isCurrentReviewOperationScope,
-      publishReviewActionPersistenceStatus,
-      refreshReviewConflictCandidates,
-      resolveDraftHistoryConflictCandidate,
-      resolvingConflictCandidateId,
-      teamName,
-    ]
-  );
 
   const hasReviewDraft = useCallback(
     (filePath: string): boolean => filePath in useStore.getState().editedContents,
@@ -4474,54 +4313,12 @@ export const ChangeReviewDialog = ({
         onOpenChange={diffNav.setShowShortcutsHelp}
       />
 
-      <AlertDialog
-        open={pendingRecoveryDiscard !== null}
-        onOpenChange={(nextOpen) => {
-          if (!nextOpen && resolvingConflictCandidateId === null) {
-            setPendingRecoveryDiscard(null);
-          }
-        }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Discard this recovery branch?</AlertDialogTitle>
-            <AlertDialogDescription>
-              {pendingRecoveryDiscard?.kind === 'decision'
-                ? `Captured ${new Date(pendingRecoveryDiscard.value.capturedAt).toLocaleString()} with ${pendingRecoveryDiscard.value.undoDepth} Undo and ${pendingRecoveryDiscard.value.redoDepth} Redo actions.`
-                : pendingRecoveryDiscard
-                  ? `Captured ${new Date(pendingRecoveryDiscard.value.capturedAt).toLocaleString()} for ${pendingRecoveryDiscard.value.filePath}.`
-                  : ''}{' '}
-              Your current branch stays saved. The selected recovery copy will be permanently
-              deleted and cannot be restored later.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={resolvingConflictCandidateId !== null}>
-              Cancel
-            </AlertDialogCancel>
-            <AlertDialogAction
-              disabled={!pendingRecoveryDiscard || resolvingConflictCandidateId !== null}
-              className="bg-red-600 text-white hover:bg-red-500"
-              onClick={() => {
-                if (!pendingRecoveryDiscard) return;
-                const operationScope = captureReviewOperationScope();
-                if (!operationScope) return;
-                const candidateId = pendingRecoveryDiscard.value.id;
-                void handleResolveReviewConflictCandidate('keep-current', candidateId).finally(
-                  () => {
-                    if (!isCurrentReviewOperationScope(operationScope)) return;
-                    setPendingRecoveryDiscard((current) =>
-                      current?.value.id === candidateId ? null : current
-                    );
-                  }
-                );
-              }}
-            >
-              Discard recovery branch
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <ChangeReviewConflictDiscardDialog
+        pendingDiscard={pendingRecoveryDiscard}
+        resolvingCandidateId={resolvingConflictCandidateId}
+        onOpenChange={handleRecoveryDiscardOpenChange}
+        onConfirm={confirmRecoveryDiscard}
+      />
 
       {/* Review toolbar */}
       {!changeSetLoading &&
@@ -4587,81 +4384,17 @@ export const ChangeReviewDialog = ({
         />
       )}
 
-      {reviewConflictLoadError && (
-        <div
-          role="alert"
-          className="flex items-center gap-3 border-b border-red-500/25 bg-red-500/10 px-4 py-2.5 text-xs text-red-200"
-        >
-          <AlertTriangle className="size-4 shrink-0 text-red-400" />
-          <div className="min-w-0 flex-1">
-            Recovery copies could not be verified. Review actions stay locked to prevent data loss.
-          </div>
-          <button
-            type="button"
-            onClick={() => void refreshReviewConflictCandidates()}
-            disabled={reviewConflictRefreshPending}
-            className="shrink-0 rounded border border-red-400/30 px-2.5 py-1.5 hover:bg-red-400/10 disabled:opacity-50"
-          >
-            Retry recovery check
-          </button>
-        </div>
-      )}
-
-      {activeReviewConflictCandidate && (
-        <div
-          role="status"
-          aria-live="polite"
-          className="flex items-center gap-3 border-b border-amber-500/25 bg-amber-500/10 px-4 py-2.5 text-xs text-amber-100"
-        >
-          <AlertTriangle className="size-4 shrink-0 text-amber-400" />
-          <div className="min-w-0 flex-1">
-            <div className="font-medium">A conflicting recovery branch is safe on disk</div>
-            <div className="mt-0.5 text-amber-100/70">
-              {activeReviewConflictCandidate.kind === 'decision'
-                ? activeReviewConflictCandidate.value.origin === 'prior-snapshot'
-                  ? `An earlier review snapshot has a saved branch with ${activeReviewConflictCandidate.value.undoDepth} Undo and ${activeReviewConflictCandidate.value.redoDepth} Redo actions. It cannot be applied to this changed diff.`
-                  : `Another window saved a different review branch. Local copy: ${activeReviewConflictCandidate.value.undoDepth} Undo and ${activeReviewConflictCandidate.value.redoDepth} Redo actions.`
-                : activeReviewConflictCandidate.value.recoverability ===
-                    'file-not-in-current-review'
-                  ? `An earlier manual-edit branch targets ${activeReviewConflictCandidate.value.filePath}, which is not part of the current review.`
-                  : activeReviewConflictCandidate.value.entryRevision === null
-                    ? `The recovery branch has no saved manual edits for ${activeReviewConflictCandidate.value.filePath}.`
-                    : `Another window saved different manual edit history for ${activeReviewConflictCandidate.value.filePath}.`}
-              {reviewConflictCandidateCount > 1
-                ? ` ${reviewConflictCandidateCount - 1} more recovery ${reviewConflictCandidateCount === 2 ? 'copy is' : 'copies are'} queued.`
-                : ''}
-              {activeReviewConflictRecoverable
-                ? ' Switching branches first preserves the current branch as another recovery copy.'
-                : ' Review actions remain locked until this incompatible copy is explicitly discarded.'}
-            </div>
-          </div>
-          <button
-            type="button"
-            onClick={() => setPendingRecoveryDiscard(activeReviewConflictCandidate)}
-            disabled={
-              resolvingConflictCandidateId !== null ||
-              reviewConflictRefreshPending ||
-              reviewConflictLoadError !== null
-            }
-            className="shrink-0 rounded border border-amber-400/30 px-2.5 py-1.5 text-amber-100 hover:bg-amber-400/10 disabled:opacity-50"
-          >
-            Discard recovery branch
-          </button>
-          <button
-            type="button"
-            onClick={() => void handleResolveReviewConflictCandidate('recover-candidate')}
-            disabled={
-              !activeReviewConflictRecoverable ||
-              resolvingConflictCandidateId !== null ||
-              reviewConflictRefreshPending ||
-              reviewConflictLoadError !== null
-            }
-            className="shrink-0 rounded bg-amber-400 px-2.5 py-1.5 font-medium text-amber-950 hover:bg-amber-300 disabled:opacity-50"
-          >
-            Switch to recovery
-          </button>
-        </div>
-      )}
+      <ChangeReviewConflictNotices
+        loadError={reviewConflictLoadError}
+        refreshPending={reviewConflictRefreshPending}
+        activeCandidate={activeReviewConflictCandidate}
+        activeCandidateRecoverable={activeReviewConflictRecoverable}
+        candidateCount={reviewConflictCandidateCount}
+        resolvingCandidateId={resolvingConflictCandidateId}
+        onRetry={refreshReviewConflictCandidates}
+        onRequestDiscard={requestRecoveryDiscard}
+        onRecover={() => handleResolveReviewConflictCandidate('recover-candidate')}
+      />
 
       {/* Apply error */}
       {applyError && (

--- a/src/renderer/components/team/review/reviewActionState.ts
+++ b/src/renderer/components/team/review/reviewActionState.ts
@@ -10,22 +10,22 @@ import {
   isReviewFileExpectedDeleted,
 } from './reviewContentPreview';
 
-import type { ReviewDraftHistoryConflictCandidateSummary } from '@features/change-review-history/contracts';
 import type {
   ConflictCheckResult,
   FileChangeSummary,
   FileChangeWithContent,
   HunkDecision,
-  ReviewDecisionConflictCandidateSummary,
   ReviewRenameRecoveryExpectation,
   ReviewUndoAction,
 } from '@shared/types';
 
 export type { ReviewOperationScopeToken } from '@features/change-review/renderer';
+export type { ReviewConflictCandidateSelection } from '@features/change-review/renderer';
 export {
   createReviewOperationScopeToken,
   getReviewDecisionHydrationGuard,
   isReviewOperationScopeCurrent,
+  selectLatestReviewConflictCandidate,
 } from '@features/change-review/renderer';
 
 export interface ReviewDecisionRecords {
@@ -39,23 +39,6 @@ export function shouldRequestReviewCloseForEscape(input: {
   hasOpenModalLayer: boolean;
 }): boolean {
   return input.key === 'Escape' && !input.defaultPrevented && !input.hasOpenModalLayer;
-}
-
-export type ReviewConflictCandidateSelection =
-  | { kind: 'decision'; value: ReviewDecisionConflictCandidateSummary }
-  | { kind: 'draft'; value: ReviewDraftHistoryConflictCandidateSummary };
-
-export function selectLatestReviewConflictCandidate(
-  decisions: readonly ReviewDecisionConflictCandidateSummary[],
-  drafts: readonly ReviewDraftHistoryConflictCandidateSummary[]
-): ReviewConflictCandidateSelection | null {
-  const decision = decisions[0];
-  const draft = drafts[0];
-  if (!decision) return draft ? { kind: 'draft', value: draft } : null;
-  if (!draft) return { kind: 'decision', value: decision };
-  return Date.parse(decision.capturedAt) >= Date.parse(draft.capturedAt)
-    ? { kind: 'decision', value: decision }
-    : { kind: 'draft', value: draft };
 }
 
 export function replaceReviewScopedRecord<T>(

--- a/test/features/change-review/renderer/ChangeReviewConflictNotices.test.tsx
+++ b/test/features/change-review/renderer/ChangeReviewConflictNotices.test.tsx
@@ -1,0 +1,120 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import {
+  ChangeReviewConflictDiscardDialog,
+  ChangeReviewConflictNotices,
+} from '@features/change-review/renderer';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ReviewConflictCandidateSelection } from '@features/change-review/renderer';
+
+vi.mock('@renderer/components/ui/alert-dialog', () => ({
+  AlertDialog: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogAction: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+  AlertDialogCancel: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+  AlertDialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+const candidate: ReviewConflictCandidateSelection = {
+  kind: 'decision',
+  value: {
+    id: 'decision-a',
+    capturedAt: '2026-07-23T12:00:00.000Z',
+    origin: 'current-snapshot',
+    recoverability: 'recoverable',
+    expectedRevision: 1,
+    observedCurrentRevision: 2,
+    hunkDecisionCount: 0,
+    fileDecisionCount: 0,
+    undoDepth: 2,
+    redoDepth: 1,
+  },
+};
+
+describe('ChangeReviewConflictNotices', () => {
+  let host: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    host.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it('routes retry, discard and recover interactions through callbacks', () => {
+    const onRetry = vi.fn(() => Promise.resolve());
+    const onRequestDiscard = vi.fn();
+    const onRecover = vi.fn(() => Promise.resolve());
+    const render = (loadError: string | null): void => {
+      act(() => {
+        root.render(
+          <ChangeReviewConflictNotices
+            loadError={loadError}
+            refreshPending={false}
+            activeCandidate={candidate}
+            activeCandidateRecoverable
+            candidateCount={2}
+            resolvingCandidateId={null}
+            onRetry={onRetry}
+            onRequestDiscard={onRequestDiscard}
+            onRecover={onRecover}
+          />
+        );
+      });
+    };
+    render('load failed');
+
+    const button = (label: string) =>
+      [...host.querySelectorAll('button')].find((item) => item.textContent === label)!;
+    act(() => button('Retry recovery check').click());
+    render(null);
+    act(() => button('Discard recovery branch').click());
+    act(() => button('Switch to recovery').click());
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onRequestDiscard).toHaveBeenCalledWith(candidate);
+    expect(onRecover).toHaveBeenCalledTimes(1);
+    expect(host.textContent).toContain('1 more recovery copy is queued.');
+  });
+
+  it('routes discard confirmation without owning persistence or store behavior', () => {
+    const onConfirm = vi.fn(() => Promise.resolve());
+    const onOpenChange = vi.fn();
+    act(() => {
+      root.render(
+        <ChangeReviewConflictDiscardDialog
+          pendingDiscard={candidate}
+          resolvingCandidateId={null}
+          onOpenChange={onOpenChange}
+          onConfirm={onConfirm}
+        />
+      );
+    });
+
+    const confirm = [...host.querySelectorAll('button')].find(
+      (button) => button.textContent === 'Discard recovery branch'
+    );
+    act(() => confirm?.click());
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(host.textContent).toContain('Your current branch stays saved.');
+  });
+});

--- a/test/features/change-review/renderer/changeReviewConflicts.test.ts
+++ b/test/features/change-review/renderer/changeReviewConflicts.test.ts
@@ -1,0 +1,50 @@
+import { selectLatestReviewConflictCandidate } from '@features/change-review/renderer';
+import { describe, expect, it } from 'vitest';
+
+import type { ReviewDraftHistoryConflictCandidateSummary } from '@features/change-review-history/contracts';
+import type { ReviewDecisionConflictCandidateSummary } from '@shared/types';
+
+function decision(capturedAt: string): ReviewDecisionConflictCandidateSummary {
+  return {
+    id: 'decision',
+    capturedAt,
+    origin: 'current-snapshot',
+    recoverability: 'recoverable',
+    expectedRevision: 1,
+    observedCurrentRevision: 2,
+    hunkDecisionCount: 0,
+    fileDecisionCount: 0,
+    undoDepth: 1,
+    redoDepth: 0,
+  };
+}
+
+function draft(capturedAt: string): ReviewDraftHistoryConflictCandidateSummary {
+  return {
+    id: 'draft',
+    capturedAt,
+    origin: 'current-snapshot',
+    recoverability: 'recoverable',
+    filePath: '/repo/file.ts',
+    expectedRevision: 1,
+    expectedGeneration: 'first',
+    observedCurrentRevision: 2,
+    observedCurrentGeneration: 'second',
+    entryRevision: 1,
+  };
+}
+
+describe('change review conflict selection', () => {
+  it('returns no selection when both conflict queues are empty', () => {
+    expect(selectLatestReviewConflictCandidate([], [])).toBeNull();
+  });
+
+  it('uses the decision candidate as the stable tie breaker', () => {
+    const capturedAt = '2026-07-23T12:00:00.000Z';
+
+    expect(selectLatestReviewConflictCandidate([decision(capturedAt)], [draft(capturedAt)])).toEqual({
+      kind: 'decision',
+      value: decision(capturedAt),
+    });
+  });
+});

--- a/test/features/change-review/renderer/createChangeReviewConflictPorts.test.ts
+++ b/test/features/change-review/renderer/createChangeReviewConflictPorts.test.ts
@@ -1,0 +1,81 @@
+import {
+  createChangeReviewConflictCommandPort,
+  createChangeReviewConflictQueryPort,
+} from '@features/change-review/renderer';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ReviewAPI } from '@shared/types/api';
+
+describe('change review conflict ports', () => {
+  it('resolves the query API lazily for every operation', async () => {
+    const firstApi = {
+      loadDecisionConflictCandidates: vi.fn(() => Promise.resolve([])),
+      loadDraftHistoryConflictCandidates: vi.fn(() => Promise.resolve([])),
+    };
+    const secondApi = {
+      loadDecisionConflictCandidates: vi.fn(() => Promise.resolve([])),
+      loadDraftHistoryConflictCandidates: vi.fn(() => Promise.resolve([])),
+    };
+    let currentApi = firstApi;
+    const getReviewApi = vi.fn(() => currentApi);
+    const port = createChangeReviewConflictQueryPort(getReviewApi);
+    const scope = { teamName: 'team-a', scopeKey: 'task-a', scopeToken: 'token-a' };
+
+    expect(getReviewApi).not.toHaveBeenCalled();
+    await port.loadDecisionCandidates(scope);
+    currentApi = secondApi;
+    await port.loadDraftHistoryCandidates(scope);
+
+    expect(firstApi.loadDecisionConflictCandidates).toHaveBeenCalledWith(
+      'team-a',
+      'task-a',
+      'token-a'
+    );
+    expect(secondApi.loadDraftHistoryConflictCandidates).toHaveBeenCalledWith(
+      'team-a',
+      'task-a',
+      'token-a'
+    );
+    expect(getReviewApi).toHaveBeenCalledTimes(2);
+  });
+
+  it('resolves the command API lazily and preserves decision CAS arguments', async () => {
+    const firstResolve = vi.fn<ReviewAPI['resolveDecisionConflictCandidate']>(() =>
+      Promise.resolve({ revision: 4 })
+    );
+    const secondResolve = vi.fn<ReviewAPI['resolveDecisionConflictCandidate']>(() =>
+      Promise.resolve({ revision: 5 })
+    );
+    let currentApi = { resolveDecisionConflictCandidate: firstResolve };
+    const getReviewApi = vi.fn(() => currentApi);
+    const port = createChangeReviewConflictCommandPort(getReviewApi);
+    const input = {
+      scope: { teamName: 'team-a', scopeKey: 'task-a', scopeToken: 'token-a' },
+      candidateId: 'candidate-a',
+      resolution: 'recover-candidate' as const,
+      observedCurrentRevision: 3,
+    };
+
+    await expect(port.resolveDecisionCandidate(input)).resolves.toEqual({ revision: 4 });
+    currentApi = { resolveDecisionConflictCandidate: secondResolve };
+    await port.resolveDecisionCandidate({ ...input, resolution: 'keep-current' });
+
+    expect(firstResolve).toHaveBeenCalledWith(
+      'team-a',
+      'task-a',
+      'token-a',
+      'candidate-a',
+      'recover-candidate',
+      3
+    );
+    expect(secondResolve).toHaveBeenCalledWith(
+      'team-a',
+      'task-a',
+      'token-a',
+      'candidate-a',
+      'keep-current',
+      3
+    );
+    expect(getReviewApi).toHaveBeenCalledTimes(2);
+  });
+});

--- a/test/features/change-review/renderer/useChangeReviewConflictDiscoveryController.test.tsx
+++ b/test/features/change-review/renderer/useChangeReviewConflictDiscoveryController.test.tsx
@@ -1,0 +1,215 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { useChangeReviewConflictDiscoveryController } from '@features/change-review/renderer';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  ChangeReviewConflictDiscoveryController,
+  ChangeReviewConflictQueryPort,
+  ChangeReviewConflictScope,
+} from '@features/change-review/renderer';
+import type { ReviewDecisionConflictCandidateSummary } from '@shared/types';
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+function decision(id: string): ReviewDecisionConflictCandidateSummary {
+  return {
+    id,
+    capturedAt: '2026-07-23T12:00:00.000Z',
+    origin: 'current-snapshot',
+    recoverability: 'recoverable',
+    expectedRevision: 1,
+    observedCurrentRevision: 2,
+    hunkDecisionCount: 0,
+    fileDecisionCount: 0,
+    undoDepth: 0,
+    redoDepth: 0,
+  };
+}
+
+interface ProbeProps {
+  active: boolean;
+  hydrationKey: string | null;
+  scope: ChangeReviewConflictScope | null;
+  expectedHydrationKey: { current: string | null };
+  hydrateDecisions: (
+    scope: ChangeReviewConflictScope,
+    hydrationKey: string
+  ) => Promise<void>;
+  port: ChangeReviewConflictQueryPort;
+}
+
+let latest: ChangeReviewConflictDiscoveryController | null = null;
+
+function DiscoveryProbe(props: Readonly<ProbeProps>): React.JSX.Element {
+  latest = useChangeReviewConflictDiscoveryController({
+    ...props,
+    isExpectedHydrationKey: (hydrationKey) =>
+      props.expectedHydrationKey.current === hydrationKey,
+    clearReportedLoadError: vi.fn(),
+    reportLoadError: vi.fn(),
+  });
+  return <div />;
+}
+
+describe('useChangeReviewConflictDiscoveryController', () => {
+  let host: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+  const scopeA = { teamName: 'team-a', scopeKey: 'task-a', scopeToken: 'token-a' };
+  const scopeB = { teamName: 'team-a', scopeKey: 'task-b', scopeToken: 'token-b' };
+
+  beforeEach(() => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    latest = null;
+    host.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it('lets only the newest concurrent discovery commit candidates', async () => {
+    const decisionLoads = [
+      deferred<ReviewDecisionConflictCandidateSummary[]>(),
+      deferred<ReviewDecisionConflictCandidateSummary[]>(),
+    ];
+    const draftLoads = [deferred<[]>(), deferred<[]>()];
+    let decisionLoadIndex = 0;
+    let draftLoadIndex = 0;
+    const port: ChangeReviewConflictQueryPort = {
+      loadDecisionCandidates: vi.fn(() => decisionLoads[decisionLoadIndex++].promise),
+      loadDraftHistoryCandidates: vi.fn(() => draftLoads[draftLoadIndex++].promise),
+    };
+    const expectedHydrationKey = { current: 'scope-a' };
+    act(() => {
+      root.render(
+        <DiscoveryProbe
+          active
+          hydrationKey="scope-a"
+          scope={scopeA}
+          expectedHydrationKey={expectedHydrationKey}
+          hydrateDecisions={vi.fn(() => Promise.resolve())}
+          port={port}
+        />
+      );
+    });
+
+    let first!: Promise<void>;
+    let second!: Promise<void>;
+    act(() => {
+      first = latest!.refresh();
+      second = latest!.refresh();
+    });
+    await act(async () => {
+      decisionLoads[1].resolve([decision('newest')]);
+      draftLoads[1].resolve([]);
+      await second;
+    });
+    expect(latest!.decisionCandidates.map(({ id }) => id)).toEqual(['newest']);
+    expect(latest!.refreshPending).toBe(false);
+
+    await act(async () => {
+      decisionLoads[0].resolve([decision('stale')]);
+      draftLoads[0].resolve([]);
+      await first;
+    });
+    expect(latest!.decisionCandidates.map(({ id }) => id)).toEqual(['newest']);
+    expect(latest!.refreshPending).toBe(false);
+  });
+
+  it('fences a stale load across A -> B -> A even when the key repeats', async () => {
+    const decisionLoad = deferred<ReviewDecisionConflictCandidateSummary[]>();
+    const draftLoad = deferred<[]>();
+    const port: ChangeReviewConflictQueryPort = {
+      loadDecisionCandidates: vi.fn(() => decisionLoad.promise),
+      loadDraftHistoryCandidates: vi.fn(() => draftLoad.promise),
+    };
+    const expectedHydrationKey = { current: 'scope-a' };
+    const render = (hydrationKey: string, scope: ChangeReviewConflictScope): void => {
+      expectedHydrationKey.current = hydrationKey;
+      act(() => {
+        root.render(
+          <DiscoveryProbe
+            active
+            hydrationKey={hydrationKey}
+            scope={scope}
+            expectedHydrationKey={expectedHydrationKey}
+            hydrateDecisions={vi.fn(() => Promise.resolve())}
+            port={port}
+          />
+        );
+      });
+    };
+    render('scope-a', scopeA);
+    let pending!: Promise<void>;
+    act(() => {
+      pending = latest!.refresh();
+    });
+    render('scope-b', scopeB);
+    render('scope-a', scopeA);
+
+    await act(async () => {
+      decisionLoad.resolve([decision('stale-a')]);
+      draftLoad.resolve([]);
+      await pending;
+    });
+    expect(latest!.decisionCandidates).toEqual([]);
+  });
+
+  it('does not publish candidates after decision hydration becomes stale', async () => {
+    const hydration = deferred<void>();
+    const hydrateDecisions = vi.fn(() => hydration.promise);
+    const port: ChangeReviewConflictQueryPort = {
+      loadDecisionCandidates: vi.fn(() => Promise.resolve([decision('candidate-a')])),
+      loadDraftHistoryCandidates: vi.fn(() => Promise.resolve([])),
+    };
+    const expectedHydrationKey = { current: 'scope-a' };
+    const render = (hydrationKey: string, scope: ChangeReviewConflictScope): void => {
+      expectedHydrationKey.current = hydrationKey;
+      act(() => {
+        root.render(
+          <DiscoveryProbe
+            active
+            hydrationKey={hydrationKey}
+            scope={scope}
+            expectedHydrationKey={expectedHydrationKey}
+            hydrateDecisions={hydrateDecisions}
+            port={port}
+          />
+        );
+      });
+    };
+    render('scope-a', scopeA);
+    let pending!: Promise<void>;
+    act(() => {
+      pending = latest!.refresh();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(hydrateDecisions).toHaveBeenCalledWith(scopeA, 'scope-a');
+
+    render('scope-b', scopeB);
+    await act(async () => {
+      hydration.resolve();
+      await pending;
+    });
+    expect(latest!.decisionCandidates).toEqual([]);
+  });
+});

--- a/test/features/change-review/renderer/useChangeReviewConflictInteractionController.test.tsx
+++ b/test/features/change-review/renderer/useChangeReviewConflictInteractionController.test.tsx
@@ -1,0 +1,281 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import {
+  createReviewOperationScopeToken,
+  useChangeReviewConflictInteractionController,
+} from '@features/change-review/renderer';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  ChangeReviewConflictCommandPort,
+  ChangeReviewConflictInteractionController,
+  ChangeReviewConflictScope,
+  ReviewOperationScopeToken,
+} from '@features/change-review/renderer';
+import type { ReviewDraftHistoryConflictCandidateSummary } from '@features/change-review-history/contracts';
+import type {
+  ReviewConflictResolution,
+  ReviewDecisionConflictCandidateSummary,
+} from '@shared/types';
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+function decision(): ReviewDecisionConflictCandidateSummary {
+  return {
+    id: 'decision-a',
+    capturedAt: '2026-07-23T12:00:00.000Z',
+    origin: 'current-snapshot',
+    recoverability: 'recoverable',
+    expectedRevision: 1,
+    observedCurrentRevision: 2,
+    hunkDecisionCount: 0,
+    fileDecisionCount: 0,
+    undoDepth: 1,
+    redoDepth: 0,
+  };
+}
+
+function draft(): ReviewDraftHistoryConflictCandidateSummary {
+  return {
+    id: 'draft-a',
+    capturedAt: '2026-07-23T12:00:00.000Z',
+    origin: 'current-snapshot',
+    recoverability: 'recoverable',
+    filePath: '/repo/file.ts',
+    expectedRevision: 1,
+    expectedGeneration: 'first',
+    observedCurrentRevision: 2,
+    observedCurrentGeneration: 'second',
+    entryRevision: 1,
+  };
+}
+
+interface ProbeProps {
+  active: boolean;
+  hydrationKey: string;
+  scope: ChangeReviewConflictScope;
+  decisionCandidates: ReviewDecisionConflictCandidateSummary[];
+  draftHistoryCandidates: ReviewDraftHistoryConflictCandidateSummary[];
+  currentOperation: { value: ReviewOperationScopeToken | null };
+  currentHydrationKey: { value: string };
+  port: ChangeReviewConflictCommandPort;
+  hydrateDecisions: () => Promise<void>;
+  isDecisionHydrationLoaded: () => boolean;
+  publishDecisionPersistenceSaved: () => void;
+  resolveDraftHistoryCandidate: (
+    candidate: ReviewDraftHistoryConflictCandidateSummary,
+    resolution: ReviewConflictResolution,
+    operationScope: ReviewOperationScopeToken
+  ) => Promise<boolean>;
+  clearResolutionError: () => void;
+  reportResolutionError: (message: string) => void;
+  refreshCandidates: () => Promise<void>;
+}
+
+let latest: ChangeReviewConflictInteractionController | null = null;
+
+function InteractionProbe(props: Readonly<ProbeProps>): React.JSX.Element {
+  latest = useChangeReviewConflictInteractionController({
+    ...props,
+    captureOperationScope: () => props.currentOperation.value,
+    isCurrentOperationScope: (
+      operationScope
+    ): operationScope is ReviewOperationScopeToken =>
+      props.currentOperation.value !== null &&
+      props.currentOperation.value === operationScope,
+    isExpectedHydrationKey: (hydrationKey) =>
+      props.currentHydrationKey.value === hydrationKey,
+    hydrateDecisions: () => props.hydrateDecisions(),
+    isDecisionHydrationLoaded: () => props.isDecisionHydrationLoaded(),
+    resolveDraftHistoryCandidate: (candidate, resolution, operationScope) =>
+      props.resolveDraftHistoryCandidate(candidate, resolution, operationScope),
+  });
+  return <div />;
+}
+
+describe('useChangeReviewConflictInteractionController', () => {
+  let host: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+  const scope = { teamName: 'team-a', scopeKey: 'task-a', scopeToken: 'token-a' };
+
+  beforeEach(() => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    latest = null;
+    host.remove();
+    vi.unstubAllGlobals();
+  });
+
+  function baseProps(overrides: Partial<ProbeProps> = {}): ProbeProps {
+    const token = createReviewOperationScopeToken('scope-a');
+    return {
+      hydrationKey: 'scope-a',
+      active: true,
+      scope,
+      decisionCandidates: [decision()],
+      draftHistoryCandidates: [],
+      currentOperation: { value: token },
+      currentHydrationKey: { value: 'scope-a' },
+      port: { resolveDecisionCandidate: vi.fn(() => Promise.resolve({ revision: 3 })) },
+      hydrateDecisions: vi.fn(() => Promise.resolve()),
+      isDecisionHydrationLoaded: vi.fn(() => true),
+      publishDecisionPersistenceSaved: vi.fn(),
+      resolveDraftHistoryCandidate: vi.fn(() => Promise.resolve(true)),
+      clearResolutionError: vi.fn(),
+      reportResolutionError: vi.fn(),
+      refreshCandidates: vi.fn(() => Promise.resolve()),
+      ...overrides,
+    };
+  }
+
+  it('preserves strict decision resolve, reload, verification, publish and refresh order', async () => {
+    const order: string[] = [];
+    const props = baseProps({
+      port: {
+        resolveDecisionCandidate: vi.fn(() => {
+          order.push('resolve');
+          return Promise.resolve({ revision: 3 });
+        }),
+      },
+      hydrateDecisions: vi.fn(() => {
+        order.push('hydrate');
+        return Promise.resolve();
+      }),
+      isDecisionHydrationLoaded: vi.fn(() => {
+        order.push('verify');
+        return true;
+      }),
+      publishDecisionPersistenceSaved: vi.fn(() => order.push('publish')),
+      clearResolutionError: vi.fn(() => order.push('clear-error')),
+      refreshCandidates: vi.fn(() => {
+        order.push('refresh');
+        return Promise.resolve();
+      }),
+    });
+    act(() => root.render(<InteractionProbe {...props} />));
+
+    await act(() => latest!.resolveActiveCandidate('recover-candidate'));
+
+    expect(order).toEqual([
+      'resolve',
+      'hydrate',
+      'verify',
+      'publish',
+      'clear-error',
+      'refresh',
+    ]);
+    expect(latest!.resolvingCandidateId).toBeNull();
+  });
+
+  it('fails closed when reloaded decisions do not verify as loaded', async () => {
+    const order: string[] = [];
+    const props = baseProps({
+      port: {
+        resolveDecisionCandidate: vi.fn(() => {
+          order.push('resolve');
+          return Promise.resolve({ revision: 3 });
+        }),
+      },
+      hydrateDecisions: vi.fn(() => {
+        order.push('hydrate');
+        return Promise.resolve();
+      }),
+      isDecisionHydrationLoaded: vi.fn(() => {
+        order.push('verify');
+        return false;
+      }),
+      publishDecisionPersistenceSaved: vi.fn(() => order.push('publish')),
+      clearResolutionError: vi.fn(() => order.push('clear-error')),
+      reportResolutionError: vi.fn(() => order.push('report-error')),
+      refreshCandidates: vi.fn(() => {
+        order.push('refresh');
+        return Promise.resolve();
+      }),
+    });
+    act(() => root.render(<InteractionProbe {...props} />));
+
+    await act(() => latest!.resolveActiveCandidate('recover-candidate'));
+
+    expect(order).toEqual(['resolve', 'hydrate', 'verify', 'report-error', 'refresh']);
+    expect(props.reportResolutionError).toHaveBeenCalledWith(
+      'Unable to resolve the durable recovery copy: Error: Resolved decisions could not be reloaded'
+    );
+  });
+
+  it('delegates draft resolution and ignores its stale result after dialog deactivation', async () => {
+    const resolution = deferred<boolean>();
+    const props = baseProps({
+      decisionCandidates: [],
+      draftHistoryCandidates: [draft()],
+      resolveDraftHistoryCandidate: vi.fn(() => resolution.promise),
+    });
+    act(() => root.render(<InteractionProbe {...props} />));
+    const initialOperation = props.currentOperation.value;
+    let pending!: Promise<void>;
+    act(() => {
+      pending = latest!.resolveActiveCandidate('recover-candidate');
+    });
+    expect(props.resolveDraftHistoryCandidate).toHaveBeenCalledWith(
+      draft(),
+      'recover-candidate',
+      initialOperation
+    );
+    expect(latest!.resolvingCandidateId).toBe('draft-a');
+
+    props.currentOperation.value = null;
+    act(() => root.render(<InteractionProbe {...props} active={false} />));
+    await act(async () => {
+      resolution.resolve(true);
+      await pending;
+    });
+
+    expect(props.clearResolutionError).not.toHaveBeenCalled();
+    expect(props.refreshCandidates).not.toHaveBeenCalled();
+    expect(latest!.resolvingCandidateId).toBeNull();
+  });
+
+  it('keeps one in-flight decision identity and rejects a stale expected candidate', async () => {
+    const resolution = deferred<{ revision: number }>();
+    const resolveDecisionCandidate = vi.fn(() => resolution.promise);
+    const props = baseProps({
+      port: { resolveDecisionCandidate },
+    });
+    act(() => root.render(<InteractionProbe {...props} />));
+
+    await act(() =>
+      latest!.resolveActiveCandidate('keep-current', 'different-candidate')
+    );
+    expect(resolveDecisionCandidate).not.toHaveBeenCalled();
+
+    let first!: Promise<void>;
+    let duplicate!: Promise<void>;
+    act(() => {
+      first = latest!.resolveActiveCandidate('recover-candidate');
+      duplicate = latest!.resolveActiveCandidate('recover-candidate');
+    });
+    expect(resolveDecisionCandidate).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      resolution.resolve({ revision: 3 });
+      await Promise.all([first, duplicate]);
+    });
+    expect(resolveDecisionCandidate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/features/change-review/renderer/useChangeReviewConflictInteractionController.test.tsx
+++ b/test/features/change-review/renderer/useChangeReviewConflictInteractionController.test.tsx
@@ -299,9 +299,12 @@ describe('useChangeReviewConflictInteractionController', () => {
       first = latest!.resolveActiveCandidate('recover-candidate');
     });
     expect(latest!.resolvingCandidateId).toBe('decision-a');
+    act(() => latest!.requestDiscard(latest!.activeCandidate!));
+    expect(latest!.pendingDiscard?.value.id).toBe('decision-a');
 
     props.currentOperation.value = null;
     render(false);
+    expect(latest!.pendingDiscard).toBeNull();
     props.currentOperation.value = createReviewOperationScopeToken('scope-a');
     render(true);
 

--- a/test/features/change-review/renderer/useChangeReviewConflictInteractionController.test.tsx
+++ b/test/features/change-review/renderer/useChangeReviewConflictInteractionController.test.tsx
@@ -278,4 +278,50 @@ describe('useChangeReviewConflictInteractionController', () => {
     });
     expect(resolveDecisionCandidate).toHaveBeenCalledTimes(1);
   });
+
+  it('keeps a reopened resolution busy when the previous operation finishes late', async () => {
+    const firstResolution = deferred<{ revision: number }>();
+    const secondResolution = deferred<{ revision: number }>();
+    const resolveDecisionCandidate = vi
+      .fn<ChangeReviewConflictCommandPort['resolveDecisionCandidate']>()
+      .mockImplementationOnce(() => firstResolution.promise)
+      .mockImplementationOnce(() => secondResolution.promise);
+    const props = baseProps({
+      port: { resolveDecisionCandidate },
+    });
+    const render = (active: boolean): void => {
+      act(() => root.render(<InteractionProbe {...props} active={active} />));
+    };
+    render(true);
+
+    let first!: Promise<void>;
+    act(() => {
+      first = latest!.resolveActiveCandidate('recover-candidate');
+    });
+    expect(latest!.resolvingCandidateId).toBe('decision-a');
+
+    props.currentOperation.value = null;
+    render(false);
+    props.currentOperation.value = createReviewOperationScopeToken('scope-a');
+    render(true);
+
+    let second!: Promise<void>;
+    act(() => {
+      second = latest!.resolveActiveCandidate('recover-candidate');
+    });
+    expect(resolveDecisionCandidate).toHaveBeenCalledTimes(2);
+    expect(latest!.resolvingCandidateId).toBe('decision-a');
+
+    await act(async () => {
+      firstResolution.resolve({ revision: 3 });
+      await first;
+    });
+    expect(latest!.resolvingCandidateId).toBe('decision-a');
+
+    await act(async () => {
+      secondResolution.resolve({ revision: 4 });
+      await second;
+    });
+    expect(latest!.resolvingCandidateId).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

- extract durable recovery conflict discovery and resolution into feature-owned controllers
- use narrow lazy query and command ports around review IPC
- move conflict selection and notices UI behind the change-review public boundary
- preserve decision CAS ordering, draft-history buffer delegation, stale-operation fences, and close/reopen identity
- classify the five existing ReviewAPI conflict methods in the hosted-web mutation census
- reduce ChangeReviewDialog.tsx from 4,827 to 4,560 lines

## Verification

- pnpm typecheck
- fast and type-aware ESLint on changed files: 0 errors
- focused change-review and legacy review tests: 126/126
- architecture suite: 23/23
- production renderer build and Radix bundle verification
- independent architecture review: no P0-P2 findings
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added change-review recovery conflict handling with separate discovery and interaction flows (decision + draft-history candidates).
  * Introduced conflict notices and a discard confirmation dialog, including “retry recovery check”, “switch to recovery”, and “discard recovery branch” actions.
* **Bug Fixes**
  * Prevented stale or concurrent recovery/loading/resolution results from overwriting the latest review state.
  * Improved error reporting and recovery-load hydration readiness checks.
* **Tests**
  * Added/expanded coverage for candidate selection, discovery refresh staleness, interaction resolution/discard flows, and conflict ports wiring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactors durable recovery conflict handling behind the change-review feature boundary.
- Extracts conflict discovery, resolution, state bridging, selection, and notices into feature-owned modules.
- Introduces narrow query and command ports around the existing review API.
- Rewires `ChangeReviewDialog` to use the extracted controllers and UI.
- Adds focused controller, adapter, selection, and notice tests.
- Updates the hosted-web mutation census for the existing conflict APIs.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no eligible blocking failures remain.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/features/change-review/renderer/hooks/useChangeReviewConflictDiscoveryController.ts | Extracts conflict candidate loading, refresh generation fencing, hydration, and load-error state. |
| src/features/change-review/renderer/hooks/useChangeReviewConflictInteractionController.ts | Extracts conflict selection, resolution, discard confirmation, operation fencing, and post-resolution refresh behavior. |
| src/features/change-review/renderer/adapters/createChangeReviewConflictPorts.ts | Adapts narrow feature-owned conflict query and command ports to the existing review API. |
| src/features/change-review/renderer/ui/ChangeReviewConflictNotices.tsx | Moves recovery notices and discard confirmation UI behind the change-review renderer boundary. |
| src/renderer/components/team/review/ChangeReviewDialog.tsx | Replaces inline conflict state, operations, and presentation with the extracted change-review modules. |
| src/renderer/components/team/review/reviewActionState.ts | Re-exports conflict selection utilities from the change-review feature while retaining review action helpers. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  D[ChangeReviewDialog] --> Q[Conflict discovery controller]
  D --> I[Conflict interaction controller]
  Q --> QP[Conflict query port]
  I --> CP[Conflict command port]
  QP --> API[Review API]
  CP --> API
  Q --> N[Conflict notices]
  I --> N
  I --> S[Conflict state bridge]
  S --> Z[Review store]
```

<sub>Reviews (3): Last reviewed commit: ["fix(change-review): clear stale conflict..."](https://github.com/777genius/agent-teams-ai/commit/f17b761a7fae93699da31bc71db3f4e69c2141a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46610433)</sub>

<!-- /greptile_comment -->