### PR TITLE
refactor(change-review): isolate history mutations

### DIFF
--- a/src/features/change-review/README.md
+++ b/src/features/change-review/README.md
@@ -6,10 +6,11 @@ This is a thin renderer feature extracted incrementally from the legacy
 - `renderer/view-models` owns pure presentation projections.
 - `renderer/utils` owns pure scope and operation-generation policies.
 - `renderer/hooks` owns scope/lifecycle, draft history, conflict recovery, action-history,
-  decision-persistence, and keyboard orchestration through narrow ports.
+  decision-persistence, keyboard orchestration, and durable Undo/Redo/checkpoint Restore through
+  narrow command, state, and view ports.
 - `renderer/ui` owns store-free presentation components.
-- The legacy dialog remains the temporary composition shell for Zustand, editor and disk
-  mutations, and outer close coordination while later slices move those responsibilities
-  behind focused hooks and use cases.
+- The legacy dialog remains the temporary composition shell for Zustand, editor mutations,
+  forward Accept/Reject disk mutations, and outer close coordination while later slices move
+  those responsibilities behind focused hooks and use cases.
 
 Production callers import through `@features/change-review/renderer`.

--- a/src/features/change-review/renderer/adapters/createChangeReviewHistoryMutationPorts.ts
+++ b/src/features/change-review/renderer/adapters/createChangeReviewHistoryMutationPorts.ts
@@ -1,0 +1,56 @@
+import type {
+  ChangeReviewHistoryMutationCommandPort,
+  ChangeReviewHistoryMutationStatePort,
+  ChangeReviewHistoryPersistenceScope,
+  ChangeReviewHistoryStateSnapshot,
+} from '../ports/changeReviewHistoryMutationPorts';
+import type { ReviewPersistedStateSnapshot } from '@shared/types';
+import type { ReviewAPI } from '@shared/types/api';
+
+type ChangeReviewHistoryMutationApi = Pick<
+  ReviewAPI,
+  'executeMutation' | 'restoreHistory' | 'retryMutationRecovery'
+>;
+
+export function createChangeReviewHistoryMutationCommandPort(
+  getReviewApi: () => ChangeReviewHistoryMutationApi
+): ChangeReviewHistoryMutationCommandPort {
+  return {
+    executeMutation: (request) => getReviewApi().executeMutation(request),
+    restoreHistory: (request) => getReviewApi().restoreHistory(request),
+    retryRecovery: (request) => getReviewApi().retryMutationRecovery(request),
+  };
+}
+
+interface CreateChangeReviewHistoryMutationStatePortInput {
+  getSnapshot: () => ChangeReviewHistoryStateSnapshot;
+  quiesceDecisionPersistence: (scope: ChangeReviewHistoryPersistenceScope) => Promise<boolean>;
+  recordDecisionRevision: (scope: ChangeReviewHistoryPersistenceScope, revision: number) => void;
+  applyDecisionState: ChangeReviewHistoryMutationStatePort['applyDecisionState'];
+  applyPersistedState: (state: ReviewPersistedStateSnapshot, applyError: string | null) => void;
+  reportError: (message: string) => void;
+  clearExternalChange: (filePath: string) => void;
+  invalidateResolvedFileContent: (filePath: string) => void;
+}
+
+export function createChangeReviewHistoryMutationStatePort({
+  getSnapshot,
+  quiesceDecisionPersistence,
+  recordDecisionRevision,
+  applyDecisionState,
+  applyPersistedState,
+  reportError,
+  clearExternalChange,
+  invalidateResolvedFileContent,
+}: CreateChangeReviewHistoryMutationStatePortInput): ChangeReviewHistoryMutationStatePort {
+  return {
+    getSnapshot,
+    quiesceDecisionPersistence,
+    recordDecisionRevision,
+    applyDecisionState,
+    applyPersistedState,
+    reportError,
+    clearExternalChange,
+    invalidateResolvedFileContent,
+  };
+}

