### PR TITLE
chore(review): pin revision-aware runtime on dev

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -1,40 +1,50 @@
 name: ReviewRouter Codex OAuth
 
+run-name: ${{ inputs.review_request_id != '' && format('ReviewRouter review {0}', inputs.review_request_id) || 'ReviewRouter Codex OAuth maintenance' }}
+
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
-  pull_request_target:
-    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
   workflow_dispatch:
+    inputs:
+      review_request_id:
+        description: Durable ReviewRouter request identity
+        required: false
+        type: string
+      pr_number:
+        description: Pull request number selected by ReviewRouter
+        required: false
+        type: string
+      review_head_sha:
+        description: Expected pull request head selected by ReviewRouter
+        required: false
+        type: string
   schedule:
-    - cron: '17 */6 * * *'
+    - cron: "17 */6 * * *"
 
 permissions: {}
 
 jobs:
   codex-review:
     name: codex-review
-    runs-on: ubuntu-24.04
-    timeout-minutes: ${{ fromJSON(vars.REVIEW_ROUTER_TIMEOUT_MINUTES || '60') }}
-    concurrency:
-      group: reviewrouter-codex-oauth-${{ github.repository_id }}-codex-rotating-1163183284
-      cancel-in-progress: false
-    if: ${{ ((github.event_name == 'pull_request' && github.event.pull_request.draft == false) || (github.event_name == 'pull_request_target' && github.event.pull_request.draft == true && vars.REVIEW_ROUTER_REVIEW_DRAFTS == 'true')) && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.type != 'Bot' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.review_request_id != '' && inputs.pr_number != '' && inputs.review_head_sha != '' }}
     permissions:
+      contents: read
+      pull-requests: read
       id-token: write
-    steps:
-      - name: ReviewRouter Codex OAuth review
-        id: run_codex
-        uses: 777genius/review-router@main
-        with:
-          mode: codex-oauth-rotating
-          api-url: 'https://api.reviewrouter.site'
-          provider-instance-id: 'codex-rotating:1163183284'
-          workflow-schema-version: '1'
-          review-drafts: ${{ vars.REVIEW_ROUTER_REVIEW_DRAFTS == 'true' }}
-          max-changed-lines: ${{ vars.REVIEW_ROUTER_MAX_CHANGED_LINES }}
-          review-timeout-minutes: ${{ vars.REVIEW_ROUTER_TIMEOUT_MINUTES || '60' }}
-          auth-json: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON }}
+    uses: 777genius/review-router/.github/workflows/reviewrouter-reusable.yml@ceb4d251389ac5733504b61e08f6085810a0a2f0
+    with:
+      runtime_ref: "ceb4d251389ac5733504b61e08f6085810a0a2f0"
+      api_url: "https://api.reviewrouter.site"
+      runtime_config_mode: oidc
+      review_action_v2_mode: t0
+      pr_number: ${{ inputs.pr_number }}
+      review_head_sha: ${{ inputs.review_head_sha }}
+      provider_instance_id: "codex-rotating:1163183284"
+      workflow_schema_version: 1
+      review_drafts: ${{ vars.REVIEW_ROUTER_REVIEW_DRAFTS == 'true' }}
+      max_changed_lines: ${{ vars.REVIEW_ROUTER_MAX_CHANGED_LINES }}
+      review_timeout_minutes: ${{ fromJSON(vars.REVIEW_ROUTER_TIMEOUT_MINUTES || '60') }}
+    secrets:
+      CODEX_AUTH_JSON: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON }}
 
   codex-refresh:
     name: codex-refresh
@@ -43,16 +53,16 @@ jobs:
     concurrency:
       group: reviewrouter-codex-oauth-${{ github.repository_id }}-codex-rotating-1163183284
       cancel-in-progress: false
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.review_request_id == '') }}
     permissions:
       id-token: write
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@main
+        uses: 777genius/review-router@ceb4d251389ac5733504b61e08f6085810a0a2f0
         with:
           mode: codex-oauth-refresh
-          api-url: 'https://api.reviewrouter.site'
-          provider-instance-id: 'codex-rotating:1163183284'
-          workflow-schema-version: '1'
+          api-url: "https://api.reviewrouter.site"
+          provider-instance-id: "codex-rotating:1163183284"
+          workflow-schema-version: "1"
           auth-json: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON }}

--- a/.github/workflows/reviewrouter-interaction.yml
+++ b/.github/workflows/reviewrouter-interaction.yml
@@ -20,52 +20,46 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.event_name == 'workflow_dispatch' || ((github.event_name != 'issue_comment' || github.event.issue.pull_request) && github.event.comment.user.type != 'Bot') }}
     env:
-      REVIEWROUTER_API_URL: 'https://api.reviewrouter.site'
-      REVIEWROUTER_ACTION_VERSION: '1603215454b4c5cf3387b40ae674a46eeb7ee96b'
-      REVIEWROUTER_OIDC_AUDIENCE: 'reviewrouter'
-      REVIEWROUTER_RUNTIME_CONFIG_MODE: 'oidc'
-      REVIEWROUTER_STATIC_CONFIG_FALLBACK: 'true'
-      REVIEWROUTER_COMMENT_TOKEN_MODE: 'app-oidc'
+      RR_RUNTIME_REF: "ceb4d251389ac5733504b61e08f6085810a0a2f0"
+      REVIEWROUTER_API_URL: "https://api.reviewrouter.site"
+      REVIEWROUTER_OIDC_AUDIENCE: "reviewrouter"
+      REVIEWROUTER_RUNTIME_CONFIG_MODE: "oidc"
+      REVIEWROUTER_STATIC_CONFIG_FALLBACK: "true"
+      REVIEWROUTER_COMMENT_TOKEN_MODE: "app-oidc"
       CODEX_AUTH_JSON_PRESENT: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON != '' && '1' || '0' }}
