### PR TITLE
refactor(change-review): isolate action history state

### DIFF
--- a/src/features/change-review/README.md
+++ b/src/features/change-review/README.md
@@ -5,10 +5,11 @@ This is a thin renderer feature extracted incrementally from the legacy
 
 - `renderer/view-models` owns pure presentation projections.
 - `renderer/utils` owns pure scope and operation-generation policies.
-- `renderer/hooks` owns scope projection and lifecycle orchestration through narrow ports.
+- `renderer/hooks` owns scope/lifecycle, draft history, conflict recovery, action-history,
+  decision-persistence, and keyboard orchestration through narrow ports.
 - `renderer/ui` owns store-free presentation components.
-- The legacy dialog temporarily retains Zustand, IPC, editor, mutation, persistence,
-  and close-flush orchestration while later slices move those responsibilities behind
-  focused hooks and use cases.
+- The legacy dialog remains the temporary composition shell for Zustand, editor and disk
+  mutations, and outer close coordination while later slices move those responsibilities
+  behind focused hooks and use cases.
 
 Production callers import through `@features/change-review/renderer`.

--- a/src/features/change-review/renderer/adapters/createChangeReviewActionHistoryPorts.ts
+++ b/src/features/change-review/renderer/adapters/createChangeReviewActionHistoryPorts.ts
@@ -1,0 +1,60 @@
+import type {
+  ChangeReviewActionHistoryStorePort,
+  ChangeReviewDecisionPersistencePort,
+  ChangeReviewDecisionPersistenceSnapshot,
+} from '../ports/changeReviewActionHistoryPorts';
+import type { ReviewRedoAction, ReviewUndoAction } from '@shared/types';
+
+interface ChangeReviewActionHistoryStore {
+  setReviewActionHistory(history: ReviewUndoAction[]): void;
+  setReviewRedoHistory(history: ReviewRedoAction[]): void;
+}
+
+interface CreateChangeReviewActionHistoryStorePortInput {
+  getStore: () => ChangeReviewActionHistoryStore;
+  clearLegacyUndoStack: () => void;
+}
+
+export function createChangeReviewActionHistoryStorePort({
+  getStore,
+  clearLegacyUndoStack,
+}: CreateChangeReviewActionHistoryStorePortInput): ChangeReviewActionHistoryStorePort {
+  return {
+    publishUndoHistory: (history) => getStore().setReviewActionHistory(history),
+    publishRedoHistory: (history) => getStore().setReviewRedoHistory(history),
+    clearLegacyUndoStack,
+  };
+}
+
+interface ChangeReviewDecisionPersistenceStore extends ChangeReviewDecisionPersistenceSnapshot {
+  loadDecisionsFromDisk(teamName: string, scopeKey: string, scopeToken: string): Promise<void>;
+  persistDecisions(teamName: string, scopeKey: string, scopeToken: string): void;
+  flushDecisionsToDisk(teamName: string, scopeKey: string, scopeToken: string): Promise<boolean>;
+  clearDecisionsFromDisk(teamName: string, scopeKey: string, scopeToken?: string): Promise<boolean>;
+}
+
+interface CreateChangeReviewDecisionPersistencePortInput {
+  getStore: () => ChangeReviewDecisionPersistenceStore;
+  setApplyError: (message: string | null) => void;
+}
+
+export function createChangeReviewDecisionPersistencePort({
+  getStore,
+  setApplyError,
+}: CreateChangeReviewDecisionPersistencePortInput): ChangeReviewDecisionPersistencePort {
+  return {
+    getSnapshot: () => getStore(),
+    load: ({ teamName, scopeKey, scopeToken }) =>
+      getStore().loadDecisionsFromDisk(teamName, scopeKey, scopeToken),
+    schedule: ({ teamName, scopeKey, scopeToken }) =>
+      getStore().persistDecisions(teamName, scopeKey, scopeToken),
+    flush: ({ teamName, scopeKey, scopeToken }) =>
+      getStore().flushDecisionsToDisk(teamName, scopeKey, scopeToken),
+    clear: ({ teamName, scopeKey, scopeToken }) =>
+      getStore().clearDecisionsFromDisk(teamName, scopeKey, scopeToken),
+    reportError: setApplyError,
+    clearError: (expectedMessage) => {
+      if (getStore().applyError === expectedMessage) setApplyError(null);
+    },
+  };
+}

--- a/src/features/change-review/renderer/hooks/useChangeReviewActionHistoryController.ts
+++ b/src/features/change-review/renderer/hooks/useChangeReviewActionHistoryController.ts
@@ -1,0 +1,251 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import {
+  appendOrderedReviewAction,
+  createReviewUndoAction,
+  filterReviewActionHistoryForFile,
+  popOrderedReviewAction,
+  replaceLatestReviewAction,
+} from '../utils/changeReviewActionHistory';
+
+import type { ChangeReviewActionHistoryStorePort } from '../ports/changeReviewActionHistoryPorts';
+import type { ReviewUndoActionInput } from '../utils/changeReviewActionHistory';
+import type { ReviewRedoAction, ReviewUndoAction } from '@shared/types';
+
+interface UseChangeReviewActionHistoryControllerInput {
+  resetKey: string;
+  hydrationKey: string | null;
+  hydrationScopeKey: string | null;
+  hydrationStatus: 'idle' | 'loading' | 'loaded' | 'error';
+  hydratedUndoHistory: ReviewUndoAction[];
+  hydratedRedoHistory: ReviewRedoAction[];
+  store: ChangeReviewActionHistoryStorePort;
+}
+
+export interface ChangeReviewActionHistoryController {
+  undoDepth: number;
+  redoDepth: number;
+  getUndoHistory: () => ReviewUndoAction[];
+  getRedoHistory: () => ReviewRedoAction[];
+  getLatestUndoAction: () => ReviewUndoAction | undefined;
+  getLatestRedoAction: () => ReviewRedoAction | undefined;
+  pushUndoAction: (input: ReviewUndoActionInput) => ReviewUndoAction;
+  completeUndoAction: (action: ReviewUndoAction, redoAction: ReviewRedoAction) => boolean;
+  bindCommittedAction: (
+    optimistic: ReviewUndoAction,
+    committed: ReviewUndoAction | undefined
+  ) => boolean;
+  completeRedoAction: (redoAction: ReviewRedoAction) => boolean;
+  discardLatestAction: (action: ReviewUndoAction) => boolean;
+  publishUndoHistory: () => void;
+  replaceHistories: (undoHistory: ReviewUndoAction[], redoHistory: ReviewRedoAction[]) => void;
+  clear: () => void;
+  clearForFile: (filePath: string) => void;
+}
+
+export function useChangeReviewActionHistoryController({
+  resetKey,
+  hydrationKey,
+  hydrationScopeKey,
+  hydrationStatus,
+  hydratedUndoHistory,
+  hydratedRedoHistory,
+  store,
+}: UseChangeReviewActionHistoryControllerInput): ChangeReviewActionHistoryController {
+  const undoHistoryRef = useRef<ReviewUndoAction[]>([]);
+  const redoHistoryRef = useRef<ReviewRedoAction[]>([]);
+  const redoBeforePreparedActionRef = useRef<{
+    action: ReviewUndoAction;
+    actionId: string;
+    history: ReviewRedoAction[];
+  } | null>(null);
+  const [undoDepth, setUndoDepth] = useState(0);
+  const [redoDepth, setRedoDepth] = useState(0);
+
+  useEffect(() => {
+    undoHistoryRef.current = [];
+    redoHistoryRef.current = [];
+    redoBeforePreparedActionRef.current = null;
+    setUndoDepth(0);
+    setRedoDepth(0);
+  }, [resetKey]);
+
+  useEffect(() => {
+    if (
+      hydrationKey === null ||
+      hydrationScopeKey !== hydrationKey ||
+      hydrationStatus !== 'loaded'
+    ) {
+      return;
+    }
+    undoHistoryRef.current = hydratedUndoHistory;
+    redoHistoryRef.current = hydratedRedoHistory;
+    setUndoDepth(hydratedUndoHistory.length);
+    setRedoDepth(hydratedRedoHistory.length);
+  }, [hydratedRedoHistory, hydratedUndoHistory, hydrationKey, hydrationScopeKey, hydrationStatus]);
+
+  const getUndoHistory = useCallback((): ReviewUndoAction[] => undoHistoryRef.current, []);
+  const getRedoHistory = useCallback((): ReviewRedoAction[] => redoHistoryRef.current, []);
+  const getLatestUndoAction = useCallback(
+    (): ReviewUndoAction | undefined => undoHistoryRef.current.at(-1),
+    []
+  );
+  const getLatestRedoAction = useCallback(
+    (): ReviewRedoAction | undefined => redoHistoryRef.current.at(-1),
+    []
+  );
+
+  const pushUndoAction = useCallback(
+    (input: ReviewUndoActionInput): ReviewUndoAction => {
+      const action = createReviewUndoAction(input);
+      const undoHistory = appendOrderedReviewAction(undoHistoryRef.current, action);
+      undoHistoryRef.current = undoHistory;
+      store.publishUndoHistory(undoHistory);
+      redoBeforePreparedActionRef.current = {
+        action,
+        actionId: action.id,
+        history: redoHistoryRef.current,
+      };
+      redoHistoryRef.current = [];
+      store.publishRedoHistory([]);
+      setUndoDepth(undoHistory.length);
+      setRedoDepth(0);
+      return action;
+    },
+    [store]
+  );
+
+  const completeUndoAction = useCallback(
+    (action: ReviewUndoAction, redoAction: ReviewRedoAction): boolean => {
+      const result = popOrderedReviewAction(undoHistoryRef.current, action);
+      if (!result.popped) return false;
+      const redoHistory = [...redoHistoryRef.current, redoAction];
+      undoHistoryRef.current = result.stack;
+      redoHistoryRef.current = redoHistory;
+      redoBeforePreparedActionRef.current = null;
+      store.publishUndoHistory(result.stack);
+      store.publishRedoHistory(redoHistory);
+      setUndoDepth(result.stack.length);
+      setRedoDepth(redoHistory.length);
+      return true;
+    },
+    [store]
+  );
+
+  const bindCommittedAction = useCallback(
+    (optimistic: ReviewUndoAction, committed: ReviewUndoAction | undefined): boolean => {
+      if (!committed) return false;
+      const result = replaceLatestReviewAction(undoHistoryRef.current, optimistic, committed);
+      if (!result.replaced) return false;
+      undoHistoryRef.current = result.stack;
+      store.publishUndoHistory(result.stack);
+      return true;
+    },
+    [store]
+  );
+
+  const completeRedoAction = useCallback(
+    (redoAction: ReviewRedoAction): boolean => {
+      const latest = redoHistoryRef.current.at(-1);
+      if (latest?.action.id !== redoAction.action.id) return false;
+      const redoHistory = redoHistoryRef.current.slice(0, -1);
+      const undoHistory = appendOrderedReviewAction(undoHistoryRef.current, redoAction.action);
+      redoHistoryRef.current = redoHistory;
+      undoHistoryRef.current = undoHistory;
+      redoBeforePreparedActionRef.current = null;
+      store.publishRedoHistory(redoHistory);
+      store.publishUndoHistory(undoHistory);
+      setRedoDepth(redoHistory.length);
+      setUndoDepth(undoHistory.length);
+      return true;
+    },
+    [store]
+  );
+
+  const discardLatestAction = useCallback(
+    (action: ReviewUndoAction): boolean => {
+      const result = popOrderedReviewAction(undoHistoryRef.current, action);
+      if (!result.popped) return false;
+      undoHistoryRef.current = result.stack;
+      store.publishUndoHistory(result.stack);
+      const redoBackup = redoBeforePreparedActionRef.current;
+      if (redoBackup?.actionId === action.id && redoBackup.action === action) {
+        redoHistoryRef.current = redoBackup.history;
+        store.publishRedoHistory(redoBackup.history);
+        setRedoDepth(redoBackup.history.length);
+        redoBeforePreparedActionRef.current = null;
+      }
+      setUndoDepth(result.stack.length);
+      return true;
+    },
+    [store]
+  );
+
+  const publishUndoHistory = useCallback((): void => {
+    store.publishUndoHistory([...undoHistoryRef.current]);
+  }, [store]);
+
+  const replaceHistories = useCallback(
+    (undoHistory: ReviewUndoAction[], redoHistory: ReviewRedoAction[]): void => {
+      undoHistoryRef.current = undoHistory;
+      redoHistoryRef.current = redoHistory;
+      redoBeforePreparedActionRef.current = null;
+      store.publishUndoHistory(undoHistory);
+      store.publishRedoHistory(redoHistory);
+      setUndoDepth(undoHistory.length);
+      setRedoDepth(redoHistory.length);
+    },
+    [store]
+  );
+
+  const clear = useCallback((): void => {
+    undoHistoryRef.current = [];
+    redoHistoryRef.current = [];
+    redoBeforePreparedActionRef.current = null;
+    store.publishUndoHistory([]);
+    store.publishRedoHistory([]);
+    store.clearLegacyUndoStack();
+    setUndoDepth(0);
+    setRedoDepth(0);
+  }, [store]);
+
+  const clearForFile = useCallback(
+    (filePath: string): void => {
+      const filtered = filterReviewActionHistoryForFile({
+        undoHistory: undoHistoryRef.current,
+        redoHistory: redoHistoryRef.current,
+        filePath,
+      });
+      if (filtered.clearAll) {
+        clear();
+        return;
+      }
+      undoHistoryRef.current = filtered.undoHistory;
+      redoHistoryRef.current = filtered.redoHistory;
+      redoBeforePreparedActionRef.current = null;
+      store.publishUndoHistory(filtered.undoHistory);
+      store.publishRedoHistory(filtered.redoHistory);
+      setUndoDepth(filtered.undoHistory.length);
+      setRedoDepth(0);
+    },
+    [clear, store]
+  );
+
+  return {
+    undoDepth,
+    redoDepth,
+    getUndoHistory,
+    getRedoHistory,
+    getLatestUndoAction,
+    getLatestRedoAction,
+    pushUndoAction,
+    completeUndoAction,
+    bindCommittedAction,
+    completeRedoAction,
+    discardLatestAction,
+    publishUndoHistory,
+    replaceHistories,
+    clear,
+    clearForFile,
+  };
+}

--- a/src/features/change-review/renderer/hooks/useChangeReviewDecisionAutoPersistence.ts
+++ b/src/features/change-review/renderer/hooks/useChangeReviewDecisionAutoPersistence.ts
@@ -1,0 +1,79 @@
+import { useEffect, useRef } from 'react';
+
+import type { ChangeReviewDecisionPersistenceScope } from '../ports/changeReviewActionHistoryPorts';
+import type { ChangeReviewAutoClearResult } from './useChangeReviewDecisionPersistenceController';
+
+interface UseChangeReviewDecisionAutoPersistenceInput {
+  active: boolean;
+  hydrationKey: string | null;
+  scope: ChangeReviewDecisionPersistenceScope | null;
+  hydrationReady: boolean;
+  blocked: boolean;
+  hasDurableReviewState: boolean;
+  hunkDecisions: object;
+  fileDecisions: object;
+  undoHistory: object;
+  redoHistory: object;
+  fileContents: object;
+  fileChunkCounts: object;
+  scheduleAutoPersistence: (scope: ChangeReviewDecisionPersistenceScope) => void;
+  clearAfterDurableStateEmptied: (
+    scope: ChangeReviewDecisionPersistenceScope,
+    hydrationKey: string
+  ) => Promise<ChangeReviewAutoClearResult>;
+}
+
+export function useChangeReviewDecisionAutoPersistence({
+  active,
+  hydrationKey,
+  scope,
+  hydrationReady,
+  blocked,
+  hasDurableReviewState,
+  hunkDecisions,
+  fileDecisions,
+  undoHistory,
+  redoHistory,
+  fileContents,
+  fileChunkCounts,
+  scheduleAutoPersistence,
+  clearAfterDurableStateEmptied,
+}: UseChangeReviewDecisionAutoPersistenceInput): void {
+  const hadDurableReviewStateRef = useRef(false);
+  const hasDurableReviewStateRef = useRef(hasDurableReviewState);
+  hasDurableReviewStateRef.current = hasDurableReviewState;
+
+  useEffect(() => {
+    hadDurableReviewStateRef.current = false;
+  }, [scope?.scopeToken]);
+
+  useEffect(() => {
+    if (!active || !scope || !hydrationKey || !hydrationReady || blocked) return;
+    if (hasDurableReviewState) {
+      hadDurableReviewStateRef.current = true;
+      scheduleAutoPersistence(scope);
+      return;
+    }
+    if (!hadDurableReviewStateRef.current) return;
+    void clearAfterDurableStateEmptied(scope, hydrationKey).then((result) => {
+      if (result === 'cleared' && !hasDurableReviewStateRef.current) {
+        hadDurableReviewStateRef.current = false;
+      }
+    });
+  }, [
+    active,
+    blocked,
+    clearAfterDurableStateEmptied,
+    fileChunkCounts,
+    fileContents,
+    fileDecisions,
+    hasDurableReviewState,
+    hunkDecisions,
+    hydrationKey,
+    hydrationReady,
+    redoHistory,
+    scheduleAutoPersistence,
+    scope,
+    undoHistory,
+  ]);
+}