--- a/src/features/change-review/renderer/hooks/useChangeReviewActionHistoryController.ts
+++ b/src/features/change-review/renderer/hooks/useChangeReviewActionHistoryController.ts
@@ -10,13 +10,14 @@ import {
 
 import type { ChangeReviewActionHistoryStorePort } from '../ports/changeReviewActionHistoryPorts';
 import type { ReviewUndoActionInput } from '../utils/changeReviewActionHistory';
+import type { ReviewDecisionHydrationStatus } from '../utils/changeReviewScope';
 import type { ReviewRedoAction, ReviewUndoAction } from '@shared/types';
 
 interface UseChangeReviewActionHistoryControllerInput {
   resetKey: string;
   hydrationKey: string | null;
   hydrationScopeKey: string | null;
-  hydrationStatus: 'idle' | 'loading' | 'loaded' | 'error';
+  hydrationStatus: ReviewDecisionHydrationStatus;
   hydratedUndoHistory: ReviewUndoAction[];
   hydratedRedoHistory: ReviewRedoAction[];
   store: ChangeReviewActionHistoryStorePort;
@@ -164,12 +165,14 @@ export function useChangeReviewActionHistoryController({
 
   const discardLatestAction = useCallback(
     (action: ReviewUndoAction): boolean => {
-      const result = popOrderedReviewAction(undoHistoryRef.current, action);
+      const latest = undoHistoryRef.current.at(-1);
+      if (latest?.id !== action.id) return false;
+      const result = popOrderedReviewAction(undoHistoryRef.current, latest);
       if (!result.popped) return false;
       undoHistoryRef.current = result.stack;
       store.publishUndoHistory(result.stack);
       const redoBackup = redoBeforePreparedActionRef.current;
-      if (redoBackup?.actionId === action.id && redoBackup.action === action) {
+      if (redoBackup?.actionId === action.id) {
         redoHistoryRef.current = redoBackup.history;
         store.publishRedoHistory(redoBackup.history);
         setRedoDepth(redoBackup.history.length);

--- a/src/features/change-review/renderer/hooks/useChangeReviewHistoryMutationController.ts
+++ b/src/features/change-review/renderer/hooks/useChangeReviewHistoryMutationController.ts
@@ -188,13 +188,17 @@ export function useChangeReviewHistoryMutationController({
       target: ReviewHistoryRestoreTarget
     ): void => {
       applyCommittedState(persistedState, decisionRevision, null);
-      if (direction === 'undo' && diskSnapshots.length > 0) refreshAfterUndo(diskSnapshots);
-      if (direction === 'redo') {
+      if (direction === 'undo') {
+        if (diskSnapshots.length > 0) {
+          refreshAfterUndo(diskSnapshots);
+        } else {
+          viewPort.incrementDiscardCounters(
+            orderedActions.flatMap((action) => getReviewActionAffectedPaths(action, files))
+          );
+        }
+      } else {
         for (const action of orderedActions) refreshAfterRedo(action);
       }
-      viewPort.incrementDiscardCounters(
-        orderedActions.flatMap((action) => getReviewActionAffectedPaths(action, files))
-      );
       if (target.kind !== 'after-action') return;
       const targetAction =
         persistedState.reviewActionHistory.find((action) => action.id === target.actionId) ??
@@ -311,7 +315,9 @@ export function useChangeReviewHistoryMutationController({
       statePort.applyDecisionState(decisionState);
       if (diskSnapshots.length > 0) refreshAfterUndo(diskSnapshots);
       if (!history.completeUndoAction(action, redoAction)) return;
-      viewPort.incrementDiscardCounters(getReviewActionAffectedPaths(action, files));
+      if (diskSnapshots.length === 0) {
+        viewPort.incrementDiscardCounters(getReviewActionAffectedPaths(action, files));
+      }
     } catch (error) {
       if (!isCurrentOperationScope(operationScope)) return;
       statePort.reportError(

--- a/src/features/change-review/renderer/hooks/useChangeReviewHistoryMutationController.ts
+++ b/src/features/change-review/renderer/hooks/useChangeReviewHistoryMutationController.ts
@@ -1,0 +1,585 @@
+import { useCallback } from 'react';
+
+import {
+  buildRedoDiskMutationSteps,
+  buildReviewHistoryRestoreDiskImpact,
+  buildReviewHistoryRestoreDiskSteps,
+  buildReviewHistoryRestorePlan,
+  buildReviewUndoDecisionState,
+  buildUndoDiskMutationSteps,
+  getReviewActionDiskSnapshots,
+} from '@features/review-mutations';
+
+import {
+  classifyReviewHistoryRecovery,
+  createReviewRedoAction,
+  getReviewActionAffectedPaths,
+  getReviewDiskMutationExpectedContent,
+  resolveReviewFile,
+} from '../utils/changeReviewHistoryMutation';
+
+import { CHANGE_REVIEW_PERSISTENCE_ERROR } from './useChangeReviewDecisionPersistenceController';
+
+import type {
+  ChangeReviewHistoryMutationCommandPort,
+  ChangeReviewHistoryMutationScope,
+  ChangeReviewHistoryMutationStatePort,
+  ChangeReviewHistoryMutationViewPort,
+  ChangeReviewHistoryPersistenceScope,
+} from '../ports/changeReviewHistoryMutationPorts';
+import type { ReviewActionPersistenceStatus } from '../utils/changeReviewActionHistory';
+import type { ReviewOperationScopeToken } from '../utils/reviewOperationGeneration';
+import type { ChangeReviewActionHistoryController } from './useChangeReviewActionHistoryController';
+import type {
+  FileChangeSummary,
+  RetryReviewMutationRecoveryResult,
+  ReviewDecisionPersistenceScope,
+  ReviewDiskUndoSnapshot,
+  ReviewHistoryRestoreTarget,
+  ReviewPersistedStateSnapshot,
+  ReviewUndoAction,
+} from '@shared/types';
+
+type ActionHistory = Pick<
+  ChangeReviewActionHistoryController,
+  | 'getUndoHistory'
+  | 'getRedoHistory'
+  | 'getLatestUndoAction'
+  | 'getLatestRedoAction'
+  | 'completeUndoAction'
+  | 'completeRedoAction'
+  | 'replaceHistories'
+>;
+
+interface UseChangeReviewHistoryMutationControllerInput {
+  teamName: string;
+  memberName: string | undefined;
+  files: readonly FileChangeSummary[];
+  editedCount: number;
+  decisionHydrationReady: boolean;
+  scope: ChangeReviewHistoryMutationScope | null;
+  history: ActionHistory;
+  commandPort: ChangeReviewHistoryMutationCommandPort;
+  statePort: ChangeReviewHistoryMutationStatePort;
+  viewPort: ChangeReviewHistoryMutationViewPort;
+  captureOperationScope: () => ReviewOperationScopeToken | null;
+  isCurrentOperationScope: (scope: ReviewOperationScopeToken | null) => boolean;
+  hasActionInFlight: () => boolean;
+  isFileMutationInFlight: (filePath: string) => boolean;
+  blockForExternalChange: () => boolean;
+  getPersistenceStatus: () => ReviewActionPersistenceStatus;
+}
+
+export interface ChangeReviewHistoryRestorePreview {
+  direction: 'undo' | 'redo';
+  actions: ReviewUndoAction[];
+  diskTransitions: ReturnType<typeof buildReviewHistoryRestoreDiskImpact>;
+}
+
+export interface ChangeReviewHistoryMutationController {
+  undoLatest: () => Promise<void>;
+  redoLatest: () => Promise<void>;
+  getRestorePreview: (target: ReviewHistoryRestoreTarget) => ChangeReviewHistoryRestorePreview;
+  restoreHistory: (target: ReviewHistoryRestoreTarget) => Promise<void>;
+  recoverFailedHistory: (target: ReviewHistoryRestoreTarget) => Promise<void>;
+}
+
+function getRestoreDirection(direction: 'undo' | 'redo' | 'none'): 'undo' | 'redo' {
+  if (direction === 'none') throw new Error('Review history restore plan is inconsistent.');
+  return direction;
+}
+
+function toDecisionPersistenceScope(
+  scope: ChangeReviewHistoryPersistenceScope
+): ReviewDecisionPersistenceScope {
+  return { scopeKey: scope.scopeKey, scopeToken: scope.scopeToken };
+}
+
+export function useChangeReviewHistoryMutationController({
+  teamName,
+  memberName,
+  files,
+  editedCount,
+  decisionHydrationReady,
+  scope,
+  history,
+  commandPort,
+  statePort,
+  viewPort,
+  captureOperationScope,
+  isCurrentOperationScope,
+  hasActionInFlight,
+  isFileMutationInFlight,
+  blockForExternalChange,
+  getPersistenceStatus,
+}: UseChangeReviewHistoryMutationControllerInput): ChangeReviewHistoryMutationController {
+  const executeWithPreparedExpectations = useCallback(
+    async <T>(
+      snapshots: readonly ReviewDiskUndoSnapshot[],
+      direction: 'undo' | 'redo',
+      execute: () => Promise<T>
+    ): Promise<T> => {
+      for (const snapshot of snapshots) {
+        viewPort.markExpectedWrite(
+          snapshot.filePath,
+          getReviewDiskMutationExpectedContent(snapshot, direction)
+        );
+      }
+      return execute();
+    },
+    [viewPort]
+  );
+
+  const refreshAfterUndo = useCallback(
+    (snapshots: readonly ReviewDiskUndoSnapshot[]): void => {
+      for (const snapshot of snapshots) {
+        const restoreMode =
+          snapshot.restoreMode ??
+          (snapshot.renameExpectation ? 'restore-rejected-rename' : 'content');
+        if (snapshot.afterContent === null && snapshot.file && restoreMode !== 'create-file') {
+          viewPort.addMissingFile(snapshot.file, snapshot.fileIndex, snapshot.beforeContent);
+        }
+        statePort.clearExternalChange(snapshot.filePath);
+        statePort.invalidateResolvedFileContent(snapshot.filePath);
+        viewPort.fetchFileContent(teamName, memberName, snapshot.filePath);
+      }
+      viewPort.incrementDiscardCounters(snapshots.map((snapshot) => snapshot.filePath));
+    },
+    [memberName, statePort, teamName, viewPort]
+  );
+
+  const refreshAfterRedo = useCallback(
+    (action: ReviewUndoAction): void => {
+      const snapshots = getReviewActionDiskSnapshots(action);
+      for (const snapshot of snapshots) {
+        statePort.clearExternalChange(snapshot.filePath);
+        statePort.invalidateResolvedFileContent(snapshot.filePath);
+        viewPort.fetchFileContent(teamName, memberName, snapshot.filePath);
+      }
+      viewPort.incrementDiscardCounters(getReviewActionAffectedPaths(action, files));
+    },
+    [files, memberName, statePort, teamName, viewPort]
+  );
+
+  const applyCommittedState = useCallback(
+    (
+      persistedState: ReviewPersistedStateSnapshot,
+      decisionRevision: number,
+      applyError: string | null
+    ): void => {
+      if (!scope) throw new Error('Durable review history scope is unavailable.');
+      statePort.recordDecisionRevision(scope.persistence, decisionRevision);
+      history.replaceHistories(
+        persistedState.reviewActionHistory,
+        persistedState.reviewRedoHistory
+      );
+      statePort.applyPersistedState(persistedState, applyError);
+    },
+    [history, scope, statePort]
+  );
+
+  const applyRestoredHistory = useCallback(
+    (
+      persistedState: ReviewPersistedStateSnapshot,
+      decisionRevision: number,
+      direction: 'undo' | 'redo',
+      diskSnapshots: readonly ReviewDiskUndoSnapshot[],
+      orderedActions: readonly ReviewUndoAction[],
+      target: ReviewHistoryRestoreTarget
+    ): void => {
+      applyCommittedState(persistedState, decisionRevision, null);
+      if (direction === 'undo' && diskSnapshots.length > 0) refreshAfterUndo(diskSnapshots);
+      if (direction === 'redo') {
+        for (const action of orderedActions) refreshAfterRedo(action);
+      }
+      viewPort.incrementDiscardCounters(
+        orderedActions.flatMap((action) => getReviewActionAffectedPaths(action, files))
+      );
+      if (target.kind !== 'after-action') return;
+      const targetAction =
+        persistedState.reviewActionHistory.find((action) => action.id === target.actionId) ??
+        persistedState.reviewRedoHistory.find((entry) => entry.action.id === target.actionId)
+          ?.action;
+      if (targetAction) viewPort.navigateToAction(targetAction);
+    },
+    [applyCommittedState, files, refreshAfterRedo, refreshAfterUndo, viewPort]
+  );
+
+  const synchronizeRecoveredState = useCallback(
+    (
+      persistedState: ReviewPersistedStateSnapshot,
+      decisionRevision: number,
+      message: string
+    ): void => {
+      applyCommittedState(persistedState, decisionRevision, message);
+      const affectedPaths = files.map((file) => file.filePath);
+      for (const filePath of affectedPaths) {
+        statePort.clearExternalChange(filePath);
+        statePort.invalidateResolvedFileContent(filePath);
+        viewPort.fetchFileContent(teamName, memberName, filePath);
+      }
+      viewPort.incrementDiscardCounters(affectedPaths);
+    },
+    [applyCommittedState, files, memberName, statePort, teamName, viewPort]
+  );
+
+  const buildCurrentRestorePlan = useCallback(
+    (target: ReviewHistoryRestoreTarget) => {
+      const state = statePort.getSnapshot();
+      const plan = buildReviewHistoryRestorePlan(
+        {
+          hunkDecisions: state.hunkDecisions,
+          fileDecisions: state.fileDecisions,
+          hunkContextHashesByFile: state.hunkContextHashesByFile,
+          reviewActionHistory: history.getUndoHistory(),
+          reviewRedoHistory: history.getRedoHistory(),
+        },
+        target,
+        (filePath) => resolveReviewFile(files, filePath)
+      );
+      return { state, plan };
+    },
+    [files, history, statePort]
+  );
+
+  const getRestorePreview = useCallback(
+    (target: ReviewHistoryRestoreTarget): ChangeReviewHistoryRestorePreview => {
+      const { plan } = buildCurrentRestorePlan(target);
+      if (plan.direction === 'none') throw new Error('This review checkpoint is already current.');
+      const direction = getRestoreDirection(plan.direction);
+      return {
+        direction,
+        actions: plan.orderedActions,
+        diskTransitions: buildReviewHistoryRestoreDiskImpact(
+          plan.orderedActions.map((action) => ({ direction, action }))
+        ),
+      };
+    },
+    [buildCurrentRestorePlan]
+  );
+
+  const undoLatest = useCallback(async (): Promise<void> => {
+    if (hasActionInFlight() || editedCount > 0 || blockForExternalChange()) return;
+    const action = history.getLatestUndoAction();
+    if (!action) return;
+    if (!scope) {
+      statePort.reportError('Durable review scope is unavailable; refusing an unsafe Undo.');
+      return;
+    }
+    if (action.kind === 'disk' && isFileMutationInFlight(action.action.snapshot.filePath)) return;
+    const operationScope = captureOperationScope();
+    if (!operationScope) return;
+    const state = statePort.getSnapshot();
+    const decisionState = buildReviewUndoDecisionState(action, state, (filePath) =>
+      resolveReviewFile(files, filePath)
+    );
+    if (!decisionState) {
+      statePort.reportError('Reviewed file is unavailable for Undo.');
+      return;
+    }
+
+    viewPort.setMutationInFlight(true);
+    try {
+      const quiesced = await statePort.quiesceDecisionPersistence(scope.persistence);
+      if (!isCurrentOperationScope(operationScope)) return;
+      if (!quiesced)
+        throw new Error('Unable to finish saving the previous review state. Retry Undo.');
+      const current = statePort.getSnapshot();
+      const redoAction = createReviewRedoAction(action, current);
+      const redoHistory = [...history.getRedoHistory(), redoAction];
+      const diskSnapshots = getReviewActionDiskSnapshots(action);
+      const committed = await executeWithPreparedExpectations(diskSnapshots, 'undo', () =>
+        commandPort.executeMutation({
+          scope: scope.review,
+          decisionPersistenceScope: toDecisionPersistenceScope(scope.persistence),
+          kind: 'undo',
+          diskSteps: buildUndoDiskMutationSteps(action.id, diskSnapshots),
+          persistedState: {
+            hunkDecisions: decisionState.hunkDecisions,
+            fileDecisions: decisionState.fileDecisions,
+            hunkContextHashesByFile: current.hunkContextHashesByFile,
+            reviewActionHistory: history.getUndoHistory().slice(0, -1),
+            reviewRedoHistory: redoHistory,
+          },
+          expectedTopActionId: action.id,
+          expectedDecisionRevision: current.decisionRevision,
+        })
+      );
+      if (!isCurrentOperationScope(operationScope)) return;
+      viewPort.markCommittedPostimages(committed.diskPostimages);
+      statePort.recordDecisionRevision(scope.persistence, committed.decisionRevision);
+      statePort.applyDecisionState(decisionState);
+      if (diskSnapshots.length > 0) refreshAfterUndo(diskSnapshots);
+      if (!history.completeUndoAction(action, redoAction)) return;
+      viewPort.incrementDiscardCounters(getReviewActionAffectedPaths(action, files));
+    } catch (error) {
+      if (!isCurrentOperationScope(operationScope)) return;
+      statePort.reportError(
+        error instanceof Error ? error.message : 'Unable to undo because the file changed on disk.'
+      );
+    } finally {
+      if (isCurrentOperationScope(operationScope)) viewPort.setMutationInFlight(false);
+    }
+  }, [
+    blockForExternalChange,
+    captureOperationScope,
+    commandPort,
+    editedCount,
+    executeWithPreparedExpectations,
+    files,
+    hasActionInFlight,
+    history,
+    isCurrentOperationScope,
+    isFileMutationInFlight,
+    refreshAfterUndo,
+    scope,
+    statePort,
+    viewPort,
+  ]);
+
+  const redoLatest = useCallback(async (): Promise<void> => {
+    if (hasActionInFlight() || editedCount > 0 || blockForExternalChange()) return;
+    const redoAction = history.getLatestRedoAction();
+    if (!redoAction || !scope) return;
+    const operationScope = captureOperationScope();
+    if (!operationScope) return;
+    viewPort.setMutationInFlight(true);
+    try {
+      const quiesced = await statePort.quiesceDecisionPersistence(scope.persistence);
+      if (!isCurrentOperationScope(operationScope)) return;
+      if (!quiesced)
+        throw new Error('Unable to finish saving the previous review state. Retry Redo.');
+      const state = statePort.getSnapshot();
+      const action = redoAction.action;
+      const diskSnapshots = getReviewActionDiskSnapshots(action);
+      const committed = await executeWithPreparedExpectations(diskSnapshots, 'redo', () =>
+        commandPort.executeMutation({
+          scope: scope.review,
+          decisionPersistenceScope: toDecisionPersistenceScope(scope.persistence),
+          kind: 'redo',
+          diskSteps: buildRedoDiskMutationSteps(action.id, diskSnapshots),
+          persistedState: {
+            hunkDecisions: redoAction.decisionSnapshot.hunkDecisions,
+            fileDecisions: redoAction.decisionSnapshot.fileDecisions,
+            hunkContextHashesByFile:
+              redoAction.hunkContextHashesByFile ?? state.hunkContextHashesByFile,
+            reviewActionHistory: [...history.getUndoHistory(), action],
+            reviewRedoHistory: history.getRedoHistory().slice(0, -1),
+          },
+          expectedTopRedoActionId: action.id,
+          expectedDecisionRevision: state.decisionRevision,
+        })
+      );
+      if (!isCurrentOperationScope(operationScope)) return;
+      viewPort.markCommittedPostimages(committed.diskPostimages);
+      statePort.recordDecisionRevision(scope.persistence, committed.decisionRevision);
+      statePort.applyDecisionState({
+        hunkDecisions: { ...redoAction.decisionSnapshot.hunkDecisions },
+        fileDecisions: { ...redoAction.decisionSnapshot.fileDecisions },
+        hunkContextHashesByFile:
+          redoAction.hunkContextHashesByFile ?? state.hunkContextHashesByFile,
+      });
+      refreshAfterRedo(action);
+      history.completeRedoAction(redoAction);
+    } catch (error) {
+      if (!isCurrentOperationScope(operationScope)) return;
+      statePort.reportError(
+        error instanceof Error ? error.message : 'Unable to redo because the file changed on disk.'
+      );
+    } finally {
+      if (isCurrentOperationScope(operationScope)) viewPort.setMutationInFlight(false);
+    }
+  }, [
+    blockForExternalChange,
+    captureOperationScope,
+    commandPort,
+    editedCount,
+    executeWithPreparedExpectations,
+    hasActionInFlight,
+    history,
+    isCurrentOperationScope,
+    refreshAfterRedo,
+    scope,
+    statePort,
+    viewPort,
+  ]);
+
+  const restoreHistory = useCallback(
+    async (target: ReviewHistoryRestoreTarget): Promise<void> => {
+      if (hasActionInFlight()) throw new Error('Another review action is still running.');
+      if (editedCount > 0)
+        throw new Error('Save or discard manual edits before restoring review history.');
+      if (blockForExternalChange()) {
+        throw new Error('Reload files changed outside Changes before restoring review history.');
+      }
+      if (!scope || !decisionHydrationReady)
+        throw new Error('Durable review history is not ready yet.');
+      if (getPersistenceStatus() !== 'saved') throw new Error(CHANGE_REVIEW_PERSISTENCE_ERROR);
+      const operationScope = captureOperationScope();
+      if (!operationScope) throw new Error('Durable review history scope is no longer active.');
+      const { state, plan } = buildCurrentRestorePlan(target);
+      if (plan.actionCount === 0) return;
+      const direction = getRestoreDirection(plan.direction);
+      const diskSnapshots = plan.orderedActions.flatMap(getReviewActionDiskSnapshots);
+      viewPort.setMutationInFlight(true);
+      try {
+        const quiesced = await statePort.quiesceDecisionPersistence(scope.persistence);
+        if (!isCurrentOperationScope(operationScope)) return;
+        if (!quiesced)
+          throw new Error('Unable to finish saving the previous review state. Retry Restore.');
+        const committed = await executeWithPreparedExpectations(diskSnapshots, direction, () =>
+          commandPort.restoreHistory({
+            scope: scope.review,
+            decisionPersistenceScope: toDecisionPersistenceScope(scope.persistence),
+            target,
+            expectedDecisionRevision: state.decisionRevision,
+          })
+        );
+        if (!isCurrentOperationScope(operationScope)) return;
+        viewPort.markCommittedPostimages(committed.diskPostimages);
+        applyRestoredHistory(
+          committed.persistedState,
+          committed.decisionRevision,
+          direction,
+          diskSnapshots,
+          plan.orderedActions,
+          target
+        );
+      } catch (error) {
+        if (!isCurrentOperationScope(operationScope)) return;
+        const message =
+          error instanceof Error ? error.message : 'Unable to restore the selected review history.';
+        statePort.reportError(message);
+        throw error instanceof Error ? error : new Error(message);
+      } finally {
+        if (isCurrentOperationScope(operationScope)) viewPort.setMutationInFlight(false);
+      }
+    },
+    [
+      applyRestoredHistory,
+      blockForExternalChange,
+      buildCurrentRestorePlan,
+      captureOperationScope,
+      commandPort,
+      decisionHydrationReady,
+      editedCount,
+      executeWithPreparedExpectations,
+      getPersistenceStatus,
+      hasActionInFlight,
+      isCurrentOperationScope,
+      scope,
+      statePort,
+      viewPort,
+    ]
+  );
+
+  const recoverFailedHistory = useCallback(
+    async (target: ReviewHistoryRestoreTarget): Promise<void> => {
+      if (!scope || !decisionHydrationReady) {
+        throw new Error('Durable review history is not ready for recovery.');
+      }
+      const operationScope = captureOperationScope();
+      if (!operationScope) throw new Error('Durable review history scope is no longer active.');
+      const currentRevision = statePort.getSnapshot().decisionRevision;
+      const { plan } = buildCurrentRestorePlan(target);
+      const direction = plan.direction;
+      const diskSteps =
+        direction === 'undo' || direction === 'redo'
+          ? buildReviewHistoryRestoreDiskSteps(
+              plan.orderedActions.map((action) => ({ direction, action }))
+            )
+          : [];
+      const diskSnapshots = plan.orderedActions.flatMap(getReviewActionDiskSnapshots);
+      const retryRecovery = (): Promise<RetryReviewMutationRecoveryResult> =>
+        commandPort.retryRecovery({
+          scope: scope.review,
+          decisionPersistenceScope: toDecisionPersistenceScope(scope.persistence),
+          expectedRestore: {
+            expectedDecisionRevision: currentRevision,
+            persistedState: plan.persistedState,
+            diskSteps,
+          },
+        });
+      let retryOriginalRestore = false;
+      viewPort.setMutationInFlight(true);
+      try {
+        const recovered =
+          direction === 'undo' || direction === 'redo'
+            ? await executeWithPreparedExpectations(diskSnapshots, direction, retryRecovery)
+            : await retryRecovery();
+        if (!isCurrentOperationScope(operationScope)) return;
+        const disposition = classifyReviewHistoryRecovery(
+          recovered,
+          currentRevision,
+          plan.persistedState
+        );
+        if (disposition === 'retry-restore') {
+          for (const snapshot of diskSnapshots) viewPort.clearExpectedWrite(snapshot.filePath);
+          retryOriginalRestore = true;
+        } else if (disposition === 'different-mutation-pending') {
+          for (const snapshot of diskSnapshots) viewPort.clearExpectedWrite(snapshot.filePath);
+          throw new Error(
+            'A different interrupted review update must be recovered first. Close Restore and retry the saved review state.'
+          );
+        } else if (disposition === 'apply-selected-restore') {
+          if (!recovered.persistedState) {
+            throw new Error('Recovered checkpoint state is unavailable. Reload Changes.');
+          }
+          if (direction !== 'undo' && direction !== 'redo') {
+            throw new Error('Recovered review history no longer matches this checkpoint.');
+          }
+          viewPort.markCommittedPostimages(recovered.diskPostimages);
+          applyRestoredHistory(
+            recovered.persistedState,
+            recovered.decisionRevision,
+            direction,
+            diskSnapshots,
+            plan.orderedActions,
+            target
+          );
+        } else {
+          if (!recovered.persistedState) {
+            throw new Error(
+              'Recovered review state is unavailable. Reload Changes before retrying.'
+            );
+          }
+          for (const snapshot of diskSnapshots) viewPort.clearExpectedWrite(snapshot.filePath);
+          synchronizeRecoveredState(
+            recovered.persistedState,
+            recovered.decisionRevision,
+            recovered.recoveredMutation
+              ? 'A different interrupted review action was recovered. Latest durable state was loaded; select the checkpoint again.'
+              : 'Review history changed while Restore was finishing. Latest durable state was loaded; verify it before continuing.'
+          );
+        }
+      } catch (error) {
+        if (!isCurrentOperationScope(operationScope)) return;
+        const message =
+          error instanceof Error ? error.message : 'Unable to recover the interrupted Restore.';
+        statePort.reportError(message);
+        throw error instanceof Error ? error : new Error(message);
+      } finally {
+        if (isCurrentOperationScope(operationScope)) viewPort.setMutationInFlight(false);
+      }
+      if (retryOriginalRestore && isCurrentOperationScope(operationScope)) {
+        await restoreHistory(target);
+      }
+    },
+    [
+      applyRestoredHistory,
+      buildCurrentRestorePlan,
+      captureOperationScope,
+      commandPort,
+      decisionHydrationReady,
+      executeWithPreparedExpectations,
+      isCurrentOperationScope,
+      restoreHistory,
+      scope,
+      statePort,
+      synchronizeRecoveredState,
+      viewPort,
+    ]
+  );
+
+  return { undoLatest, redoLatest, getRestorePreview, restoreHistory, recoverFailedHistory };
+}

--- a/src/features/change-review/renderer/index.ts
+++ b/src/features/change-review/renderer/index.ts
@@ -9,6 +9,10 @@ export {
 export type { ChangeReviewConflictStateBridge } from './adapters/createChangeReviewConflictStateBridge';
 export { createChangeReviewConflictStateBridge } from './adapters/createChangeReviewConflictStateBridge';
 export { createChangeReviewDraftHistoryPort } from './adapters/createChangeReviewDraftHistoryPort';
+export {
+  createChangeReviewHistoryMutationCommandPort,
+  createChangeReviewHistoryMutationStatePort,
+} from './adapters/createChangeReviewHistoryMutationPorts';
 export type { ChangeReviewActionHistoryController } from './hooks/useChangeReviewActionHistoryController';
 export { useChangeReviewActionHistoryController } from './hooks/useChangeReviewActionHistoryController';
 export type { ChangeReviewConflictDiscoveryController } from './hooks/useChangeReviewConflictDiscoveryController';
@@ -32,6 +36,11 @@ export type {
 export { useChangeReviewDraftHistoryController } from './hooks/useChangeReviewDraftHistoryController';
 export type { ChangeReviewKeyboardEditorContext } from './hooks/useChangeReviewHistoryKeyboardShortcuts';
 export { useChangeReviewHistoryKeyboardShortcuts } from './hooks/useChangeReviewHistoryKeyboardShortcuts';
+export type {
+  ChangeReviewHistoryMutationController,
+  ChangeReviewHistoryRestorePreview,
+} from './hooks/useChangeReviewHistoryMutationController';
+export { useChangeReviewHistoryMutationController } from './hooks/useChangeReviewHistoryMutationController';
 export { useChangeReviewLifecycleRegistration } from './hooks/useChangeReviewLifecycleRegistration';
 export { useChangeReviewOperationGeneration } from './hooks/useChangeReviewOperationGeneration';
 export { useChangeReviewScopeIdentity } from './hooks/useChangeReviewScopeIdentity';
@@ -52,6 +61,14 @@ export type {
   ChangeReviewDraftHistoryScope,
   ChangeReviewDraftHistoryVersion,
 } from './ports/changeReviewDraftHistoryPort';
+export type {
+  ChangeReviewHistoryMutationCommandPort,
+  ChangeReviewHistoryMutationScope,
+  ChangeReviewHistoryMutationStatePort,
+  ChangeReviewHistoryMutationViewPort,
+  ChangeReviewHistoryPersistenceScope,
+  ChangeReviewHistoryStateSnapshot,
+} from './ports/changeReviewHistoryMutationPorts';
 export type {
   RegisterChangeReviewAppCloseParticipant,
   RegisterChangeReviewLifecycleOwner,
@@ -81,6 +98,15 @@ export {
   describeReviewConflictDiscard,
   selectLatestReviewConflictCandidate,
 } from './utils/changeReviewConflicts';
+export type { ReviewHistoryRecoveryDisposition } from './utils/changeReviewHistoryMutation';
+export {
+  areReviewPersistedStatesEqual,
+  classifyReviewHistoryRecovery,
+  createReviewRedoAction,
+  getReviewActionAffectedPaths,
+  getReviewDiskMutationExpectedContent,
+  resolveReviewFile,
+} from './utils/changeReviewHistoryMutation';
 export type {
   BuildChangeReviewScopeProjectionInput,
   ChangeReviewScopeProjection,

--- a/src/features/change-review/renderer/ports/changeReviewActionHistoryPorts.ts
+++ b/src/features/change-review/renderer/ports/changeReviewActionHistoryPorts.ts
@@ -1,4 +1,10 @@
-import type { ReviewRedoAction, ReviewUndoAction } from '@shared/types';
+import type { ReviewDecisionHydrationStatus } from '../utils/changeReviewScope';
+import type {
+  FileChangeWithContent,
+  HunkDecision,
+  ReviewRedoAction,
+  ReviewUndoAction,
+} from '@shared/types';
 
 export interface ChangeReviewActionHistoryStorePort {
   publishUndoHistory(history: ReviewUndoAction[]): void;
@@ -13,14 +19,14 @@ export interface ChangeReviewDecisionPersistenceScope {
 }
 
 export interface ChangeReviewDecisionPersistenceSnapshot {
-  hunkDecisions: object;
-  fileDecisions: object;
-  reviewActionHistory: object;
-  reviewRedoHistory: object;
-  fileContents: object;
-  fileChunkCounts: object;
+  hunkDecisions: Record<string, HunkDecision>;
+  fileDecisions: Record<string, HunkDecision>;
+  reviewActionHistory: ReviewUndoAction[];
+  reviewRedoHistory: ReviewRedoAction[];
+  fileContents: Record<string, FileChangeWithContent>;
+  fileChunkCounts: Record<string, number>;
   decisionHydrationScopeKey: string | null;
-  decisionHydrationStatus: 'idle' | 'loading' | 'loaded' | 'error';
+  decisionHydrationStatus: ReviewDecisionHydrationStatus;
   applyError: string | null;
 }
 

--- a/src/features/change-review/renderer/ports/changeReviewHistoryMutationPorts.ts
+++ b/src/features/change-review/renderer/ports/changeReviewHistoryMutationPorts.ts
@@ -1,0 +1,65 @@
+import type {
+  ExecuteReviewMutationRequest,
+  ExecuteReviewMutationResult,
+  FileChangeSummary,
+  HunkDecision,
+  RestoreReviewHistoryRequest,
+  RestoreReviewHistoryResult,
+  RetryReviewMutationRecoveryRequest,
+  RetryReviewMutationRecoveryResult,
+  ReviewDecisionPersistenceScope,
+  ReviewFileScope,
+  ReviewMutationDiskPostimage,
+  ReviewPersistedStateSnapshot,
+  ReviewUndoAction,
+} from '@shared/types';
+
+export interface ChangeReviewHistoryStateSnapshot {
+  hunkDecisions: Record<string, HunkDecision>;
+  fileDecisions: Record<string, HunkDecision>;
+  hunkContextHashesByFile: Record<string, Record<number, string>>;
+  decisionRevision: number;
+}
+
+export interface ChangeReviewHistoryMutationCommandPort {
+  executeMutation(request: ExecuteReviewMutationRequest): Promise<ExecuteReviewMutationResult>;
+  restoreHistory(request: RestoreReviewHistoryRequest): Promise<RestoreReviewHistoryResult>;
+  retryRecovery(
+    request: RetryReviewMutationRecoveryRequest
+  ): Promise<RetryReviewMutationRecoveryResult>;
+}
+
+export interface ChangeReviewHistoryMutationStatePort {
+  getSnapshot(): ChangeReviewHistoryStateSnapshot;
+  quiesceDecisionPersistence(scope: ChangeReviewHistoryPersistenceScope): Promise<boolean>;
+  recordDecisionRevision(scope: ChangeReviewHistoryPersistenceScope, revision: number): void;
+  applyDecisionState(state: {
+    hunkDecisions: Record<string, HunkDecision>;
+    fileDecisions: Record<string, HunkDecision>;
+    hunkContextHashesByFile?: Record<string, Record<number, string>>;
+  }): void;
+  applyPersistedState(state: ReviewPersistedStateSnapshot, applyError: string | null): void;
+  reportError(message: string): void;
+  clearExternalChange(filePath: string): void;
+  invalidateResolvedFileContent(filePath: string): void;
+}
+
+export interface ChangeReviewHistoryPersistenceScope extends ReviewDecisionPersistenceScope {
+  teamName: string;
+}
+
+export interface ChangeReviewHistoryMutationViewPort {
+  addMissingFile(file: FileChangeSummary, index: number | undefined, content: string): void;
+  fetchFileContent(teamName: string, memberName: string | undefined, filePath: string): void;
+  incrementDiscardCounters(filePaths: readonly string[]): void;
+  navigateToAction(action: ReviewUndoAction): void;
+  markExpectedWrite(filePath: string, expectedContent: string | null): void;
+  clearExpectedWrite(filePath: string): void;
+  markCommittedPostimages(postimages: readonly ReviewMutationDiskPostimage[] | undefined): void;
+  setMutationInFlight(value: boolean): void;
+}
+
+export interface ChangeReviewHistoryMutationScope {
+  review: ReviewFileScope;
+  persistence: ChangeReviewHistoryPersistenceScope;
+}

--- a/src/features/change-review/renderer/utils/changeReviewActionHistory.ts
+++ b/src/features/change-review/renderer/utils/changeReviewActionHistory.ts
@@ -25,11 +25,7 @@ export function createReviewUndoAction(input: ReviewUndoActionInput): ReviewUndo
   } as ReviewUndoAction;
 }
 
-export function appendOrderedReviewAction<T>(
-  stack: readonly T[],
-  action: T,
-  _legacyMaxDepth?: number
-): T[] {
+export function appendOrderedReviewAction<T>(stack: readonly T[], action: T): T[] {
   return [...stack, action];
 }
 

--- a/src/features/change-review/renderer/utils/changeReviewHistoryMutation.ts
+++ b/src/features/change-review/renderer/utils/changeReviewHistoryMutation.ts
@@ -1,0 +1,109 @@
+import { normalizePathForComparison } from '@shared/utils/platformPath';
+
+import type {
+  FileChangeSummary,
+  HunkDecision,
+  RetryReviewMutationRecoveryResult,
+  ReviewDiskUndoSnapshot,
+  ReviewPersistedStateSnapshot,
+  ReviewRedoAction,
+  ReviewUndoAction,
+} from '@shared/types';
+
+function toCanonicalReviewValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(toCanonicalReviewValue);
+  if (!value || typeof value !== 'object') return value;
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([, entry]) => entry !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => [key, toCanonicalReviewValue(entry)])
+  );
+}
+
+export function areReviewPersistedStatesEqual(
+  left: ReviewPersistedStateSnapshot,
+  right: ReviewPersistedStateSnapshot
+): boolean {
+  return (
+    JSON.stringify(toCanonicalReviewValue(left)) === JSON.stringify(toCanonicalReviewValue(right))
+  );
+}
+
+export type ReviewHistoryRecoveryDisposition =
+  | 'retry-restore'
+  | 'apply-selected-restore'
+  | 'different-mutation-pending'
+  | 'synchronize-latest';
+
+export function classifyReviewHistoryRecovery(
+  recovery: RetryReviewMutationRecoveryResult,
+  currentRevision: number,
+  plannedState: ReviewPersistedStateSnapshot
+): ReviewHistoryRecoveryDisposition {
+  if (recovery.differentMutationPending) return 'different-mutation-pending';
+  if (!recovery.recoveredMutation && recovery.decisionRevision === currentRevision) {
+    return 'retry-restore';
+  }
+  if (
+    recovery.expectedRestoreCompleted &&
+    recovery.persistedState &&
+    areReviewPersistedStatesEqual(recovery.persistedState, plannedState)
+  ) {
+    return 'apply-selected-restore';
+  }
+  return 'synchronize-latest';
+}
+
+export function createReviewRedoAction(
+  action: ReviewUndoAction,
+  state: {
+    hunkDecisions: Record<string, HunkDecision>;
+    fileDecisions: Record<string, HunkDecision>;
+    hunkContextHashesByFile: Record<string, Record<number, string>>;
+  }
+): ReviewRedoAction {
+  return {
+    action: structuredClone(action),
+    decisionSnapshot: {
+      hunkDecisions: { ...state.hunkDecisions },
+      fileDecisions: { ...state.fileDecisions },
+    },
+    hunkContextHashesByFile: structuredClone(state.hunkContextHashesByFile),
+  };
+}
+
+export function getReviewDiskMutationExpectedContent(
+  snapshot: ReviewDiskUndoSnapshot,
+  direction: 'undo' | 'redo'
+): string | null {
+  const restoreMode =
+    snapshot.restoreMode ?? (snapshot.renameExpectation ? 'restore-rejected-rename' : 'content');
+  if (direction === 'undo') {
+    return restoreMode === 'delete-file' || restoreMode === 'reapply-rejected-rename'
+      ? null
+      : snapshot.beforeContent;
+  }
+  return restoreMode === 'create-file' || restoreMode === 'restore-rejected-rename'
+    ? null
+    : snapshot.afterContent;
+}
+
+export function getReviewActionAffectedPaths(
+  action: ReviewUndoAction,
+  files: readonly FileChangeSummary[]
+): string[] {
+  if (action.kind === 'bulk') return files.map((file) => file.filePath);
+  return [action.kind === 'disk' ? action.action.snapshot.filePath : action.action.filePath];
+}
+
+export function resolveReviewFile(
+  files: readonly FileChangeSummary[],
+  filePath: string
+): FileChangeSummary | null {
+  const normalizedPath = normalizePathForComparison(filePath);
+  return (
+    files.find((candidate) => normalizePathForComparison(candidate.filePath) === normalizedPath) ??
+    null
+  );
+}

--- a/src/renderer/components/team/review/ChangeReviewDialog.tsx
+++ b/src/renderer/components/team/review/ChangeReviewDialog.tsx
@@ -17,7 +17,6 @@ import {
   buildReviewFileLabels,
   buildReviewStats,
   buildWatchedReviewFilePathsKey,
-  CHANGE_REVIEW_PERSISTENCE_ERROR,
   ChangeReviewConflictDiscardDialog,
   ChangeReviewConflictNotices,
   createChangeReviewActionHistoryStorePort,
@@ -26,6 +25,8 @@ import {
   createChangeReviewConflictStateBridge,
   createChangeReviewDecisionPersistencePort,
   createChangeReviewDraftHistoryPort,
+  createChangeReviewHistoryMutationCommandPort,
+  createChangeReviewHistoryMutationStatePort,
   findActiveReviewFile,
   isReviewActionPersistenceBlocking,
   resolveReviewFileLabel as resolveReviewFileLabelFromMap,
@@ -40,6 +41,7 @@ import {
   useChangeReviewDecisionPersistenceController,
   useChangeReviewDraftHistoryController,
   useChangeReviewHistoryKeyboardShortcuts,
+  useChangeReviewHistoryMutationController,
   useChangeReviewLifecycleRegistration,
   useChangeReviewOperationGeneration,
   useChangeReviewScopeIdentity,
@@ -64,7 +66,7 @@ import {
   registerChangeReviewLifecycleOwner,
 } from '@renderer/utils/changeReviewLifecycleCoordinator';
 import { buildSelectionInfo, SELECTION_DEBOUNCE_MS } from '@renderer/utils/codemirrorSelectionInfo';
-import { buildHunkDecisionKey, getFileReviewKey } from '@renderer/utils/reviewKey';
+import { getFileReviewKey } from '@renderer/utils/reviewKey';
 import { normalizePathForComparison } from '@shared/utils/platformPath';
 import { threeWayTextMerge } from '@shared/utils/threeWayTextMerge';
 import { ChevronDown, Clock, X } from 'lucide-react';
@@ -111,15 +113,6 @@ import { resolveReviewFilePath } from './reviewFilePathResolution';
 import { ReviewFileTree } from './ReviewFileTree';
 import {
   buildForwardDiskMutationSteps,
-  buildRedoDiskMutationSteps,
-  buildReviewHistoryRestoreDiskImpact,
-  buildReviewHistoryRestoreDiskSteps,
-  buildReviewHistoryRestorePlan,
-  buildUndoDiskMutationSteps,
-  classifyReviewHistoryRecovery,
-  createReviewRedoAction,
-  executeWithPreparedReviewWriteExpectations,
-  getReviewActionDiskSnapshots,
   markReviewMutationDiskPostimages,
 } from './reviewHistoryTimeline';
 import { ReviewToolbar } from './ReviewToolbar';
@@ -129,7 +122,10 @@ import { ViewedProgressBar } from './ViewedProgressBar';
 
 import type { ReviewDecisionRecords } from './reviewActionState';
 import type { EditorView } from '@codemirror/view';
-import type { ReviewDraftHistoryHydrationState } from '@features/change-review/renderer';
+import type {
+  ChangeReviewHistoryMutationViewPort,
+  ReviewDraftHistoryHydrationState,
+} from '@features/change-review/renderer';
 import type { TaskChangeRequestOptions } from '@renderer/utils/taskChangeRequest';
 import type {
   FileChangeSummary,
@@ -137,9 +133,7 @@ import type {
   ReviewDecisionSnapshot,
   ReviewDiskUndoAction,
   ReviewDiskUndoSnapshot,
-  ReviewHistoryRestoreTarget,
   ReviewMutationDiskPostimage,
-  ReviewPersistedStateSnapshot,
   ReviewRedoAction,
   ReviewRenameRecoveryExpectation,
   ReviewUndoAction,
@@ -172,6 +166,33 @@ const changeReviewActionHistoryStorePort = createChangeReviewActionHistoryStoreP
 const changeReviewDecisionPersistencePort = createChangeReviewDecisionPersistencePort({
   getStore: useStore.getState,
   setApplyError: (applyError) => useStore.setState({ applyError }),
+});
+const changeReviewHistoryMutationCommandPort = createChangeReviewHistoryMutationCommandPort(
+  () => api.review
+);
+const changeReviewHistoryMutationStatePort = createChangeReviewHistoryMutationStatePort({
+  getSnapshot: () => useStore.getState(),
+  quiesceDecisionPersistence: ({ teamName, scopeKey, scopeToken }) =>
+    useStore.getState().quiesceDecisionPersistence(teamName, scopeKey, scopeToken),
+  recordDecisionRevision: ({ teamName, scopeKey, scopeToken }, revision) =>
+    useStore.getState().recordDecisionRevision(teamName, scopeKey, scopeToken, revision),
+  applyDecisionState: ({ hunkDecisions, fileDecisions, hunkContextHashesByFile }) =>
+    useStore.setState({
+      hunkDecisions,
+      fileDecisions,
+      ...(hunkContextHashesByFile ? { hunkContextHashesByFile } : {}),
+    }),
+  applyPersistedState: (state, applyError) =>
+    useStore.setState({
+      hunkDecisions: state.hunkDecisions,
+      fileDecisions: state.fileDecisions,
+      hunkContextHashesByFile: state.hunkContextHashesByFile ?? {},
+      applyError,
+    }),
+  reportError: (applyError) => useStore.setState({ applyError }),
+  clearExternalChange: (filePath) => useStore.getState().clearReviewFileExternalChange(filePath),
+  invalidateResolvedFileContent: (filePath) =>
+    useStore.getState().invalidateResolvedFileContent(filePath),
 });
 
 function alignDiskUndoSnapshotWithAppliedContent(
@@ -488,7 +509,9 @@ export const ChangeReviewDialog = ({
     reportLoadError: changeReviewConflictStateBridge.reportError,
     port: changeReviewConflictQueryPort,
   });
-  refreshReviewConflictCandidatesRef.current = refreshReviewConflictCandidates;
+  useLayoutEffect(() => {
+    refreshReviewConflictCandidatesRef.current = refreshReviewConflictCandidates;
+  }, [refreshReviewConflictCandidates]);
   const commitHydratedDrafts = useCallback(
     ({
       scopeFilePaths,
@@ -2453,690 +2476,112 @@ export const ChangeReviewDialog = ({
     ]
   );
 
-  // Undo last bulk review operation (Accept All / Reject All)
-  const refreshAfterDurableUndo = useCallback(
-    (snapshots: readonly ReviewDiskUndoSnapshot[]): void => {
-      for (const snapshot of snapshots) {
-        const restoreMode =
-          snapshot.restoreMode ??
-          (snapshot.renameExpectation ? 'restore-rejected-rename' : 'content');
-        if (snapshot.afterContent === null && snapshot.file && restoreMode !== 'create-file') {
-          addReviewFile(snapshot.file, {
-            index: snapshot.fileIndex,
-            content: {
-              ...snapshot.file,
-              originalFullContent: '',
-              modifiedFullContent: snapshot.beforeContent,
-              isNewFile: true,
-              contentSource: 'disk-current',
-            },
-          });
-        }
-        clearReviewFileExternalChange(snapshot.filePath);
-        useStore.getState().invalidateResolvedFileContent(snapshot.filePath);
-        setDiscardCounters((previous) => ({
-          ...previous,
-          [snapshot.filePath]: (previous[snapshot.filePath] ?? 0) + 1,
-        }));
-        void fetchFileContent(teamName, memberName, snapshot.filePath);
-      }
-    },
-    [addReviewFile, clearReviewFileExternalChange, fetchFileContent, memberName, teamName]
-  );
-
-  const refreshAfterDurableRedo = useCallback(
-    (action: ReviewUndoAction): void => {
-      const snapshots = getReviewActionDiskSnapshots(action);
-      for (const snapshot of snapshots) {
-        clearReviewFileExternalChange(snapshot.filePath);
-        useStore.getState().invalidateResolvedFileContent(snapshot.filePath);
-        void fetchFileContent(teamName, memberName, snapshot.filePath);
-      }
-
-      const affectedPaths =
-        action.kind === 'bulk'
-          ? (activeChangeSet?.files.map((file) => file.filePath) ?? [])
-          : action.kind === 'disk'
-            ? [action.action.snapshot.filePath]
-            : [action.action.filePath];
-      setDiscardCounters((previous) => {
-        const next = { ...previous };
-        for (const filePath of affectedPaths) {
-          next[filePath] = (next[filePath] ?? 0) + 1;
-        }
-        return next;
-      });
-    },
-    [activeChangeSet, clearReviewFileExternalChange, fetchFileContent, memberName, teamName]
-  );
-
-  const commitUndoMutation = useCallback(
-    async (
-      action: ReviewUndoAction,
-      hunkDecisions: Record<string, HunkDecision>,
-      fileDecisions: Record<string, HunkDecision>
-    ): Promise<ReviewRedoAction | null> => {
-      if (!decisionScopeToken) {
-        useStore.setState({
-          applyError: 'Durable review scope is unavailable; refusing an unsafe Undo.',
-        });
-        return null;
-      }
-      const operationScope = captureReviewOperationScope();
-      if (!operationScope) return null;
-      setUndoInFlight(true);
-      try {
-        const quiesced = await quiesceDecisionPersistence(
-          teamName,
-          decisionScopeKey,
-          decisionScopeToken
-        );
-        if (!isCurrentReviewOperationScope(operationScope)) return null;
-        if (!quiesced) {
-          throw new Error('Unable to finish saving the previous review state. Retry Undo.');
-        }
-        const state = useStore.getState();
-        const redoAction = createReviewRedoAction(action, state);
-        const redoHistory = [...getReviewRedoHistory(), redoAction];
-        const diskSnapshots = getReviewActionDiskSnapshots(action);
-        const diskSteps = buildUndoDiskMutationSteps(action.id, diskSnapshots);
-        const committed = await executeWithPreparedReviewWriteExpectations(
-          diskSnapshots,
-          'undo',
-          markRecentReviewWrite,
-          () =>
-            api.review.executeMutation({
-              scope: reviewScope,
-              decisionPersistenceScope: {
-                scopeKey: decisionScopeKey,
-                scopeToken: decisionScopeToken,
-              },
-              kind: 'undo',
-              diskSteps,
-              persistedState: {
-                hunkDecisions,
-                fileDecisions,
-                hunkContextHashesByFile: state.hunkContextHashesByFile,
-                reviewActionHistory: getReviewUndoHistory().slice(0, -1),
-                reviewRedoHistory: redoHistory,
-              },
-              expectedTopActionId: action.id,
-              expectedDecisionRevision: state.decisionRevision,
-            })
-        );
-        if (!isCurrentReviewOperationScope(operationScope)) return null;
-        markCommittedReviewPostimages(committed.diskPostimages);
-        recordDecisionRevision(
-          teamName,
-          decisionScopeKey,
-          decisionScopeToken,
-          committed.decisionRevision
-        );
-        useStore.setState({ hunkDecisions, fileDecisions });
-        if (diskSnapshots.length > 0) refreshAfterDurableUndo(diskSnapshots);
-        return redoAction;
-      } catch (error) {
-        if (!isCurrentReviewOperationScope(operationScope)) return null;
-        useStore.setState({
-          applyError:
-            error instanceof Error
-              ? error.message
-              : 'Unable to undo because the file changed on disk.',
-        });
-        return null;
-      } finally {
-        if (isCurrentReviewOperationScope(operationScope)) setUndoInFlight(false);
-      }
-    },
-    [
-      captureReviewOperationScope,
-      decisionScopeKey,
-      decisionScopeToken,
-      getReviewRedoHistory,
-      getReviewUndoHistory,
-      isCurrentReviewOperationScope,
-      markCommittedReviewPostimages,
-      markRecentReviewWrite,
-      quiesceDecisionPersistence,
-      recordDecisionRevision,
-      refreshAfterDurableUndo,
-      reviewScope,
-      setUndoInFlight,
-      teamName,
-    ]
-  );
-
-  const handleUndoLatestReviewAction = useCallback(async (): Promise<void> => {
-    if (hasReviewActionInFlight() || editedCount > 0 || blockReviewMutationForExternalChange()) {
-      return;
-    }
-    const action = getLatestUndoAction();
-    if (!action) return;
-    const state = useStore.getState();
-    let hunkDecisions = { ...state.hunkDecisions };
-    let fileDecisions = { ...state.fileDecisions };
-
-    if (action.kind === 'bulk') {
-      hunkDecisions = { ...action.decisionSnapshot.hunkDecisions };
-      fileDecisions = { ...action.decisionSnapshot.fileDecisions };
-    } else if (action.kind === 'disk') {
-      const diskAction = action.action;
-      if (fileApplyInFlightRef.current.has(diskAction.snapshot.filePath)) return;
-      if (diskAction.originalIndex !== undefined) {
-        const file = activeChangeSet?.files.find(
-          (candidate) =>
-            normalizePathForComparison(candidate.filePath) ===
-            normalizePathForComparison(diskAction.snapshot.filePath)
-        );
-        if (!file) {
-          useStore.setState({ applyError: 'Reviewed file is unavailable for Undo.' });
-          return;
-        }
-        delete hunkDecisions[
-          buildHunkDecisionKey(getFileReviewKey(file), diskAction.originalIndex)
-        ];
-      } else if (diskAction.file && diskAction.decisionSnapshot) {
-        const restored = restoreReviewDecisionRecordsForFile(
-          diskAction.file,
-          state,
-          diskAction.decisionSnapshot
-        );
-        hunkDecisions = restored.hunkDecisions;
-        fileDecisions = restored.fileDecisions;
-      }
-    } else {
-      const file = activeChangeSet?.files.find(
-        (candidate) =>
-          normalizePathForComparison(candidate.filePath) ===
-          normalizePathForComparison(action.action.filePath)
-      );
-      if (!file) {
-        useStore.setState({ applyError: 'Reviewed file is unavailable for Undo.' });
-        return;
-      }
-      delete hunkDecisions[
-        buildHunkDecisionKey(getFileReviewKey(file), action.action.originalIndex)
-      ];
-    }
-
-    const redoAction = await commitUndoMutation(action, hunkDecisions, fileDecisions);
-    if (!redoAction || !completeReviewUndoAction(action, redoAction)) return;
-    const affectedPaths =
-      action.kind === 'bulk'
-        ? (activeChangeSet?.files.map((file) => file.filePath) ?? [])
-        : action.kind === 'disk'
-          ? [action.action.snapshot.filePath]
-          : [action.action.filePath];
-    setDiscardCounters((previous) => {
-      const next = { ...previous };
-      for (const filePath of affectedPaths) next[filePath] = (next[filePath] ?? 0) + 1;
-      return next;
-    });
-  }, [
-    activeChangeSet,
-    blockReviewMutationForExternalChange,
-    commitUndoMutation,
-    completeReviewUndoAction,
-    editedCount,
-    getLatestUndoAction,
-    hasReviewActionInFlight,
-  ]);
-
-  const handleRedoLatestReviewAction = useCallback(async (): Promise<void> => {
-    if (hasReviewActionInFlight() || editedCount > 0 || blockReviewMutationForExternalChange()) {
-      return;
-    }
-    const redoAction = getLatestRedoAction();
-    if (!redoAction || !decisionScopeToken) return;
-    const operationScope = captureReviewOperationScope();
-    if (!operationScope) return;
-    setUndoInFlight(true);
-    try {
-      const quiesced = await quiesceDecisionPersistence(
-        teamName,
-        decisionScopeKey,
-        decisionScopeToken
-      );
-      if (!isCurrentReviewOperationScope(operationScope)) return;
-      if (!quiesced) {
-        throw new Error('Unable to finish saving the previous review state. Retry Redo.');
-      }
-      const state = useStore.getState();
-      const action = redoAction.action;
-      const undoHistory = [...getReviewUndoHistory(), action];
-      const redoHistory = getReviewRedoHistory().slice(0, -1);
-      const diskSnapshots = getReviewActionDiskSnapshots(action);
-      const diskSteps = buildRedoDiskMutationSteps(action.id, diskSnapshots);
-      const committed = await executeWithPreparedReviewWriteExpectations(
-        diskSnapshots,
-        'redo',
-        markRecentReviewWrite,
-        () =>
-          api.review.executeMutation({
-            scope: reviewScope,
-            decisionPersistenceScope: {
+  const reviewHistoryMutationScope = useMemo(
+    () =>
+      decisionScopeToken
+        ? {
+            review: reviewScope,
+            persistence: {
+              teamName,
               scopeKey: decisionScopeKey,
               scopeToken: decisionScopeToken,
             },
-            kind: 'redo',
-            diskSteps,
-            persistedState: {
-              hunkDecisions: redoAction.decisionSnapshot.hunkDecisions,
-              fileDecisions: redoAction.decisionSnapshot.fileDecisions,
-              hunkContextHashesByFile:
-                redoAction.hunkContextHashesByFile ?? state.hunkContextHashesByFile,
-              reviewActionHistory: undoHistory,
-              reviewRedoHistory: redoHistory,
-            },
-            expectedTopRedoActionId: action.id,
-            expectedDecisionRevision: state.decisionRevision,
-          })
-      );
-      if (!isCurrentReviewOperationScope(operationScope)) return;
-      markCommittedReviewPostimages(committed.diskPostimages);
-      recordDecisionRevision(
-        teamName,
-        decisionScopeKey,
-        decisionScopeToken,
-        committed.decisionRevision
-      );
-      useStore.setState({
-        hunkDecisions: { ...redoAction.decisionSnapshot.hunkDecisions },
-        fileDecisions: { ...redoAction.decisionSnapshot.fileDecisions },
-        hunkContextHashesByFile:
-          redoAction.hunkContextHashesByFile ?? state.hunkContextHashesByFile,
-      });
-      refreshAfterDurableRedo(action);
-      completeReviewRedoAction(redoAction);
-    } catch (error) {
-      if (!isCurrentReviewOperationScope(operationScope)) return;
-      useStore.setState({
-        applyError:
-          error instanceof Error
-            ? error.message
-            : 'Unable to redo because the file changed on disk.',
-      });
-    } finally {
-      if (isCurrentReviewOperationScope(operationScope)) setUndoInFlight(false);
-    }
-  }, [
-    captureReviewOperationScope,
-    completeReviewRedoAction,
-    blockReviewMutationForExternalChange,
-    decisionScopeKey,
-    decisionScopeToken,
-    editedCount,
-    getLatestRedoAction,
-    getReviewRedoHistory,
-    getReviewUndoHistory,
-    hasReviewActionInFlight,
-    isCurrentReviewOperationScope,
-    markCommittedReviewPostimages,
-    markRecentReviewWrite,
-    quiesceDecisionPersistence,
-    recordDecisionRevision,
-    refreshAfterDurableRedo,
-    reviewScope,
-    setUndoInFlight,
-    teamName,
-  ]);
-
-  const buildCurrentReviewHistoryRestorePlan = useCallback(
-    (target: ReviewHistoryRestoreTarget) => {
-      const state = useStore.getState();
-      const plan = buildReviewHistoryRestorePlan(
-        {
-          hunkDecisions: state.hunkDecisions,
-          fileDecisions: state.fileDecisions,
-          hunkContextHashesByFile: state.hunkContextHashesByFile,
-          reviewActionHistory: getReviewUndoHistory(),
-          reviewRedoHistory: getReviewRedoHistory(),
-        },
-        target,
-        (filePath) =>
-          activeChangeSet?.files.find(
-            (file) =>
-              normalizePathForComparison(file.filePath) === normalizePathForComparison(filePath)
-          ) ?? null
-      );
-      return { state, plan };
-    },
-    [activeChangeSet, getReviewRedoHistory, getReviewUndoHistory]
+          }
+        : null,
+    [decisionScopeKey, decisionScopeToken, reviewScope, teamName]
   );
-
-  const getRestoreReviewHistoryPreview = useCallback(
-    (target: ReviewHistoryRestoreTarget) => {
-      const { plan } = buildCurrentReviewHistoryRestorePlan(target);
-      if (plan.direction === 'none') {
-        throw new Error('This review checkpoint is already current.');
-      }
-      const direction = plan.direction;
-      return {
-        direction,
-        actions: plan.orderedActions,
-        diskTransitions: buildReviewHistoryRestoreDiskImpact(
-          plan.orderedActions.map((action) => ({ direction, action }))
-        ),
-      };
-    },
-    [buildCurrentReviewHistoryRestorePlan]
-  );
-
-  const applyCommittedReviewState = useCallback(
-    (
-      restored: ReviewPersistedStateSnapshot,
-      decisionRevision: number,
-      applyError: string | null
-    ): void => {
-      if (!decisionScopeToken) {
-        throw new Error('Durable review history scope is unavailable.');
-      }
-      recordDecisionRevision(teamName, decisionScopeKey, decisionScopeToken, decisionRevision);
-      replaceReviewActionHistories(restored.reviewActionHistory, restored.reviewRedoHistory);
-      useStore.setState({
-        hunkDecisions: restored.hunkDecisions,
-        fileDecisions: restored.fileDecisions,
-        hunkContextHashesByFile: restored.hunkContextHashesByFile ?? {},
-        applyError,
-      });
-    },
+  const reviewHistoryActions = useMemo(
+    () => ({
+      getUndoHistory: () => getReviewUndoHistory(),
+      getRedoHistory: () => getReviewRedoHistory(),
+      getLatestUndoAction: () => getLatestUndoAction(),
+      getLatestRedoAction: () => getLatestRedoAction(),
+      completeUndoAction: (action: ReviewUndoAction, redoAction: ReviewRedoAction) =>
+        completeReviewUndoAction(action, redoAction),
+      completeRedoAction: (redoAction: ReviewRedoAction) => completeReviewRedoAction(redoAction),
+      replaceHistories: (undoHistory: ReviewUndoAction[], redoHistory: ReviewRedoAction[]) =>
+        replaceReviewActionHistories(undoHistory, redoHistory),
+    }),
     [
-      decisionScopeKey,
-      decisionScopeToken,
-      recordDecisionRevision,
+      completeReviewRedoAction,
+      completeReviewUndoAction,
+      getLatestRedoAction,
+      getLatestUndoAction,
+      getReviewRedoHistory,
+      getReviewUndoHistory,
       replaceReviewActionHistories,
-      teamName,
     ]
   );
-
-  const applyRestoredReviewHistory = useCallback(
-    (
-      restored: ReviewPersistedStateSnapshot,
-      decisionRevision: number,
-      direction: 'undo' | 'redo',
-      diskSnapshots: readonly ReviewDiskUndoSnapshot[],
-      orderedActions: readonly ReviewUndoAction[],
-      target: ReviewHistoryRestoreTarget
-    ): void => {
-      applyCommittedReviewState(restored, decisionRevision, null);
-      if (direction === 'undo' && diskSnapshots.length > 0) {
-        refreshAfterDurableUndo(diskSnapshots);
-      } else if (direction === 'redo') {
-        for (const action of orderedActions) refreshAfterDurableRedo(action);
-      }
-      const affectedPaths = orderedActions.flatMap((action) =>
-        action.kind === 'bulk'
-          ? (activeChangeSet?.files.map((file) => file.filePath) ?? [])
-          : action.kind === 'disk'
-            ? [action.action.snapshot.filePath]
-            : [action.action.filePath]
-      );
-      setDiscardCounters((previous) => {
-        const next = { ...previous };
-        for (const filePath of affectedPaths) next[filePath] = (next[filePath] ?? 0) + 1;
-        return next;
-      });
-      if (target.kind === 'after-action') {
-        const targetAction =
-          restored.reviewActionHistory.find((action) => action.id === target.actionId) ??
-          restored.reviewRedoHistory.find((entry) => entry.action.id === target.actionId)?.action;
-        if (targetAction) handleHistoryActionNavigation(targetAction);
-      }
-    },
-    [
-      activeChangeSet,
-      applyCommittedReviewState,
-      handleHistoryActionNavigation,
-      refreshAfterDurableRedo,
-      refreshAfterDurableUndo,
-    ]
-  );
-
-  const synchronizeRecoveredReviewState = useCallback(
-    (restored: ReviewPersistedStateSnapshot, decisionRevision: number, message: string): void => {
-      applyCommittedReviewState(restored, decisionRevision, message);
-      const affectedPaths = activeChangeSet?.files.map((file) => file.filePath) ?? [];
-      for (const filePath of affectedPaths) {
-        clearReviewFileExternalChange(filePath);
-        useStore.getState().invalidateResolvedFileContent(filePath);
-        void fetchFileContent(teamName, memberName, filePath);
-      }
-      setDiscardCounters((previous) => {
-        const next = { ...previous };
-        for (const filePath of affectedPaths) next[filePath] = (next[filePath] ?? 0) + 1;
-        return next;
-      });
-    },
-    [
-      activeChangeSet,
-      applyCommittedReviewState,
-      clearReviewFileExternalChange,
-      fetchFileContent,
-      memberName,
-      teamName,
-    ]
-  );
-
-  const handleRestoreReviewHistory = useCallback(
-    async (target: ReviewHistoryRestoreTarget): Promise<void> => {
-      if (hasReviewActionInFlight()) throw new Error('Another review action is still running.');
-      if (editedCount > 0) {
-        throw new Error('Save or discard manual edits before restoring review history.');
-      }
-      if (blockReviewMutationForExternalChange()) {
-        throw new Error('Reload files changed outside Changes before restoring review history.');
-      }
-      if (!decisionScopeToken || !decisionHydrationReady) {
-        throw new Error('Durable review history is not ready yet.');
-      }
-      if (getReviewActionPersistenceStatus() !== 'saved') {
-        throw new Error(CHANGE_REVIEW_PERSISTENCE_ERROR);
-      }
-      const operationScope = captureReviewOperationScope();
-      if (!operationScope) throw new Error('Durable review history scope is no longer active.');
-
-      const { state, plan } = buildCurrentReviewHistoryRestorePlan(target);
-      if (plan.actionCount === 0) return;
-      if (plan.direction === 'none')
-        throw new Error('Review history restore plan is inconsistent.');
-      const direction = plan.direction;
-      const diskSnapshots = plan.orderedActions.flatMap((action) =>
-        getReviewActionDiskSnapshots(action)
-      );
-
-      setUndoInFlight(true);
-      try {
-        const quiesced = await quiesceDecisionPersistence(
-          teamName,
-          decisionScopeKey,
-          decisionScopeToken
-        );
-        if (!isCurrentReviewOperationScope(operationScope)) return;
-        if (!quiesced) {
-          throw new Error('Unable to finish saving the previous review state. Retry Restore.');
-        }
-        const committed = await executeWithPreparedReviewWriteExpectations(
-          diskSnapshots,
-          direction,
-          markRecentReviewWrite,
-          () =>
-            api.review.restoreHistory({
-              scope: reviewScope,
-              decisionPersistenceScope: {
-                scopeKey: decisionScopeKey,
-                scopeToken: decisionScopeToken,
-              },
-              target,
-              expectedDecisionRevision: state.decisionRevision,
-            })
-        );
-        if (!isCurrentReviewOperationScope(operationScope)) return;
-        markCommittedReviewPostimages(committed.diskPostimages);
-        applyRestoredReviewHistory(
-          committed.persistedState,
-          committed.decisionRevision,
-          direction,
-          diskSnapshots,
-          plan.orderedActions,
-          target
-        );
-      } catch (error) {
-        if (!isCurrentReviewOperationScope(operationScope)) return;
-        const message =
-          error instanceof Error ? error.message : 'Unable to restore the selected review history.';
-        useStore.setState({ applyError: message });
-        throw error instanceof Error ? error : new Error(message);
-      } finally {
-        if (isCurrentReviewOperationScope(operationScope)) setUndoInFlight(false);
-      }
-    },
-    [
-      applyRestoredReviewHistory,
-      blockReviewMutationForExternalChange,
-      buildCurrentReviewHistoryRestorePlan,
-      captureReviewOperationScope,
-      decisionHydrationReady,
-      decisionScopeKey,
-      decisionScopeToken,
-      editedCount,
-      getReviewActionPersistenceStatus,
-      hasReviewActionInFlight,
-      isCurrentReviewOperationScope,
-      markCommittedReviewPostimages,
-      markRecentReviewWrite,
-      quiesceDecisionPersistence,
-      reviewScope,
-      setUndoInFlight,
-      teamName,
-    ]
-  );
-
-  const handleRecoverFailedReviewHistory = useCallback(
-    async (target: ReviewHistoryRestoreTarget): Promise<void> => {
-      if (!decisionScopeToken || !decisionHydrationReady) {
-        throw new Error('Durable review history is not ready for recovery.');
-      }
-      const operationScope = captureReviewOperationScope();
-      if (!operationScope) throw new Error('Durable review history scope is no longer active.');
-      const currentRevision = useStore.getState().decisionRevision;
-      const { plan } = buildCurrentReviewHistoryRestorePlan(target);
-      const direction = plan.direction;
-      const diskSteps =
-        direction === 'undo' || direction === 'redo'
-          ? buildReviewHistoryRestoreDiskSteps(
-              plan.orderedActions.map((action) => ({ direction, action }))
-            )
-          : [];
-      const diskSnapshots = plan.orderedActions.flatMap((action) =>
-        getReviewActionDiskSnapshots(action)
-      );
-      const retryRecovery = () =>
-        api.review.retryMutationRecovery({
-          scope: reviewScope,
-          decisionPersistenceScope: {
-            scopeKey: decisionScopeKey,
-            scopeToken: decisionScopeToken,
+  const reviewHistoryMutationViewPort = useMemo<ChangeReviewHistoryMutationViewPort>(
+    () => ({
+      addMissingFile: (file, index, content) =>
+        addReviewFile(file, {
+          index,
+          content: {
+            ...file,
+            originalFullContent: '',
+            modifiedFullContent: content,
+            isNewFile: true,
+            contentSource: 'disk-current',
           },
-          expectedRestore: {
-            expectedDecisionRevision: currentRevision,
-            persistedState: plan.persistedState,
-            diskSteps,
-          },
+        }),
+      fetchFileContent: (targetTeamName, targetMemberName, filePath) => {
+        void fetchFileContent(targetTeamName, targetMemberName, filePath);
+      },
+      incrementDiscardCounters: (filePaths) => {
+        setDiscardCounters((previous) => {
+          const next = { ...previous };
+          for (const filePath of filePaths) {
+            next[filePath] = (next[filePath] ?? 0) + 1;
+          }
+          return next;
         });
-
-      let retryOriginalRestore = false;
-      setUndoInFlight(true);
-      try {
-        const recovered =
-          direction === 'undo' || direction === 'redo'
-            ? await executeWithPreparedReviewWriteExpectations(
-                diskSnapshots,
-                direction,
-                markRecentReviewWrite,
-                retryRecovery
-              )
-            : await retryRecovery();
-        if (!isCurrentReviewOperationScope(operationScope)) return;
-        const disposition = classifyReviewHistoryRecovery(
-          recovered,
-          currentRevision,
-          plan.persistedState
-        );
-        if (disposition === 'retry-restore') {
-          for (const snapshot of diskSnapshots) {
-            recentReviewWritesRef.current.delete(normalizePathForComparison(snapshot.filePath));
-          }
-          retryOriginalRestore = true;
-        } else if (disposition === 'different-mutation-pending') {
-          for (const snapshot of diskSnapshots) {
-            recentReviewWritesRef.current.delete(normalizePathForComparison(snapshot.filePath));
-          }
-          throw new Error(
-            'A different interrupted review update must be recovered first. Close Restore and retry the saved review state.'
-          );
-        } else if (disposition === 'apply-selected-restore') {
-          if (!recovered.persistedState) {
-            throw new Error('Recovered checkpoint state is unavailable. Reload Changes.');
-          }
-          if (direction !== 'undo' && direction !== 'redo') {
-            throw new Error('Recovered review history no longer matches this checkpoint.');
-          }
-          markCommittedReviewPostimages(recovered.diskPostimages);
-          applyRestoredReviewHistory(
-            recovered.persistedState,
-            recovered.decisionRevision,
-            direction,
-            diskSnapshots,
-            plan.orderedActions,
-            target
-          );
-        } else {
-          if (!recovered.persistedState) {
-            throw new Error(
-              'Recovered review state is unavailable. Reload Changes before retrying.'
-            );
-          }
-          for (const snapshot of diskSnapshots) {
-            recentReviewWritesRef.current.delete(normalizePathForComparison(snapshot.filePath));
-          }
-          synchronizeRecoveredReviewState(
-            recovered.persistedState,
-            recovered.decisionRevision,
-            recovered.recoveredMutation
-              ? 'A different interrupted review action was recovered. Latest durable state was loaded; select the checkpoint again.'
-              : 'Review history changed while Restore was finishing. Latest durable state was loaded; verify it before continuing.'
-          );
-        }
-      } catch (error) {
-        if (!isCurrentReviewOperationScope(operationScope)) return;
-        const message =
-          error instanceof Error ? error.message : 'Unable to recover the interrupted Restore.';
-        useStore.setState({ applyError: message });
-        throw error instanceof Error ? error : new Error(message);
-      } finally {
-        if (isCurrentReviewOperationScope(operationScope)) setUndoInFlight(false);
-      }
-
-      if (retryOriginalRestore && isCurrentReviewOperationScope(operationScope)) {
-        await handleRestoreReviewHistory(target);
-      }
-    },
+      },
+      navigateToAction: handleHistoryActionNavigation,
+      markExpectedWrite: markRecentReviewWrite,
+      clearExpectedWrite: (filePath) => {
+        recentReviewWritesRef.current.delete(normalizePathForComparison(filePath));
+      },
+      markCommittedPostimages: markCommittedReviewPostimages,
+      setMutationInFlight: setUndoInFlight,
+    }),
     [
-      applyRestoredReviewHistory,
-      buildCurrentReviewHistoryRestorePlan,
-      captureReviewOperationScope,
-      decisionHydrationReady,
-      decisionScopeKey,
-      decisionScopeToken,
-      handleRestoreReviewHistory,
-      isCurrentReviewOperationScope,
+      addReviewFile,
+      fetchFileContent,
+      handleHistoryActionNavigation,
       markCommittedReviewPostimages,
       markRecentReviewWrite,
-      reviewScope,
       setUndoInFlight,
-      synchronizeRecoveredReviewState,
     ]
   );
+  const isReviewFileMutationInFlight = useCallback(
+    (filePath: string): boolean => fileApplyInFlightRef.current.has(filePath),
+    []
+  );
+  const {
+    undoLatest: handleUndoLatestReviewAction,
+    redoLatest: handleRedoLatestReviewAction,
+    getRestorePreview: getRestoreReviewHistoryPreview,
+    restoreHistory: handleRestoreReviewHistory,
+    recoverFailedHistory: handleRecoverFailedReviewHistory,
+  } = useChangeReviewHistoryMutationController({
+    teamName,
+    memberName,
+    files: activeChangeSet?.files ?? [],
+    editedCount,
+    decisionHydrationReady,
+    scope: reviewHistoryMutationScope,
+    history: reviewHistoryActions,
+    commandPort: changeReviewHistoryMutationCommandPort,
+    statePort: changeReviewHistoryMutationStatePort,
+    viewPort: reviewHistoryMutationViewPort,
+    captureOperationScope: captureReviewOperationScope,
+    isCurrentOperationScope: isCurrentReviewOperationScope,
+    hasActionInFlight: hasReviewActionInFlight,
+    isFileMutationInFlight: isReviewFileMutationInFlight,
+    blockForExternalChange: blockReviewMutationForExternalChange,
+    getPersistenceStatus: getReviewActionPersistenceStatus,
+  });
 
   // Selection change handler (debounced for non-empty, immediate for clear)
   const handleSelectionChange = useCallback((info: EditorSelectionInfo | null) => {

--- a/src/renderer/components/team/review/reviewHistoryTimeline.ts
+++ b/src/renderer/components/team/review/reviewHistoryTimeline.ts
@@ -1,57 +1,14 @@
-import type {
-  HunkDecision,
-  RetryReviewMutationRecoveryResult,
-  ReviewDiskUndoSnapshot,
-  ReviewMutationDiskPostimage,
-  ReviewPersistedStateSnapshot,
-  ReviewRedoAction,
-  ReviewUndoAction,
-} from '@shared/types';
+import { getReviewDiskMutationExpectedContent } from '@features/change-review/renderer';
 
-function toCanonicalReviewValue(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(toCanonicalReviewValue);
-  if (!value || typeof value !== 'object') return value;
-  return Object.fromEntries(
-    Object.entries(value)
-      .filter(([, entry]) => entry !== undefined)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([key, entry]) => [key, toCanonicalReviewValue(entry)])
-  );
-}
+import type { ReviewDiskUndoSnapshot, ReviewMutationDiskPostimage } from '@shared/types';
 
-export function areReviewPersistedStatesEqual(
-  left: ReviewPersistedStateSnapshot,
-  right: ReviewPersistedStateSnapshot
-): boolean {
-  return (
-    JSON.stringify(toCanonicalReviewValue(left)) === JSON.stringify(toCanonicalReviewValue(right))
-  );
-}
-
-export type ReviewHistoryRecoveryDisposition =
-  | 'retry-restore'
-  | 'apply-selected-restore'
-  | 'different-mutation-pending'
-  | 'synchronize-latest';
-
-export function classifyReviewHistoryRecovery(
-  recovery: RetryReviewMutationRecoveryResult,
-  currentRevision: number,
-  plannedState: ReviewPersistedStateSnapshot
-): ReviewHistoryRecoveryDisposition {
-  if (recovery.differentMutationPending) return 'different-mutation-pending';
-  if (!recovery.recoveredMutation && recovery.decisionRevision === currentRevision) {
-    return 'retry-restore';
-  }
-  if (
-    recovery.expectedRestoreCompleted &&
-    recovery.persistedState &&
-    areReviewPersistedStatesEqual(recovery.persistedState, plannedState)
-  ) {
-    return 'apply-selected-restore';
-  }
-  return 'synchronize-latest';
-}
+export type { ReviewHistoryRecoveryDisposition } from '@features/change-review/renderer';
+export {
+  areReviewPersistedStatesEqual,
+  classifyReviewHistoryRecovery,
+  createReviewRedoAction,
+  getReviewDiskMutationExpectedContent,
+} from '@features/change-review/renderer';
 
 export function markReviewMutationDiskPostimages(
   postimages: readonly ReviewMutationDiskPostimage[] | undefined,
@@ -72,22 +29,6 @@ export {
   getReviewActionDiskSnapshots,
 } from '@features/review-mutations';
 
-export function getReviewDiskMutationExpectedContent(
-  snapshot: ReviewDiskUndoSnapshot,
-  direction: 'undo' | 'redo'
-): string | null {
-  const restoreMode =
-    snapshot.restoreMode ?? (snapshot.renameExpectation ? 'restore-rejected-rename' : 'content');
-  if (direction === 'undo') {
-    return restoreMode === 'delete-file' || restoreMode === 'reapply-rejected-rename'
-      ? null
-      : snapshot.beforeContent;
-  }
-  return restoreMode === 'create-file' || restoreMode === 'restore-rejected-rename'
-    ? null
-    : snapshot.afterContent;
-}
-
 export async function executeWithPreparedReviewWriteExpectations<T>(
   snapshots: readonly ReviewDiskUndoSnapshot[],
   direction: 'undo' | 'redo',
@@ -98,22 +39,4 @@ export async function executeWithPreparedReviewWriteExpectations<T>(
     markExpectedWrite(snapshot.filePath, getReviewDiskMutationExpectedContent(snapshot, direction));
   }
   return execute();
-}
-
-export function createReviewRedoAction(
-  action: ReviewUndoAction,
-  state: {
-    hunkDecisions: Record<string, HunkDecision>;
-    fileDecisions: Record<string, HunkDecision>;
-    hunkContextHashesByFile: Record<string, Record<number, string>>;
-  }
-): ReviewRedoAction {
-  return {
-    action: structuredClone(action),
-    decisionSnapshot: {
-      hunkDecisions: { ...state.hunkDecisions },
-      fileDecisions: { ...state.fileDecisions },
-    },
-    hunkContextHashesByFile: structuredClone(state.hunkContextHashesByFile),
-  };
 }

--- a/test/features/change-review/renderer/createChangeReviewHistoryMutationPorts.test.ts
+++ b/test/features/change-review/renderer/createChangeReviewHistoryMutationPorts.test.ts
@@ -1,0 +1,66 @@
+import {
+  createChangeReviewHistoryMutationCommandPort,
+  createChangeReviewHistoryMutationStatePort,
+} from '@features/change-review/renderer';
+import { describe, expect, it, vi } from 'vitest';
+
+describe('change review history mutation ports', () => {
+  it('maps command calls lazily to the active review API', async () => {
+    const executeMutation = vi.fn().mockResolvedValue({ decisionRevision: 2, diskPostimages: [] });
+    const restoreHistory = vi.fn().mockResolvedValue({
+      decisionRevision: 2,
+      persistedState: {},
+      direction: 'undo',
+      actionCount: 1,
+      diskPostimages: [],
+    });
+    const retryMutationRecovery = vi.fn().mockResolvedValue({ decisionRevision: 2 });
+    const getReviewApi = vi.fn(() => ({
+      executeMutation,
+      restoreHistory,
+      retryMutationRecovery,
+    }));
+    const port = createChangeReviewHistoryMutationCommandPort(getReviewApi);
+    const request = { kind: 'request' } as never;
+
+    await port.executeMutation(request);
+    await port.restoreHistory(request);
+    await port.retryRecovery(request);
+
+    expect(getReviewApi).toHaveBeenCalledTimes(3);
+    expect(executeMutation).toHaveBeenCalledWith(request);
+    expect(restoreHistory).toHaveBeenCalledWith(request);
+    expect(retryMutationRecovery).toHaveBeenCalledWith(request);
+  });
+
+  it('keeps state effects behind the supplied adapter callbacks', async () => {
+    const snapshot = {
+      hunkDecisions: {},
+      fileDecisions: {},
+      hunkContextHashesByFile: {},
+      decisionRevision: 1,
+    };
+    const callbacks = {
+      getSnapshot: vi.fn(() => snapshot),
+      quiesceDecisionPersistence: vi.fn().mockResolvedValue(true),
+      recordDecisionRevision: vi.fn(),
+      applyDecisionState: vi.fn(),
+      applyPersistedState: vi.fn(),
+      reportError: vi.fn(),
+      clearExternalChange: vi.fn(),
+      invalidateResolvedFileContent: vi.fn(),
+    };
+    const port = createChangeReviewHistoryMutationStatePort(callbacks);
+    const scope = { teamName: 'team', scopeKey: 'scope', scopeToken: 'token' };
+
+    expect(port.getSnapshot()).toBe(snapshot);
+    await expect(port.quiesceDecisionPersistence(scope)).resolves.toBe(true);
+    port.recordDecisionRevision(scope, 2);
+    port.reportError('failed');
+    port.clearExternalChange('/repo/file.ts');
+    port.invalidateResolvedFileContent('/repo/file.ts');
+
+    expect(callbacks.recordDecisionRevision).toHaveBeenCalledWith(scope, 2);
+    expect(callbacks.reportError).toHaveBeenCalledWith('failed');
+  });
+});

--- a/test/features/change-review/renderer/useChangeReviewActionHistoryController.test.tsx
+++ b/test/features/change-review/renderer/useChangeReviewActionHistoryController.test.tsx
@@ -186,11 +186,11 @@ describe('useChangeReviewActionHistoryController', () => {
       latest!.bindCommittedAction(optimistic, committed);
     });
     expect(latest!.getLatestUndoAction()).toBe(committed);
-    let discardedOptimistic = false;
+    let discardedCommitted = false;
     await act(async () => {
-      discardedOptimistic = latest!.discardLatestAction(optimistic);
+      discardedCommitted = latest!.discardLatestAction(committed);
     });
-    expect(discardedOptimistic).toBe(true);
+    expect(discardedCommitted).toBe(true);
     expect(store.redo).toEqual([previousRedo]);
     await act(async () => root.unmount());
   });

--- a/test/features/change-review/renderer/useChangeReviewActionHistoryController.test.tsx
+++ b/test/features/change-review/renderer/useChangeReviewActionHistoryController.test.tsx
@@ -1,9 +1,7 @@
 import React, { act } from 'react';
 import { createRoot } from 'react-dom/client';
 
-import {
-  useChangeReviewActionHistoryController,
-} from '@features/change-review/renderer';
+import { useChangeReviewActionHistoryController } from '@features/change-review/renderer';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type {
@@ -133,7 +131,7 @@ describe('useChangeReviewActionHistoryController', () => {
     await act(async () => root.unmount());
   });
 
-  it('restores redo only when the exact optimistic top action is discarded', async () => {
+  it('restores redo when a main-bound replacement of the optimistic action is discarded', async () => {
     vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
     const root = createRoot(document.body.appendChild(document.createElement('div')));
     const store = createStore();
@@ -173,13 +171,21 @@ describe('useChangeReviewActionHistoryController', () => {
         />
       );
     });
-    const cloned = { ...optimistic };
-    let discardedClone = true;
+    const unrelated = { ...optimistic, id: 'other-action' };
+    let discardedUnrelated = true;
     await act(async () => {
-      discardedClone = latest!.discardLatestAction(cloned);
+      discardedUnrelated = latest!.discardLatestAction(unrelated);
     });
-    expect(discardedClone).toBe(false);
+    expect(discardedUnrelated).toBe(false);
     expect(store.redo).toEqual([]);
+    const committed = {
+      ...optimistic,
+      action: { filePath: '/repo/file.ts', originalIndex: 7 },
+    } as ReviewUndoAction;
+    await act(async () => {
+      latest!.bindCommittedAction(optimistic, committed);
+    });
+    expect(latest!.getLatestUndoAction()).toBe(committed);
     let discardedOptimistic = false;
     await act(async () => {
       discardedOptimistic = latest!.discardLatestAction(optimistic);

--- a/test/features/change-review/renderer/useChangeReviewDecisionPersistenceController.test.tsx
+++ b/test/features/change-review/renderer/useChangeReviewDecisionPersistenceController.test.tsx
@@ -118,7 +118,10 @@ describe('useChangeReviewDecisionPersistenceController', () => {
     };
     const port = makePort(snapshotRef);
     const refresh = vi.fn(async () => {});
-    const render = async (snapshot: ChangeReviewDecisionPersistenceSnapshot, autoActive: boolean) => {
+    const render = async (
+      snapshot: ChangeReviewDecisionPersistenceSnapshot,
+      autoActive: boolean
+    ) => {
       snapshotRef.current = snapshot;
       await act(async () => {
         root.render(
@@ -144,7 +147,7 @@ describe('useChangeReviewDecisionPersistenceController', () => {
 
     const changedIdentity = {
       ...snapshotRef.current,
-      hunkDecisions: { h: 'accepted' },
+      hunkDecisions: { h: 'accepted' as const },
     };
     await render(changedIdentity, true);
     expect(port.schedule).toHaveBeenCalledTimes(1);
@@ -264,10 +267,7 @@ describe('useChangeReviewDecisionPersistenceController', () => {
     };
     const port = makePort(snapshotRef);
     const refresh = vi.fn(async () => {});
-    const render = async (
-      snapshot: ChangeReviewDecisionPersistenceSnapshot,
-      hasState: boolean
-    ) => {
+    const render = async (snapshot: ChangeReviewDecisionPersistenceSnapshot, hasState: boolean) => {
       snapshotRef.current = snapshot;
       await act(async () => {
         root.render(
@@ -366,10 +366,7 @@ describe('useChangeReviewDecisionPersistenceController', () => {
     vi.mocked(port.clear)
       .mockImplementationOnce(() => firstClear.promise)
       .mockResolvedValue(true);
-    const render = async (
-      snapshot: ChangeReviewDecisionPersistenceSnapshot,
-      hasState: boolean
-    ) => {
+    const render = async (snapshot: ChangeReviewDecisionPersistenceSnapshot, hasState: boolean) => {
       snapshotRef.current = snapshot;
       await act(async () => {
         root.render(
@@ -407,7 +404,16 @@ describe('useChangeReviewDecisionPersistenceController', () => {
   it('chooses save versus clear for close and reuses a pending clear', async () => {
     vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
     const root = createRoot(document.body.appendChild(document.createElement('div')));
-    const nonempty = makeSnapshot({ reviewActionHistory: [{ id: 'a' }] });
+    const nonempty = makeSnapshot({
+      reviewActionHistory: [
+        {
+          id: 'a',
+          createdAt: '2026-07-23T00:00:00.000Z',
+          kind: 'hunk',
+          action: { filePath: '/repo/file.ts', originalIndex: 0 },
+        },
+      ],
+    });
     const snapshotRef = { current: nonempty };
     const port = makePort(snapshotRef);
     const refresh = vi.fn(async () => {});

--- a/test/features/change-review/renderer/useChangeReviewHistoryMutationController.test.tsx
+++ b/test/features/change-review/renderer/useChangeReviewHistoryMutationController.test.tsx
@@ -1,0 +1,378 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import {
+  createReviewOperationScopeToken,
+  useChangeReviewHistoryMutationController,
+} from '@features/change-review/renderer';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  ChangeReviewActionHistoryController,
+  ChangeReviewHistoryMutationCommandPort,
+  ChangeReviewHistoryMutationController,
+  ChangeReviewHistoryMutationScope,
+  ChangeReviewHistoryMutationStatePort,
+  ChangeReviewHistoryMutationViewPort,
+  ChangeReviewHistoryStateSnapshot,
+  ReviewActionPersistenceStatus,
+  ReviewOperationScopeToken,
+} from '@features/change-review/renderer';
+import type {
+  FileChangeSummary,
+  RestoreReviewHistoryResult,
+  RetryReviewMutationRecoveryResult,
+  ReviewPersistedStateSnapshot,
+  ReviewRedoAction,
+  ReviewUndoAction,
+} from '@shared/types';
+
+type ActionHistory = Pick<
+  ChangeReviewActionHistoryController,
+  | 'getUndoHistory'
+  | 'getRedoHistory'
+  | 'getLatestUndoAction'
+  | 'getLatestRedoAction'
+  | 'completeUndoAction'
+  | 'completeRedoAction'
+  | 'replaceHistories'
+>;
+
+interface Harness {
+  files: FileChangeSummary[];
+  history: ActionHistory;
+  commandPort: ChangeReviewHistoryMutationCommandPort;
+  statePort: ChangeReviewHistoryMutationStatePort;
+  viewPort: ChangeReviewHistoryMutationViewPort;
+  scope: ChangeReviewHistoryMutationScope;
+  current: boolean;
+  editedCount: number;
+  persistenceStatus: ReviewActionPersistenceStatus;
+  hasActionInFlight: boolean;
+  externalChange: boolean;
+}
+
+interface ProbeProps {
+  readonly harness: Harness;
+}
+
+let latest: ChangeReviewHistoryMutationController | null = null;
+
+function Probe({ harness }: ProbeProps): React.JSX.Element {
+  latest = useChangeReviewHistoryMutationController({
+    teamName: 'team',
+    memberName: 'member',
+    files: harness.files,
+    editedCount: harness.editedCount,
+    decisionHydrationReady: true,
+    scope: harness.scope,
+    history: harness.history,
+    commandPort: harness.commandPort,
+    statePort: harness.statePort,
+    viewPort: harness.viewPort,
+    captureOperationScope: () => createReviewOperationScopeToken('scope'),
+    isCurrentOperationScope: (_scope: ReviewOperationScopeToken | null) => harness.current,
+    hasActionInFlight: () => harness.hasActionInFlight,
+    isFileMutationInFlight: () => false,
+    blockForExternalChange: () => harness.externalChange,
+    getPersistenceStatus: () => harness.persistenceStatus,
+  });
+  return <div />;
+}
+
+function hunkAction(id = 'action-1'): ReviewUndoAction {
+  return {
+    id,
+    createdAt: '2026-07-23T00:00:00.000Z',
+    kind: 'hunk',
+    action: { filePath: '/repo/file.ts', originalIndex: 0 },
+  };
+}
+
+function diskAction(id = 'disk-1'): ReviewUndoAction {
+  return {
+    id,
+    createdAt: '2026-07-23T00:00:00.000Z',
+    kind: 'disk',
+    action: {
+      originalIndex: 0,
+      snapshot: {
+        filePath: '/repo/file.ts',
+        beforeContent: 'before',
+        afterContent: 'after',
+      },
+    },
+  } as ReviewUndoAction;
+}
+
+function persistedState(
+  undo: ReviewUndoAction[] = [],
+  redo: ReviewRedoAction[] = []
+): ReviewPersistedStateSnapshot {
+  return {
+    hunkDecisions: {},
+    fileDecisions: {},
+    hunkContextHashesByFile: {},
+    reviewActionHistory: undo,
+    reviewRedoHistory: redo,
+  };
+}
+
+function recoveryResult(
+  input: Partial<RetryReviewMutationRecoveryResult> = {}
+): RetryReviewMutationRecoveryResult {
+  return {
+    decisionRevision: 4,
+    recoveredMutation: false,
+    recoveredRestoreHistory: false,
+    differentMutationPending: false,
+    persistedState: null,
+    expectedRestoreCompleted: false,
+    diskPostimages: [],
+    retried: false,
+    ...input,
+  };
+}
+
+function createHarness(
+  input: {
+    undo?: ReviewUndoAction[];
+    redo?: ReviewRedoAction[];
+    state?: Partial<ChangeReviewHistoryStateSnapshot>;
+  } = {}
+): Harness {
+  let undo = input.undo ?? [];
+  let redo = input.redo ?? [];
+  const state: ChangeReviewHistoryStateSnapshot = {
+    hunkDecisions: { '/repo/file.ts:0': 'accepted' },
+    fileDecisions: {},
+    hunkContextHashesByFile: {},
+    decisionRevision: 4,
+    ...input.state,
+  };
+  const history: ActionHistory = {
+    getUndoHistory: vi.fn(() => undo),
+    getRedoHistory: vi.fn(() => redo),
+    getLatestUndoAction: vi.fn(() => undo.at(-1)),
+    getLatestRedoAction: vi.fn(() => redo.at(-1)),
+    completeUndoAction: vi.fn((action, redoAction) => {
+      if (undo.at(-1) !== action) return false;
+      undo = undo.slice(0, -1);
+      redo = [...redo, redoAction];
+      return true;
+    }),
+    completeRedoAction: vi.fn((redoAction) => {
+      if (redo.at(-1) !== redoAction) return false;
+      redo = redo.slice(0, -1);
+      undo = [...undo, redoAction.action];
+      return true;
+    }),
+    replaceHistories: vi.fn((nextUndo, nextRedo) => {
+      undo = nextUndo;
+      redo = nextRedo;
+    }),
+  };
+  const commandPort: ChangeReviewHistoryMutationCommandPort = {
+    executeMutation: vi.fn().mockResolvedValue({ decisionRevision: 5, diskPostimages: [] }),
+    restoreHistory: vi.fn().mockResolvedValue({
+      decisionRevision: 5,
+      persistedState: persistedState(),
+      direction: 'undo',
+      actionCount: 1,
+      diskPostimages: [],
+    } satisfies RestoreReviewHistoryResult),
+    retryRecovery: vi.fn().mockResolvedValue(recoveryResult()),
+  };
+  const statePort: ChangeReviewHistoryMutationStatePort = {
+    getSnapshot: vi.fn(() => state),
+    quiesceDecisionPersistence: vi.fn().mockResolvedValue(true),
+    recordDecisionRevision: vi.fn(),
+    applyDecisionState: vi.fn(),
+    applyPersistedState: vi.fn(),
+    reportError: vi.fn(),
+    clearExternalChange: vi.fn(),
+    invalidateResolvedFileContent: vi.fn(),
+  };
+  const viewPort: ChangeReviewHistoryMutationViewPort = {
+    addMissingFile: vi.fn(),
+    fetchFileContent: vi.fn(),
+    incrementDiscardCounters: vi.fn(),
+    navigateToAction: vi.fn(),
+    markExpectedWrite: vi.fn(),
+    clearExpectedWrite: vi.fn(),
+    markCommittedPostimages: vi.fn(),
+    setMutationInFlight: vi.fn(),
+  };
+  return {
+    files: [
+      {
+        filePath: '/repo/file.ts',
+        relativePath: 'file.ts',
+        snippets: [],
+        linesAdded: 1,
+        linesRemoved: 0,
+        isNewFile: false,
+      },
+    ],
+    history,
+    commandPort,
+    statePort,
+    viewPort,
+    scope: {
+      review: { teamName: 'team', memberName: 'member' },
+      persistence: { teamName: 'team', scopeKey: 'scope', scopeToken: 'token' },
+    },
+    current: true,
+    editedCount: 0,
+    persistenceStatus: 'saved',
+    hasActionInFlight: false,
+    externalChange: false,
+  };
+}
+
+async function renderHarness(harness: Harness): Promise<ReturnType<typeof createRoot>> {
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  const root = createRoot(document.body.appendChild(document.createElement('div')));
+  await act(async () => root.render(<Probe harness={harness} />));
+  return root;
+}
+
+describe('useChangeReviewHistoryMutationController', () => {
+  afterEach(() => {
+    latest = null;
+    document.body.innerHTML = '';
+    vi.unstubAllGlobals();
+  });
+
+  it('commits Undo with exact top-action and revision CAS before popping local history', async () => {
+    const action = hunkAction();
+    const harness = createHarness({ undo: [action] });
+    await renderHarness(harness);
+
+    await act(async () => latest!.undoLatest());
+
+    const request = vi.mocked(harness.commandPort.executeMutation).mock.calls[0]![0];
+    expect(request.expectedTopActionId).toBe(action.id);
+    expect(request.expectedDecisionRevision).toBe(4);
+    expect(request.decisionPersistenceScope).toEqual({ scopeKey: 'scope', scopeToken: 'token' });
+    expect(request.persistedState.hunkDecisions).toEqual({});
+    expect(request.persistedState.reviewActionHistory).toEqual([]);
+    expect(harness.history.completeUndoAction).toHaveBeenCalledTimes(1);
+    expect(harness.statePort.recordDecisionRevision).toHaveBeenCalledWith(
+      harness.scope.persistence,
+      5
+    );
+    expect(harness.viewPort.setMutationInFlight).toHaveBeenNthCalledWith(1, true);
+    expect(harness.viewPort.setMutationInFlight).toHaveBeenLastCalledWith(false);
+  });
+
+  it('does not execute or publish Undo after the operation scope becomes stale', async () => {
+    const action = hunkAction();
+    const harness = createHarness({ undo: [action] });
+    vi.mocked(harness.statePort.quiesceDecisionPersistence).mockImplementation(async () => {
+      harness.current = false;
+      return true;
+    });
+    await renderHarness(harness);
+
+    await act(async () => latest!.undoLatest());
+
+    expect(harness.commandPort.executeMutation).not.toHaveBeenCalled();
+    expect(harness.history.completeUndoAction).not.toHaveBeenCalled();
+    expect(harness.statePort.applyDecisionState).not.toHaveBeenCalled();
+    expect(harness.viewPort.setMutationInFlight).toHaveBeenCalledTimes(1);
+  });
+
+  it('prepares Redo disk expectations and commits the exact redo-head CAS', async () => {
+    const action = diskAction();
+    const redoAction: ReviewRedoAction = {
+      action,
+      decisionSnapshot: { hunkDecisions: { restored: 'rejected' }, fileDecisions: {} },
+    };
+    const harness = createHarness({ redo: [redoAction] });
+    const order: string[] = [];
+    vi.mocked(harness.viewPort.markExpectedWrite).mockImplementation(() => order.push('expect'));
+    vi.mocked(harness.commandPort.executeMutation).mockImplementation(async () => {
+      order.push('execute');
+      return { decisionRevision: 5, diskPostimages: [] };
+    });
+    await renderHarness(harness);
+
+    await act(async () => latest!.redoLatest());
+
+    const request = vi.mocked(harness.commandPort.executeMutation).mock.calls[0]![0];
+    expect(order).toEqual(['expect', 'execute']);
+    expect(harness.viewPort.markExpectedWrite).toHaveBeenCalledWith('/repo/file.ts', 'after');
+    expect(request.expectedTopRedoActionId).toBe(action.id);
+    expect(request.expectedDecisionRevision).toBe(4);
+    expect(harness.history.completeRedoAction).toHaveBeenCalledWith(redoAction);
+  });
+
+  it('retries the original Restore only after a no-journal recovery finishes its busy scope', async () => {
+    const action = hunkAction();
+    const harness = createHarness({ undo: [action] });
+    vi.mocked(harness.commandPort.retryRecovery).mockResolvedValue(
+      recoveryResult({ decisionRevision: 4 })
+    );
+    await renderHarness(harness);
+
+    await act(async () => latest!.recoverFailedHistory({ kind: 'start' }));
+
+    expect(harness.commandPort.retryRecovery).toHaveBeenCalledTimes(1);
+    expect(harness.commandPort.restoreHistory).toHaveBeenCalledTimes(1);
+    expect(harness.viewPort.setMutationInFlight).toHaveBeenNthCalledWith(1, true);
+    expect(harness.viewPort.setMutationInFlight).toHaveBeenNthCalledWith(2, false);
+    expect(harness.viewPort.setMutationInFlight).toHaveBeenNthCalledWith(3, true);
+    expect(harness.viewPort.setMutationInFlight).toHaveBeenLastCalledWith(false);
+  });
+
+  it('clears prepared expectations and fails closed for a different pending mutation', async () => {
+    const action = diskAction();
+    const harness = createHarness({ undo: [action] });
+    vi.mocked(harness.commandPort.retryRecovery).mockResolvedValue(
+      recoveryResult({ differentMutationPending: true })
+    );
+    await renderHarness(harness);
+
+    let recoveryError: unknown;
+    await act(async () => {
+      try {
+        await latest!.recoverFailedHistory({ kind: 'start' });
+      } catch (error) {
+        recoveryError = error;
+      }
+    });
+
+    expect(recoveryError).toEqual(
+      expect.objectContaining({
+        message: expect.stringContaining('different interrupted review update'),
+      })
+    );
+    expect(harness.viewPort.clearExpectedWrite).toHaveBeenCalledWith('/repo/file.ts');
+    expect(harness.commandPort.restoreHistory).not.toHaveBeenCalled();
+    expect(harness.statePort.reportError).toHaveBeenCalledWith(
+      expect.stringContaining('different interrupted review update')
+    );
+  });
+
+  it('blocks Restore before IPC while decision persistence is not saved', async () => {
+    const harness = createHarness({ undo: [hunkAction()] });
+    harness.persistenceStatus = 'saving';
+    await renderHarness(harness);
+
+    let restoreError: unknown;
+    await act(async () => {
+      try {
+        await latest!.restoreHistory({ kind: 'start' });
+      } catch (error) {
+        restoreError = error;
+      }
+    });
+    expect(restoreError).toEqual(
+      expect.objectContaining({
+        message: expect.stringContaining('Latest review action is not saved'),
+      })
+    );
+    expect(harness.commandPort.restoreHistory).not.toHaveBeenCalled();
+  });
+});

--- a/test/renderer/components/team/review/ChangeReviewDialog.guards.test.ts
+++ b/test/renderer/components/team/review/ChangeReviewDialog.guards.test.ts
@@ -538,7 +538,7 @@ describe('ChangeReviewDialog interaction guards', () => {
   it('keeps ordered review history beyond the former ten-action limit', () => {
     const actions = Array.from({ length: 100 }, (_, index) => `action-${index}`);
     let stack: string[] = [];
-    for (const action of actions) stack = appendOrderedReviewAction(stack, action, 10);
+    for (const action of actions) stack = appendOrderedReviewAction(stack, action);
     expect(stack).toEqual(actions);
   });
 


### PR DESCRIPTION
## Summary

- move durable Undo, Redo, checkpoint Restore, and interrupted-Restore recovery into a focused controller
- isolate review mutation commands, persisted state, and renderer refresh effects behind narrow ports
- preserve quiesce ordering, disk write expectations, revision and history-head CAS, and stale-scope fencing
- fix rollback after a main-bound action replacement so the previous Redo branch is restored
- tighten persisted snapshot types and keep adapter-only fields out of IPC payloads
- reduce ChangeReviewDialog from 4155 to 3600 lines

## Verification

- pnpm typecheck
- pnpm lint:fast:files for the changed production scope
- type-aware ESLint for changed production files: 0 errors
- 31 change-review test files, 176 tests passed
- focused mutation and regression suite: 54 tests passed
- pnpm test:arch:node: 23/23 passed
- production Electron build and Radix bundle verification passed
- git diff --check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced durable Undo/Redo, checkpoint restore, and recovery flows for change reviews, including restore previews with affected actions and disk transitions.
* **Bug Fixes**
  * Improved optimistic discard matching to restore the correct redo history reliably.
  * Prevented restore operations while review decision persistence is still saving; improved recovery classification and conflict handling.
* **Tests**
  * Added/expanded unit and React hook test suites covering mutation ports, undo/redo, restore/recovery, and safety guards.
* **Documentation**
  * Updated change-review documentation clarifying ownership boundaries for history and dialog responsibilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactors durable change-review history mutations behind focused controller and port boundaries.
- Moves Undo, Redo, checkpoint Restore, and interrupted-Restore recovery out of `ChangeReviewDialog`.
- Adds typed command, state, and view ports for mutation orchestration.
- Preserves revision checks, persistence quiescing, stale-scope fencing, disk refresh effects, and history synchronization.
- Fixes restoration of the previous Redo branch after discarding a main-bound replacement action.
- Adds focused controller, adapter, persistence, history, and interaction-guard tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no eligible blocking failures remain.

No blocking failures remain.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/features/change-review/renderer/hooks/useChangeReviewHistoryMutationController.ts | Introduces the focused orchestration layer for durable Undo, Redo, Restore, and recovery operations. |
| src/renderer/components/team/review/ChangeReviewDialog.tsx | Replaces inline history-mutation logic with memoized scopes, adapters, ports, and the extracted controller. |
| src/features/change-review/renderer/hooks/useChangeReviewActionHistoryController.ts | Makes rollback identify replaced optimistic actions by stable action ID so the prior Redo branch is restored. |
| src/features/change-review/renderer/utils/changeReviewHistoryMutation.ts | Centralizes pure recovery classification, redo snapshot construction, expected-content selection, and path resolution. |
| src/features/change-review/renderer/ports/changeReviewHistoryMutationPorts.ts | Defines narrow typed boundaries for durable commands, state effects, and renderer refresh behavior. |
| test/features/change-review/renderer/useChangeReviewHistoryMutationController.test.tsx | Covers revision and history-head checks, stale-scope fencing, write expectations, recovery sequencing, and persistence guards. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Dialog[ChangeReviewDialog] --> Controller[History Mutation Controller]
  Controller --> CommandPort[Command Port]
  Controller --> StatePort[State Port]
  Controller --> ViewPort[View Port]
  CommandPort --> ReviewAPI[Review API / Durable Mutations]
  StatePort --> Store[Review State Store]
  ViewPort --> Renderer[Renderer Refresh and Navigation]
  Controller --> History[Action History Controller]
```

<sub>Reviews (2): Last reviewed commit: ["fix(change-review): avoid duplicate edit..."](https://github.com/777genius/agent-teams-ai/commit/76b39ffef55dac51a623b9e12ba9a2055a89c485) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46629775)</sub>

<!-- /greptile_comment -->