-      REVIEW_ROUTER_REVIEW_WORKFLOW_FILE: 'reviewrouter-codex.yml'
+      REVIEW_ROUTER_REVIEW_WORKFLOW_FILE: "reviewrouter-codex.yml"
+      REVIEW_ROUTER_MEMORY_ENABLED: "true"
+      REVIEW_ROUTER_MEMORY_PROTOCOL_VERSION: "1"
+      REVIEW_ROUTER_MEMORY_BUNDLE_ENDPOINT: "/api/action/v1/memory"
+      REVIEW_ROUTER_MEMORY_CANDIDATE_ENDPOINT: "/api/action/v1/memory-candidates"
+      REVIEW_ROUTER_MEMORY_COMMAND_ENDPOINT: "/api/action/v1/memory-commands"
     steps:
-      - name: Fetch ReviewRouter runtime config
-        if: ${{ github.event_name != 'merge_group' && (github.event_name == 'workflow_dispatch' || github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [ -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ] || [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
-            echo "ReviewRouter OIDC is unavailable. Check id-token: write permission."
-            exit 1
-          fi
-          echo "ReviewRouter runtime config will be fetched by the runtime using GitHub OIDC."
-
-      - name: Checkout ReviewRouter runtime
+      - name: Checkout ReviewRouter interaction runtime
         uses: actions/checkout@v6
         with:
           repository: 777genius/review-router
-          ref: ${{ env.REVIEWROUTER_ACTION_VERSION }}
+          ref: ${{ env.RR_RUNTIME_REF }}
           path: .reviewrouter-runtime
           persist-credentials: false
 
-      - name: Setup Node.js for ReviewRouter
+      - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: "24"
 
       - name: Preflight ReviewRouter interaction
         id: preflight
         shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          REVIEW_ROUTER_MODE: 'interaction-preflight'
+          REVIEW_ROUTER_MODE: "interaction-preflight"
           REVIEW_ROUTER_DISCUSSION_MODE: ${{ vars.REVIEW_ROUTER_DISCUSSION_MODE || 'off' }}
         run: node .reviewrouter-runtime/dist/index.js
 
       - name: Install Codex CLI for discussion replies
         if: ${{ steps.preflight.outputs.needs_discussion == 'true' && env.CODEX_AUTH_JSON_PRESENT == '1' }}
         shell: bash
-        run: npm install -g @openai/codex@0.125.0
+        run: npm install -g @openai/codex@0.141.0
 
       - name: Restore Codex subscription auth for discussion replies
         if: ${{ steps.preflight.outputs.needs_discussion == 'true' && env.CODEX_AUTH_JSON_PRESENT == '1' }}
@@ -89,7 +83,8 @@ jobs:
         shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          REVIEW_ROUTER_MODE: 'interaction'
+          REVIEW_ROUTER_MODE: "interaction"
+          REVIEW_ROUTER_LEDGER_KEY: ${{ secrets.REVIEW_ROUTER_LEDGER_KEY }}
           REVIEW_ROUTER_DISCUSSION_MODE: ${{ vars.REVIEW_ROUTER_DISCUSSION_MODE || 'off' }}
           REVIEW_ROUTER_DISCUSSION_MAX_PER_PR: ${{ vars.REVIEW_ROUTER_DISCUSSION_MAX_PER_PR || '20' }}
           REVIEW_ROUTER_DISCUSSION_MAX_PER_THREAD: ${{ vars.REVIEW_ROUTER_DISCUSSION_MAX_PER_THREAD || '5' }}


### PR DESCRIPTION
Pins the managed ReviewRouter review and interaction workflows on dev to the same immutable revision-aware Action release already merged on main. This is required for draft PRs targeting dev, including #252, to use the durable workflow-dispatch path instead of the legacy pull_request workflow.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Pins ReviewRouter workflows to an immutable revision-aware runtime.
- Replaces pull-request-triggered Codex reviews with durable, identity-bearing workflow dispatches through a reusable workflow.
- Pins the interaction runtime to the same immutable revision and enables its memory and ledger configuration.
- Updates the discussion-reply Codex CLI dependency.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete changed-code failure identified.

The review and interaction workflows consistently use the same immutable runtime revision, and the new dispatch conditions cleanly separate identity-bearing reviews from scheduled or input-free maintenance runs.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/reviewrouter-codex.yml | Moves reviews to revision-aware workflow dispatch while retaining scheduled and input-free maintenance refreshes. |
| .github/workflows/reviewrouter-interaction.yml | Pins the interaction runtime, adds memory and ledger settings, and updates the discussion CLI version. |

<sub>Reviews (1): Last reviewed commit: ["chore(review): pin revision-aware runtim..."](https://github.com/777genius/agent-teams-ai/commit/7b5c6b86b8b8770582b56fef8b66a74d714b6128) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46615598)</sub>

<!-- /greptile_comment -->