--- a/src/features/change-review/renderer/hooks/useChangeReviewDecisionPersistenceController.ts
+++ b/src/features/change-review/renderer/hooks/useChangeReviewDecisionPersistenceController.ts
@@ -1,0 +1,303 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import type {
+  ChangeReviewDecisionPersistencePort,
+  ChangeReviewDecisionPersistenceScope,
+  ChangeReviewDecisionPersistenceSnapshot,
+} from '../ports/changeReviewActionHistoryPorts';
+import type { ReviewActionPersistenceStatus } from '../utils/changeReviewActionHistory';
+
+export const CHANGE_REVIEW_PERSISTENCE_ERROR =
+  'Latest review action is not saved. Retry from History before continuing.';
+const REVIEW_AUTO_CLEAR_ERROR =
+  'Unable to clear saved review decisions. Retry from History or keep Changes open.';
+
+interface ReviewPersistenceSnapshotIdentity {
+  scopeToken: string;
+  hunkDecisions: object;
+  fileDecisions: object;
+  reviewActionHistory: object;
+  reviewRedoHistory: object;
+  fileContents: object;
+  fileChunkCounts: object;
+}
+
+interface PendingAutoClear {
+  hydrationKey: string;
+  generation: number;
+  operation: object;
+  promise: Promise<ChangeReviewAutoClearResult>;
+}
+
+export type ChangeReviewAutoClearResult = 'cleared' | 'failed' | 'stale' | 'pending';
+
+interface UseChangeReviewDecisionPersistenceControllerInput {
+  hydrationKey: string | null;
+  scope: ChangeReviewDecisionPersistenceScope | null;
+  hydrationReady: boolean;
+  isExpectedHydrationKey: (hydrationKey: string) => boolean;
+  refreshConflictCandidates: () => Promise<void>;
+  port: ChangeReviewDecisionPersistencePort;
+}
+
+export interface ChangeReviewDecisionPersistenceDiagnostics {
+  pendingDecisionClear: boolean;
+  persistenceStatus: ReviewActionPersistenceStatus;
+}
+
+export interface ChangeReviewDecisionPersistenceController {
+  status: ReviewActionPersistenceStatus;
+  getStatus: () => ReviewActionPersistenceStatus;
+  publishSaved: () => void;
+  hydrate: (scope: ChangeReviewDecisionPersistenceScope, hydrationKey: string) => Promise<void>;
+  persistLatest: () => Promise<boolean>;
+  scheduleAutoPersistence: (scope: ChangeReviewDecisionPersistenceScope) => void;
+  clearAfterDurableStateEmptied: (
+    scope: ChangeReviewDecisionPersistenceScope,
+    hydrationKey: string
+  ) => Promise<ChangeReviewAutoClearResult>;
+  flushForClose: () => Promise<boolean>;
+  getDiagnostics: () => ChangeReviewDecisionPersistenceDiagnostics;
+}
+
+function captureSnapshotIdentity(
+  scopeToken: string,
+  snapshot: ChangeReviewDecisionPersistenceSnapshot
+): ReviewPersistenceSnapshotIdentity {
+  return {
+    scopeToken,
+    hunkDecisions: snapshot.hunkDecisions,
+    fileDecisions: snapshot.fileDecisions,
+    reviewActionHistory: snapshot.reviewActionHistory,
+    reviewRedoHistory: snapshot.reviewRedoHistory,
+    fileContents: snapshot.fileContents,
+    fileChunkCounts: snapshot.fileChunkCounts,
+  };
+}
+
+function isSameSnapshot(
+  left: ReviewPersistenceSnapshotIdentity | null,
+  right: ReviewPersistenceSnapshotIdentity
+): boolean {
+  return (
+    left?.scopeToken === right.scopeToken &&
+    left.hunkDecisions === right.hunkDecisions &&
+    left.fileDecisions === right.fileDecisions &&
+    left.reviewActionHistory === right.reviewActionHistory &&
+    left.reviewRedoHistory === right.reviewRedoHistory &&
+    left.fileContents === right.fileContents &&
+    left.fileChunkCounts === right.fileChunkCounts
+  );
+}
+
+function hasDurableReviewState(snapshot: ChangeReviewDecisionPersistenceSnapshot): boolean {
+  return (
+    Object.keys(snapshot.hunkDecisions).length > 0 ||
+    Object.keys(snapshot.fileDecisions).length > 0 ||
+    Object.keys(snapshot.reviewActionHistory).length > 0 ||
+    Object.keys(snapshot.reviewRedoHistory).length > 0
+  );
+}
+
+export function useChangeReviewDecisionPersistenceController({
+  hydrationKey,
+  scope,
+  hydrationReady,
+  isExpectedHydrationKey,
+  refreshConflictCandidates,
+  port,
+}: UseChangeReviewDecisionPersistenceControllerInput): ChangeReviewDecisionPersistenceController {
+  const [status, setStatus] = useState<ReviewActionPersistenceStatus>('saved');
+  const statusRef = useRef<ReviewActionPersistenceStatus>('saved');
+  const generationRef = useRef(0);
+  const immediateSnapshotRef = useRef<ReviewPersistenceSnapshotIdentity | null>(null);
+  const pendingAutoClearRef = useRef<PendingAutoClear | null>(null);
+
+  const publishStatus = useCallback((next: ReviewActionPersistenceStatus): void => {
+    statusRef.current = next;
+    setStatus(next);
+  }, []);
+
+  useEffect(() => {
+    generationRef.current += 1;
+    immediateSnapshotRef.current = null;
+    if (pendingAutoClearRef.current?.hydrationKey !== hydrationKey) {
+      pendingAutoClearRef.current = null;
+    }
+    publishStatus('saved');
+  }, [hydrationKey, publishStatus]);
+
+  const getStatus = useCallback((): ReviewActionPersistenceStatus => statusRef.current, []);
+  const publishSaved = useCallback((): void => publishStatus('saved'), [publishStatus]);
+
+  const hydrate = useCallback(
+    async (
+      hydrationScope: ChangeReviewDecisionPersistenceScope,
+      targetHydrationKey: string
+    ): Promise<void> => {
+      const generation = generationRef.current;
+      await port.load(hydrationScope);
+      if (generationRef.current !== generation || !isExpectedHydrationKey(targetHydrationKey)) {
+        return;
+      }
+      const hydrated = port.getSnapshot();
+      if (
+        hydrated.decisionHydrationScopeKey === targetHydrationKey &&
+        hydrated.decisionHydrationStatus === 'loaded'
+      ) {
+        // Loading is already durable. Suppress only the exact reference snapshot
+        // produced by this hydration, never a structurally-equal later edit.
+        immediateSnapshotRef.current = captureSnapshotIdentity(hydrationScope.scopeToken, hydrated);
+      }
+    },
+    [isExpectedHydrationKey, port]
+  );
+
+  const persistLatest = useCallback(async (): Promise<boolean> => {
+    const generation = generationRef.current + 1;
+    generationRef.current = generation;
+    pendingAutoClearRef.current = null;
+    publishStatus('saving');
+
+    if (!scope || !hydrationReady) {
+      if (generationRef.current === generation) {
+        publishStatus('error');
+        port.reportError(CHANGE_REVIEW_PERSISTENCE_ERROR);
+      }
+      return false;
+    }
+
+    // The marker must precede both scheduling and flushing. Otherwise the
+    // post-ack render can enqueue a redundant revision before the marker exists.
+    immediateSnapshotRef.current = captureSnapshotIdentity(scope.scopeToken, port.getSnapshot());
+
+    let saved = false;
+    try {
+      port.schedule(scope);
+      saved = await port.flush(scope);
+    } catch {
+      saved = false;
+    }
+
+    if (generationRef.current !== generation || !isExpectedHydrationKey(hydrationKey ?? '')) {
+      return saved;
+    }
+    if (saved) {
+      publishStatus('saved');
+      port.clearError(CHANGE_REVIEW_PERSISTENCE_ERROR);
+      return true;
+    }
+
+    publishStatus('error');
+    port.reportError(CHANGE_REVIEW_PERSISTENCE_ERROR);
+    void refreshConflictCandidates();
+    return false;
+  }, [
+    hydrationKey,
+    hydrationReady,
+    isExpectedHydrationKey,
+    port,
+    publishStatus,
+    refreshConflictCandidates,
+    scope,
+  ]);
+
+  const scheduleAutoPersistence = useCallback(
+    (autoScope: ChangeReviewDecisionPersistenceScope): void => {
+      const currentSnapshot = captureSnapshotIdentity(autoScope.scopeToken, port.getSnapshot());
+      if (isSameSnapshot(immediateSnapshotRef.current, currentSnapshot)) {
+        immediateSnapshotRef.current = null;
+        return;
+      }
+      immediateSnapshotRef.current = null;
+      port.schedule(autoScope);
+    },
+    [port]
+  );
+
+  const clearAfterDurableStateEmptied = useCallback(
+    (
+      clearScope: ChangeReviewDecisionPersistenceScope,
+      targetHydrationKey: string
+    ): Promise<ChangeReviewAutoClearResult> => {
+      const existing = pendingAutoClearRef.current;
+      if (
+        existing?.hydrationKey === targetHydrationKey &&
+        existing.generation === generationRef.current
+      ) {
+        return existing.promise;
+      }
+
+      const generation = generationRef.current + 1;
+      generationRef.current = generation;
+      const operation = {};
+      const pending: PendingAutoClear = {
+        hydrationKey: targetHydrationKey,
+        generation,
+        operation,
+        promise: Promise.resolve('pending'),
+      };
+      const isCurrent = (): boolean =>
+        generationRef.current === generation &&
+        pendingAutoClearRef.current?.operation === operation &&
+        isExpectedHydrationKey(targetHydrationKey);
+
+      pending.promise = (async (): Promise<ChangeReviewAutoClearResult> => {
+        let cleared = false;
+        try {
+          cleared = await port.clear(clearScope);
+        } catch {
+          cleared = false;
+        }
+        if (!isCurrent()) return 'stale';
+        if (cleared) return 'cleared';
+
+        publishStatus('error');
+        port.reportError(REVIEW_AUTO_CLEAR_ERROR);
+        void refreshConflictCandidates();
+        return 'failed';
+      })().finally(() => {
+        if (pendingAutoClearRef.current?.operation === operation) {
+          pendingAutoClearRef.current = null;
+        }
+      });
+      pendingAutoClearRef.current = pending;
+      return pending.promise;
+    },
+    [isExpectedHydrationKey, port, publishStatus, refreshConflictCandidates]
+  );
+
+  const flushForClose = useCallback(async (): Promise<boolean> => {
+    if (!scope) return true;
+    if (hasDurableReviewState(port.getSnapshot())) return persistLatest();
+    const pending = pendingAutoClearRef.current;
+    if (pending?.hydrationKey === hydrationKey) {
+      return (await pending.promise) === 'cleared';
+    }
+    try {
+      return await port.clear(scope);
+    } catch {
+      return false;
+    }
+  }, [hydrationKey, persistLatest, port, scope]);
+
+  const getDiagnostics = useCallback(
+    (): ChangeReviewDecisionPersistenceDiagnostics => ({
+      pendingDecisionClear: pendingAutoClearRef.current !== null,
+      persistenceStatus: statusRef.current,
+    }),
+    []
+  );
+
+  return {
+    status,
+    getStatus,
+    publishSaved,
+    hydrate,
+    persistLatest,
+    scheduleAutoPersistence,
+    clearAfterDurableStateEmptied,
+    flushForClose,
+    getDiagnostics,
+  };
+}

--- a/src/features/change-review/renderer/hooks/useChangeReviewHistoryKeyboardShortcuts.ts
+++ b/src/features/change-review/renderer/hooks/useChangeReviewHistoryKeyboardShortcuts.ts
@@ -1,0 +1,95 @@
+import { useEffect } from 'react';
+
+import { redoDepth, undoDepth } from '@codemirror/commands';
+
+import type { EditorView } from '@codemirror/view';
+
+export interface ChangeReviewKeyboardEditorContext {
+  editor: EditorView | null;
+  hasDraft: boolean;
+}
+
+interface UseChangeReviewHistoryKeyboardShortcutsInput {
+  active: boolean;
+  editedCount: number;
+  resolveEditorContext: (target: Element | null) => ChangeReviewKeyboardEditorContext;
+  hasActionInFlight: () => boolean;
+  getUndoCount: () => number;
+  getRedoCount: () => number;
+  undoLatest: () => Promise<void>;
+  redoLatest: () => Promise<void>;
+  reportManualDraftBlock: () => void;
+}
+
+export function useChangeReviewHistoryKeyboardShortcuts({
+  active,
+  editedCount,
+  resolveEditorContext,
+  hasActionInFlight,
+  getUndoCount,
+  getRedoCount,
+  undoLatest,
+  redoLatest,
+  reportManualDraftBlock,
+}: UseChangeReviewHistoryKeyboardShortcutsInput): void {
+  useEffect(() => {
+    if (!active) return;
+    const handler = (event: KeyboardEvent): void => {
+      if (!(event.metaKey || event.ctrlKey)) return;
+      const isRedoShortcut =
+        (event.code === 'KeyZ' && event.shiftKey) || (event.code === 'KeyY' && !event.shiftKey);
+      const isUndoShortcut = event.code === 'KeyZ' && !event.shiftKey;
+      if (!isUndoShortcut && !isRedoShortcut) return;
+
+      const tag = document.activeElement?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+      const { editor, hasDraft } = resolveEditorContext(document.activeElement);
+
+      if (isRedoShortcut) {
+        if (editor && redoDepth(editor.state) > 0) return;
+        if (hasDraft) return;
+        event.preventDefault();
+        event.stopPropagation();
+        if (hasActionInFlight() || editedCount > 0) return;
+        if (getRedoCount() > 0) void redoLatest();
+        return;
+      }
+
+      if (editor && undoDepth(editor.state) > 0 && (hasDraft || getUndoCount() === 0)) return;
+      if (hasDraft) return;
+      if (hasActionInFlight()) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+
+      if (getUndoCount() > 0) {
+        event.preventDefault();
+        event.stopPropagation();
+        if (editedCount > 0) {
+          reportManualDraftBlock();
+          return;
+        }
+        void undoLatest();
+        return;
+      }
+
+      // Native CodeMirror Undo would mutate only the visual document and
+      // desynchronize it from the durable decision timeline.
+      event.preventDefault();
+      event.stopPropagation();
+    };
+    document.addEventListener('keydown', handler, true);
+    return () => document.removeEventListener('keydown', handler, true);
+  }, [
+    active,
+    editedCount,
+    getRedoCount,
+    getUndoCount,
+    hasActionInFlight,
+    redoLatest,
+    reportManualDraftBlock,
+    resolveEditorContext,
+    undoLatest,
+  ]);
+}

--- a/src/features/change-review/renderer/index.ts
+++ b/src/features/change-review/renderer/index.ts
@@ -1,22 +1,46 @@
 export {
+  createChangeReviewActionHistoryStorePort,
+  createChangeReviewDecisionPersistencePort,
+} from './adapters/createChangeReviewActionHistoryPorts';
+export {
   createChangeReviewConflictCommandPort,
   createChangeReviewConflictQueryPort,
 } from './adapters/createChangeReviewConflictPorts';
 export type { ChangeReviewConflictStateBridge } from './adapters/createChangeReviewConflictStateBridge';
 export { createChangeReviewConflictStateBridge } from './adapters/createChangeReviewConflictStateBridge';
 export { createChangeReviewDraftHistoryPort } from './adapters/createChangeReviewDraftHistoryPort';
+export type { ChangeReviewActionHistoryController } from './hooks/useChangeReviewActionHistoryController';
+export { useChangeReviewActionHistoryController } from './hooks/useChangeReviewActionHistoryController';
 export type { ChangeReviewConflictDiscoveryController } from './hooks/useChangeReviewConflictDiscoveryController';
 export { useChangeReviewConflictDiscoveryController } from './hooks/useChangeReviewConflictDiscoveryController';
 export type { ChangeReviewConflictInteractionController } from './hooks/useChangeReviewConflictInteractionController';
 export { useChangeReviewConflictInteractionController } from './hooks/useChangeReviewConflictInteractionController';
+export { useChangeReviewDecisionAutoPersistence } from './hooks/useChangeReviewDecisionAutoPersistence';
+export type {
+  ChangeReviewAutoClearResult,
+  ChangeReviewDecisionPersistenceController,
+  ChangeReviewDecisionPersistenceDiagnostics,
+} from './hooks/useChangeReviewDecisionPersistenceController';
+export {
+  CHANGE_REVIEW_PERSISTENCE_ERROR,
+  useChangeReviewDecisionPersistenceController,
+} from './hooks/useChangeReviewDecisionPersistenceController';
 export type {
   ChangeReviewDraftHistoryController,
   ChangeReviewDraftHistoryDiagnostics,
 } from './hooks/useChangeReviewDraftHistoryController';
 export { useChangeReviewDraftHistoryController } from './hooks/useChangeReviewDraftHistoryController';
+export type { ChangeReviewKeyboardEditorContext } from './hooks/useChangeReviewHistoryKeyboardShortcuts';
+export { useChangeReviewHistoryKeyboardShortcuts } from './hooks/useChangeReviewHistoryKeyboardShortcuts';
 export { useChangeReviewLifecycleRegistration } from './hooks/useChangeReviewLifecycleRegistration';
 export { useChangeReviewOperationGeneration } from './hooks/useChangeReviewOperationGeneration';
 export { useChangeReviewScopeIdentity } from './hooks/useChangeReviewScopeIdentity';
+export type {
+  ChangeReviewActionHistoryStorePort,
+  ChangeReviewDecisionPersistencePort,
+  ChangeReviewDecisionPersistenceScope,
+  ChangeReviewDecisionPersistenceSnapshot,
+} from './ports/changeReviewActionHistoryPorts';
 export type {
   ChangeReviewConflictCommandPort,
   ChangeReviewConflictQueryPort,
@@ -38,6 +62,18 @@ export {
 } from './ui/ChangeReviewConflictNotices';
 export type { TaskChangesEmptyStateProps } from './ui/TaskChangesEmptyState';
 export { TaskChangesEmptyState } from './ui/TaskChangesEmptyState';
+export type {
+  ReviewActionPersistenceStatus,
+  ReviewUndoActionInput,
+} from './utils/changeReviewActionHistory';
+export {
+  appendOrderedReviewAction,
+  createReviewUndoAction,
+  filterReviewActionHistoryForFile,
+  isReviewActionPersistenceBlocking,
+  popOrderedReviewAction,
+  replaceLatestReviewAction,
+} from './utils/changeReviewActionHistory';
 export type { ReviewConflictCandidateSelection } from './utils/changeReviewConflicts';
 export {
   CHANGE_REVIEW_CONFLICT_LOAD_ERROR_PREFIX,

--- a/src/features/change-review/renderer/ports/changeReviewActionHistoryPorts.ts
+++ b/src/features/change-review/renderer/ports/changeReviewActionHistoryPorts.ts
@@ -1,0 +1,35 @@
+import type { ReviewRedoAction, ReviewUndoAction } from '@shared/types';
+
+export interface ChangeReviewActionHistoryStorePort {
+  publishUndoHistory(history: ReviewUndoAction[]): void;
+  publishRedoHistory(history: ReviewRedoAction[]): void;
+  clearLegacyUndoStack(): void;
+}
+
+export interface ChangeReviewDecisionPersistenceScope {
+  teamName: string;
+  scopeKey: string;
+  scopeToken: string;
+}
+
+export interface ChangeReviewDecisionPersistenceSnapshot {
+  hunkDecisions: object;
+  fileDecisions: object;
+  reviewActionHistory: object;
+  reviewRedoHistory: object;
+  fileContents: object;
+  fileChunkCounts: object;
+  decisionHydrationScopeKey: string | null;
+  decisionHydrationStatus: 'idle' | 'loading' | 'loaded' | 'error';
+  applyError: string | null;
+}
+
+export interface ChangeReviewDecisionPersistencePort {
+  getSnapshot(): ChangeReviewDecisionPersistenceSnapshot;
+  load(scope: ChangeReviewDecisionPersistenceScope): Promise<void>;
+  schedule(scope: ChangeReviewDecisionPersistenceScope): void;
+  flush(scope: ChangeReviewDecisionPersistenceScope): Promise<boolean>;
+  clear(scope: ChangeReviewDecisionPersistenceScope): Promise<boolean>;
+  reportError(message: string): void;
+  clearError(expectedMessage: string): void;
+}

--- a/src/features/change-review/renderer/utils/changeReviewActionHistory.ts
+++ b/src/features/change-review/renderer/utils/changeReviewActionHistory.ts
@@ -1,0 +1,79 @@
+import { normalizePathForComparison } from '@shared/utils/platformPath';
+
+import type { ReviewRedoAction, ReviewUndoAction } from '@shared/types';
+
+export type ReviewActionPersistenceStatus = 'saved' | 'saving' | 'error';
+
+export function isReviewActionPersistenceBlocking(status: ReviewActionPersistenceStatus): boolean {
+  return status !== 'saved';
+}
+
+export type ReviewUndoActionInput =
+  | Omit<Extract<ReviewUndoAction, { kind: 'bulk' }>, 'id' | 'createdAt'>
+  | Omit<Extract<ReviewUndoAction, { kind: 'disk' }>, 'id' | 'createdAt'>
+  | Omit<Extract<ReviewUndoAction, { kind: 'hunk' }>, 'id' | 'createdAt'>;
+
+let reviewActionIdSequence = 0;
+
+export function createReviewUndoAction(input: ReviewUndoActionInput): ReviewUndoAction {
+  reviewActionIdSequence += 1;
+  const randomId = globalThis.crypto?.randomUUID?.();
+  return {
+    ...input,
+    id: randomId ?? `${Date.now().toString(36)}-${reviewActionIdSequence.toString(36)}`,
+    createdAt: new Date().toISOString(),
+  } as ReviewUndoAction;
+}
+
+export function appendOrderedReviewAction<T>(
+  stack: readonly T[],
+  action: T,
+  _legacyMaxDepth?: number
+): T[] {
+  return [...stack, action];
+}
+
+export function popOrderedReviewAction<T>(
+  stack: readonly T[],
+  expected: T
+): { stack: T[]; popped: boolean } {
+  if (stack.at(-1) !== expected) return { stack: [...stack], popped: false };
+  return { stack: stack.slice(0, -1), popped: true };
+}
+
+export function replaceLatestReviewAction(
+  stack: readonly ReviewUndoAction[],
+  optimistic: ReviewUndoAction,
+  committed: ReviewUndoAction
+): { stack: ReviewUndoAction[]; replaced: boolean } {
+  if (optimistic.id !== committed.id || stack.at(-1)?.id !== optimistic.id) {
+    return { stack: [...stack], replaced: false };
+  }
+  return { stack: [...stack.slice(0, -1), committed], replaced: true };
+}
+
+export function filterReviewActionHistoryForFile(input: {
+  undoHistory: readonly ReviewUndoAction[];
+  redoHistory: readonly ReviewRedoAction[];
+  filePath: string;
+}): { clearAll: boolean; undoHistory: ReviewUndoAction[]; redoHistory: ReviewRedoAction[] } {
+  if (
+    input.undoHistory.some((action) => action.kind === 'bulk') ||
+    input.redoHistory.some((entry) => entry.action.kind === 'bulk')
+  ) {
+    return { clearAll: true, undoHistory: [], redoHistory: [] };
+  }
+  const normalizedPath = normalizePathForComparison(input.filePath);
+  const undoHistory = input.undoHistory.filter((action) => {
+    const actionPath =
+      action.kind === 'disk'
+        ? action.action.snapshot.filePath
+        : action.kind === 'hunk'
+          ? action.action.filePath
+          : null;
+    return actionPath === null || normalizePathForComparison(actionPath) !== normalizedPath;
+  });
+  // Redo entries contain full-scope post-action snapshots. Retaining even an
+  // apparently unrelated entry could replay stale decisions for this file.
+  return { clearAll: false, undoHistory, redoHistory: [] };
+}

--- a/src/renderer/components/team/review/ChangeReviewDialog.tsx
+++ b/src/renderer/components/team/review/ChangeReviewDialog.tsx
@@ -8,7 +8,6 @@ import React, {
   useState,
 } from 'react';
 
-import { redoDepth, undoDepth } from '@codemirror/commands';
 import { Transaction } from '@codemirror/state';
 import { registerAppCloseParticipant } from '@features/app-close-coordination/renderer';
 import {
@@ -18,21 +17,29 @@ import {
   buildReviewFileLabels,
   buildReviewStats,
   buildWatchedReviewFilePathsKey,
+  CHANGE_REVIEW_PERSISTENCE_ERROR,
   ChangeReviewConflictDiscardDialog,
   ChangeReviewConflictNotices,
+  createChangeReviewActionHistoryStorePort,
   createChangeReviewConflictCommandPort,
   createChangeReviewConflictQueryPort,
   createChangeReviewConflictStateBridge,
+  createChangeReviewDecisionPersistencePort,
   createChangeReviewDraftHistoryPort,
   findActiveReviewFile,
+  isReviewActionPersistenceBlocking,
   resolveReviewFileLabel as resolveReviewFileLabelFromMap,
   shouldShowTaskScopeBanner,
   sortChangeReviewFiles,
   TaskChangesEmptyState,
   toTaskChangeSetV2,
+  useChangeReviewActionHistoryController,
   useChangeReviewConflictDiscoveryController,
   useChangeReviewConflictInteractionController,
+  useChangeReviewDecisionAutoPersistence,
+  useChangeReviewDecisionPersistenceController,
   useChangeReviewDraftHistoryController,
+  useChangeReviewHistoryKeyboardShortcuts,
   useChangeReviewLifecycleRegistration,
   useChangeReviewOperationGeneration,
   useChangeReviewScopeIdentity,
@@ -77,18 +84,14 @@ import { KeyboardShortcutsHelp } from './KeyboardShortcutsHelp';
 import { buildPathChangeLabels } from './pathChangeLabels';
 import { getReviewActionFilePath } from './reviewActionPresentation';
 import {
-  appendOrderedReviewAction,
   getReviewCloseBlockReason,
   getReviewRenameRecoveryExpectation,
   hasReviewFileRejections,
   hasUnresolvedReviewExternalChange,
   hasUnscopedLocalReviewState,
   isReviewActionLocked,
-  isReviewActionPersistenceBlocking,
   isReviewFileFullyRejected,
-  popOrderedReviewAction,
   reconcileReviewDecisionRecordsAfterApply,
-  replaceLatestReviewAction,
   replaceReviewScopedRecord,
   resolveReviewFileIsNew,
   restoreReviewDecisionRecordsForFile,
@@ -124,7 +127,7 @@ import { SavedReviewStateRecoveryGate } from './SavedReviewStateRecoveryGate';
 import { ScopeWarningBanner } from './ScopeWarningBanner';
 import { ViewedProgressBar } from './ViewedProgressBar';
 
-import type { ReviewActionPersistenceStatus, ReviewDecisionRecords } from './reviewActionState';
+import type { ReviewDecisionRecords } from './reviewActionState';
 import type { EditorView } from '@codemirror/view';
 import type { ReviewDraftHistoryHydrationState } from '@features/change-review/renderer';
 import type { TaskChangeRequestOptions } from '@renderer/utils/taskChangeRequest';
@@ -145,11 +148,6 @@ import type { EditorSelectionAction, EditorSelectionInfo } from '@shared/types/e
 
 type RecentHunkUndoAction = Extract<ReviewUndoAction, { kind: 'hunk' }>['action'];
 type RecentDiskUndoAction = ReviewDiskUndoAction;
-type ReviewUndoActionInput =
-  | Omit<Extract<ReviewUndoAction, { kind: 'bulk' }>, 'id' | 'createdAt'>
-  | Omit<Extract<ReviewUndoAction, { kind: 'disk' }>, 'id' | 'createdAt'>
-  | Omit<Extract<ReviewUndoAction, { kind: 'hunk' }>, 'id' | 'createdAt'>;
-
 interface RecentReviewWrite {
   at: number;
   expectedContent: string | null;
@@ -160,18 +158,6 @@ interface ReviewCloseFlushResult {
   blocker?: string;
 }
 
-interface ReviewPersistenceSnapshotIdentity {
-  scopeToken: string;
-  hunkDecisions: object;
-  fileDecisions: object;
-  reviewActionHistory: object;
-  reviewRedoHistory: object;
-  fileContents: object;
-  fileChunkCounts: object;
-}
-
-const REVIEW_PERSISTENCE_ERROR =
-  'Latest review action is not saved. Retry from History before continuing.';
 const changeReviewConflictQueryPort = createChangeReviewConflictQueryPort(() => api.review);
 const changeReviewConflictCommandPort = createChangeReviewConflictCommandPort(() => api.review);
 const changeReviewConflictStateBridge = createChangeReviewConflictStateBridge({
@@ -179,56 +165,14 @@ const changeReviewConflictStateBridge = createChangeReviewConflictStateBridge({
   setApplyError: (applyError) => useStore.setState({ applyError }),
 });
 const changeReviewDraftHistoryPort = createChangeReviewDraftHistoryPort(() => api.review);
-
-function captureReviewPersistenceSnapshotIdentity(
-  scopeToken: string,
-  state: Pick<
-    ReturnType<typeof useStore.getState>,
-    | 'hunkDecisions'
-    | 'fileDecisions'
-    | 'reviewActionHistory'
-    | 'reviewRedoHistory'
-    | 'fileContents'
-    | 'fileChunkCounts'
-  >
-): ReviewPersistenceSnapshotIdentity {
-  return {
-    scopeToken,
-    hunkDecisions: state.hunkDecisions,
-    fileDecisions: state.fileDecisions,
-    reviewActionHistory: state.reviewActionHistory,
-    reviewRedoHistory: state.reviewRedoHistory,
-    fileContents: state.fileContents,
-    fileChunkCounts: state.fileChunkCounts,
-  };
-}
-
-function isSameReviewPersistenceSnapshot(
-  left: ReviewPersistenceSnapshotIdentity | null,
-  right: ReviewPersistenceSnapshotIdentity
-): boolean {
-  return (
-    left?.scopeToken === right.scopeToken &&
-    left.hunkDecisions === right.hunkDecisions &&
-    left.fileDecisions === right.fileDecisions &&
-    left.reviewActionHistory === right.reviewActionHistory &&
-    left.reviewRedoHistory === right.reviewRedoHistory &&
-    left.fileContents === right.fileContents &&
-    left.fileChunkCounts === right.fileChunkCounts
-  );
-}
-
-let reviewActionIdSequence = 0;
-
-function createReviewUndoAction(input: ReviewUndoActionInput): ReviewUndoAction {
-  reviewActionIdSequence += 1;
-  const randomId = globalThis.crypto?.randomUUID?.();
-  return {
-    ...input,
-    id: randomId ?? `${Date.now().toString(36)}-${reviewActionIdSequence.toString(36)}`,
-    createdAt: new Date().toISOString(),
-  } as ReviewUndoAction;
-}
+const changeReviewActionHistoryStorePort = createChangeReviewActionHistoryStorePort({
+  getStore: useStore.getState,
+  clearLegacyUndoStack: () => useStore.setState({ reviewUndoStack: [] }),
+});
+const changeReviewDecisionPersistencePort = createChangeReviewDecisionPersistencePort({
+  getStore: useStore.getState,
+  setApplyError: (applyError) => useStore.setState({ applyError }),
+});
 
 function alignDiskUndoSnapshotWithAppliedContent(
   snapshot: ReviewDiskUndoSnapshot,
@@ -329,16 +273,11 @@ export const ChangeReviewDialog = ({
     reviewExternalChangesByFile,
     clearReviewFileExternalChange,
     reloadReviewFileFromDisk,
-    loadDecisionsFromDisk,
-    persistDecisions,
-    flushDecisionsToDisk,
     quiesceDecisionPersistence,
     recordDecisionRevision,
     clearDecisionsFromDisk,
     resetAllReviewState,
     fileChunkCounts,
-    setReviewActionHistory,
-    setReviewRedoHistory,
     hunkContextHashesByFile,
     changeSetEpoch,
     decisionHydrationScopeKey,
@@ -372,6 +311,30 @@ export const ChangeReviewDialog = ({
     decisionHydrationStatus,
     draftHistoryHydration,
   });
+  const {
+    undoDepth: reviewUndoDepth,
+    redoDepth: reviewRedoDepth,
+    getUndoHistory: getReviewUndoHistory,
+    getRedoHistory: getReviewRedoHistory,
+    getLatestUndoAction,
+    getLatestRedoAction,
+    pushUndoAction: pushReviewUndoAction,
+    completeUndoAction: completeReviewUndoAction,
+    bindCommittedAction: bindCommittedReviewAction,
+    completeRedoAction: completeReviewRedoAction,
+    discardLatestAction: discardLatestReviewAction,
+    publishUndoHistory: publishReviewUndoHistory,
+    replaceHistories: replaceReviewActionHistories,
+    clearForFile: clearReviewActionHistoryForFile,
+  } = useChangeReviewActionHistoryController({
+    resetKey: `${teamName}\0${scopeKey}\0${changeSetEpoch}`,
+    hydrationKey: decisionHydrationKey,
+    hydrationScopeKey: decisionHydrationScopeKey,
+    hydrationStatus: decisionHydrationStatus,
+    hydratedUndoHistory: reviewActionHistory,
+    hydratedRedoHistory: reviewRedoHistory,
+    store: changeReviewActionHistoryStorePort,
+  });
 
   // Active file from scroll-spy (replaces selectedReviewFilePath for continuous scroll)
   const [activeFilePath, setActiveFilePath] = useState<string | null>(null);
@@ -380,11 +343,7 @@ export const ChangeReviewDialog = ({
   const [discardCounters, setDiscardCounters] = useState<Record<string, number>>({});
   const [filesApplying, setFilesApplying] = useState<Set<string>>(() => new Set());
   const [undoing, setUndoing] = useState(false);
-  const [reviewUndoDepth, setReviewUndoDepth] = useState(0);
-  const [reviewRedoDepth, setReviewRedoDepth] = useState(0);
   const [closing, setClosing] = useState(false);
-  const [reviewActionPersistenceStatus, setReviewActionPersistenceStatus] =
-    useState<ReviewActionPersistenceStatus>('saved');
   const [collapsedFiles, setCollapsedFiles] = useState<Set<string>>(() => {
     if (typeof window === 'undefined') return new Set<string>();
     try {
@@ -409,55 +368,14 @@ export const ChangeReviewDialog = ({
   // EditorView map for all visible file editors
   const editorViewMapRef = useRef(new Map<string, EditorView>());
   const scrollContainerRef = useRef<HTMLDivElement>(null);
-  // Last focused CM editor - for Cmd+Z outside editor
-  const lastFocusedEditorRef = useRef<EditorView | null>(null);
-  // Ordered, self-contained history. The ref keeps keyboard routing synchronous while the
-  // matching Zustand array is persisted atomically with decisions.
-  const reviewUndoActionsRef = useRef<ReviewUndoAction[]>([]);
-  const reviewRedoActionsRef = useRef<ReviewRedoAction[]>([]);
-  const redoHistoryBeforePreparedActionRef = useRef<{
-    actionId: string;
-    history: ReviewRedoAction[];
-  } | null>(null);
   const fileApplyInFlightRef = useRef(new Set<string>());
   const undoInFlightRef = useRef(false);
   const closingRef = useRef(false);
   const pendingApplyCleanupKeyRef = useRef<string | null>(null);
-  const pendingAutoDecisionClearKeyRef = useRef<string | null>(null);
-  const reviewActionPersistenceStatusRef = useRef<ReviewActionPersistenceStatus>('saved');
-  const reviewActionPersistenceGenerationRef = useRef(0);
-  const immediatelyPersistedReviewSnapshotRef = useRef<ReviewPersistenceSnapshotIdentity | null>(
-    null
-  );
   const recentReviewWritesRef = useRef(new Map<string, RecentReviewWrite>());
   // Exact disk state on which each manual draft started. Map.has() distinguishes
   // a genuinely missing file (null baseline) from an uncaptured baseline.
   const expectedDraftHistoryKeyRef = useRef<string | null>(null);
-
-  const hydrateDecisionsFromDisk = useCallback(
-    async (
-      scopeTeamName: string,
-      scopeKeyValue: string,
-      scopeTokenValue: string,
-      hydrationKey: string
-    ): Promise<void> => {
-      await loadDecisionsFromDisk(scopeTeamName, scopeKeyValue, scopeTokenValue);
-      if (expectedDraftHistoryKeyRef.current !== hydrationKey) return;
-      const hydrated = useStore.getState();
-      if (
-        hydrated.decisionHydrationScopeKey === hydrationKey &&
-        hydrated.decisionHydrationStatus === 'loaded'
-      ) {
-        // Hydration is already durable. Mark the exact snapshot so the generic
-        // auto-persist effect cannot turn a plain open/reload into a revision write.
-        immediatelyPersistedReviewSnapshotRef.current = captureReviewPersistenceSnapshotIdentity(
-          scopeTokenValue,
-          hydrated
-        );
-      }
-    },
-    [loadDecisionsFromDisk]
-  );
 
   // Proxy ref for useDiffNavigation (points to active file's editor)
   const activeEditorViewRef = useRef<EditorView | null>(null);
@@ -522,16 +440,35 @@ export const ChangeReviewDialog = ({
         : null,
     [decisionScopeKey, decisionScopeToken, teamName]
   );
+  const refreshReviewConflictCandidatesRef = useRef<() => Promise<void>>(async () => {});
+  const requestReviewConflictRefresh = useCallback(
+    (): Promise<void> => refreshReviewConflictCandidatesRef.current(),
+    []
+  );
+  const decisionPersistence = useChangeReviewDecisionPersistenceController({
+    hydrationKey: decisionHydrationKey,
+    scope: conflictScope,
+    hydrationReady: decisionHydrationReady,
+    isExpectedHydrationKey: isExpectedDraftHistoryKey,
+    refreshConflictCandidates: requestReviewConflictRefresh,
+    port: changeReviewDecisionPersistencePort,
+  });
+  const {
+    status: reviewActionPersistenceStatus,
+    getStatus: getReviewActionPersistenceStatus,
+    publishSaved: publishReviewActionPersistenceSaved,
+    hydrate: hydrateReviewDecisions,
+    persistLatest: persistLatestAcceptedReviewAction,
+    scheduleAutoPersistence: scheduleReviewDecisionAutoPersistence,
+    clearAfterDurableStateEmptied: clearReviewDecisionsAfterStateEmptied,
+    flushForClose: flushReviewDecisionsForClose,
+    getDiagnostics: getReviewDecisionPersistenceDiagnostics,
+  } = decisionPersistence;
   const hydrateConflictDecisions = useCallback(
     async (scope: NonNullable<typeof conflictScope>, hydrationKey: string): Promise<void> => {
-      await hydrateDecisionsFromDisk(
-        scope.teamName,
-        scope.scopeKey,
-        scope.scopeToken,
-        hydrationKey
-      );
+      await hydrateReviewDecisions(scope, hydrationKey);
     },
-    [hydrateDecisionsFromDisk]
+    [hydrateReviewDecisions]
   );
   const {
     decisionCandidates: decisionConflictCandidates,
@@ -551,13 +488,7 @@ export const ChangeReviewDialog = ({
     reportLoadError: changeReviewConflictStateBridge.reportError,
     port: changeReviewConflictQueryPort,
   });
-  const publishReviewActionPersistenceStatus = useCallback(
-    (status: ReviewActionPersistenceStatus): void => {
-      reviewActionPersistenceStatusRef.current = status;
-      setReviewActionPersistenceStatus(status);
-    },
-    []
-  );
+  refreshReviewConflictCandidatesRef.current = refreshReviewConflictCandidates;
   const commitHydratedDrafts = useCallback(
     ({
       scopeFilePaths,
@@ -649,7 +580,7 @@ export const ChangeReviewDialog = ({
     isExpectedHydrationKey: isExpectedDraftHistoryKey,
     hydrateDecisions: hydrateConflictDecisions,
     isDecisionHydrationLoaded: changeReviewConflictStateBridge.isDecisionHydrationLoaded,
-    publishDecisionPersistenceSaved: () => publishReviewActionPersistenceStatus('saved'),
+    publishDecisionPersistenceSaved: publishReviewActionPersistenceSaved,
     resolveDraftHistoryCandidate: resolveDraftHistoryConflictCandidate,
     clearResolutionError: changeReviewConflictStateBridge.clearResolutionError,
     reportResolutionError: changeReviewConflictStateBridge.reportError,
@@ -672,16 +603,10 @@ export const ChangeReviewDialog = ({
   ]);
 
   useEffect(() => {
-    reviewActionPersistenceGenerationRef.current += 1;
-    immediatelyPersistedReviewSnapshotRef.current = null;
     if (pendingApplyCleanupKeyRef.current !== decisionHydrationKey) {
       pendingApplyCleanupKeyRef.current = null;
     }
-    if (pendingAutoDecisionClearKeyRef.current !== decisionHydrationKey) {
-      pendingAutoDecisionClearKeyRef.current = null;
-    }
-    publishReviewActionPersistenceStatus('saved');
-  }, [decisionHydrationKey, publishReviewActionPersistenceStatus]);
+  }, [decisionHydrationKey]);
 
   const setFileApplying = useCallback((filePath: string, value: boolean): void => {
     setFilesApplying((previous) => {
@@ -734,115 +659,13 @@ export const ChangeReviewDialog = ({
 
   useEffect(() => {
     fileApplyInFlightRef.current.clear();
-    reviewUndoActionsRef.current = [];
-    reviewRedoActionsRef.current = [];
-    redoHistoryBeforePreparedActionRef.current = null;
-    lastFocusedEditorRef.current = null;
     recentReviewWritesRef.current.clear();
     undoInFlightRef.current = false;
     closingRef.current = false;
     setUndoing(false);
-    setReviewUndoDepth(0);
-    setReviewRedoDepth(0);
     setClosing(false);
     setFilesApplying(new Set());
   }, [changeSetEpoch, scopeKey, teamName]);
-
-  useEffect(() => {
-    if (!decisionHydrationReady) return;
-    reviewUndoActionsRef.current = reviewActionHistory;
-    reviewRedoActionsRef.current = reviewRedoHistory;
-    setReviewUndoDepth(reviewActionHistory.length);
-    setReviewRedoDepth(reviewRedoHistory.length);
-  }, [decisionHydrationReady, reviewActionHistory, reviewRedoHistory]);
-
-  const pushReviewUndoAction = useCallback(
-    (input: ReviewUndoActionInput): ReviewUndoAction => {
-      const action = createReviewUndoAction(input);
-      const previous = reviewUndoActionsRef.current;
-      const stack = appendOrderedReviewAction(previous, action);
-      reviewUndoActionsRef.current = stack;
-      setReviewActionHistory(stack);
-      redoHistoryBeforePreparedActionRef.current = {
-        actionId: action.id,
-        history: reviewRedoActionsRef.current,
-      };
-      reviewRedoActionsRef.current = [];
-      setReviewRedoHistory([]);
-      setReviewUndoDepth(stack.length);
-      return action;
-    },
-    [setReviewActionHistory, setReviewRedoHistory]
-  );
-
-  const completeReviewUndoAction = useCallback(
-    (action: ReviewUndoAction, redoAction: ReviewRedoAction): boolean => {
-      const result = popOrderedReviewAction(reviewUndoActionsRef.current, action);
-      if (!result.popped) return false;
-      reviewUndoActionsRef.current = result.stack;
-      const redoHistory = [...reviewRedoActionsRef.current, redoAction];
-      reviewRedoActionsRef.current = redoHistory;
-      redoHistoryBeforePreparedActionRef.current = null;
-      setReviewActionHistory(result.stack);
-      setReviewRedoHistory(redoHistory);
-      setReviewUndoDepth(result.stack.length);
-      setReviewRedoDepth(redoHistory.length);
-      return true;
-    },
-    [setReviewActionHistory, setReviewRedoHistory]
-  );
-
-  const bindCommittedReviewAction = useCallback(
-    (optimistic: ReviewUndoAction, committed: ReviewUndoAction | undefined): boolean => {
-      if (!committed) return false;
-      const result = replaceLatestReviewAction(reviewUndoActionsRef.current, optimistic, committed);
-      if (!result.replaced) return false;
-      reviewUndoActionsRef.current = result.stack;
-      setReviewActionHistory(result.stack);
-      return true;
-    },
-    [setReviewActionHistory]
-  );
-
-  const completeReviewRedoAction = useCallback(
-    (redoAction: ReviewRedoAction): boolean => {
-      const latest = reviewRedoActionsRef.current.at(-1);
-      if (latest?.action.id !== redoAction.action.id) return false;
-      const redoHistory = reviewRedoActionsRef.current.slice(0, -1);
-      const undoHistory = appendOrderedReviewAction(
-        reviewUndoActionsRef.current,
-        redoAction.action
-      );
-      reviewRedoActionsRef.current = redoHistory;
-      reviewUndoActionsRef.current = undoHistory;
-      redoHistoryBeforePreparedActionRef.current = null;
-      setReviewRedoHistory(redoHistory);
-      setReviewActionHistory(undoHistory);
-      setReviewRedoDepth(redoHistory.length);
-      setReviewUndoDepth(undoHistory.length);
-      return true;
-    },
-    [setReviewActionHistory, setReviewRedoHistory]
-  );
-
-  const discardLatestReviewAction = useCallback(
-    (action: ReviewUndoAction): boolean => {
-      const result = popOrderedReviewAction(reviewUndoActionsRef.current, action);
-      if (!result.popped) return false;
-      reviewUndoActionsRef.current = result.stack;
-      setReviewActionHistory(result.stack);
-      const redoBackup = redoHistoryBeforePreparedActionRef.current;
-      if (redoBackup?.actionId === action.id) {
-        reviewRedoActionsRef.current = redoBackup.history;
-        setReviewRedoHistory(redoBackup.history);
-        setReviewRedoDepth(redoBackup.history.length);
-        redoHistoryBeforePreparedActionRef.current = null;
-      }
-      setReviewUndoDepth(result.stack.length);
-      return true;
-    },
-    [setReviewActionHistory, setReviewRedoHistory]
-  );
 
   const ensureDurableReviewScope = useCallback((): boolean => {
     if (!decisionScopeToken) {
@@ -853,102 +676,6 @@ export const ChangeReviewDialog = ({
     }
     return true;
   }, [decisionScopeToken]);
-
-  const clearReviewActionHistory = useCallback((): void => {
-    reviewUndoActionsRef.current = [];
-    reviewRedoActionsRef.current = [];
-    redoHistoryBeforePreparedActionRef.current = null;
-    setReviewActionHistory([]);
-    setReviewRedoHistory([]);
-    useStore.setState({ reviewUndoStack: [] });
-    setReviewUndoDepth(0);
-    setReviewRedoDepth(0);
-  }, [setReviewActionHistory, setReviewRedoHistory]);
-
-  const clearReviewActionHistoryForFile = useCallback(
-    (filePath: string): void => {
-      const actions = reviewUndoActionsRef.current;
-      const redoActions = reviewRedoActionsRef.current;
-      if (
-        actions.some((action) => action.kind === 'bulk') ||
-        redoActions.some((entry) => entry.action.kind === 'bulk')
-      ) {
-        // Bulk decision snapshots span files and cannot be safely split after the fact.
-        clearReviewActionHistory();
-        return;
-      }
-      const normalizedPath = normalizePathForComparison(filePath);
-      const retained = actions.filter((action) => {
-        const actionPath =
-          action.kind === 'disk'
-            ? action.action.snapshot.filePath
-            : action.kind === 'hunk'
-              ? action.action.filePath
-              : null;
-        return actionPath === null || normalizePathForComparison(actionPath) !== normalizedPath;
-      });
-      reviewUndoActionsRef.current = retained;
-      // Redo entries contain full-scope post-action snapshots. Retaining even an
-      // apparently unrelated entry could replay stale decisions for this file.
-      reviewRedoActionsRef.current = [];
-      redoHistoryBeforePreparedActionRef.current = null;
-      setReviewActionHistory(retained);
-      setReviewRedoHistory([]);
-      setReviewUndoDepth(retained.length);
-      setReviewRedoDepth(0);
-    },
-    [clearReviewActionHistory, setReviewActionHistory, setReviewRedoHistory]
-  );
-
-  const persistLatestAcceptedReviewAction = useCallback(async (): Promise<boolean> => {
-    const generation = reviewActionPersistenceGenerationRef.current + 1;
-    reviewActionPersistenceGenerationRef.current = generation;
-    publishReviewActionPersistenceStatus('saving');
-
-    if (!decisionScopeToken || !decisionHydrationReady) {
-      if (reviewActionPersistenceGenerationRef.current === generation) {
-        publishReviewActionPersistenceStatus('error');
-        useStore.setState({ applyError: REVIEW_PERSISTENCE_ERROR });
-      }
-      return false;
-    }
-
-    immediatelyPersistedReviewSnapshotRef.current = captureReviewPersistenceSnapshotIdentity(
-      decisionScopeToken,
-      useStore.getState()
-    );
-
-    let saved = false;
-    try {
-      persistDecisions(teamName, decisionScopeKey, decisionScopeToken);
-      saved = await flushDecisionsToDisk(teamName, decisionScopeKey, decisionScopeToken);
-    } catch {
-      saved = false;
-    }
-
-    if (reviewActionPersistenceGenerationRef.current !== generation) return saved;
-    if (saved) {
-      publishReviewActionPersistenceStatus('saved');
-      if (useStore.getState().applyError === REVIEW_PERSISTENCE_ERROR) {
-        useStore.setState({ applyError: null });
-      }
-      return true;
-    }
-
-    publishReviewActionPersistenceStatus('error');
-    useStore.setState({ applyError: REVIEW_PERSISTENCE_ERROR });
-    void refreshReviewConflictCandidates();
-    return false;
-  }, [
-    decisionHydrationReady,
-    decisionScopeKey,
-    decisionScopeToken,
-    flushDecisionsToDisk,
-    persistDecisions,
-    publishReviewActionPersistenceStatus,
-    refreshReviewConflictCandidates,
-    teamName,
-  ]);
 
   const reviewMutationBusy = isReviewActionLocked({
     applying,
@@ -982,7 +709,7 @@ export const ChangeReviewDialog = ({
       reviewConflictLoadError !== null ||
       reviewConflictCandidateCount > 0 ||
       resolvingConflictCandidateId !== null ||
-      isReviewActionPersistenceBlocking(reviewActionPersistenceStatusRef.current) ||
+      isReviewActionPersistenceBlocking(getReviewActionPersistenceStatus()) ||
       isReviewActionLocked({
         applying: state.applying,
         fileApplyCount: fileApplyInFlightRef.current.size,
@@ -994,6 +721,7 @@ export const ChangeReviewDialog = ({
     decisionHydrationKey,
     draftHistoryHydration.key,
     draftHistoryHydration.status,
+    getReviewActionPersistenceStatus,
     reviewConflictLoadError,
     reviewConflictRefreshPending,
     resolvingConflictCandidateId,
@@ -1448,7 +1176,7 @@ export const ChangeReviewDialog = ({
             discardLatestReviewAction(preparedAction);
             return;
           }
-          const retainedAction = reviewUndoActionsRef.current.at(-1);
+          const retainedAction = getLatestUndoAction();
           if (
             retainedAction?.id === preparedAction.id &&
             retainedAction.kind === 'bulk' &&
@@ -1497,7 +1225,7 @@ export const ChangeReviewDialog = ({
               );
             }
           }
-          setReviewActionHistory([...reviewUndoActionsRef.current]);
+          publishReviewUndoHistory();
         } finally {
           if (
             isCurrentReviewOperationScope(operationScope) &&
@@ -1542,7 +1270,8 @@ export const ChangeReviewDialog = ({
     pushReviewUndoAction,
     discardLatestReviewAction,
     ensureDurableReviewScope,
-    setReviewActionHistory,
+    getLatestUndoAction,
+    publishReviewUndoHistory,
     setUndoInFlight,
   ]);
 
@@ -1564,7 +1293,7 @@ export const ChangeReviewDialog = ({
       const content = fileContents[filePath] ?? null;
       const isExpectedDeletion = isReviewFileExpectedDeleted(file);
       const normalizedFilePath = normalizePathForComparison(filePath);
-      const diskHistory = reviewUndoActionsRef.current.flatMap((action): ReviewDiskUndoAction[] =>
+      const diskHistory = getReviewUndoHistory().flatMap((action): ReviewDiskUndoAction[] =>
         action.kind === 'disk'
           ? [action.action]
           : action.kind === 'bulk'
@@ -1736,8 +1465,8 @@ export const ChangeReviewDialog = ({
               hunkDecisions: state.hunkDecisions,
               fileDecisions: state.fileDecisions,
               hunkContextHashesByFile: state.hunkContextHashesByFile,
-              reviewActionHistory: reviewUndoActionsRef.current,
-              reviewRedoHistory: reviewRedoActionsRef.current,
+              reviewActionHistory: getReviewUndoHistory(),
+              reviewRedoHistory: getReviewRedoHistory(),
             },
             expectedDecisionRevision: state.decisionRevision,
           });
@@ -1808,6 +1537,8 @@ export const ChangeReviewDialog = ({
       clearReviewFileExternalChange,
       fetchFileContent,
       fileContents,
+      getReviewRedoHistory,
+      getReviewUndoHistory,
       hasReviewActionInFlight,
       hasReviewDraft,
       isCurrentReviewOperationScope,
@@ -2039,7 +1770,7 @@ export const ChangeReviewDialog = ({
                 if (snapshot.restoreMode !== 'delete-file' && !isLedgerRenameReviewFile(file)) {
                   alignDiskUndoSnapshotWithAppliedContent(snapshot, actualAfterContent);
                 }
-                setReviewActionHistory([...reviewUndoActionsRef.current]);
+                publishReviewUndoHistory();
               }
               markRecentReviewWrite(filePath, isLedgerRenameReviewFile(file) ? null : afterContent);
             } else {
@@ -2090,7 +1821,7 @@ export const ChangeReviewDialog = ({
       pushReviewUndoAction,
       discardLatestReviewAction,
       ensureDurableReviewScope,
-      setReviewActionHistory,
+      publishReviewUndoHistory,
     ]
   );
 
@@ -2237,7 +1968,7 @@ export const ChangeReviewDialog = ({
               ) {
                 alignDiskUndoSnapshotWithAppliedContent(snapshot, actualAfterContent);
               }
-              setReviewActionHistory([...reviewUndoActionsRef.current]);
+              publishReviewUndoHistory();
               markRecentReviewWrite(filePath, snapshot.afterContent);
               return;
             }
@@ -2298,7 +2029,7 @@ export const ChangeReviewDialog = ({
       pushReviewUndoAction,
       discardLatestReviewAction,
       ensureDurableReviewScope,
-      setReviewActionHistory,
+      publishReviewUndoHistory,
     ]
   );
 
@@ -2507,8 +2238,8 @@ export const ChangeReviewDialog = ({
             hunkDecisions: state.hunkDecisions,
             fileDecisions: state.fileDecisions,
             hunkContextHashesByFile: state.hunkContextHashesByFile,
-            reviewActionHistory: reviewUndoActionsRef.current,
-            reviewRedoHistory: reviewRedoActionsRef.current,
+            reviewActionHistory: getReviewUndoHistory(),
+            reviewRedoHistory: getReviewRedoHistory(),
           });
           const committed = await api.review.executeMutation({
             scope: reviewScope,
@@ -2528,13 +2259,7 @@ export const ChangeReviewDialog = ({
           ) {
             return;
           }
-          reviewUndoActionsRef.current = next.reviewActionHistory;
-          reviewRedoActionsRef.current = next.reviewRedoHistory;
-          redoHistoryBeforePreparedActionRef.current = null;
-          setReviewActionHistory(next.reviewActionHistory);
-          setReviewRedoHistory(next.reviewRedoHistory);
-          setReviewUndoDepth(next.reviewActionHistory.length);
-          setReviewRedoDepth(next.reviewRedoHistory.length);
+          replaceReviewActionHistories(next.reviewActionHistory, next.reviewRedoHistory);
           recordDecisionRevision(
             teamName,
             decisionScopeKey,
@@ -2596,9 +2321,10 @@ export const ChangeReviewDialog = ({
       recordDecisionRevision,
       reloadReviewFileFromDisk,
       reviewScope,
+      getReviewRedoHistory,
+      getReviewUndoHistory,
+      replaceReviewActionHistories,
       setFileApplying,
-      setReviewActionHistory,
-      setReviewRedoHistory,
       teamName,
     ]
   );
@@ -2811,7 +2537,7 @@ export const ChangeReviewDialog = ({
         }
         const state = useStore.getState();
         const redoAction = createReviewRedoAction(action, state);
-        const redoHistory = [...reviewRedoActionsRef.current, redoAction];
+        const redoHistory = [...getReviewRedoHistory(), redoAction];
         const diskSnapshots = getReviewActionDiskSnapshots(action);
         const diskSteps = buildUndoDiskMutationSteps(action.id, diskSnapshots);
         const committed = await executeWithPreparedReviewWriteExpectations(
@@ -2831,7 +2557,7 @@ export const ChangeReviewDialog = ({
                 hunkDecisions,
                 fileDecisions,
                 hunkContextHashesByFile: state.hunkContextHashesByFile,
-                reviewActionHistory: reviewUndoActionsRef.current.slice(0, -1),
+                reviewActionHistory: getReviewUndoHistory().slice(0, -1),
                 reviewRedoHistory: redoHistory,
               },
               expectedTopActionId: action.id,
@@ -2866,6 +2592,8 @@ export const ChangeReviewDialog = ({
       captureReviewOperationScope,
       decisionScopeKey,
       decisionScopeToken,
+      getReviewRedoHistory,
+      getReviewUndoHistory,
       isCurrentReviewOperationScope,
       markCommittedReviewPostimages,
       markRecentReviewWrite,
@@ -2882,7 +2610,7 @@ export const ChangeReviewDialog = ({
     if (hasReviewActionInFlight() || editedCount > 0 || blockReviewMutationForExternalChange()) {
       return;
     }
-    const action = reviewUndoActionsRef.current.at(-1);
+    const action = getLatestUndoAction();
     if (!action) return;
     const state = useStore.getState();
     let hunkDecisions = { ...state.hunkDecisions };
@@ -2950,6 +2678,7 @@ export const ChangeReviewDialog = ({
     commitUndoMutation,
     completeReviewUndoAction,
     editedCount,
+    getLatestUndoAction,
     hasReviewActionInFlight,
   ]);
 
@@ -2957,7 +2686,7 @@ export const ChangeReviewDialog = ({
     if (hasReviewActionInFlight() || editedCount > 0 || blockReviewMutationForExternalChange()) {
       return;
     }
-    const redoAction = reviewRedoActionsRef.current.at(-1);
+    const redoAction = getLatestRedoAction();
     if (!redoAction || !decisionScopeToken) return;
     const operationScope = captureReviewOperationScope();
     if (!operationScope) return;
@@ -2974,8 +2703,8 @@ export const ChangeReviewDialog = ({
       }
       const state = useStore.getState();
       const action = redoAction.action;
-      const undoHistory = appendOrderedReviewAction(reviewUndoActionsRef.current, action);
-      const redoHistory = reviewRedoActionsRef.current.slice(0, -1);
+      const undoHistory = [...getReviewUndoHistory(), action];
+      const redoHistory = getReviewRedoHistory().slice(0, -1);
       const diskSnapshots = getReviewActionDiskSnapshots(action);
       const diskSteps = buildRedoDiskMutationSteps(action.id, diskSnapshots);
       const committed = await executeWithPreparedReviewWriteExpectations(
@@ -3037,6 +2766,9 @@ export const ChangeReviewDialog = ({
     decisionScopeKey,
     decisionScopeToken,
     editedCount,
+    getLatestRedoAction,
+    getReviewRedoHistory,
+    getReviewUndoHistory,
     hasReviewActionInFlight,
     isCurrentReviewOperationScope,
     markCommittedReviewPostimages,
@@ -3057,8 +2789,8 @@ export const ChangeReviewDialog = ({
           hunkDecisions: state.hunkDecisions,
           fileDecisions: state.fileDecisions,
           hunkContextHashesByFile: state.hunkContextHashesByFile,
-          reviewActionHistory: reviewUndoActionsRef.current,
-          reviewRedoHistory: reviewRedoActionsRef.current,
+          reviewActionHistory: getReviewUndoHistory(),
+          reviewRedoHistory: getReviewRedoHistory(),
         },
         target,
         (filePath) =>
@@ -3069,7 +2801,7 @@ export const ChangeReviewDialog = ({
       );
       return { state, plan };
     },
-    [activeChangeSet]
+    [activeChangeSet, getReviewRedoHistory, getReviewUndoHistory]
   );
 
   const getRestoreReviewHistoryPreview = useCallback(
@@ -3100,12 +2832,7 @@ export const ChangeReviewDialog = ({
         throw new Error('Durable review history scope is unavailable.');
       }
       recordDecisionRevision(teamName, decisionScopeKey, decisionScopeToken, decisionRevision);
-      reviewUndoActionsRef.current = restored.reviewActionHistory;
-      reviewRedoActionsRef.current = restored.reviewRedoHistory;
-      setReviewActionHistory(restored.reviewActionHistory);
-      setReviewRedoHistory(restored.reviewRedoHistory);
-      setReviewUndoDepth(restored.reviewActionHistory.length);
-      setReviewRedoDepth(restored.reviewRedoHistory.length);
+      replaceReviewActionHistories(restored.reviewActionHistory, restored.reviewRedoHistory);
       useStore.setState({
         hunkDecisions: restored.hunkDecisions,
         fileDecisions: restored.fileDecisions,
@@ -3117,8 +2844,7 @@ export const ChangeReviewDialog = ({
       decisionScopeKey,
       decisionScopeToken,
       recordDecisionRevision,
-      setReviewActionHistory,
-      setReviewRedoHistory,
+      replaceReviewActionHistories,
       teamName,
     ]
   );
@@ -3203,8 +2929,8 @@ export const ChangeReviewDialog = ({
       if (!decisionScopeToken || !decisionHydrationReady) {
         throw new Error('Durable review history is not ready yet.');
       }
-      if (reviewActionPersistenceStatusRef.current !== 'saved') {
-        throw new Error(REVIEW_PERSISTENCE_ERROR);
+      if (getReviewActionPersistenceStatus() !== 'saved') {
+        throw new Error(CHANGE_REVIEW_PERSISTENCE_ERROR);
       }
       const operationScope = captureReviewOperationScope();
       if (!operationScope) throw new Error('Durable review history scope is no longer active.');
@@ -3273,6 +2999,7 @@ export const ChangeReviewDialog = ({
       decisionScopeKey,
       decisionScopeToken,
       editedCount,
+      getReviewActionPersistenceStatus,
       hasReviewActionInFlight,
       isCurrentReviewOperationScope,
       markCommittedReviewPostimages,
@@ -3489,6 +3216,7 @@ export const ChangeReviewDialog = ({
     };
     const state = useStore.getState();
     const draftHistoryDiagnostics = getDraftHistoryDiagnostics();
+    const decisionPersistenceDiagnostics = getReviewDecisionPersistenceDiagnostics();
     const localStateRequiresScope = hasUnscopedLocalReviewState({
       editedContentCount: Object.keys(state.editedContents).length,
       hunkDecisionCount: Object.keys(state.hunkDecisions).length,
@@ -3499,8 +3227,8 @@ export const ChangeReviewDialog = ({
       draftWriteChainCount: draftHistoryDiagnostics.writeChainCount,
       draftWriteErrorCount: draftHistoryDiagnostics.writeErrorCount,
       pendingApplyCleanup: pendingApplyCleanupKeyRef.current !== null,
-      pendingDecisionClear: pendingAutoDecisionClearKeyRef.current !== null,
-      persistenceStatus: reviewActionPersistenceStatusRef.current,
+      pendingDecisionClear: decisionPersistenceDiagnostics.pendingDecisionClear,
+      persistenceStatus: decisionPersistenceDiagnostics.persistenceStatus,
     });
     if (!decisionHydrationKey && localStateRequiresScope) {
       const blocker =
@@ -3526,8 +3254,8 @@ export const ChangeReviewDialog = ({
           scopedDraftHistoryDiagnostics.writeChainCount > 0 ||
           scopedDraftHistoryDiagnostics.writeErrorCount > 0 ||
           pendingApplyCleanupKeyRef.current === decisionHydrationKey ||
-          pendingAutoDecisionClearKeyRef.current === decisionHydrationKey ||
-          reviewActionPersistenceStatusRef.current !== 'saved';
+          decisionPersistenceDiagnostics.pendingDecisionClear ||
+          decisionPersistenceDiagnostics.persistenceStatus !== 'saved';
         if (hasLocalState) {
           const blocker =
             'Saved review state could not be reconciled with local changes. Retry recovery before closing Changes.';
@@ -3602,18 +3330,7 @@ export const ChangeReviewDialog = ({
         return { ok: true };
       }
       if (decisionScopeToken) {
-        const latestState = useStore.getState();
-        const hasCurrentReviewState =
-          Object.keys(latestState.hunkDecisions).length > 0 ||
-          Object.keys(latestState.fileDecisions).length > 0 ||
-          latestState.reviewActionHistory.length > 0 ||
-          latestState.reviewRedoHistory.length > 0;
-        let flushed: boolean;
-        if (hasCurrentReviewState) {
-          flushed = await persistLatestAcceptedReviewAction();
-        } else {
-          flushed = await clearDecisionsFromDisk(teamName, decisionScopeKey, decisionScopeToken);
-        }
+        const flushed = await flushReviewDecisionsForClose();
         if (!isCurrentReviewOperationScope(operationScope)) return scopeChangedResult;
         if (!flushed) {
           const blocker = 'Unable to save review decisions. Changes remains open.';
@@ -3637,11 +3354,12 @@ export const ChangeReviewDialog = ({
     draftHistoryHydration.key,
     draftHistoryHydration.status,
     flushDraftHistoryWrites,
+    flushReviewDecisionsForClose,
     getDraftHistoryDiagnostics,
     getDraftHistoryEntry,
+    getReviewDecisionPersistenceDiagnostics,
     handleSerializedStateChanged,
     isCurrentReviewOperationScope,
-    persistLatestAcceptedReviewAction,
     teamName,
   ]);
 
@@ -3696,10 +3414,8 @@ export const ChangeReviewDialog = ({
         });
         if (!isCurrentReviewOperationScope(operationScope)) return;
         markCommittedReviewPostimages(recovered.diskPostimages);
-        await hydrateDecisionsFromDisk(
-          teamName,
-          decisionScopeKey,
-          decisionScopeToken,
+        await hydrateReviewDecisions(
+          { teamName, scopeKey: decisionScopeKey, scopeToken: decisionScopeToken },
           decisionHydrationKey
         );
         if (!isCurrentReviewOperationScope(operationScope)) return;
@@ -3723,7 +3439,7 @@ export const ChangeReviewDialog = ({
     draftHistoryHydrationFailed,
     retryDraftHistoryHydration,
     decisionHydrationKey,
-    hydrateDecisionsFromDisk,
+    hydrateReviewDecisions,
     isCurrentReviewOperationScope,
     markCommittedReviewPostimages,
     reviewMutationBusy,
@@ -3906,10 +3622,8 @@ export const ChangeReviewDialog = ({
 
   useEffect(() => {
     if (!open || !lifecycleAuthorized || !decisionScopeToken || !decisionHydrationKey) return;
-    void hydrateDecisionsFromDisk(
-      teamName,
-      decisionScopeKey,
-      decisionScopeToken,
+    void hydrateReviewDecisions(
+      { teamName, scopeKey: decisionScopeKey, scopeToken: decisionScopeToken },
       decisionHydrationKey
     );
   }, [
@@ -3917,7 +3631,7 @@ export const ChangeReviewDialog = ({
     decisionScopeKey,
     decisionScopeToken,
     lifecycleAuthorized,
-    hydrateDecisionsFromDisk,
+    hydrateReviewDecisions,
     open,
     teamName,
   ]);
@@ -3930,80 +3644,22 @@ export const ChangeReviewDialog = ({
     Object.keys(fileDecisions).length > 0 ||
     reviewActionHistory.length > 0 ||
     reviewRedoHistory.length > 0;
-  const hadDurableReviewStateRef = useRef(false);
-  useEffect(() => {
-    hadDurableReviewStateRef.current = false;
-  }, [decisionScopeToken]);
-  useEffect(() => {
-    if (!open || !lifecycleAuthorized || !decisionScopeToken) return;
-    // Never persist a decision before its instant disk mutation has completed.
-    // On failure the decision is reconciled/rolled back first; when the busy state
-    // clears this effect runs again with the authoritative post-operation state.
-    if (!decisionHydrationReady || reviewActionsBusy) return;
-    if (hasDurableReviewState) {
-      hadDurableReviewStateRef.current = true;
-      const currentSnapshot = captureReviewPersistenceSnapshotIdentity(
-        decisionScopeToken,
-        useStore.getState()
-      );
-      if (
-        isSameReviewPersistenceSnapshot(
-          immediatelyPersistedReviewSnapshotRef.current,
-          currentSnapshot
-        )
-      ) {
-        // The Accept handler already waited for this exact decision + history snapshot
-        // to reach disk. Do not schedule a redundant debounced write after its ack.
-        immediatelyPersistedReviewSnapshotRef.current = null;
-        return;
-      }
-      immediatelyPersistedReviewSnapshotRef.current = null;
-      persistDecisions(teamName, decisionScopeKey, decisionScopeToken);
-    } else if (
-      hadDurableReviewStateRef.current &&
-      pendingAutoDecisionClearKeyRef.current !== decisionHydrationKey
-    ) {
-      pendingAutoDecisionClearKeyRef.current = decisionHydrationKey;
-      void clearDecisionsFromDisk(teamName, decisionScopeKey, decisionScopeToken).then(
-        (cleared) => {
-          if (pendingAutoDecisionClearKeyRef.current === decisionHydrationKey) {
-            pendingAutoDecisionClearKeyRef.current = null;
-          }
-          if (expectedDraftHistoryKeyRef.current !== decisionHydrationKey) return;
-          if (cleared) {
-            hadDurableReviewStateRef.current = false;
-            return;
-          }
-          publishReviewActionPersistenceStatus('error');
-          useStore.setState({
-            applyError:
-              'Unable to clear saved review decisions. Retry from History or keep Changes open.',
-          });
-          void refreshReviewConflictCandidates();
-        }
-      );
-    }
-  }, [
-    open,
-    lifecycleAuthorized,
+  useChangeReviewDecisionAutoPersistence({
+    active: open && lifecycleAuthorized,
+    hydrationKey: decisionHydrationKey,
+    scope: conflictScope,
+    hydrationReady: decisionHydrationReady,
+    blocked: reviewActionsBusy,
     hasDurableReviewState,
     hunkDecisions,
     fileDecisions,
-    reviewActionHistory,
-    reviewRedoHistory,
+    undoHistory: reviewActionHistory,
+    redoHistory: reviewRedoHistory,
     fileContents,
     fileChunkCounts,
-    teamName,
-    decisionScopeKey,
-    decisionScopeToken,
-    persistDecisions,
-    clearDecisionsFromDisk,
-    decisionHydrationKey,
-    publishReviewActionPersistenceStatus,
-    refreshReviewConflictCandidates,
-    reviewActionsBusy,
-    decisionHydrationReady,
-  ]);
+    scheduleAutoPersistence: scheduleReviewDecisionAutoPersistence,
+    clearAfterDurableStateEmptied: clearReviewDecisionsAfterStateEmptied,
+  });
 
   // Scroll to initialFilePath once data is loaded
   useEffect(() => {
@@ -4054,102 +3710,41 @@ export const ChangeReviewDialog = ({
     return () => document.removeEventListener('keydown', handler);
   }, [open, requestClose]);
 
-  // Track last focused CM editor for Cmd+Z outside editor
-  useEffect(() => {
-    if (!open) return;
-
-    const handleFocusIn = (e: FocusEvent): void => {
-      const target = e.target as Element | null;
-      if (!target?.closest?.('.cm-editor')) return;
-
-      const filePath = getEditorFilePathForTarget(target);
-      if (!filePath) return;
-
-      const view = editorViewMapRef.current.get(filePath);
-      if (view) {
-        lastFocusedEditorRef.current = view;
-      }
-    };
-
-    document.addEventListener('focusin', handleFocusIn);
-    return () => {
-      document.removeEventListener('focusin', handleFocusIn);
-      lastFocusedEditorRef.current = null;
-    };
-  }, [open, getEditorFilePathForTarget]);
-
   // Review actions use one ordered stack. Manual draft edits keep CodeMirror's native history.
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: KeyboardEvent): void => {
-      if (!(e.metaKey || e.ctrlKey)) return;
-      const isRedoShortcut =
-        (e.code === 'KeyZ' && e.shiftKey) || (e.code === 'KeyY' && !e.shiftKey);
-      const isUndoShortcut = e.code === 'KeyZ' && !e.shiftKey;
-      if (!isUndoShortcut && !isRedoShortcut) return;
-
-      const tag = document.activeElement?.tagName;
-      if (tag === 'INPUT' || tag === 'TEXTAREA') return;
-      const activeElement = document.activeElement;
-      const editorFilePath = getEditorFilePathForTarget(activeElement);
-      const hasDraftInFocusedEditor = editorFilePath ? hasReviewDraft(editorFilePath) : false;
-      const focusedEditor = editorFilePath
-        ? (editorViewMapRef.current.get(editorFilePath) ?? null)
-        : null;
-
-      if (isRedoShortcut) {
-        if (focusedEditor && redoDepth(focusedEditor.state) > 0) return;
-        if (hasDraftInFocusedEditor) return;
-        e.preventDefault();
-        e.stopPropagation();
-        if (hasReviewActionInFlight() || editedCount > 0) return;
-        if (reviewRedoActionsRef.current.length > 0) void handleRedoLatestReviewAction();
-        return;
-      }
-
-      if (
-        focusedEditor &&
-        undoDepth(focusedEditor.state) > 0 &&
-        (hasDraftInFocusedEditor || reviewUndoActionsRef.current.length === 0)
-      ) {
-        return;
-      }
-      if (hasDraftInFocusedEditor) return;
-      if (hasReviewActionInFlight()) {
-        e.preventDefault();
-        e.stopPropagation();
-        return;
-      }
-
-      if (reviewUndoActionsRef.current.length > 0) {
-        e.preventDefault();
-        e.stopPropagation();
-        if (editedCount > 0) {
-          useStore.setState({
-            applyError: 'Save or discard manual edits before undoing a review action.',
-          });
-          return;
-        }
-        void handleUndoLatestReviewAction();
-        return;
-      }
-
-      // Native CodeMirror Undo would change only the visual document and desynchronize it
-      // from the durable decision timeline, so without a manual draft there is nothing to undo.
-      e.preventDefault();
-      e.stopPropagation();
-    };
-    document.addEventListener('keydown', handler, true);
-    return () => document.removeEventListener('keydown', handler, true);
-  }, [
-    open,
-    getEditorFilePathForTarget,
+  const resolveReviewKeyboardEditorContext = useCallback(
+    (target: Element | null) => {
+      const filePath = getEditorFilePathForTarget(target);
+      return {
+        editor: filePath ? (editorViewMapRef.current.get(filePath) ?? null) : null,
+        hasDraft: filePath ? hasReviewDraft(filePath) : false,
+      };
+    },
+    [getEditorFilePathForTarget, hasReviewDraft]
+  );
+  const getReviewUndoCount = useCallback(
+    (): number => getReviewUndoHistory().length,
+    [getReviewUndoHistory]
+  );
+  const getReviewRedoCount = useCallback(
+    (): number => getReviewRedoHistory().length,
+    [getReviewRedoHistory]
+  );
+  const reportReviewUndoDraftBlock = useCallback((): void => {
+    useStore.setState({
+      applyError: 'Save or discard manual edits before undoing a review action.',
+    });
+  }, []);
+  useChangeReviewHistoryKeyboardShortcuts({
+    active: open,
     editedCount,
-    handleRedoLatestReviewAction,
-    handleUndoLatestReviewAction,
-    hasReviewActionInFlight,
-    hasReviewDraft,
-  ]);
+    resolveEditorContext: resolveReviewKeyboardEditorContext,
+    hasActionInFlight: hasReviewActionInFlight,
+    getUndoCount: getReviewUndoCount,
+    getRedoCount: getReviewRedoCount,
+    undoLatest: handleUndoLatestReviewAction,
+    redoLatest: handleRedoLatestReviewAction,
+    reportManualDraftBlock: reportReviewUndoDraftBlock,
+  });
 
   // Cmd+N IPC listener (forwarded from main process)
   useEffect(() => {

--- a/src/renderer/components/team/review/reviewActionState.ts
+++ b/src/renderer/components/team/review/reviewActionState.ts
@@ -10,17 +10,18 @@ import {
   isReviewFileExpectedDeleted,
 } from './reviewContentPreview';
 
+import type { ReviewActionPersistenceStatus } from '@features/change-review/renderer';
 import type {
   ConflictCheckResult,
   FileChangeSummary,
   FileChangeWithContent,
   HunkDecision,
   ReviewRenameRecoveryExpectation,
-  ReviewUndoAction,
 } from '@shared/types';
 
 export type { ReviewOperationScopeToken } from '@features/change-review/renderer';
 export type { ReviewConflictCandidateSelection } from '@features/change-review/renderer';
+export type { ReviewActionPersistenceStatus } from '@features/change-review/renderer';
 export {
   createReviewOperationScopeToken,
   getReviewDecisionHydrationGuard,
@@ -67,39 +68,6 @@ export function isReviewActionLocked(state: {
   closing: boolean;
 }): boolean {
   return state.applying || state.fileApplyCount > 0 || state.undoing || state.closing;
-}
-
-export type ReviewActionPersistenceStatus = 'saved' | 'saving' | 'error';
-
-export function isReviewActionPersistenceBlocking(status: ReviewActionPersistenceStatus): boolean {
-  return status !== 'saved';
-}
-
-export function appendOrderedReviewAction<T>(
-  stack: readonly T[],
-  action: T,
-  _legacyMaxDepth?: number
-): T[] {
-  return [...stack, action];
-}
-
-export function popOrderedReviewAction<T>(
-  stack: readonly T[],
-  expected: T
-): { stack: T[]; popped: boolean } {
-  if (stack.at(-1) !== expected) return { stack: [...stack], popped: false };
-  return { stack: stack.slice(0, -1), popped: true };
-}
-
-export function replaceLatestReviewAction(
-  stack: readonly ReviewUndoAction[],
-  optimistic: ReviewUndoAction,
-  committed: ReviewUndoAction
-): { stack: ReviewUndoAction[]; replaced: boolean } {
-  if (optimistic.id !== committed.id || stack.at(-1)?.id !== optimistic.id) {
-    return { stack: [...stack], replaced: false };
-  }
-  return { stack: [...stack.slice(0, -1), committed], replaced: true };
 }
 
 /** True when a retried Undo finds that its guarded disk preimage was already restored. */

--- a/test/features/change-review/renderer/createChangeReviewActionHistoryPorts.test.ts
+++ b/test/features/change-review/renderer/createChangeReviewActionHistoryPorts.test.ts
@@ -1,0 +1,76 @@
+import {
+  createChangeReviewActionHistoryStorePort,
+  createChangeReviewDecisionPersistencePort,
+} from '@features/change-review/renderer';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ReviewUndoAction } from '@shared/types';
+
+describe('change review action-history ports', () => {
+  it('publishes history through the current lazy store', () => {
+    const first = {
+      setReviewActionHistory: vi.fn(),
+      setReviewRedoHistory: vi.fn(),
+    };
+    const second = {
+      setReviewActionHistory: vi.fn(),
+      setReviewRedoHistory: vi.fn(),
+    };
+    let current = first;
+    const clearLegacyUndoStack = vi.fn();
+    const port = createChangeReviewActionHistoryStorePort({
+      getStore: () => current,
+      clearLegacyUndoStack,
+    });
+    const history = [{ id: 'a' }] as ReviewUndoAction[];
+
+    port.publishUndoHistory(history);
+    current = second;
+    port.publishRedoHistory([]);
+    port.clearLegacyUndoStack();
+
+    expect(first.setReviewActionHistory).toHaveBeenCalledWith(history);
+    expect(second.setReviewRedoHistory).toHaveBeenCalledWith([]);
+    expect(clearLegacyUndoStack).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps persistence scope and clears only its own error', async () => {
+    const store = {
+      hunkDecisions: {},
+      fileDecisions: {},
+      reviewActionHistory: [],
+      reviewRedoHistory: [],
+      fileContents: {},
+      fileChunkCounts: {},
+      decisionHydrationScopeKey: 'hydration',
+      decisionHydrationStatus: 'loaded' as const,
+      applyError: 'expected',
+      loadDecisionsFromDisk: vi.fn(async () => {}),
+      persistDecisions: vi.fn(),
+      flushDecisionsToDisk: vi.fn(async () => true),
+      clearDecisionsFromDisk: vi.fn(async () => true),
+    };
+    const setApplyError = vi.fn((message: string | null) => {
+      store.applyError = message ?? '';
+    });
+    const port = createChangeReviewDecisionPersistencePort({
+      getStore: () => store,
+      setApplyError,
+    });
+    const scope = { teamName: 'team', scopeKey: 'task-a', scopeToken: 'token-a' };
+
+    await port.load(scope);
+    port.schedule(scope);
+    expect(await port.flush(scope)).toBe(true);
+    expect(await port.clear(scope)).toBe(true);
+    expect(store.loadDecisionsFromDisk).toHaveBeenCalledWith('team', 'task-a', 'token-a');
+    expect(store.persistDecisions).toHaveBeenCalledWith('team', 'task-a', 'token-a');
+    expect(store.flushDecisionsToDisk).toHaveBeenCalledWith('team', 'task-a', 'token-a');
+    expect(store.clearDecisionsFromDisk).toHaveBeenCalledWith('team', 'task-a', 'token-a');
+
+    port.clearError('other');
+    expect(setApplyError).not.toHaveBeenCalled();
+    port.clearError('expected');
+    expect(setApplyError).toHaveBeenCalledWith(null);
+  });
+});

--- a/test/features/change-review/renderer/useChangeReviewActionHistoryController.test.tsx
+++ b/test/features/change-review/renderer/useChangeReviewActionHistoryController.test.tsx
@@ -1,0 +1,273 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import {
+  useChangeReviewActionHistoryController,
+} from '@features/change-review/renderer';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  ChangeReviewActionHistoryController,
+  ChangeReviewActionHistoryStorePort,
+} from '@features/change-review/renderer';
+import type { ReviewRedoAction, ReviewUndoAction } from '@shared/types';
+
+interface ProbeProps {
+  resetKey: string;
+  hydrationKey: string | null;
+  hydrationScopeKey: string | null;
+  hydrationStatus: 'idle' | 'loading' | 'loaded' | 'error';
+  undo: ReviewUndoAction[];
+  redo: ReviewRedoAction[];
+  store: ChangeReviewActionHistoryStorePort;
+}
+
+let latest: ChangeReviewActionHistoryController | null = null;
+
+function Probe(props: ProbeProps): React.JSX.Element {
+  latest = useChangeReviewActionHistoryController({
+    resetKey: props.resetKey,
+    hydrationKey: props.hydrationKey,
+    hydrationScopeKey: props.hydrationScopeKey,
+    hydrationStatus: props.hydrationStatus,
+    hydratedUndoHistory: props.undo,
+    hydratedRedoHistory: props.redo,
+    store: props.store,
+  });
+  return <div />;
+}
+
+function hunkAction(id: string, filePath = '/repo/file.ts'): ReviewUndoAction {
+  return {
+    id,
+    createdAt: '2026-07-23T00:00:00.000Z',
+    kind: 'hunk',
+    action: { filePath, originalIndex: 0 },
+  };
+}
+
+function bulkAction(id: string): ReviewUndoAction {
+  return {
+    id,
+    createdAt: '2026-07-23T00:00:00.000Z',
+    kind: 'bulk',
+    decisionSnapshot: { hunkDecisions: {}, fileDecisions: {} },
+    diskSnapshots: [],
+  };
+}
+
+function redoAction(action: ReviewUndoAction): ReviewRedoAction {
+  return {
+    action,
+    decisionSnapshot: { hunkDecisions: {}, fileDecisions: {} },
+  };
+}
+
+function createStore(): ChangeReviewActionHistoryStorePort & {
+  undo: ReviewUndoAction[];
+  redo: ReviewRedoAction[];
+  legacyClears: number;
+} {
+  return {
+    undo: [],
+    redo: [],
+    legacyClears: 0,
+    publishUndoHistory(history) {
+      this.undo = history;
+    },
+    publishRedoHistory(history) {
+      this.redo = history;
+    },
+    clearLegacyUndoStack() {
+      this.legacyClears += 1;
+    },
+  };
+}
+
+describe('useChangeReviewActionHistoryController', () => {
+  afterEach(() => {
+    latest = null;
+    document.body.innerHTML = '';
+    vi.unstubAllGlobals();
+  });
+
+  it('hydrates only the matching loaded scope across A -> B -> A', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    const root = createRoot(document.body.appendChild(document.createElement('div')));
+    const store = createStore();
+    const render = async (props: Omit<ProbeProps, 'store'>) => {
+      await act(async () => root.render(<Probe {...props} store={store} />));
+    };
+    const firstA = hunkAction('first-a');
+    const reopenedA = hunkAction('reopened-a');
+
+    await render({
+      resetKey: 'a:1',
+      hydrationKey: 'a',
+      hydrationScopeKey: 'a',
+      hydrationStatus: 'loaded',
+      undo: [firstA],
+      redo: [],
+    });
+    expect(latest!.getUndoHistory()).toEqual([firstA]);
+
+    await render({
+      resetKey: 'b:1',
+      hydrationKey: 'b',
+      hydrationScopeKey: 'a',
+      hydrationStatus: 'loaded',
+      undo: [firstA],
+      redo: [],
+    });
+    expect(latest!.getUndoHistory()).toEqual([]);
+
+    await render({
+      resetKey: 'a:2',
+      hydrationKey: 'a',
+      hydrationScopeKey: 'a',
+      hydrationStatus: 'loaded',
+      undo: [reopenedA],
+      redo: [],
+    });
+    expect(latest!.getUndoHistory()).toEqual([reopenedA]);
+    await act(async () => root.unmount());
+  });
+
+  it('restores redo only when the exact optimistic top action is discarded', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    const root = createRoot(document.body.appendChild(document.createElement('div')));
+    const store = createStore();
+    const previousRedo = redoAction(hunkAction('redo-old'));
+    await act(async () => {
+      root.render(
+        <Probe
+          resetKey="a"
+          hydrationKey="a"
+          hydrationScopeKey="a"
+          hydrationStatus="loaded"
+          undo={[]}
+          redo={[previousRedo]}
+          store={store}
+        />
+      );
+    });
+
+    let optimistic!: ReviewUndoAction;
+    await act(async () => {
+      optimistic = latest!.pushUndoAction({
+        kind: 'hunk',
+        action: { filePath: '/repo/file.ts', originalIndex: 1 },
+      });
+    });
+    expect(store.redo).toEqual([]);
+    await act(async () => {
+      root.render(
+        <Probe
+          resetKey="a"
+          hydrationKey="a"
+          hydrationScopeKey="a"
+          hydrationStatus="loaded"
+          undo={store.undo}
+          redo={store.redo}
+          store={store}
+        />
+      );
+    });
+    const cloned = { ...optimistic };
+    let discardedClone = true;
+    await act(async () => {
+      discardedClone = latest!.discardLatestAction(cloned);
+    });
+    expect(discardedClone).toBe(false);
+    expect(store.redo).toEqual([]);
+    let discardedOptimistic = false;
+    await act(async () => {
+      discardedOptimistic = latest!.discardLatestAction(optimistic);
+    });
+    expect(discardedOptimistic).toBe(true);
+    expect(store.redo).toEqual([previousRedo]);
+    await act(async () => root.unmount());
+  });
+
+  it('binds, completes and replaces histories without truncating strict LIFO order', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    const root = createRoot(document.body.appendChild(document.createElement('div')));
+    const store = createStore();
+    const initial = Array.from({ length: 24 }, (_, index) => hunkAction(`a-${index}`));
+    await act(async () => {
+      root.render(
+        <Probe
+          resetKey="a"
+          hydrationKey="a"
+          hydrationScopeKey="a"
+          hydrationStatus="loaded"
+          undo={initial}
+          redo={[]}
+          store={store}
+        />
+      );
+    });
+    expect(latest!.undoDepth).toBe(24);
+    let optimistic!: ReviewUndoAction;
+    await act(async () => {
+      optimistic = latest!.pushUndoAction({
+        kind: 'hunk',
+        action: { filePath: '/repo/new.ts', originalIndex: 0 },
+      });
+    });
+    const committed = {
+      ...optimistic,
+      kind: 'hunk',
+      action: { filePath: '/repo/new.ts', originalIndex: 7 },
+    } as ReviewUndoAction;
+    let bound = false;
+    await act(async () => {
+      bound = latest!.bindCommittedAction(optimistic, committed);
+    });
+    expect(bound).toBe(true);
+    expect(latest!.getLatestUndoAction()).toBe(committed);
+    let completed = false;
+    await act(async () => {
+      completed = latest!.completeUndoAction(committed, redoAction(committed));
+    });
+    expect(completed).toBe(true);
+    expect(latest!.getUndoHistory()).toEqual(initial);
+    expect(latest!.getLatestRedoAction()?.action).toBe(committed);
+
+    const replacement = [hunkAction('replacement')];
+    await act(async () => latest!.replaceHistories(replacement, []));
+    expect(latest!.getUndoHistory()).toBe(replacement);
+    expect(latest!.undoDepth).toBe(1);
+    await act(async () => root.unmount());
+  });
+
+  it('clears normalized file history and clears every stack for bulk history', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    const root = createRoot(document.body.appendChild(document.createElement('div')));
+    const store = createStore();
+    const retained = hunkAction('keep', '/repo/other.ts');
+    await act(async () => {
+      root.render(
+        <Probe
+          resetKey="a"
+          hydrationKey="a"
+          hydrationScopeKey="a"
+          hydrationStatus="loaded"
+          undo={[hunkAction('drop', 'C:\\Repo\\File.ts'), retained]}
+          redo={[redoAction(retained)]}
+          store={store}
+        />
+      );
+    });
+    await act(async () => latest!.clearForFile('c:/repo/file.ts'));
+    expect(store.undo).toEqual([retained]);
+    expect(store.redo).toEqual([]);
+
+    await act(async () => latest!.replaceHistories([bulkAction('bulk')], [redoAction(retained)]));
+    await act(async () => latest!.clearForFile('/repo/other.ts'));
+    expect(store.undo).toEqual([]);
+    expect(store.redo).toEqual([]);
+    expect(store.legacyClears).toBe(1);
+    await act(async () => root.unmount());
+  });
+});

--- a/test/features/change-review/renderer/useChangeReviewDecisionPersistenceController.test.tsx
+++ b/test/features/change-review/renderer/useChangeReviewDecisionPersistenceController.test.tsx
@@ -1,0 +1,460 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import {
+  useChangeReviewDecisionAutoPersistence,
+  useChangeReviewDecisionPersistenceController,
+} from '@features/change-review/renderer';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  ChangeReviewDecisionPersistenceController,
+  ChangeReviewDecisionPersistencePort,
+  ChangeReviewDecisionPersistenceScope,
+  ChangeReviewDecisionPersistenceSnapshot,
+} from '@features/change-review/renderer';
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+function makeSnapshot(
+  input: Partial<ChangeReviewDecisionPersistenceSnapshot> = {}
+): ChangeReviewDecisionPersistenceSnapshot {
+  return {
+    hunkDecisions: {},
+    fileDecisions: {},
+    reviewActionHistory: [],
+    reviewRedoHistory: [],
+    fileContents: {},
+    fileChunkCounts: {},
+    decisionHydrationScopeKey: 'a',
+    decisionHydrationStatus: 'loaded',
+    applyError: null,
+    ...input,
+  };
+}
+
+function makePort(snapshotRef: { current: ChangeReviewDecisionPersistenceSnapshot }) {
+  const port: ChangeReviewDecisionPersistencePort = {
+    getSnapshot: vi.fn(() => snapshotRef.current),
+    load: vi.fn(async () => {}),
+    schedule: vi.fn(),
+    flush: vi.fn(async () => true),
+    clear: vi.fn(async () => true),
+    reportError: vi.fn(),
+    clearError: vi.fn(),
+  };
+  return port;
+}
+
+interface ProbeProps {
+  hydrationKey: string | null;
+  expectedHydrationKey: string | null;
+  scope: ChangeReviewDecisionPersistenceScope | null;
+  hydrationReady: boolean;
+  port: ChangeReviewDecisionPersistencePort;
+  refresh: () => Promise<void>;
+  autoActive?: boolean;
+  blocked?: boolean;
+  hasDurableReviewState?: boolean;
+  snapshot: ChangeReviewDecisionPersistenceSnapshot;
+}
+
+let latest: ChangeReviewDecisionPersistenceController | null = null;
+
+function Probe(props: ProbeProps): React.JSX.Element {
+  latest = useChangeReviewDecisionPersistenceController({
+    hydrationKey: props.hydrationKey,
+    scope: props.scope,
+    hydrationReady: props.hydrationReady,
+    isExpectedHydrationKey: (key) => key === props.expectedHydrationKey,
+    refreshConflictCandidates: props.refresh,
+    port: props.port,
+  });
+  useChangeReviewDecisionAutoPersistence({
+    active: props.autoActive ?? false,
+    hydrationKey: props.hydrationKey,
+    scope: props.scope,
+    hydrationReady: props.hydrationReady,
+    blocked: props.blocked ?? false,
+    hasDurableReviewState: props.hasDurableReviewState ?? false,
+    hunkDecisions: props.snapshot.hunkDecisions,
+    fileDecisions: props.snapshot.fileDecisions,
+    undoHistory: props.snapshot.reviewActionHistory,
+    redoHistory: props.snapshot.reviewRedoHistory,
+    fileContents: props.snapshot.fileContents,
+    fileChunkCounts: props.snapshot.fileChunkCounts,
+    scheduleAutoPersistence: latest.scheduleAutoPersistence,
+    clearAfterDurableStateEmptied: latest.clearAfterDurableStateEmptied,
+  });
+  return <div />;
+}
+
+const scopeA = { teamName: 'team', scopeKey: 'task-a', scopeToken: 'token-a' };
+const scopeB = { teamName: 'team', scopeKey: 'task-b', scopeToken: 'token-b' };
+
+describe('useChangeReviewDecisionPersistenceController', () => {
+  afterEach(() => {
+    latest = null;
+    document.body.innerHTML = '';
+    vi.unstubAllGlobals();
+  });
+
+  it('marks hydration before auto persistence and compares snapshot identity by reference', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    const root = createRoot(document.body.appendChild(document.createElement('div')));
+    const snapshotRef = {
+      current: makeSnapshot({ hunkDecisions: { h: 'accepted' } }),
+    };
+    const port = makePort(snapshotRef);
+    const refresh = vi.fn(async () => {});
+    const render = async (snapshot: ChangeReviewDecisionPersistenceSnapshot, autoActive: boolean) => {
+      snapshotRef.current = snapshot;
+      await act(async () => {
+        root.render(
+          <Probe
+            hydrationKey="a"
+            expectedHydrationKey="a"
+            scope={scopeA}
+            hydrationReady
+            port={port}
+            refresh={refresh}
+            autoActive={autoActive}
+            hasDurableReviewState
+            snapshot={snapshot}
+          />
+        );
+      });
+    };
+
+    await render(snapshotRef.current, false);
+    await act(async () => latest!.hydrate(scopeA, 'a'));
+    await render(snapshotRef.current, true);
+    expect(port.schedule).not.toHaveBeenCalled();
+
+    const changedIdentity = {
+      ...snapshotRef.current,
+      hunkDecisions: { h: 'accepted' },
+    };
+    await render(changedIdentity, true);
+    expect(port.schedule).toHaveBeenCalledTimes(1);
+    await act(async () => root.unmount());
+  });
+
+  it('fences overlapping writes, stale A -> B -> A hydration, and current failures', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    const root = createRoot(document.body.appendChild(document.createElement('div')));
+    const snapshotRef = { current: makeSnapshot({ hunkDecisions: { h: 'accepted' } }) };
+    const port = makePort(snapshotRef);
+    const refresh = vi.fn(async () => {});
+    const render = async (
+      hydrationKey: string,
+      expectedHydrationKey: string,
+      scope: ChangeReviewDecisionPersistenceScope
+    ) => {
+      await act(async () => {
+        root.render(
+          <Probe
+            hydrationKey={hydrationKey}
+            expectedHydrationKey={expectedHydrationKey}
+            scope={scope}
+            hydrationReady
+            port={port}
+            refresh={refresh}
+            snapshot={snapshotRef.current}
+          />
+        );
+      });
+    };
+    await render('a', 'a', scopeA);
+
+    const firstFlush = deferred<boolean>();
+    const secondFlush = deferred<boolean>();
+    vi.mocked(port.flush)
+      .mockImplementationOnce(() => firstFlush.promise)
+      .mockImplementationOnce(() => secondFlush.promise);
+    let firstWrite!: Promise<boolean>;
+    let secondWrite!: Promise<boolean>;
+    await act(async () => {
+      firstWrite = latest!.persistLatest();
+      await Promise.resolve();
+      secondWrite = latest!.persistLatest();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      firstFlush.resolve(false);
+      await firstWrite;
+    });
+    expect(port.reportError).not.toHaveBeenCalled();
+    expect(refresh).not.toHaveBeenCalled();
+    await act(async () => {
+      secondFlush.resolve(true);
+      await secondWrite;
+    });
+    expect(latest!.status).toBe('saved');
+
+    const staleLoad = deferred<void>();
+    vi.mocked(port.load).mockImplementationOnce(() => staleLoad.promise);
+    let staleHydration!: Promise<void>;
+    await act(async () => {
+      staleHydration = latest!.hydrate(scopeA, 'a');
+      await Promise.resolve();
+    });
+    await render('b', 'b', scopeB);
+    await render('a', 'a', scopeA);
+    await act(async () => {
+      staleLoad.resolve();
+      await staleHydration;
+    });
+    latest!.scheduleAutoPersistence(scopeA);
+    expect(port.schedule).toHaveBeenCalledTimes(3);
+
+    vi.mocked(port.flush).mockResolvedValueOnce(false);
+    await act(async () => {
+      expect(await latest!.persistLatest()).toBe(false);
+    });
+    expect(latest!.status).toBe('error');
+    expect(port.reportError).toHaveBeenCalledTimes(1);
+    expect(refresh).toHaveBeenCalledTimes(1);
+    await act(async () => root.unmount());
+  });
+
+  it('fails closed without a durable scope', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    const root = createRoot(document.body.appendChild(document.createElement('div')));
+    const snapshotRef = { current: makeSnapshot() };
+    const port = makePort(snapshotRef);
+    await act(async () => {
+      root.render(
+        <Probe
+          hydrationKey={null}
+          expectedHydrationKey={null}
+          scope={null}
+          hydrationReady={false}
+          port={port}
+          refresh={vi.fn(async () => {})}
+          snapshot={snapshotRef.current}
+        />
+      );
+    });
+    await act(async () => {
+      expect(await latest!.persistLatest()).toBe(false);
+    });
+    expect(latest!.status).toBe('error');
+    expect(port.schedule).not.toHaveBeenCalled();
+    expect(port.reportError).toHaveBeenCalledTimes(1);
+    await act(async () => root.unmount());
+  });
+
+  it('clears an emptied durable scope once after the awaited clear succeeds', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    const root = createRoot(document.body.appendChild(document.createElement('div')));
+    const snapshotRef = {
+      current: makeSnapshot({ fileDecisions: { file: 'accepted' } }),
+    };
+    const port = makePort(snapshotRef);
+    const refresh = vi.fn(async () => {});
+    const render = async (
+      snapshot: ChangeReviewDecisionPersistenceSnapshot,
+      hasState: boolean
+    ) => {
+      snapshotRef.current = snapshot;
+      await act(async () => {
+        root.render(
+          <Probe
+            hydrationKey="a"
+            expectedHydrationKey="a"
+            scope={scopeA}
+            hydrationReady
+            port={port}
+            refresh={refresh}
+            autoActive
+            hasDurableReviewState={hasState}
+            snapshot={snapshot}
+          />
+        );
+        await Promise.resolve();
+      });
+    };
+
+    await render(snapshotRef.current, true);
+    const empty = makeSnapshot();
+    await render(empty, false);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await render({ ...empty, fileContents: {} }, false);
+    expect(port.clear).toHaveBeenCalledTimes(1);
+    expect(latest!.getDiagnostics().pendingDecisionClear).toBe(false);
+    expect(port.reportError).not.toHaveBeenCalled();
+    await act(async () => root.unmount());
+  });
+
+  it('awaits one nonempty -> empty clear and fences a stale A -> B -> A completion', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    const root = createRoot(document.body.appendChild(document.createElement('div')));
+    const nonempty = makeSnapshot({ hunkDecisions: { h: 'accepted' } });
+    const empty = makeSnapshot();
+    const snapshotRef = { current: nonempty };
+    const port = makePort(snapshotRef);
+    const refresh = vi.fn(async () => {});
+    const clear = deferred<boolean>();
+    vi.mocked(port.clear).mockImplementation(() => clear.promise);
+    const render = async (
+      snapshot: ChangeReviewDecisionPersistenceSnapshot,
+      hydrationKey: string,
+      scope: ChangeReviewDecisionPersistenceScope,
+      hasState: boolean
+    ) => {
+      snapshotRef.current = snapshot;
+      await act(async () => {
+        root.render(
+          <Probe
+            hydrationKey={hydrationKey}
+            expectedHydrationKey={hydrationKey}
+            scope={scope}
+            hydrationReady
+            port={port}
+            refresh={refresh}
+            autoActive
+            hasDurableReviewState={hasState}
+            snapshot={snapshot}
+          />
+        );
+      });
+    };
+
+    await render(nonempty, 'a', scopeA, true);
+    await render(empty, 'a', scopeA, false);
+    await render(empty, 'a', scopeA, false);
+    expect(port.clear).toHaveBeenCalledTimes(1);
+    expect(latest!.getDiagnostics()).toEqual({
+      pendingDecisionClear: true,
+      persistenceStatus: 'saved',
+    });
+    await render(nonempty, 'b', scopeB, true);
+    await render(empty, 'a', scopeA, false);
+    await act(async () => {
+      clear.resolve(false);
+      await Promise.resolve();
+    });
+    expect(port.reportError).not.toHaveBeenCalled();
+    expect(refresh).not.toHaveBeenCalled();
+    expect(latest!.status).toBe('saved');
+    await act(async () => root.unmount());
+  });
+
+  it('retains the durable-state marker when new state appears before clear completes', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    const root = createRoot(document.body.appendChild(document.createElement('div')));
+    const nonempty = makeSnapshot({ hunkDecisions: { h: 'accepted' } });
+    const empty = makeSnapshot();
+    const snapshotRef = { current: nonempty };
+    const port = makePort(snapshotRef);
+    const firstClear = deferred<boolean>();
+    vi.mocked(port.clear)
+      .mockImplementationOnce(() => firstClear.promise)
+      .mockResolvedValue(true);
+    const render = async (
+      snapshot: ChangeReviewDecisionPersistenceSnapshot,
+      hasState: boolean
+    ) => {
+      snapshotRef.current = snapshot;
+      await act(async () => {
+        root.render(
+          <Probe
+            hydrationKey="a"
+            expectedHydrationKey="a"
+            scope={scopeA}
+            hydrationReady
+            port={port}
+            refresh={vi.fn(async () => {})}
+            autoActive
+            hasDurableReviewState={hasState}
+            snapshot={snapshot}
+          />
+        );
+      });
+    };
+
+    await render(nonempty, true);
+    await render(empty, false);
+    await render({ ...nonempty, hunkDecisions: { h: 'rejected' } }, true);
+    await act(async () => {
+      firstClear.resolve(true);
+      await Promise.resolve();
+    });
+    await render({ ...empty, fileContents: {} }, false);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(port.clear).toHaveBeenCalledTimes(2);
+    await act(async () => root.unmount());
+  });
+
+  it('chooses save versus clear for close and reuses a pending clear', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    const root = createRoot(document.body.appendChild(document.createElement('div')));
+    const nonempty = makeSnapshot({ reviewActionHistory: [{ id: 'a' }] });
+    const snapshotRef = { current: nonempty };
+    const port = makePort(snapshotRef);
+    const refresh = vi.fn(async () => {});
+    const render = async (snapshot: ChangeReviewDecisionPersistenceSnapshot) => {
+      snapshotRef.current = snapshot;
+      await act(async () => {
+        root.render(
+          <Probe
+            hydrationKey="a"
+            expectedHydrationKey="a"
+            scope={scopeA}
+            hydrationReady
+            port={port}
+            refresh={refresh}
+            snapshot={snapshot}
+          />
+        );
+      });
+    };
+    await render(nonempty);
+    await act(async () => expect(await latest!.flushForClose()).toBe(true));
+    expect(port.schedule).toHaveBeenCalledTimes(1);
+    expect(port.flush).toHaveBeenCalledTimes(1);
+    expect(port.clear).not.toHaveBeenCalled();
+
+    await render(makeSnapshot());
+    await act(async () => expect(await latest!.flushForClose()).toBe(true));
+    expect(port.clear).toHaveBeenCalledTimes(1);
+
+    const pending = deferred<boolean>();
+    vi.mocked(port.clear).mockImplementationOnce(() => pending.promise);
+    let autoClear!: Promise<unknown>;
+    await act(async () => {
+      autoClear = latest!.clearAfterDurableStateEmptied(scopeA, 'a');
+      await Promise.resolve();
+    });
+    let closeFlush!: Promise<boolean>;
+    await act(async () => {
+      closeFlush = latest!.flushForClose();
+      await Promise.resolve();
+    });
+    expect(port.clear).toHaveBeenCalledTimes(2);
+    await act(async () => {
+      pending.resolve(true);
+      await autoClear;
+      expect(await closeFlush).toBe(true);
+    });
+    await act(async () => root.unmount());
+  });
+});

--- a/test/features/change-review/renderer/useChangeReviewHistoryKeyboardShortcuts.test.tsx
+++ b/test/features/change-review/renderer/useChangeReviewHistoryKeyboardShortcuts.test.tsx
@@ -1,0 +1,186 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { history } from '@codemirror/commands';
+import { EditorState } from '@codemirror/state';
+import { useChangeReviewHistoryKeyboardShortcuts } from '@features/change-review/renderer';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { ChangeReviewKeyboardEditorContext } from '@features/change-review/renderer';
+
+interface ProbeProps {
+  active: boolean;
+  editedCount: number;
+  context: ChangeReviewKeyboardEditorContext;
+  inFlight: boolean;
+  undoCount: number;
+  redoCount: number;
+  undo: () => Promise<void>;
+  redo: () => Promise<void>;
+  reportBlock: () => void;
+}
+
+function Probe(props: ProbeProps): React.JSX.Element {
+  useChangeReviewHistoryKeyboardShortcuts({
+    active: props.active,
+    editedCount: props.editedCount,
+    resolveEditorContext: () => props.context,
+    hasActionInFlight: () => props.inFlight,
+    getUndoCount: () => props.undoCount,
+    getRedoCount: () => props.redoCount,
+    undoLatest: props.undo,
+    redoLatest: props.redo,
+    reportManualDraftBlock: props.reportBlock,
+  });
+  return <div />;
+}
+
+function shortcut(input: { redo?: boolean; keyY?: boolean } = {}): KeyboardEvent {
+  return new KeyboardEvent('keydown', {
+    bubbles: true,
+    cancelable: true,
+    ctrlKey: true,
+    code: input.keyY ? 'KeyY' : 'KeyZ',
+    shiftKey: input.redo ?? false,
+  });
+}
+
+describe('useChangeReviewHistoryKeyboardShortcuts', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.unstubAllGlobals();
+  });
+
+  it('preserves input and native CodeMirror history priority', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    const host = document.body.appendChild(document.createElement('div'));
+    const root = createRoot(host);
+    const input = document.body.appendChild(document.createElement('input'));
+    const undo = vi.fn(async () => {});
+    const redo = vi.fn(async () => {});
+    const reportBlock = vi.fn();
+    const baseProps = {
+      active: true,
+      editedCount: 0,
+      context: { editor: null, hasDraft: false },
+      inFlight: false,
+      undoCount: 1,
+      redoCount: 1,
+      undo,
+      redo,
+      reportBlock,
+    };
+    await act(async () => root.render(<Probe {...baseProps} />));
+    input.focus();
+    const inputEvent = shortcut();
+    input.dispatchEvent(inputEvent);
+    expect(inputEvent.defaultPrevented).toBe(false);
+    expect(undo).not.toHaveBeenCalled();
+
+    let editorState = EditorState.create({ doc: 'a', extensions: [history()] });
+    editorState = editorState.update({ changes: { from: 1, insert: 'b' } }).state;
+    await act(async () => {
+      root.render(
+        <Probe
+          {...baseProps}
+          context={{
+            editor: { state: editorState } as ChangeReviewKeyboardEditorContext['editor'],
+            hasDraft: true,
+          }}
+        />
+      );
+    });
+    host.focus();
+    const nativeEvent = shortcut();
+    document.dispatchEvent(nativeEvent);
+    expect(nativeEvent.defaultPrevented).toBe(false);
+    expect(undo).not.toHaveBeenCalled();
+    await act(async () => root.unmount());
+  });
+
+  it('blocks in-flight and manual-draft-conflicted actions with preventDefault parity', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    const root = createRoot(document.body.appendChild(document.createElement('div')));
+    const undo = vi.fn(async () => {});
+    const redo = vi.fn(async () => {});
+    const reportBlock = vi.fn();
+    const render = async (inFlight: boolean, editedCount: number) => {
+      await act(async () => {
+        root.render(
+          <Probe
+            active
+            editedCount={editedCount}
+            context={{ editor: null, hasDraft: false }}
+            inFlight={inFlight}
+            undoCount={1}
+            redoCount={1}
+            undo={undo}
+            redo={redo}
+            reportBlock={reportBlock}
+          />
+        );
+      });
+    };
+
+    await render(true, 0);
+    const blocked = shortcut();
+    document.dispatchEvent(blocked);
+    expect(blocked.defaultPrevented).toBe(true);
+    expect(undo).not.toHaveBeenCalled();
+
+    await render(false, 1);
+    const manualDraft = shortcut();
+    document.dispatchEvent(manualDraft);
+    expect(manualDraft.defaultPrevented).toBe(true);
+    expect(reportBlock).toHaveBeenCalledTimes(1);
+    expect(undo).not.toHaveBeenCalled();
+
+    const redoBlocked = shortcut({ redo: true });
+    document.dispatchEvent(redoBlocked);
+    expect(redoBlocked.defaultPrevented).toBe(true);
+    expect(redo).not.toHaveBeenCalled();
+    await act(async () => root.unmount());
+  });
+
+  it('routes undo/redo, prevents no-history native undo, and removes capture listener', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    const root = createRoot(document.body.appendChild(document.createElement('div')));
+    const undo = vi.fn(async () => {});
+    const redo = vi.fn(async () => {});
+    const reportBlock = vi.fn();
+    const render = async (undoCount: number, redoCount: number) => {
+      await act(async () => {
+        root.render(
+          <Probe
+            active
+            editedCount={0}
+            context={{ editor: null, hasDraft: false }}
+            inFlight={false}
+            undoCount={undoCount}
+            redoCount={redoCount}
+            undo={undo}
+            redo={redo}
+            reportBlock={reportBlock}
+          />
+        );
+      });
+    };
+
+    await render(1, 1);
+    document.dispatchEvent(shortcut());
+    document.dispatchEvent(shortcut({ keyY: true }));
+    expect(undo).toHaveBeenCalledTimes(1);
+    expect(redo).toHaveBeenCalledTimes(1);
+
+    await render(0, 0);
+    const noHistory = shortcut();
+    document.dispatchEvent(noHistory);
+    expect(noHistory.defaultPrevented).toBe(true);
+    await act(async () => root.unmount());
+
+    const afterCleanup = shortcut();
+    document.dispatchEvent(afterCleanup);
+    expect(afterCleanup.defaultPrevented).toBe(false);
+    expect(undo).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/renderer/components/team/review/ChangeReviewDialog.guards.test.ts
+++ b/test/renderer/components/team/review/ChangeReviewDialog.guards.test.ts
@@ -1,7 +1,12 @@
+import {
+  appendOrderedReviewAction,
+  isReviewActionPersistenceBlocking,
+  popOrderedReviewAction,
+  replaceLatestReviewAction,
+} from '@features/change-review/renderer';
 import { describe, expect, it } from 'vitest';
 
 import {
-  appendOrderedReviewAction,
   createReviewOperationScopeToken,
   getReviewCloseBlockReason,
   getReviewDecisionHydrationGuard,
@@ -10,14 +15,11 @@ import {
   hasUnresolvedReviewExternalChange,
   hasUnscopedLocalReviewState,
   isReviewActionLocked,
-  isReviewActionPersistenceBlocking,
   isReviewDiskPreimageRestored,
   isReviewFileFullyRejected,
   isReviewOperationScopeCurrent,
   partitionReviewFilesByApplyErrors,
-  popOrderedReviewAction,
   reconcileReviewDecisionRecordsAfterApply,
-  replaceLatestReviewAction,
   replaceReviewScopedRecord,
   resolveDraftBaselineAfterSave,
   resolveReviewFileIsNew,


### PR DESCRIPTION
## Summary

- move undo and redo history ownership behind a focused controller and store port
- isolate decision persistence and keyboard shortcut orchestration
- preserve hydration, close flush, stale generation, and durable clear semantics
- reduce ChangeReviewDialog from 4560 to 4155 lines

## Verification

- pnpm typecheck
- pnpm lint:fast:files for changed production modules
- type-aware ESLint for changed production modules: 0 errors
- 29 change-review test files, 168 tests passed
- pnpm test:arch:node: 23/23 passed
- production Electron build and Radix bundle verification passed
- git diff --check passed

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactors change-review action history, persistence, and keyboard orchestration behind focused controllers and ports.
- Moves undo/redo ownership and file-scoped history clearing into an action-history controller.
- Extracts hydration, automatic persistence, durable clearing, and close flushing into persistence hooks.
- Extracts review-history keyboard shortcut routing and adds focused controller, adapter, and integration tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code defects identified.

The extracted controllers preserve the prior history, persistence, hydration, close-flush, and keyboard-routing behavior, while focused tests cover the important state transitions and stale-generation paths.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/features/change-review/renderer/hooks/useChangeReviewActionHistoryController.ts | Encapsulates undo/redo history, hydration, optimistic rollback, replacement, and file-scoped clearing with behavior matching the prior dialog-owned implementation. |
| src/features/change-review/renderer/hooks/useChangeReviewDecisionPersistenceController.ts | Encapsulates persistence status, generation fencing, hydration, automatic clearing, and close flushing with focused race and lifecycle coverage. |
| src/features/change-review/renderer/hooks/useChangeReviewDecisionAutoPersistence.ts | Isolates automatic save-or-clear orchestration while retaining durable-state transition tracking. |
| src/features/change-review/renderer/hooks/useChangeReviewHistoryKeyboardShortcuts.ts | Extracts document-level undo/redo routing while preserving input and CodeMirror history priority. |
| src/renderer/components/team/review/ChangeReviewDialog.tsx | Replaces dialog-owned history and persistence machinery with the new controllers and stable store adapters. |
| src/features/change-review/renderer/utils/changeReviewActionHistory.ts | Relocates action creation and ordered-history policies and adds explicit file-scoped filtering. |
| test/features/change-review/renderer/useChangeReviewDecisionPersistenceController.test.tsx | Covers snapshot suppression, overlapping generations, stale scopes, durable clearing, and close-flush behavior. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  D[ChangeReviewDialog] --> H[Action History Controller]
  D --> P[Decision Persistence Controller]
  D --> K[Keyboard Shortcut Hook]
  H --> S[Zustand Store Port]
  P --> S
  P --> R[Review Persistence APIs]
  K --> H
```

<sub>Reviews (1): Last reviewed commit: ["refactor(change-review): isolate action ..."](https://github.com/777genius/agent-teams-ai/commit/f103cc68c0850e137de8a9f41852b2528be2b9e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46621719)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved change review undo and redo history management.
  * Added automatic saving and cleanup of review decisions.
  * Added safer close-time persistence and conflict recovery.
  * Added keyboard shortcuts for undo and redo, with protection for drafts and editor-native history.
* **Bug Fixes**
  * Prevented stale saves, hydration results, and history updates from overwriting current review state.
  * Improved handling of file-specific and bulk history cleanup.
* **Documentation**
  * Clarified ownership and responsibilities across change review components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->