### PR TITLE
refactor(agent-graph): isolate team layout state

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -385,7 +385,7 @@ export default defineConfig([
                 '@features/agent-graph/renderer/**',
               ],
               message:
-                'Import agent-graph only through its public entrypoint: @features/agent-graph/renderer.',
+                'Import agent-graph only through public entrypoints: @features/agent-graph or @features/agent-graph/renderer.',
             },
           ],
         },

--- a/src/features/agent-graph/README.md
+++ b/src/features/agent-graph/README.md
@@ -3,19 +3,25 @@
 This feature is a thin renderer slice over the reusable graph engine in `packages/agent-graph`.
 
 Read first:
-- [Feature Architecture Standard](../../docs/FEATURE_ARCHITECTURE_STANDARD.md)
+
+- [Feature Architecture Standard](../../../docs/FEATURE_ARCHITECTURE_STANDARD.md)
 - [Feature root guidance](../CLAUDE.md)
 - [Stable Slot Layout Plan](./STABLE_SLOT_LAYOUT_PLAN.md)
 
-Public entrypoint:
-- `@features/agent-graph/renderer`
+Public entrypoints:
+
+- `@features/agent-graph` - layout policies plus the port-driven store action factory
+- `@features/agent-graph/renderer` - renderer adapters, hooks, and UI
 
 Responsibilities:
+
 - `packages/agent-graph` owns reusable graph rendering and low-level graph mechanics
-- `src/features/agent-graph/core/domain` owns project-specific graph semantics and pure projection helpers
+- `src/features/agent-graph/core/domain` owns project-specific graph semantics, layout state transitions, and pure projection helpers
+- `src/features/agent-graph/core/application` owns store action orchestration through narrow state, seed-selection, and diagnostic ports
 - `src/features/agent-graph/renderer` owns the renderer integration layer, hooks, adapters, and UI
 
 Use this feature as the thin-slice example when a feature:
+
 - has no dedicated `main` or `preload` transport boundary
 - integrates an existing reusable package into the app shell
 - still needs its own feature boundary and public entrypoint

--- a/src/features/agent-graph/core/application/createTeamGraphLayoutActions.ts
+++ b/src/features/agent-graph/core/application/createTeamGraphLayoutActions.ts
@@ -1,0 +1,166 @@
+import {
+  type TeamGraphLayoutActions,
+  type TeamGraphLayoutDiagnostic,
+  type TeamGraphLayoutState,
+  type TeamGraphLayoutStatePatch,
+  type TeamGraphLayoutTransition,
+} from '../domain/teamGraphLayoutState';
+import {
+  assignTeamGraphOwnerSlot,
+  changeTeamGraphLayoutMode,
+  clearTeamGraphLayout,
+  commitTeamGraphOwnerSlotDrop,
+  ensureTeamGraphLayoutState,
+  resetTeamGraphLayoutToDefaults,
+  swapTeamGraphGridOwners,
+  swapTeamGraphOwnerSlots,
+} from '../domain/teamGraphLayoutTransitions';
+
+import type { TeamGraphDefaultLayoutSeed } from '../domain/teamGraphDefaultLayout';
+
+interface TeamGraphLayoutActionPorts<TState extends TeamGraphLayoutState> {
+  setState: (updater: (state: TState) => TeamGraphLayoutStatePatch | null) => void;
+  selectDefaultLayoutSeed: (state: TState, teamName: string) => TeamGraphDefaultLayoutSeed | null;
+  warn: (message: string) => void;
+}
+
+function formatDiagnostic(diagnostic: TeamGraphLayoutDiagnostic): string {
+  switch (diagnostic.code) {
+    case 'duplicate-stable-owner-id':
+      return (
+        `[graph-layout] refusing duplicate owner identities team=${diagnostic.teamName} ` +
+        `owners=${diagnostic.duplicateStableOwnerIds.join(',')}`
+      );
+    case 'invalid-team-name':
+      return '[graph-layout] refusing blank team name';
+    case 'invalid-slot-assignment':
+      return (
+        `[graph-layout] refusing invalid ${diagnostic.assignmentRole} slot assignment ` +
+        `team=${diagnostic.teamName} owner=${diagnostic.stableOwnerId} ` +
+        `target=${diagnostic.assignment.ringIndex}:${diagnostic.assignment.sectorIndex}`
+      );
+    case 'incomplete-slot-drop-displacement':
+      return (
+        `[graph-layout] refusing incomplete slot drop team=${diagnostic.teamName} ` +
+        `owner=${diagnostic.stableOwnerId} ` +
+        `target=${diagnostic.assignment.ringIndex}:${diagnostic.assignment.sectorIndex}`
+      );
+    case 'inconsistent-slot-drop-displacement':
+      return (
+        `[graph-layout] refusing inconsistent slot drop team=${diagnostic.teamName} ` +
+        `owner=${diagnostic.stableOwnerId} displaced=${diagnostic.displacedStableOwnerId} ` +
+        `target=${diagnostic.assignment.ringIndex}:${diagnostic.assignment.sectorIndex} ` +
+        `reason=${diagnostic.reason}`
+      );
+    case 'occupied-slot-assignment':
+      return (
+        `[graph-layout] refusing occupied slot assignment team=${diagnostic.teamName} ` +
+        `owner=${diagnostic.stableOwnerId} ` +
+        `target=${diagnostic.assignment.ringIndex}:${diagnostic.assignment.sectorIndex} ` +
+        `occupiedBy=${diagnostic.conflictingStableOwnerId}`
+      );
+    case 'slot-drop-conflict':
+      return (
+        `[graph-layout] refusing slot drop team=${diagnostic.teamName} ` +
+        `owner=${diagnostic.stableOwnerId} ` +
+        `target=${diagnostic.assignment.ringIndex}:${diagnostic.assignment.sectorIndex} ` +
+        `conflict=${diagnostic.conflictingStableOwnerId}`
+      );
+  }
+}
+
+function resolveTransition(
+  transition: TeamGraphLayoutTransition,
+  warn: (message: string) => void
+): TeamGraphLayoutStatePatch | null {
+  if (transition.kind === 'updated') {
+    return transition.patch;
+  }
+  if (transition.kind === 'refused') {
+    warn(formatDiagnostic(transition.diagnostic));
+  }
+  return null;
+}
+
+export function createTeamGraphLayoutActions<TState extends TeamGraphLayoutState>(
+  ports: TeamGraphLayoutActionPorts<TState>
+): TeamGraphLayoutActions {
+  const apply = (transition: (state: TState) => TeamGraphLayoutTransition): void => {
+    ports.setState((state) => resolveTransition(transition(state), ports.warn));
+  };
+
+  return {
+    ensureTeamGraphSlotAssignments: (teamName, members, configMembers = []) => {
+      apply((state) => ensureTeamGraphLayoutState(state, teamName, members, configMembers));
+    },
+    setTeamGraphOwnerSlotAssignment: (teamName, stableOwnerId, assignment) => {
+      apply((state) => assignTeamGraphOwnerSlot(state, teamName, stableOwnerId, assignment));
+    },
+    commitTeamGraphOwnerSlotDrop: (
+      teamName,
+      stableOwnerId,
+      assignment,
+      displacedStableOwnerId,
+      displacedAssignment
+    ) => {
+      apply((state) => {
+        const visibleOwnerIds =
+          ports.selectDefaultLayoutSeed(state, teamName)?.orderedVisibleOwnerIds ?? [];
+        return commitTeamGraphOwnerSlotDrop(
+          state,
+          teamName,
+          stableOwnerId,
+          assignment,
+          displacedStableOwnerId,
+          displacedAssignment,
+          visibleOwnerIds
+        );
+      });
+    },
+    setTeamGraphLayoutMode: (teamName, mode) => {
+      apply((state) => changeTeamGraphLayoutMode(state, teamName, mode));
+    },
+    swapTeamGraphGridOwners: (teamName, stableOwnerId, targetStableOwnerId) => {
+      if (stableOwnerId === targetStableOwnerId) {
+        return;
+      }
+      apply((state) => {
+        const defaultSeed = ports.selectDefaultLayoutSeed(state, teamName);
+        const fallbackVisibleOwnerIds = [...(state.gridOwnerOrderByTeam[teamName] ?? [])];
+        for (const ownerId of [stableOwnerId, targetStableOwnerId]) {
+          if (!fallbackVisibleOwnerIds.includes(ownerId)) {
+            fallbackVisibleOwnerIds.push(ownerId);
+          }
+        }
+        const visibleOwnerIds = defaultSeed?.orderedVisibleOwnerIds ?? fallbackVisibleOwnerIds;
+        return swapTeamGraphGridOwners(
+          state,
+          teamName,
+          stableOwnerId,
+          targetStableOwnerId,
+          visibleOwnerIds
+        );
+      });
+    },
+    swapTeamGraphOwnerSlots: (teamName, stableOwnerId, otherStableOwnerId) => {
+      if (stableOwnerId === otherStableOwnerId) {
+        return;
+      }
+      apply((state) => swapTeamGraphOwnerSlots(state, teamName, stableOwnerId, otherStableOwnerId));
+    },
+    clearTeamGraphSlotAssignments: (teamName) => {
+      apply((state) => clearTeamGraphLayout(state, teamName));
+    },
+    resetTeamGraphSlotAssignmentsToDefaults: (teamName) => {
+      apply((state) => {
+        const defaultSeed = ports.selectDefaultLayoutSeed(state, teamName) ?? {
+          orderedVisibleOwnerIds: [],
+          signature: null,
+          assignments: {},
+          duplicateStableOwnerIds: [],
+        };
+        return resetTeamGraphLayoutToDefaults(state, teamName, defaultSeed);
+      });
+    },
+  };
+}

--- a/src/features/agent-graph/core/domain/graphOwnerIdentity.ts
+++ b/src/features/agent-graph/core/domain/graphOwnerIdentity.ts
@@ -1,7 +1,5 @@
 import { getStableTeamOwnerId, type StableTeamOwnerLike } from '@shared/utils/teamStableOwnerId';
 
-export const GRAPH_STABLE_SLOT_LAYOUT_VERSION = 'stable-slots-v1' as const;
-
 export function getGraphStableOwnerId(member: StableTeamOwnerLike): string {
   return getStableTeamOwnerId(member);
 }

--- a/src/features/agent-graph/core/domain/teamGraphDefaultLayout.ts
+++ b/src/features/agent-graph/core/domain/teamGraphDefaultLayout.ts
@@ -13,6 +13,7 @@ export interface TeamGraphDefaultLayoutSeed {
   orderedVisibleOwnerIds: string[];
   signature: string | null;
   assignments: Record<string, GraphOwnerSlotAssignment>;
+  duplicateStableOwnerIds: string[];
 }
 
 const DEFAULT_OWNER_SLOT_PRESETS: readonly (readonly GraphOwnerSlotAssignment[])[] = [
@@ -136,18 +137,34 @@ const DEFAULT_OWNER_SLOT_PRESETS: readonly (readonly GraphOwnerSlotAssignment[])
   ],
 ];
 
-export function buildOrderedVisibleTeamGraphOwnerIds(
+function resolveOrderedVisibleTeamGraphOwnerIds(
   members: readonly TeamGraphDefaultLayoutMemberInput[],
   configMembers: readonly TeamGraphDefaultLayoutMemberInput[] = []
-): string[] {
+): { orderedVisibleOwnerIds: string[]; duplicateStableOwnerIds: string[] } {
   const visibleMembers = members.filter((member) => !member.removedAt && !isLeadMember(member));
   if (visibleMembers.length === 0) {
-    return [];
+    return { orderedVisibleOwnerIds: [], duplicateStableOwnerIds: [] };
   }
 
-  const visibleMemberByStableOwnerId = new Map(
-    visibleMembers.map((member) => [getStableTeamOwnerId(member), member] as const)
-  );
+  const visibleMemberByStableOwnerId = new Map<string, TeamGraphDefaultLayoutMemberInput>();
+  const duplicateStableOwnerIds = new Set<string>();
+  for (const member of visibleMembers) {
+    const stableOwnerId = getStableTeamOwnerId(member);
+    if (visibleMemberByStableOwnerId.has(stableOwnerId)) {
+      duplicateStableOwnerIds.add(stableOwnerId);
+      continue;
+    }
+    visibleMemberByStableOwnerId.set(stableOwnerId, member);
+  }
+  if (duplicateStableOwnerIds.size > 0) {
+    return {
+      orderedVisibleOwnerIds: [],
+      duplicateStableOwnerIds: [...duplicateStableOwnerIds].toSorted((left, right) =>
+        left.localeCompare(right)
+      ),
+    };
+  }
+
   const orderedVisibleOwnerIds: string[] = [];
   const seenVisibleOwnerIds = new Set<string>();
 
@@ -166,20 +183,27 @@ export function buildOrderedVisibleTeamGraphOwnerIds(
     seenVisibleOwnerIds.add(stableOwnerId);
   }
 
-  const remainingVisibleOwnerIds = visibleMembers
-    .map((member) => getStableTeamOwnerId(member))
+  const remainingVisibleOwnerIds = [...visibleMemberByStableOwnerId.keys()]
     .filter((stableOwnerId) => !seenVisibleOwnerIds.has(stableOwnerId))
     .toSorted((left, right) => left.localeCompare(right));
 
   orderedVisibleOwnerIds.push(...remainingVisibleOwnerIds);
-  return orderedVisibleOwnerIds;
+  return { orderedVisibleOwnerIds, duplicateStableOwnerIds: [] };
+}
+
+export function buildOrderedVisibleTeamGraphOwnerIds(
+  members: readonly TeamGraphDefaultLayoutMemberInput[],
+  configMembers: readonly TeamGraphDefaultLayoutMemberInput[] = []
+): string[] {
+  return resolveOrderedVisibleTeamGraphOwnerIds(members, configMembers).orderedVisibleOwnerIds;
 }
 
 export function buildTeamGraphDefaultLayoutSeed(
   members: readonly TeamGraphDefaultLayoutMemberInput[],
   configMembers: readonly TeamGraphDefaultLayoutMemberInput[] = []
 ): TeamGraphDefaultLayoutSeed {
-  const orderedVisibleOwnerIds = buildOrderedVisibleTeamGraphOwnerIds(members, configMembers);
+  const { orderedVisibleOwnerIds, duplicateStableOwnerIds } =
+    resolveOrderedVisibleTeamGraphOwnerIds(members, configMembers);
   const signature = orderedVisibleOwnerIds.length > 0 ? orderedVisibleOwnerIds.join('|') : null;
   const preset = DEFAULT_OWNER_SLOT_PRESETS[orderedVisibleOwnerIds.length];
   const assignments: Record<string, GraphOwnerSlotAssignment> = {};
@@ -194,5 +218,6 @@ export function buildTeamGraphDefaultLayoutSeed(
     orderedVisibleOwnerIds,
     signature,
     assignments,
+    duplicateStableOwnerIds,
   };
 }

--- a/src/features/agent-graph/core/domain/teamGraphLayoutAssignments.ts
+++ b/src/features/agent-graph/core/domain/teamGraphLayoutAssignments.ts
@@ -1,23 +1,12 @@
-import { buildTeamGraphDefaultLayoutSeed } from '@shared/utils/teamGraphDefaultLayout';
 import { getStableTeamOwnerId } from '@shared/utils/teamStableOwnerId';
 
-import type { GraphOwnerSlotAssignment } from '@claude-teams/agent-graph';
-import type { TeamMemberSnapshot, TeamViewSnapshot } from '@shared/types';
-
-export const GRAPH_STABLE_SLOT_LAYOUT_VERSION = 'stable-slots-v1' as const;
-export const DISABLE_PERSISTED_TEAM_GRAPH_SLOT_ASSIGNMENTS = true;
-
-export type TeamGraphSlotAssignments = Record<string, GraphOwnerSlotAssignment>;
-export type TeamGraphMemberSeedInput = Pick<TeamMemberSnapshot, 'name' | 'agentId' | 'removedAt'>;
-export type TeamGraphConfigMemberSeedInput = Pick<
-  NonNullable<TeamViewSnapshot['config']['members']>[number],
-  'name' | 'agentId' | 'removedAt'
->;
-
-export interface TeamGraphLayoutSessionState {
-  mode: 'default' | 'manual';
-  signature: string | null;
-}
+import { buildTeamGraphDefaultLayoutSeed } from './teamGraphDefaultLayout';
+import {
+  DISABLE_PERSISTED_TEAM_GRAPH_SLOT_ASSIGNMENTS,
+  type TeamGraphConfigMemberSeedInput,
+  type TeamGraphMemberSeedInput,
+  type TeamGraphSlotAssignments,
+} from './teamGraphLayoutState';
 
 export function migrateStableSlotAssignmentsForMembers(
   assignments: TeamGraphSlotAssignments | undefined,

--- a/src/features/agent-graph/core/domain/teamGraphLayoutState.ts
+++ b/src/features/agent-graph/core/domain/teamGraphLayoutState.ts
@@ -1,0 +1,128 @@
+import type { GraphLayoutMode, GraphOwnerSlotAssignment } from '@claude-teams/agent-graph';
+import type { TeamMemberSnapshot, TeamViewSnapshot } from '@shared/types';
+
+export const GRAPH_STABLE_SLOT_LAYOUT_VERSION = 'stable-slots-v1' as const;
+export const DISABLE_PERSISTED_TEAM_GRAPH_SLOT_ASSIGNMENTS = true;
+
+export type TeamGraphSlotAssignments = Record<string, GraphOwnerSlotAssignment>;
+export type TeamGraphMemberSeedInput = Pick<TeamMemberSnapshot, 'name' | 'agentId' | 'removedAt'>;
+export type TeamGraphConfigMemberSeedInput = Pick<
+  NonNullable<TeamViewSnapshot['config']['members']>[number],
+  'name' | 'agentId' | 'removedAt'
+>;
+
+export interface TeamGraphLayoutSessionState {
+  mode: 'default' | 'manual';
+  signature: string | null;
+}
+
+export interface TeamGraphLayoutState {
+  slotLayoutVersion: string;
+  graphLayoutModeByTeam: Record<string, GraphLayoutMode>;
+  gridOwnerOrderByTeam: Record<string, string[]>;
+  slotAssignmentsByTeam: Record<string, TeamGraphSlotAssignments>;
+  graphLayoutSessionByTeam: Record<string, TeamGraphLayoutSessionState>;
+}
+
+export interface TeamGraphLayoutActions {
+  ensureTeamGraphSlotAssignments: (
+    teamName: string,
+    members: readonly TeamGraphMemberSeedInput[],
+    configMembers?: readonly TeamGraphConfigMemberSeedInput[]
+  ) => void;
+  setTeamGraphOwnerSlotAssignment: (
+    teamName: string,
+    stableOwnerId: string,
+    assignment: GraphOwnerSlotAssignment
+  ) => void;
+  commitTeamGraphOwnerSlotDrop: (
+    teamName: string,
+    stableOwnerId: string,
+    assignment: GraphOwnerSlotAssignment,
+    displacedStableOwnerId?: string,
+    displacedAssignment?: GraphOwnerSlotAssignment
+  ) => void;
+  setTeamGraphLayoutMode: (teamName: string, mode: GraphLayoutMode) => void;
+  swapTeamGraphGridOwners: (
+    teamName: string,
+    stableOwnerId: string,
+    targetStableOwnerId: string
+  ) => void;
+  swapTeamGraphOwnerSlots: (
+    teamName: string,
+    stableOwnerId: string,
+    otherStableOwnerId: string
+  ) => void;
+  clearTeamGraphSlotAssignments: (teamName?: string) => void;
+  resetTeamGraphSlotAssignmentsToDefaults: (teamName: string) => void;
+}
+
+export type TeamGraphLayoutSlice = TeamGraphLayoutState & TeamGraphLayoutActions;
+export type TeamGraphLayoutStatePatch = Partial<TeamGraphLayoutState>;
+
+export type TeamGraphLayoutDiagnostic =
+  | {
+      code: 'duplicate-stable-owner-id';
+      teamName: string;
+      duplicateStableOwnerIds: string[];
+    }
+  | {
+      code: 'invalid-slot-assignment';
+      teamName: string;
+      stableOwnerId: string;
+      assignment: GraphOwnerSlotAssignment;
+      assignmentRole: 'target' | 'displaced';
+    }
+  | {
+      code: 'invalid-team-name';
+      teamName: string;
+    }
+  | {
+      code: 'occupied-slot-assignment';
+      teamName: string;
+      stableOwnerId: string;
+      assignment: GraphOwnerSlotAssignment;
+      conflictingStableOwnerId: string;
+    }
+  | {
+      code: 'incomplete-slot-drop-displacement';
+      teamName: string;
+      stableOwnerId: string;
+      assignment: GraphOwnerSlotAssignment;
+    }
+  | {
+      code: 'inconsistent-slot-drop-displacement';
+      teamName: string;
+      stableOwnerId: string;
+      assignment: GraphOwnerSlotAssignment;
+      displacedStableOwnerId: string;
+      reason:
+        | 'same-owner'
+        | 'same-slot'
+        | 'missing-source-owner'
+        | 'missing-displaced-owner'
+        | 'stale-source-assignment'
+        | 'stale-displaced-assignment';
+    }
+  | {
+      code: 'slot-drop-conflict';
+      teamName: string;
+      stableOwnerId: string;
+      assignment: GraphOwnerSlotAssignment;
+      conflictingStableOwnerId: string;
+    };
+
+export type TeamGraphLayoutTransition =
+  | { kind: 'updated'; patch: TeamGraphLayoutStatePatch }
+  | { kind: 'unchanged' }
+  | { kind: 'refused'; diagnostic: TeamGraphLayoutDiagnostic };
+
+export function createInitialTeamGraphLayoutState(): TeamGraphLayoutState {
+  return {
+    slotLayoutVersion: GRAPH_STABLE_SLOT_LAYOUT_VERSION,
+    graphLayoutModeByTeam: {},
+    gridOwnerOrderByTeam: {},
+    slotAssignmentsByTeam: {},
+    graphLayoutSessionByTeam: {},
+  };
+}

--- a/src/features/agent-graph/core/domain/teamGraphLayoutTransitions.ts
+++ b/src/features/agent-graph/core/domain/teamGraphLayoutTransitions.ts
@@ -1,0 +1,615 @@
+import { DEFAULT_TEAM_GRAPH_LAYOUT_MODE } from '@shared/constants/teamGraphLayoutMode';
+
+import {
+  buildTeamGraphDefaultLayoutSeed,
+  type TeamGraphDefaultLayoutSeed,
+} from './teamGraphDefaultLayout';
+import {
+  areTeamGraphSlotAssignmentsEqual,
+  migrateStableSlotAssignmentsForMembers,
+  normalizeTeamGraphGridOwnerOrder,
+  pruneTeamGraphSlotAssignmentsForVisibleOwners,
+  seedStableSlotAssignmentsForMembers,
+} from './teamGraphLayoutAssignments';
+import {
+  DISABLE_PERSISTED_TEAM_GRAPH_SLOT_ASSIGNMENTS,
+  GRAPH_STABLE_SLOT_LAYOUT_VERSION,
+  type TeamGraphConfigMemberSeedInput,
+  type TeamGraphLayoutState,
+  type TeamGraphLayoutStatePatch,
+  type TeamGraphLayoutTransition,
+  type TeamGraphMemberSeedInput,
+  type TeamGraphSlotAssignments,
+} from './teamGraphLayoutState';
+
+import type { GraphLayoutMode, GraphOwnerSlotAssignment } from '@claude-teams/agent-graph';
+
+const UNCHANGED: TeamGraphLayoutTransition = { kind: 'unchanged' };
+
+function updated(patch: TeamGraphLayoutStatePatch): TeamGraphLayoutTransition {
+  return { kind: 'updated', patch };
+}
+
+function areSlotAssignmentsEqual(
+  left: GraphOwnerSlotAssignment | undefined,
+  right: GraphOwnerSlotAssignment
+): boolean {
+  return left?.ringIndex === right.ringIndex && left.sectorIndex === right.sectorIndex;
+}
+
+function isValidSlotAssignment(assignment: GraphOwnerSlotAssignment): boolean {
+  return (
+    Number.isSafeInteger(assignment.ringIndex) &&
+    assignment.ringIndex >= 0 &&
+    Number.isSafeInteger(assignment.sectorIndex) &&
+    assignment.sectorIndex >= 0
+  );
+}
+
+function getWritableLayoutContainers(
+  state: TeamGraphLayoutState
+): Pick<TeamGraphLayoutState, 'slotAssignmentsByTeam' | 'graphLayoutSessionByTeam'> {
+  if (state.slotLayoutVersion === GRAPH_STABLE_SLOT_LAYOUT_VERSION) {
+    return {
+      slotAssignmentsByTeam: state.slotAssignmentsByTeam,
+      graphLayoutSessionByTeam: state.graphLayoutSessionByTeam,
+    };
+  }
+  return {
+    slotAssignmentsByTeam: {},
+    graphLayoutSessionByTeam: {},
+  };
+}
+
+export function ensureTeamGraphLayoutState(
+  state: TeamGraphLayoutState,
+  teamName: string,
+  members: readonly TeamGraphMemberSeedInput[],
+  configMembers: readonly TeamGraphConfigMemberSeedInput[] = []
+): TeamGraphLayoutTransition {
+  const defaultSeed = buildTeamGraphDefaultLayoutSeed(members, configMembers);
+  if (defaultSeed.duplicateStableOwnerIds.length > 0) {
+    return {
+      kind: 'refused',
+      diagnostic: {
+        code: 'duplicate-stable-owner-id',
+        teamName,
+        duplicateStableOwnerIds: defaultSeed.duplicateStableOwnerIds,
+      },
+    };
+  }
+
+  const nextState: TeamGraphLayoutStatePatch = {};
+  let changed = false;
+
+  let nextSlotAssignmentsByTeam = state.slotAssignmentsByTeam;
+  let nextGraphLayoutSessionByTeam = state.graphLayoutSessionByTeam;
+  if (state.slotLayoutVersion !== GRAPH_STABLE_SLOT_LAYOUT_VERSION) {
+    nextState.slotLayoutVersion = GRAPH_STABLE_SLOT_LAYOUT_VERSION;
+    nextSlotAssignmentsByTeam = {};
+    nextGraphLayoutSessionByTeam = {};
+    changed = true;
+  }
+
+  const visibleAssignments = pruneTeamGraphSlotAssignmentsForVisibleOwners(
+    nextSlotAssignmentsByTeam[teamName],
+    defaultSeed.orderedVisibleOwnerIds
+  );
+  const currentSession = nextGraphLayoutSessionByTeam[teamName];
+
+  if (DISABLE_PERSISTED_TEAM_GRAPH_SLOT_ASSIGNMENTS) {
+    if (currentSession?.mode === 'manual') {
+      if (
+        !areTeamGraphSlotAssignmentsEqual(nextSlotAssignmentsByTeam[teamName], visibleAssignments)
+      ) {
+        nextSlotAssignmentsByTeam = { ...nextSlotAssignmentsByTeam };
+        if (visibleAssignments) {
+          nextSlotAssignmentsByTeam[teamName] = visibleAssignments;
+        } else {
+          delete nextSlotAssignmentsByTeam[teamName];
+        }
+        changed = true;
+      }
+    } else {
+      if (
+        !areTeamGraphSlotAssignmentsEqual(
+          nextSlotAssignmentsByTeam[teamName],
+          visibleAssignments
+        ) ||
+        !areTeamGraphSlotAssignmentsEqual(visibleAssignments, defaultSeed.assignments)
+      ) {
+        nextSlotAssignmentsByTeam = { ...nextSlotAssignmentsByTeam };
+        if (Object.keys(defaultSeed.assignments).length === 0) {
+          delete nextSlotAssignmentsByTeam[teamName];
+        } else {
+          nextSlotAssignmentsByTeam[teamName] = defaultSeed.assignments;
+        }
+        changed = true;
+      }
+      if (
+        currentSession?.mode !== 'default' ||
+        currentSession?.signature !== defaultSeed.signature
+      ) {
+        nextGraphLayoutSessionByTeam = {
+          ...nextGraphLayoutSessionByTeam,
+          [teamName]: {
+            mode: 'default',
+            signature: defaultSeed.signature,
+          },
+        };
+        changed = true;
+      }
+    }
+
+    if (!changed) {
+      return UNCHANGED;
+    }
+
+    nextState.slotAssignmentsByTeam = nextSlotAssignmentsByTeam;
+    nextState.graphLayoutSessionByTeam = nextGraphLayoutSessionByTeam;
+    return updated(nextState);
+  }
+
+  const currentAssignments = nextSlotAssignmentsByTeam[teamName];
+  const migrated = migrateStableSlotAssignmentsForMembers(currentAssignments, members);
+  const seeded = seedStableSlotAssignmentsForMembers(migrated.assignments, members, configMembers);
+  if (migrated.changed || seeded.changed) {
+    nextSlotAssignmentsByTeam = {
+      ...nextSlotAssignmentsByTeam,
+      [teamName]: seeded.assignments,
+    };
+    changed = true;
+  }
+
+  if (!changed) {
+    return UNCHANGED;
+  }
+
+  nextState.slotAssignmentsByTeam = nextSlotAssignmentsByTeam;
+  if (nextGraphLayoutSessionByTeam !== state.graphLayoutSessionByTeam) {
+    nextState.graphLayoutSessionByTeam = nextGraphLayoutSessionByTeam;
+  }
+  return updated(nextState);
+}
+
+export function assignTeamGraphOwnerSlot(
+  state: TeamGraphLayoutState,
+  teamName: string,
+  stableOwnerId: string,
+  assignment: GraphOwnerSlotAssignment
+): TeamGraphLayoutTransition {
+  if (!isValidSlotAssignment(assignment)) {
+    return {
+      kind: 'refused',
+      diagnostic: {
+        code: 'invalid-slot-assignment',
+        teamName,
+        stableOwnerId,
+        assignment,
+        assignmentRole: 'target',
+      },
+    };
+  }
+
+  const writable = getWritableLayoutContainers(state);
+  const currentAssignments = writable.slotAssignmentsByTeam[teamName] ?? {};
+  const existing = currentAssignments[stableOwnerId];
+  const occupiedByOther = Object.entries(currentAssignments).find(
+    ([otherStableOwnerId, otherAssignment]) =>
+      otherStableOwnerId !== stableOwnerId &&
+      otherAssignment.ringIndex === assignment.ringIndex &&
+      otherAssignment.sectorIndex === assignment.sectorIndex
+  );
+
+  if (
+    areSlotAssignmentsEqual(existing, assignment) &&
+    state.slotLayoutVersion === GRAPH_STABLE_SLOT_LAYOUT_VERSION
+  ) {
+    return UNCHANGED;
+  }
+
+  if (occupiedByOther) {
+    return {
+      kind: 'refused',
+      diagnostic: {
+        code: 'occupied-slot-assignment',
+        teamName,
+        stableOwnerId,
+        assignment,
+        conflictingStableOwnerId: occupiedByOther[0],
+      },
+    };
+  }
+
+  return updated({
+    slotLayoutVersion: GRAPH_STABLE_SLOT_LAYOUT_VERSION,
+    slotAssignmentsByTeam: {
+      ...writable.slotAssignmentsByTeam,
+      [teamName]: {
+        ...currentAssignments,
+        [stableOwnerId]: assignment,
+      },
+    },
+    graphLayoutSessionByTeam: {
+      ...writable.graphLayoutSessionByTeam,
+      [teamName]: {
+        mode: 'manual',
+        signature: writable.graphLayoutSessionByTeam[teamName]?.signature ?? null,
+      },
+    },
+  });
+}
+
+export function commitTeamGraphOwnerSlotDrop(
+  state: TeamGraphLayoutState,
+  teamName: string,
+  stableOwnerId: string,
+  assignment: GraphOwnerSlotAssignment,
+  displacedStableOwnerId?: string,
+  displacedAssignment?: GraphOwnerSlotAssignment,
+  visibleOwnerIds: readonly string[] = []
+): TeamGraphLayoutTransition {
+  if (!isValidSlotAssignment(assignment)) {
+    return {
+      kind: 'refused',
+      diagnostic: {
+        code: 'invalid-slot-assignment',
+        teamName,
+        stableOwnerId,
+        assignment,
+        assignmentRole: 'target',
+      },
+    };
+  }
+
+  const hasDisplacedOwner = displacedStableOwnerId !== undefined;
+  const hasDisplacedAssignment = displacedAssignment !== undefined;
+  if (hasDisplacedOwner !== hasDisplacedAssignment) {
+    return {
+      kind: 'refused',
+      diagnostic: {
+        code: 'incomplete-slot-drop-displacement',
+        teamName,
+        stableOwnerId,
+        assignment,
+      },
+    };
+  }
+
+  if (displacedAssignment && !isValidSlotAssignment(displacedAssignment)) {
+    return {
+      kind: 'refused',
+      diagnostic: {
+        code: 'invalid-slot-assignment',
+        teamName,
+        stableOwnerId,
+        assignment: displacedAssignment,
+        assignmentRole: 'displaced',
+      },
+    };
+  }
+
+  const writable = getWritableLayoutContainers(state);
+  const currentAssignments = writable.slotAssignmentsByTeam[teamName] ?? {};
+  const existing = currentAssignments[stableOwnerId];
+
+  if (
+    areSlotAssignmentsEqual(existing, assignment) &&
+    !displacedStableOwnerId &&
+    state.slotLayoutVersion === GRAPH_STABLE_SLOT_LAYOUT_VERSION
+  ) {
+    return UNCHANGED;
+  }
+
+  if (displacedStableOwnerId && displacedAssignment) {
+    const refuseInconsistentDisplacement = (
+      reason:
+        | 'same-owner'
+        | 'same-slot'
+        | 'missing-source-owner'
+        | 'missing-displaced-owner'
+        | 'stale-source-assignment'
+        | 'stale-displaced-assignment'
+    ): TeamGraphLayoutTransition => ({
+      kind: 'refused',
+      diagnostic: {
+        code: 'inconsistent-slot-drop-displacement',
+        teamName,
+        stableOwnerId,
+        assignment,
+        displacedStableOwnerId,
+        reason,
+      },
+    });
+
+    if (displacedStableOwnerId === stableOwnerId) {
+      return refuseInconsistentDisplacement('same-owner');
+    }
+    if (areSlotAssignmentsEqual(displacedAssignment, assignment)) {
+      return refuseInconsistentDisplacement('same-slot');
+    }
+    const existingDisplacedAssignment = currentAssignments[displacedStableOwnerId];
+    if (!existing && !existingDisplacedAssignment) {
+      if (!visibleOwnerIds.includes(stableOwnerId)) {
+        return refuseInconsistentDisplacement('missing-source-owner');
+      }
+      if (!visibleOwnerIds.includes(displacedStableOwnerId)) {
+        return refuseInconsistentDisplacement('missing-displaced-owner');
+      }
+    } else {
+      if (!existing) {
+        return refuseInconsistentDisplacement('missing-source-owner');
+      }
+      if (!existingDisplacedAssignment) {
+        return refuseInconsistentDisplacement('missing-displaced-owner');
+      }
+      if (!areSlotAssignmentsEqual(existing, displacedAssignment)) {
+        return refuseInconsistentDisplacement('stale-source-assignment');
+      }
+      if (!areSlotAssignmentsEqual(existingDisplacedAssignment, assignment)) {
+        return refuseInconsistentDisplacement('stale-displaced-assignment');
+      }
+    }
+  }
+
+  const occupiedByConflict = Object.entries(currentAssignments).find(
+    ([ownerId, nextAssignment]) => {
+      if (ownerId === stableOwnerId || ownerId === displacedStableOwnerId) {
+        return false;
+      }
+      return (
+        areSlotAssignmentsEqual(nextAssignment, assignment) ||
+        (displacedAssignment != null &&
+          areSlotAssignmentsEqual(nextAssignment, displacedAssignment))
+      );
+    }
+  );
+
+  if (occupiedByConflict) {
+    return {
+      kind: 'refused',
+      diagnostic: {
+        code: 'slot-drop-conflict',
+        teamName,
+        stableOwnerId,
+        assignment,
+        conflictingStableOwnerId: occupiedByConflict[0],
+      },
+    };
+  }
+
+  const nextAssignments: TeamGraphSlotAssignments = {
+    ...currentAssignments,
+    [stableOwnerId]: assignment,
+  };
+  if (displacedStableOwnerId && displacedAssignment) {
+    nextAssignments[displacedStableOwnerId] = displacedAssignment;
+  }
+
+  return updated({
+    slotLayoutVersion: GRAPH_STABLE_SLOT_LAYOUT_VERSION,
+    slotAssignmentsByTeam: {
+      ...writable.slotAssignmentsByTeam,
+      [teamName]: nextAssignments,
+    },
+    graphLayoutSessionByTeam: {
+      ...writable.graphLayoutSessionByTeam,
+      [teamName]: {
+        mode: 'manual',
+        signature: writable.graphLayoutSessionByTeam[teamName]?.signature ?? null,
+      },
+    },
+  });
+}
+
+export function changeTeamGraphLayoutMode(
+  state: TeamGraphLayoutState,
+  teamName: string,
+  mode: GraphLayoutMode
+): TeamGraphLayoutTransition {
+  if ((state.graphLayoutModeByTeam[teamName] ?? DEFAULT_TEAM_GRAPH_LAYOUT_MODE) === mode) {
+    return UNCHANGED;
+  }
+
+  return updated({
+    graphLayoutModeByTeam: {
+      ...state.graphLayoutModeByTeam,
+      [teamName]: mode,
+    },
+  });
+}
+
+export function swapTeamGraphGridOwners(
+  state: TeamGraphLayoutState,
+  teamName: string,
+  stableOwnerId: string,
+  targetStableOwnerId: string,
+  visibleOwnerIds: readonly string[]
+): TeamGraphLayoutTransition {
+  if (stableOwnerId === targetStableOwnerId) {
+    return UNCHANGED;
+  }
+
+  const normalizedOrder = normalizeTeamGraphGridOwnerOrder(
+    state.gridOwnerOrderByTeam[teamName],
+    visibleOwnerIds
+  );
+  const stableOwnerIndex = normalizedOrder.indexOf(stableOwnerId);
+  const targetOwnerIndex = normalizedOrder.indexOf(targetStableOwnerId);
+
+  if (stableOwnerIndex < 0 || targetOwnerIndex < 0) {
+    return UNCHANGED;
+  }
+
+  const nextOrder = [...normalizedOrder];
+  nextOrder[stableOwnerIndex] = targetStableOwnerId;
+  nextOrder[targetOwnerIndex] = stableOwnerId;
+
+  return updated({
+    gridOwnerOrderByTeam: {
+      ...state.gridOwnerOrderByTeam,
+      [teamName]: nextOrder,
+    },
+  });
+}
+
+export function swapTeamGraphOwnerSlots(
+  state: TeamGraphLayoutState,
+  teamName: string,
+  stableOwnerId: string,
+  otherStableOwnerId: string
+): TeamGraphLayoutTransition {
+  if (stableOwnerId === otherStableOwnerId) {
+    return UNCHANGED;
+  }
+
+  const writable = getWritableLayoutContainers(state);
+  const currentAssignments = writable.slotAssignmentsByTeam[teamName] ?? {};
+  const left = currentAssignments[stableOwnerId];
+  const right = currentAssignments[otherStableOwnerId];
+  if (!left || !right) {
+    return UNCHANGED;
+  }
+
+  return updated({
+    slotLayoutVersion: GRAPH_STABLE_SLOT_LAYOUT_VERSION,
+    slotAssignmentsByTeam: {
+      ...writable.slotAssignmentsByTeam,
+      [teamName]: {
+        ...currentAssignments,
+        [stableOwnerId]: right,
+        [otherStableOwnerId]: left,
+      },
+    },
+    graphLayoutSessionByTeam: {
+      ...writable.graphLayoutSessionByTeam,
+      [teamName]: {
+        mode: 'manual',
+        signature: writable.graphLayoutSessionByTeam[teamName]?.signature ?? null,
+      },
+    },
+  });
+}
+
+export function clearTeamGraphLayout(
+  state: TeamGraphLayoutState,
+  teamName?: string
+): TeamGraphLayoutTransition {
+  if (teamName === undefined) {
+    if (
+      Object.keys(state.slotAssignmentsByTeam).length === 0 &&
+      state.slotLayoutVersion === GRAPH_STABLE_SLOT_LAYOUT_VERSION &&
+      Object.keys(state.graphLayoutSessionByTeam).length === 0
+    ) {
+      return UNCHANGED;
+    }
+    return updated({
+      slotLayoutVersion: GRAPH_STABLE_SLOT_LAYOUT_VERSION,
+      slotAssignmentsByTeam: {},
+      graphLayoutSessionByTeam: {},
+    });
+  }
+
+  if (teamName.trim().length === 0) {
+    return {
+      kind: 'refused',
+      diagnostic: {
+        code: 'invalid-team-name',
+        teamName,
+      },
+    };
+  }
+
+  if (state.slotLayoutVersion !== GRAPH_STABLE_SLOT_LAYOUT_VERSION) {
+    return updated({
+      slotLayoutVersion: GRAPH_STABLE_SLOT_LAYOUT_VERSION,
+      slotAssignmentsByTeam: {},
+      graphLayoutSessionByTeam: {},
+    });
+  }
+
+  if (!(teamName in state.slotAssignmentsByTeam) && !(teamName in state.graphLayoutSessionByTeam)) {
+    return UNCHANGED;
+  }
+
+  const nextAssignmentsByTeam = { ...state.slotAssignmentsByTeam };
+  const nextGraphLayoutSessionByTeam = { ...state.graphLayoutSessionByTeam };
+  delete nextAssignmentsByTeam[teamName];
+  delete nextGraphLayoutSessionByTeam[teamName];
+  return updated({
+    slotLayoutVersion: GRAPH_STABLE_SLOT_LAYOUT_VERSION,
+    slotAssignmentsByTeam: nextAssignmentsByTeam,
+    graphLayoutSessionByTeam: nextGraphLayoutSessionByTeam,
+  });
+}
+
+export function resetTeamGraphLayoutToDefaults(
+  state: TeamGraphLayoutState,
+  teamName: string,
+  defaultSeed: TeamGraphDefaultLayoutSeed
+): TeamGraphLayoutTransition {
+  if (defaultSeed.duplicateStableOwnerIds.length > 0) {
+    return {
+      kind: 'refused',
+      diagnostic: {
+        code: 'duplicate-stable-owner-id',
+        teamName,
+        duplicateStableOwnerIds: defaultSeed.duplicateStableOwnerIds,
+      },
+    };
+  }
+
+  const writable = getWritableLayoutContainers(state);
+  const versionChanged = state.slotLayoutVersion !== GRAPH_STABLE_SLOT_LAYOUT_VERSION;
+
+  if (!DISABLE_PERSISTED_TEAM_GRAPH_SLOT_ASSIGNMENTS) {
+    const currentAssignments = writable.slotAssignmentsByTeam[teamName];
+    if (!currentAssignments || Object.keys(currentAssignments).length === 0) {
+      return versionChanged
+        ? updated({
+            slotLayoutVersion: GRAPH_STABLE_SLOT_LAYOUT_VERSION,
+            slotAssignmentsByTeam: {},
+            graphLayoutSessionByTeam: {},
+          })
+        : UNCHANGED;
+    }
+
+    const nextAssignmentsByTeam = { ...writable.slotAssignmentsByTeam };
+    delete nextAssignmentsByTeam[teamName];
+    return updated({
+      slotLayoutVersion: GRAPH_STABLE_SLOT_LAYOUT_VERSION,
+      slotAssignmentsByTeam: nextAssignmentsByTeam,
+    });
+  }
+
+  const currentAssignments = writable.slotAssignmentsByTeam[teamName];
+  const currentSession = writable.graphLayoutSessionByTeam[teamName];
+
+  if (
+    !versionChanged &&
+    areTeamGraphSlotAssignmentsEqual(currentAssignments, defaultSeed.assignments) &&
+    currentSession?.mode === 'default' &&
+    currentSession.signature === defaultSeed.signature
+  ) {
+    return UNCHANGED;
+  }
+
+  const nextAssignmentsByTeam = { ...writable.slotAssignmentsByTeam };
+  if (Object.keys(defaultSeed.assignments).length === 0) {
+    delete nextAssignmentsByTeam[teamName];
+  } else {
+    nextAssignmentsByTeam[teamName] = defaultSeed.assignments;
+  }
+
+  return updated({
+    slotLayoutVersion: GRAPH_STABLE_SLOT_LAYOUT_VERSION,
+    slotAssignmentsByTeam: nextAssignmentsByTeam,
+    graphLayoutSessionByTeam: {
+      ...writable.graphLayoutSessionByTeam,
+      [teamName]: {
+        mode: 'default',
+        signature: defaultSeed.signature,
+      },
+    },
+  });
+}

--- a/src/features/agent-graph/index.ts
+++ b/src/features/agent-graph/index.ts
@@ -1,0 +1,54 @@
+/**
+ * Agent graph feature - browser-safe public API.
+ *
+ * Renderer UI remains available from `@features/agent-graph/renderer`.
+ * This root entrypoint exposes layout contracts, pure policies, and a port-driven action factory.
+ */
+
+export { createTeamGraphLayoutActions } from './core/application/createTeamGraphLayoutActions';
+export type {
+  TeamGraphDefaultLayoutMemberInput,
+  TeamGraphDefaultLayoutSeed,
+} from './core/domain/teamGraphDefaultLayout';
+export {
+  buildOrderedVisibleTeamGraphOwnerIds,
+  buildTeamGraphDefaultLayoutSeed,
+} from './core/domain/teamGraphDefaultLayout';
+export {
+  areTeamGraphSlotAssignmentsEqual,
+  getDefaultTeamGraphSlotAssignmentsForMembers,
+  isTeamGraphSlotPersistenceDisabled,
+  migrateStableSlotAssignmentsForMembers,
+  normalizeLegacySixRowOrbitAssignments,
+  normalizeTeamGraphGridOwnerOrder,
+  normalizeTeamGraphSlotAssignmentsForVisibleOwners,
+  pruneTeamGraphSlotAssignmentsForVisibleOwners,
+  seedStableSlotAssignmentsForMembers,
+} from './core/domain/teamGraphLayoutAssignments';
+export type {
+  TeamGraphConfigMemberSeedInput,
+  TeamGraphLayoutActions,
+  TeamGraphLayoutDiagnostic,
+  TeamGraphLayoutSessionState,
+  TeamGraphLayoutSlice,
+  TeamGraphLayoutState,
+  TeamGraphLayoutStatePatch,
+  TeamGraphLayoutTransition,
+  TeamGraphMemberSeedInput,
+  TeamGraphSlotAssignments,
+} from './core/domain/teamGraphLayoutState';
+export {
+  createInitialTeamGraphLayoutState,
+  DISABLE_PERSISTED_TEAM_GRAPH_SLOT_ASSIGNMENTS,
+  GRAPH_STABLE_SLOT_LAYOUT_VERSION,
+} from './core/domain/teamGraphLayoutState';
+export {
+  assignTeamGraphOwnerSlot,
+  changeTeamGraphLayoutMode,
+  clearTeamGraphLayout,
+  commitTeamGraphOwnerSlotDrop,
+  ensureTeamGraphLayoutState,
+  resetTeamGraphLayoutToDefaults,
+  swapTeamGraphGridOwners,
+  swapTeamGraphOwnerSlots,
+} from './core/domain/teamGraphLayoutTransitions';

--- a/src/features/agent-graph/renderer/adapters/TeamGraphAdapter.ts
+++ b/src/features/agent-graph/renderer/adapters/TeamGraphAdapter.ts
@@ -37,7 +37,6 @@ import {
 } from '@shared/utils/idleNotificationSemantics';
 import { isInboxNoiseMessage } from '@shared/utils/inboxNoise';
 import { isLeadMember } from '@shared/utils/leadDetection';
-import { buildOrderedVisibleTeamGraphOwnerIds } from '@shared/utils/teamGraphDefaultLayout';
 import {
   hasUnsafeProvisionedButNotAliveRuntimeEvidenceWithSpawnContext,
   isBootstrapConfirmedProvisionedButNotAliveFailure,
@@ -56,7 +55,6 @@ import {
   buildGraphMemberNodeIdAliasMap,
   buildGraphMemberNodeIdForMember,
   getGraphStableOwnerId,
-  GRAPH_STABLE_SLOT_LAYOUT_VERSION,
 } from '../../core/domain/graphOwnerIdentity';
 import {
   isTaskBlocked,
@@ -64,6 +62,8 @@ import {
   resolveTaskGraphColumn,
   resolveTaskReviewer,
 } from '../../core/domain/taskGraphSemantics';
+import { buildOrderedVisibleTeamGraphOwnerIds } from '../../core/domain/teamGraphDefaultLayout';
+import { GRAPH_STABLE_SLOT_LAYOUT_VERSION } from '../../core/domain/teamGraphLayoutState';
 
 import type {
   ActiveToolCall,

--- a/src/features/agent-graph/renderer/hooks/useTeamGraphAdapter.ts
+++ b/src/features/agent-graph/renderer/hooks/useTeamGraphAdapter.ts
@@ -5,22 +5,24 @@
 
 import { useLayoutEffect, useMemo, useRef, useSyncExternalStore } from 'react';
 
+import {
+  buildTeamGraphDefaultLayoutSeed,
+  isTeamGraphSlotPersistenceDisabled,
+} from '@features/agent-graph';
 import { useAppTranslation } from '@features/localization/renderer';
 import { useTeamAgentRuntimeWatcher } from '@renderer/components/team/useTeamAgentRuntimeWatcher';
 import { getSnapshot, subscribe } from '@renderer/services/commentReadStorage';
 import { useStore } from '@renderer/store';
 import {
   getCurrentProvisioningProgressForTeam,
-  isTeamGraphSlotPersistenceDisabled,
   selectResolvedMembersForTeamName,
   selectTeamDataForName,
   selectTeamMessages,
 } from '@renderer/store/slices/teamSlice';
 import { DEFAULT_TEAM_GRAPH_LAYOUT_MODE } from '@shared/constants/teamGraphLayoutMode';
-import { buildTeamGraphDefaultLayoutSeed } from '@shared/utils/teamGraphDefaultLayout';
 import { useShallow } from 'zustand/react/shallow';
 
-import { GRAPH_STABLE_SLOT_LAYOUT_VERSION } from '../../core/domain/graphOwnerIdentity';
+import { GRAPH_STABLE_SLOT_LAYOUT_VERSION } from '../../core/domain/teamGraphLayoutState';
 import { TeamGraphAdapter } from '../adapters/TeamGraphAdapter';
 
 import type { TeamGraphData } from '../adapters/TeamGraphAdapter';

--- a/src/features/agent-graph/renderer/hooks/useTeamGraphSurfaceActions.ts
+++ b/src/features/agent-graph/renderer/hooks/useTeamGraphSurfaceActions.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 
+import { isTeamGraphSlotPersistenceDisabled } from '@features/agent-graph';
 import { useStore } from '@renderer/store';
-import { isTeamGraphSlotPersistenceDisabled } from '@renderer/store/slices/teamSlice';
 import { DEFAULT_TEAM_GRAPH_LAYOUT_MODE } from '@shared/constants/teamGraphLayoutMode';
 
 import { parseGraphMemberNodeId } from '../../core/domain/graphOwnerIdentity';
@@ -45,16 +45,19 @@ export function useTeamGraphSurfaceActions(teamName: string): {
       const displacedStableOwnerId = payload.displacedNodeId
         ? parseGraphMemberNodeId(payload.displacedNodeId, teamName)
         : null;
+      if (payload.displacedNodeId !== undefined && !displacedStableOwnerId) {
+        return;
+      }
       const store = useStore.getState();
       if ((store.graphLayoutModeByTeam[teamName] ?? DEFAULT_TEAM_GRAPH_LAYOUT_MODE) !== 'radial') {
         return;
       }
-      if (displacedStableOwnerId && payload.displacedAssignment) {
+      if (payload.displacedNodeId !== undefined || payload.displacedAssignment !== undefined) {
         store.commitTeamGraphOwnerSlotDrop(
           teamName,
           stableOwnerId,
           payload.assignment,
-          displacedStableOwnerId,
+          displacedStableOwnerId ?? undefined,
           payload.displacedAssignment
         );
         return;

--- a/src/renderer/store/slices/teamSlice.ts
+++ b/src/renderer/store/slices/teamSlice.ts
@@ -1,4 +1,12 @@
 import {
+  buildTeamGraphDefaultLayoutSeed,
+  createInitialTeamGraphLayoutState,
+  createTeamGraphLayoutActions,
+  getDefaultTeamGraphSlotAssignmentsForMembers,
+  isTeamGraphSlotPersistenceDisabled,
+  type TeamGraphLayoutSlice,
+} from '@features/agent-graph';
+import {
   buildProviderMix,
   classifyAnalyticsError,
   elapsedMsBetweenIso,
@@ -23,12 +31,10 @@ import {
   type TaskChangeRequestOptions,
 } from '@renderer/utils/taskChangeRequest';
 import { IpcError, unwrapIpc } from '@renderer/utils/unwrapIpc';
-import { DEFAULT_TEAM_GRAPH_LAYOUT_MODE } from '@shared/constants/teamGraphLayoutMode';
 import { DEFAULT_TOOL_APPROVAL_SETTINGS } from '@shared/types/team';
 import { isLeadMember } from '@shared/utils/leadDetection';
 import { createLogger } from '@shared/utils/logger';
 import { calculateTaskImplementationDuration } from '@shared/utils/taskWorkDuration';
-import { buildTeamGraphDefaultLayoutSeed } from '@shared/utils/teamGraphDefaultLayout';
 
 import { areTeamAgentRuntimeSnapshotsEqual } from '../team/teamAgentRuntimeSnapshotEquality';
 import { stabilizeTeamAgentRuntimeSnapshot } from '../team/teamAgentRuntimeSnapshotStabilizer';
@@ -58,19 +64,6 @@ import {
   resetGlobalTaskNotificationTrackerForTests,
 } from '../team/teamGlobalTaskNotifications';
 import { projectTeamSnapshotOntoGlobalTasks } from '../team/teamGlobalTaskProjection';
-import {
-  areTeamGraphSlotAssignmentsEqual,
-  DISABLE_PERSISTED_TEAM_GRAPH_SLOT_ASSIGNMENTS,
-  GRAPH_STABLE_SLOT_LAYOUT_VERSION,
-  migrateStableSlotAssignmentsForMembers,
-  normalizeTeamGraphGridOwnerOrder,
-  pruneTeamGraphSlotAssignmentsForVisibleOwners,
-  seedStableSlotAssignmentsForMembers,
-  type TeamGraphConfigMemberSeedInput,
-  type TeamGraphLayoutSessionState,
-  type TeamGraphMemberSeedInput,
-  type TeamGraphSlotAssignments,
-} from '../team/teamGraphLayout';
 import {
   areTeamLaunchParamsEqual,
   buildLaunchParamsFromRuntimeRequest,
@@ -161,7 +154,6 @@ import type {
   TeamMessagesCacheEntry,
 } from '../team/teamMessagesCache';
 import type { AppState } from '../types';
-import type { GraphLayoutMode, GraphOwnerSlotAssignment } from '@claude-teams/agent-graph';
 import type { TeamMessagesPanelMode } from '@renderer/types/teamMessagesPanelMode';
 import type { OpenCodeRuntimeDeliveryDebugDetails } from '@renderer/utils/openCodeRuntimeDeliveryDiagnostics';
 import type {
@@ -226,10 +218,7 @@ export {
   selectTeamMemberSnapshotsForName,
   selectTeamTasksForName,
 } from '../team/teamDataSelectors';
-export {
-  getDefaultTeamGraphSlotAssignmentsForMembers,
-  isTeamGraphSlotPersistenceDisabled,
-} from '../team/teamGraphLayout';
+export { getDefaultTeamGraphSlotAssignmentsForMembers, isTeamGraphSlotPersistenceDisabled };
 export type { TeamLaunchParams } from '../team/teamLaunchParams';
 export type {
   RefreshTeamMessagesHeadResult,
@@ -1413,7 +1402,7 @@ function isVisibleInActiveTeamSurface(
   });
 }
 
-export interface TeamSlice {
+export interface TeamSlice extends TeamGraphLayoutSlice {
   teams: TeamSummary[];
   /** O(1) lookup to avoid array scans in render-hot paths */
   teamByName: Record<string, TeamSummary>;
@@ -1458,13 +1447,8 @@ export interface TeamSlice {
   } | null;
   /** Team-scoped detailed cache used by multi-pane views like agent graph. */
   teamDataCacheByName: Record<string, TeamViewSnapshot>;
-  slotLayoutVersion: string;
-  graphLayoutModeByTeam: Record<string, GraphLayoutMode>;
-  gridOwnerOrderByTeam: Record<string, string[]>;
-  slotAssignmentsByTeam: Record<string, TeamGraphSlotAssignments>;
   teamMessagesByName: Record<string, TeamMessagesCacheEntry>;
   memberActivityMetaByTeam: Record<string, TeamMemberActivityMeta>;
-  graphLayoutSessionByTeam: Record<string, TeamGraphLayoutSessionState>;
   selectedTeamLoading: boolean;
   selectedTeamLoadNonce: number;
   selectedTeamError: string | null;
@@ -1517,36 +1501,6 @@ export interface TeamSlice {
   openTeamsTab: (projectPath?: string) => void;
   openTeamTab: (teamName: string, projectPath?: string, taskId?: string) => void;
   clearKanbanFilter: () => void;
-  ensureTeamGraphSlotAssignments: (
-    teamName: string,
-    members: readonly TeamGraphMemberSeedInput[],
-    configMembers?: readonly TeamGraphConfigMemberSeedInput[]
-  ) => void;
-  setTeamGraphOwnerSlotAssignment: (
-    teamName: string,
-    stableOwnerId: string,
-    assignment: GraphOwnerSlotAssignment
-  ) => void;
-  commitTeamGraphOwnerSlotDrop: (
-    teamName: string,
-    stableOwnerId: string,
-    assignment: GraphOwnerSlotAssignment,
-    displacedStableOwnerId?: string,
-    displacedAssignment?: GraphOwnerSlotAssignment
-  ) => void;
-  setTeamGraphLayoutMode: (teamName: string, mode: GraphLayoutMode) => void;
-  swapTeamGraphGridOwners: (
-    teamName: string,
-    stableOwnerId: string,
-    targetStableOwnerId: string
-  ) => void;
-  swapTeamGraphOwnerSlots: (
-    teamName: string,
-    stableOwnerId: string,
-    otherStableOwnerId: string
-  ) => void;
-  clearTeamGraphSlotAssignments: (teamName?: string) => void;
-  resetTeamGraphSlotAssignmentsToDefaults: (teamName: string) => void;
   setSelectedTeamTaskChangePresence: (
     teamName: string,
     taskId: string,
@@ -1846,13 +1800,9 @@ export const createTeamSlice: StateCreator<AppState, [], [], TeamSlice> = (set, 
   selectedTeamData: null,
   teamsProjectNavigationIntent: null,
   teamDataCacheByName: {},
-  slotLayoutVersion: GRAPH_STABLE_SLOT_LAYOUT_VERSION,
-  graphLayoutModeByTeam: {},
-  gridOwnerOrderByTeam: {},
-  slotAssignmentsByTeam: {},
+  ...createInitialTeamGraphLayoutState(),
   teamMessagesByName: {},
   memberActivityMetaByTeam: {},
-  graphLayoutSessionByTeam: {},
   selectedTeamLoading: false,
   selectedTeamLoadNonce: 0,
   selectedTeamError: null,
@@ -2326,398 +2276,16 @@ export const createTeamSlice: StateCreator<AppState, [], [], TeamSlice> = (set, 
     set({ kanbanFilterQuery: null });
   },
 
-  ensureTeamGraphSlotAssignments: (teamName, members, configMembers = []) => {
-    set((state) => {
-      const nextState: Partial<TeamSlice> = {};
-      let changed = false;
-
-      let nextSlotAssignmentsByTeam = state.slotAssignmentsByTeam;
-      let nextGraphLayoutSessionByTeam = state.graphLayoutSessionByTeam;
-      if (state.slotLayoutVersion !== GRAPH_STABLE_SLOT_LAYOUT_VERSION) {
-        nextState.slotLayoutVersion = GRAPH_STABLE_SLOT_LAYOUT_VERSION;
-        nextSlotAssignmentsByTeam = {};
-        nextGraphLayoutSessionByTeam = {};
-        changed = true;
-      }
-
-      const defaultSeed = buildTeamGraphDefaultLayoutSeed(members, configMembers);
-      const visibleAssignments = pruneTeamGraphSlotAssignmentsForVisibleOwners(
-        nextSlotAssignmentsByTeam[teamName],
-        defaultSeed.orderedVisibleOwnerIds
-      );
-      const currentSession = nextGraphLayoutSessionByTeam[teamName];
-
-      if (DISABLE_PERSISTED_TEAM_GRAPH_SLOT_ASSIGNMENTS) {
-        if (currentSession?.mode === 'manual') {
-          if (
-            !areTeamGraphSlotAssignmentsEqual(
-              nextSlotAssignmentsByTeam[teamName],
-              visibleAssignments
-            )
-          ) {
-            nextSlotAssignmentsByTeam = { ...nextSlotAssignmentsByTeam };
-            if (visibleAssignments) {
-              nextSlotAssignmentsByTeam[teamName] = visibleAssignments;
-            } else {
-              delete nextSlotAssignmentsByTeam[teamName];
-            }
-            changed = true;
-          }
-        } else {
-          if (
-            !areTeamGraphSlotAssignmentsEqual(
-              nextSlotAssignmentsByTeam[teamName],
-              visibleAssignments
-            ) ||
-            !areTeamGraphSlotAssignmentsEqual(visibleAssignments, defaultSeed.assignments)
-          ) {
-            nextSlotAssignmentsByTeam = { ...nextSlotAssignmentsByTeam };
-            if (Object.keys(defaultSeed.assignments).length === 0) {
-              delete nextSlotAssignmentsByTeam[teamName];
-            } else {
-              nextSlotAssignmentsByTeam[teamName] = defaultSeed.assignments;
-            }
-            changed = true;
-          }
-          if (
-            currentSession?.mode !== 'default' ||
-            currentSession?.signature !== defaultSeed.signature
-          ) {
-            nextGraphLayoutSessionByTeam = {
-              ...nextGraphLayoutSessionByTeam,
-              [teamName]: {
-                mode: 'default',
-                signature: defaultSeed.signature,
-              },
-            };
-            changed = true;
-          }
-        }
-
-        if (!changed) {
-          return {};
-        }
-
-        nextState.slotAssignmentsByTeam = nextSlotAssignmentsByTeam;
-        nextState.graphLayoutSessionByTeam = nextGraphLayoutSessionByTeam;
-        return nextState;
-      }
-
-      const currentAssignments = nextSlotAssignmentsByTeam[teamName];
-      const migrated = migrateStableSlotAssignmentsForMembers(currentAssignments, members);
-      const seeded = seedStableSlotAssignmentsForMembers(
-        migrated.assignments,
-        members,
-        configMembers
-      );
-      if (migrated.changed || seeded.changed) {
-        nextSlotAssignmentsByTeam = {
-          ...nextSlotAssignmentsByTeam,
-          [teamName]: seeded.assignments,
-        };
-        changed = true;
-      }
-
-      if (!changed) {
-        return {};
-      }
-
-      nextState.slotAssignmentsByTeam = nextSlotAssignmentsByTeam;
-      if (nextGraphLayoutSessionByTeam !== state.graphLayoutSessionByTeam) {
-        nextState.graphLayoutSessionByTeam = nextGraphLayoutSessionByTeam;
-      }
-      return nextState;
-    });
-  },
-
-  setTeamGraphOwnerSlotAssignment: (teamName, stableOwnerId, assignment) => {
-    set((state) => {
-      const currentAssignments = state.slotAssignmentsByTeam[teamName] ?? {};
-      const existing = currentAssignments[stableOwnerId];
-      const occupiedByOther = Object.entries(currentAssignments).find(
-        ([otherStableOwnerId, otherAssignment]) =>
-          otherStableOwnerId !== stableOwnerId &&
-          otherAssignment.ringIndex === assignment.ringIndex &&
-          otherAssignment.sectorIndex === assignment.sectorIndex
-      );
-      if (
-        existing?.ringIndex === assignment.ringIndex &&
-        existing?.sectorIndex === assignment.sectorIndex &&
-        state.slotLayoutVersion === GRAPH_STABLE_SLOT_LAYOUT_VERSION
-      ) {
-        return {};
-      }
-      if (occupiedByOther) {
-        logger.warn(
-          `[graph-layout] refusing occupied slot assignment team=${teamName} owner=${stableOwnerId} target=${assignment.ringIndex}:${assignment.sectorIndex} occupiedBy=${occupiedByOther[0]}`
-        );
-        return {};
-      }
-
-      return {
-        slotLayoutVersion: GRAPH_STABLE_SLOT_LAYOUT_VERSION,
-        slotAssignmentsByTeam: {
-          ...state.slotAssignmentsByTeam,
-          [teamName]: {
-            ...currentAssignments,
-            [stableOwnerId]: assignment,
-          },
-        },
-        graphLayoutSessionByTeam: {
-          ...state.graphLayoutSessionByTeam,
-          [teamName]: {
-            mode: 'manual',
-            signature: state.graphLayoutSessionByTeam[teamName]?.signature ?? null,
-          },
-        },
-      };
-    });
-  },
-
-  commitTeamGraphOwnerSlotDrop: (
-    teamName,
-    stableOwnerId,
-    assignment,
-    displacedStableOwnerId,
-    displacedAssignment
-  ) => {
-    set((state) => {
-      const currentAssignments = state.slotAssignmentsByTeam[teamName] ?? {};
-      const existing = currentAssignments[stableOwnerId];
-      const nextAssignments: TeamGraphSlotAssignments = {
-        ...currentAssignments,
-        [stableOwnerId]: assignment,
-      };
-
-      if (
-        existing?.ringIndex === assignment.ringIndex &&
-        existing?.sectorIndex === assignment.sectorIndex &&
-        !displacedStableOwnerId &&
-        state.slotLayoutVersion === GRAPH_STABLE_SLOT_LAYOUT_VERSION
-      ) {
-        return {};
-      }
-
-      if (displacedStableOwnerId && displacedAssignment) {
-        nextAssignments[displacedStableOwnerId] = displacedAssignment;
-      }
-
-      const occupiedByConflict = Object.entries(nextAssignments).find(
-        ([ownerId, nextAssignment]) => {
-          if (ownerId === stableOwnerId || ownerId === displacedStableOwnerId) {
-            return false;
-          }
-          return (
-            (nextAssignment.ringIndex === assignment.ringIndex &&
-              nextAssignment.sectorIndex === assignment.sectorIndex) ||
-            (nextAssignment.ringIndex === displacedAssignment?.ringIndex &&
-              nextAssignment.sectorIndex === displacedAssignment.sectorIndex)
-          );
-        }
-      );
-
-      if (occupiedByConflict) {
-        logger.warn(
-          `[graph-layout] refusing slot drop team=${teamName} owner=${stableOwnerId} target=${assignment.ringIndex}:${assignment.sectorIndex} conflict=${occupiedByConflict[0]}`
-        );
-        return {};
-      }
-
-      return {
-        slotLayoutVersion: GRAPH_STABLE_SLOT_LAYOUT_VERSION,
-        slotAssignmentsByTeam: {
-          ...state.slotAssignmentsByTeam,
-          [teamName]: nextAssignments,
-        },
-        graphLayoutSessionByTeam: {
-          ...state.graphLayoutSessionByTeam,
-          [teamName]: {
-            mode: 'manual',
-            signature: state.graphLayoutSessionByTeam[teamName]?.signature ?? null,
-          },
-        },
-      };
-    });
-  },
-
-  setTeamGraphLayoutMode: (teamName, mode) => {
-    set((state) => {
-      if ((state.graphLayoutModeByTeam[teamName] ?? DEFAULT_TEAM_GRAPH_LAYOUT_MODE) === mode) {
-        return {};
-      }
-
-      return {
-        graphLayoutModeByTeam: {
-          ...state.graphLayoutModeByTeam,
-          [teamName]: mode,
-        },
-      };
-    });
-  },
-
-  swapTeamGraphGridOwners: (teamName, stableOwnerId, targetStableOwnerId) => {
-    if (stableOwnerId === targetStableOwnerId) {
-      return;
-    }
-
-    set((state) => {
+  ...createTeamGraphLayoutActions<AppState>({
+    setState: (updater) => set((state) => updater(state) ?? state),
+    selectDefaultLayoutSeed: (state, teamName) => {
       const teamData = selectTeamDataForName(state, teamName);
-      const fallbackVisibleOwnerIds = [...(state.gridOwnerOrderByTeam[teamName] ?? [])];
-      for (const ownerId of [stableOwnerId, targetStableOwnerId]) {
-        if (!fallbackVisibleOwnerIds.includes(ownerId)) {
-          fallbackVisibleOwnerIds.push(ownerId);
-        }
-      }
-      const visibleOwnerIds = teamData
+      return teamData
         ? buildTeamGraphDefaultLayoutSeed(teamData.members, teamData.config.members ?? [])
-            .orderedVisibleOwnerIds
-        : fallbackVisibleOwnerIds;
-      const normalizedOrder = normalizeTeamGraphGridOwnerOrder(
-        state.gridOwnerOrderByTeam[teamName],
-        visibleOwnerIds
-      );
-      const stableOwnerIndex = normalizedOrder.indexOf(stableOwnerId);
-      const targetOwnerIndex = normalizedOrder.indexOf(targetStableOwnerId);
-
-      if (stableOwnerIndex < 0 || targetOwnerIndex < 0) {
-        return {};
-      }
-
-      const nextOrder = [...normalizedOrder];
-      nextOrder[stableOwnerIndex] = targetStableOwnerId;
-      nextOrder[targetOwnerIndex] = stableOwnerId;
-
-      return {
-        gridOwnerOrderByTeam: {
-          ...state.gridOwnerOrderByTeam,
-          [teamName]: nextOrder,
-        },
-      };
-    });
-  },
-
-  swapTeamGraphOwnerSlots: (teamName, stableOwnerId, otherStableOwnerId) => {
-    if (stableOwnerId === otherStableOwnerId) {
-      return;
-    }
-
-    set((state) => {
-      const currentAssignments = state.slotAssignmentsByTeam[teamName] ?? {};
-      const left = currentAssignments[stableOwnerId];
-      const right = currentAssignments[otherStableOwnerId];
-      if (!left || !right) {
-        return {};
-      }
-
-      return {
-        slotLayoutVersion: GRAPH_STABLE_SLOT_LAYOUT_VERSION,
-        slotAssignmentsByTeam: {
-          ...state.slotAssignmentsByTeam,
-          [teamName]: {
-            ...currentAssignments,
-            [stableOwnerId]: right,
-            [otherStableOwnerId]: left,
-          },
-        },
-        graphLayoutSessionByTeam: {
-          ...state.graphLayoutSessionByTeam,
-          [teamName]: {
-            mode: 'manual',
-            signature: state.graphLayoutSessionByTeam[teamName]?.signature ?? null,
-          },
-        },
-      };
-    });
-  },
-
-  clearTeamGraphSlotAssignments: (teamName) => {
-    set((state) => {
-      if (!teamName) {
-        if (
-          Object.keys(state.slotAssignmentsByTeam).length === 0 &&
-          state.slotLayoutVersion === GRAPH_STABLE_SLOT_LAYOUT_VERSION &&
-          Object.keys(state.graphLayoutSessionByTeam).length === 0
-        ) {
-          return {};
-        }
-        return {
-          slotLayoutVersion: GRAPH_STABLE_SLOT_LAYOUT_VERSION,
-          slotAssignmentsByTeam: {},
-          graphLayoutSessionByTeam: {},
-        };
-      }
-
-      if (
-        !(teamName in state.slotAssignmentsByTeam) &&
-        !(teamName in state.graphLayoutSessionByTeam)
-      ) {
-        return {};
-      }
-
-      const nextAssignmentsByTeam = { ...state.slotAssignmentsByTeam };
-      const nextGraphLayoutSessionByTeam = { ...state.graphLayoutSessionByTeam };
-      delete nextAssignmentsByTeam[teamName];
-      delete nextGraphLayoutSessionByTeam[teamName];
-      return {
-        slotLayoutVersion: GRAPH_STABLE_SLOT_LAYOUT_VERSION,
-        slotAssignmentsByTeam: nextAssignmentsByTeam,
-        graphLayoutSessionByTeam: nextGraphLayoutSessionByTeam,
-      };
-    });
-  },
-
-  resetTeamGraphSlotAssignmentsToDefaults: (teamName) => {
-    set((state) => {
-      if (!DISABLE_PERSISTED_TEAM_GRAPH_SLOT_ASSIGNMENTS) {
-        const currentAssignments = state.slotAssignmentsByTeam[teamName];
-        if (!currentAssignments || Object.keys(currentAssignments).length === 0) {
-          return {};
-        }
-
-        const nextAssignmentsByTeam = { ...state.slotAssignmentsByTeam };
-        delete nextAssignmentsByTeam[teamName];
-        return {
-          slotLayoutVersion: GRAPH_STABLE_SLOT_LAYOUT_VERSION,
-          slotAssignmentsByTeam: nextAssignmentsByTeam,
-        };
-      }
-
-      const teamData = selectTeamDataForName(state, teamName);
-      const defaultSeed = teamData
-        ? buildTeamGraphDefaultLayoutSeed(teamData.members, teamData.config.members ?? [])
-        : { orderedVisibleOwnerIds: [], signature: null, assignments: {} };
-      const currentAssignments = state.slotAssignmentsByTeam[teamName];
-      const currentSession = state.graphLayoutSessionByTeam[teamName];
-
-      if (
-        areTeamGraphSlotAssignmentsEqual(currentAssignments, defaultSeed.assignments) &&
-        currentSession?.mode === 'default' &&
-        currentSession.signature === defaultSeed.signature
-      ) {
-        return {};
-      }
-
-      const nextAssignmentsByTeam = { ...state.slotAssignmentsByTeam };
-      if (Object.keys(defaultSeed.assignments).length === 0) {
-        delete nextAssignmentsByTeam[teamName];
-      } else {
-        nextAssignmentsByTeam[teamName] = defaultSeed.assignments;
-      }
-
-      return {
-        slotLayoutVersion: GRAPH_STABLE_SLOT_LAYOUT_VERSION,
-        slotAssignmentsByTeam: nextAssignmentsByTeam,
-        graphLayoutSessionByTeam: {
-          ...state.graphLayoutSessionByTeam,
-          [teamName]: {
-            mode: 'default',
-            signature: defaultSeed.signature,
-          },
-        },
-      };
-    });
-  },
-
+        : null;
+    },
+    warn: (message) => logger.warn(message),
+  }),
   setSelectedTeamTaskChangePresence: (teamName, taskId, presence) => {
     get().setSelectedTeamTaskChangePresences(teamName, { [taskId]: presence });
   },

--- a/test/features/agent-graph/core/agentGraphRootBoundary.test.ts
+++ b/test/features/agent-graph/core/agentGraphRootBoundary.test.ts
@@ -1,0 +1,24 @@
+// @vitest-environment node
+
+import { readFileSync } from 'node:fs';
+
+import * as agentGraph from '@features/agent-graph';
+import { describe, expect, it } from 'vitest';
+
+describe('agent graph root boundary', () => {
+  it('stays browser-safe and does not re-export the renderer composition layer', () => {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- fixed repository-owned module URL
+    const source = readFileSync(
+      new URL('../../../../src/features/agent-graph/index.ts', import.meta.url),
+      'utf8'
+    );
+    const moduleTargets = [...source.matchAll(/\bfrom\s+['"]([^'"]+)['"]/g)].map(
+      (match) => match[1]
+    );
+
+    expect(moduleTargets).not.toContain('./renderer');
+    expect(moduleTargets.some((target) => target?.startsWith('@renderer'))).toBe(false);
+    expect(agentGraph.createTeamGraphLayoutActions).toBeTypeOf('function');
+    expect('TeamGraphAdapter' in agentGraph).toBe(false);
+  });
+});

--- a/test/features/agent-graph/core/application/createTeamGraphLayoutActions.test.ts
+++ b/test/features/agent-graph/core/application/createTeamGraphLayoutActions.test.ts
@@ -1,0 +1,254 @@
+import {
+  createInitialTeamGraphLayoutState,
+  createTeamGraphLayoutActions,
+  type TeamGraphLayoutActions,
+  type TeamGraphLayoutState,
+  type TeamGraphLayoutStatePatch,
+} from '@features/agent-graph';
+import { describe, expect, it, vi } from 'vitest';
+import { create } from 'zustand';
+
+import type { StoreApi, UseBoundStore } from 'zustand';
+
+type TeamGraphLayoutStore = TeamGraphLayoutState & TeamGraphLayoutActions;
+
+function createLayoutStore(
+  initialState: Partial<TeamGraphLayoutState> = {},
+  warn = vi.fn()
+): UseBoundStore<StoreApi<TeamGraphLayoutStore>> {
+  return create<TeamGraphLayoutStore>()((set) => ({
+    ...createInitialTeamGraphLayoutState(),
+    ...initialState,
+    ...createTeamGraphLayoutActions<TeamGraphLayoutStore>({
+      setState: (updater) => set((state) => updater(state) ?? state),
+      selectDefaultLayoutSeed: (_state, teamName) =>
+        teamName === 'my-team'
+          ? {
+              orderedVisibleOwnerIds: ['alice', 'bob'],
+              signature: 'alice|bob',
+              assignments: {
+                alice: { ringIndex: 0, sectorIndex: 0 },
+                bob: { ringIndex: 0, sectorIndex: 1 },
+              },
+              duplicateStableOwnerIds: [],
+            }
+          : null,
+      warn,
+    }),
+  }));
+}
+
+describe('createTeamGraphLayoutActions', () => {
+  it('maps a refused domain transition to a diagnostic without mutating state', () => {
+    let state: TeamGraphLayoutState = {
+      ...createInitialTeamGraphLayoutState(),
+      slotAssignmentsByTeam: {
+        'my-team': {
+          alice: { ringIndex: 0, sectorIndex: 0 },
+          bob: { ringIndex: 0, sectorIndex: 1 },
+        },
+      },
+    };
+    const warn = vi.fn();
+    const actions = createTeamGraphLayoutActions<TeamGraphLayoutState>({
+      setState: (updater) => {
+        const patch = updater(state);
+        if (patch) {
+          state = { ...state, ...patch };
+        }
+      },
+      selectDefaultLayoutSeed: () => null,
+      warn,
+    });
+
+    actions.setTeamGraphOwnerSlotAssignment('my-team', 'alice', {
+      ringIndex: 0,
+      sectorIndex: 1,
+    });
+
+    expect(state.slotAssignmentsByTeam['my-team']).toEqual({
+      alice: { ringIndex: 0, sectorIndex: 0 },
+      bob: { ringIndex: 0, sectorIndex: 1 },
+    });
+    expect(warn).toHaveBeenCalledWith(
+      '[graph-layout] refusing occupied slot assignment team=my-team owner=alice target=0:1 occupiedBy=bob'
+    );
+  });
+
+  it('returns null for unchanged and refused transitions so adapters can preserve identity', () => {
+    const state: TeamGraphLayoutState = {
+      ...createInitialTeamGraphLayoutState(),
+      slotAssignmentsByTeam: {
+        'my-team': {
+          alice: { ringIndex: 0, sectorIndex: 0 },
+          bob: { ringIndex: 0, sectorIndex: 1 },
+        },
+      },
+    };
+    const updates: (TeamGraphLayoutStatePatch | null)[] = [];
+    const warn = vi.fn();
+    const actions = createTeamGraphLayoutActions<TeamGraphLayoutState>({
+      setState: (updater) => {
+        updates.push(updater(state));
+      },
+      selectDefaultLayoutSeed: () => null,
+      warn,
+    });
+
+    actions.setTeamGraphOwnerSlotAssignment('my-team', 'alice', {
+      ringIndex: 0,
+      sectorIndex: 0,
+    });
+    actions.setTeamGraphOwnerSlotAssignment('my-team', 'alice', {
+      ringIndex: 0,
+      sectorIndex: 1,
+    });
+
+    expect(updates).toEqual([null, null]);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('warns once for an incomplete displacement without producing a patch', () => {
+    const state: TeamGraphLayoutState = {
+      ...createInitialTeamGraphLayoutState(),
+      slotAssignmentsByTeam: {
+        'my-team': {
+          alice: { ringIndex: 0, sectorIndex: 0 },
+          bob: { ringIndex: 0, sectorIndex: 1 },
+        },
+      },
+    };
+    const setState = vi.fn();
+    const warn = vi.fn();
+    const actions = createTeamGraphLayoutActions<TeamGraphLayoutState>({
+      setState: (updater) => setState(updater(state)),
+      selectDefaultLayoutSeed: () => null,
+      warn,
+    });
+
+    actions.commitTeamGraphOwnerSlotDrop(
+      'my-team',
+      'alice',
+      { ringIndex: 0, sectorIndex: 1 },
+      'bob'
+    );
+
+    expect(setState).toHaveBeenCalledWith(null);
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(
+      '[graph-layout] refusing incomplete slot drop team=my-team owner=alice target=0:1'
+    );
+  });
+
+  it('uses the latest visible-owner seed to materialize a generated-slot swap', () => {
+    const store = createLayoutStore();
+
+    store
+      .getState()
+      .commitTeamGraphOwnerSlotDrop('my-team', 'alice', { ringIndex: 4, sectorIndex: 1 }, 'bob', {
+        ringIndex: 4,
+        sectorIndex: 0,
+      });
+
+    expect(store.getState().slotAssignmentsByTeam['my-team']).toEqual({
+      alice: { ringIndex: 4, sectorIndex: 1 },
+      bob: { ringIndex: 4, sectorIndex: 0 },
+    });
+  });
+
+  it('does not publish Zustand state for unchanged or refused transitions', () => {
+    const warn = vi.fn();
+    const store = createLayoutStore(
+      {
+        slotAssignmentsByTeam: {
+          'my-team': {
+            alice: { ringIndex: 0, sectorIndex: 0 },
+            bob: { ringIndex: 0, sectorIndex: 1 },
+          },
+        },
+        graphLayoutSessionByTeam: {
+          'my-team': { mode: 'default', signature: 'alice|bob' },
+        },
+      },
+      warn
+    );
+    const members = [
+      { name: 'alice', agentId: 'alice' },
+      { name: 'bob', agentId: 'bob' },
+    ];
+    const listener = vi.fn();
+    const unsubscribe = store.subscribe(listener);
+
+    const expectNoPublication = (action: () => void): void => {
+      const before = store.getState();
+      listener.mockClear();
+      action();
+      expect(store.getState()).toBe(before);
+      expect(listener).not.toHaveBeenCalled();
+    };
+
+    expectNoPublication(() => store.getState().ensureTeamGraphSlotAssignments('my-team', members));
+    expectNoPublication(() =>
+      store.getState().setTeamGraphOwnerSlotAssignment('my-team', 'alice', {
+        ringIndex: 0,
+        sectorIndex: 0,
+      })
+    );
+    expectNoPublication(() =>
+      store.getState().setTeamGraphLayoutMode('my-team', 'grid-under-lead')
+    );
+    expectNoPublication(() =>
+      store.getState().swapTeamGraphOwnerSlots('my-team', 'alice', 'missing-owner')
+    );
+    expectNoPublication(() => store.getState().clearTeamGraphSlotAssignments('missing-team'));
+    expectNoPublication(() => store.getState().resetTeamGraphSlotAssignmentsToDefaults('my-team'));
+    expectNoPublication(() =>
+      store.getState().setTeamGraphOwnerSlotAssignment('my-team', 'alice', {
+        ringIndex: 0,
+        sectorIndex: 1,
+      })
+    );
+
+    expect(warn).toHaveBeenCalledOnce();
+    unsubscribe();
+  });
+
+  it('composes interleaved action references against the latest Zustand state', () => {
+    const store = createLayoutStore({
+      gridOwnerOrderByTeam: {
+        'my-team': ['alice', 'bob'],
+      },
+      slotAssignmentsByTeam: {
+        'other-team': {
+          tom: { ringIndex: 2, sectorIndex: 2 },
+        },
+      },
+    });
+    const paneA = store.getState();
+    const paneB = store.getState();
+    const otherTeamAssignments = store.getState().slotAssignmentsByTeam['other-team'];
+
+    paneA.setTeamGraphOwnerSlotAssignment('my-team', 'alice', {
+      ringIndex: 0,
+      sectorIndex: 0,
+    });
+    paneB.setTeamGraphOwnerSlotAssignment('my-team', 'bob', {
+      ringIndex: 0,
+      sectorIndex: 1,
+    });
+    paneA.swapTeamGraphGridOwners('my-team', 'alice', 'bob');
+    paneB.setTeamGraphOwnerSlotAssignment('my-team', 'alice', {
+      ringIndex: 1,
+      sectorIndex: 0,
+    });
+    paneA.setTeamGraphLayoutMode('my-team', 'radial');
+
+    expect(store.getState().slotAssignmentsByTeam['my-team']).toEqual({
+      alice: { ringIndex: 1, sectorIndex: 0 },
+      bob: { ringIndex: 0, sectorIndex: 1 },
+    });
+    expect(store.getState().gridOwnerOrderByTeam['my-team']).toEqual(['bob', 'alice']);
+    expect(store.getState().graphLayoutModeByTeam['my-team']).toBe('radial');
+    expect(store.getState().slotAssignmentsByTeam['other-team']).toBe(otherTeamAssignments);
+  });
+});

--- a/test/features/agent-graph/core/teamGraphDefaultLayout.test.ts
+++ b/test/features/agent-graph/core/teamGraphDefaultLayout.test.ts
@@ -1,8 +1,11 @@
-import { buildTeamGraphDefaultLayoutSeed } from '@shared/utils/teamGraphDefaultLayout';
+import {
+  buildOrderedVisibleTeamGraphOwnerIds,
+  buildTeamGraphDefaultLayoutSeed,
+} from '@features/agent-graph';
 import { describe, expect, it } from 'vitest';
 
 describe('team graph default layout', () => {
-  function members(count: number): Array<{ name: string; agentId: string }> {
+  function members(count: number): { name: string; agentId: string }[] {
     return Array.from({ length: count }, (_, index) => ({
       name: `member-${index}`,
       agentId: `agent-${index}`,
@@ -74,6 +77,22 @@ describe('team graph default layout', () => {
       'agent-11': { ringIndex: 4, sectorIndex: 0 },
       'agent-12': { ringIndex: 4, sectorIndex: 1 },
       'agent-13': { ringIndex: 4, sectorIndex: 2 },
+    });
+  });
+
+  it('fails closed instead of merging duplicate stable owner identities', () => {
+    const duplicateMembers = [
+      { name: 'alice', agentId: 'shared-agent' },
+      { name: 'bob', agentId: 'shared-agent' },
+      { name: 'tom', agentId: 'agent-tom' },
+    ];
+
+    expect(buildOrderedVisibleTeamGraphOwnerIds(duplicateMembers)).toEqual([]);
+    expect(buildTeamGraphDefaultLayoutSeed(duplicateMembers)).toEqual({
+      orderedVisibleOwnerIds: [],
+      signature: null,
+      assignments: {},
+      duplicateStableOwnerIds: ['shared-agent'],
     });
   });
 });

--- a/test/features/agent-graph/core/teamGraphLayoutAssignments.test.ts
+++ b/test/features/agent-graph/core/teamGraphLayoutAssignments.test.ts
@@ -1,5 +1,3 @@
-import { describe, expect, it } from 'vitest';
-
 import {
   areTeamGraphSlotAssignmentsEqual,
   getDefaultTeamGraphSlotAssignmentsForMembers,
@@ -10,7 +8,8 @@ import {
   normalizeTeamGraphSlotAssignmentsForVisibleOwners,
   pruneTeamGraphSlotAssignmentsForVisibleOwners,
   seedStableSlotAssignmentsForMembers,
-} from '../../../src/renderer/store/team/teamGraphLayout';
+} from '@features/agent-graph';
+import { describe, expect, it } from 'vitest';
 
 describe('teamGraphLayout', () => {
   it('migrates legacy name-keyed assignments to stable owner ids', () => {
@@ -94,8 +93,11 @@ describe('teamGraphLayout', () => {
     );
 
     expect(normalized).toEqual({ a: { ringIndex: 0, sectorIndex: 0 } });
-    expect(pruneTeamGraphSlotAssignmentsForVisibleOwners({ hidden: { ringIndex: 4, sectorIndex: 4 } }, ['a']))
-      .toBeUndefined();
+    expect(
+      pruneTeamGraphSlotAssignmentsForVisibleOwners({ hidden: { ringIndex: 4, sectorIndex: 4 } }, [
+        'a',
+      ])
+    ).toBeUndefined();
   });
 
   it('normalizes grid owner order by filtering stale and duplicate ids then appending missing ids', () => {

--- a/test/features/agent-graph/core/teamGraphLayoutTransitions.test.ts
+++ b/test/features/agent-graph/core/teamGraphLayoutTransitions.test.ts
@@ -1,0 +1,625 @@
+import {
+  assignTeamGraphOwnerSlot,
+  changeTeamGraphLayoutMode,
+  clearTeamGraphLayout,
+  commitTeamGraphOwnerSlotDrop,
+  createInitialTeamGraphLayoutState,
+  ensureTeamGraphLayoutState,
+  resetTeamGraphLayoutToDefaults,
+  swapTeamGraphGridOwners,
+  swapTeamGraphOwnerSlots,
+  type TeamGraphLayoutState,
+  type TeamGraphLayoutTransition,
+} from '@features/agent-graph';
+import { describe, expect, it } from 'vitest';
+
+function applyTransition(
+  state: TeamGraphLayoutState,
+  transition: TeamGraphLayoutTransition
+): TeamGraphLayoutState {
+  return transition.kind === 'updated' ? { ...state, ...transition.patch } : state;
+}
+
+describe('team graph layout transitions', () => {
+  it('creates isolated initial state containers', () => {
+    const first = createInitialTeamGraphLayoutState();
+    const second = createInitialTeamGraphLayoutState();
+
+    expect(first).toEqual(second);
+    expect(first.slotAssignmentsByTeam).not.toBe(second.slotAssignmentsByTeam);
+    expect(first.graphLayoutSessionByTeam).not.toBe(second.graphLayoutSessionByTeam);
+  });
+
+  it('seeds defaults once and then returns an explicit no-op', () => {
+    const initial = createInitialTeamGraphLayoutState();
+    const first = ensureTeamGraphLayoutState(initial, 'my-team', [
+      { name: 'alice', agentId: 'agent-alice' },
+      { name: 'bob', agentId: 'agent-bob' },
+    ]);
+    const seeded = applyTransition(initial, first);
+
+    expect(first.kind).toBe('updated');
+    expect(seeded.slotAssignmentsByTeam['my-team']).toEqual({
+      'agent-alice': { ringIndex: 0, sectorIndex: 0 },
+      'agent-bob': { ringIndex: 0, sectorIndex: 1 },
+    });
+    expect(
+      ensureTeamGraphLayoutState(seeded, 'my-team', [
+        { name: 'alice', agentId: 'agent-alice' },
+        { name: 'bob', agentId: 'agent-bob' },
+      ])
+    ).toEqual({ kind: 'unchanged' });
+  });
+
+  it('resets every stale team when the layout version changes', () => {
+    const stale: TeamGraphLayoutState = {
+      ...createInitialTeamGraphLayoutState(),
+      graphLayoutModeByTeam: {
+        'my-team': 'radial',
+      },
+      gridOwnerOrderByTeam: {
+        'my-team': ['alice'],
+      },
+      slotLayoutVersion: 'legacy-layout',
+      slotAssignmentsByTeam: {
+        'other-team': {
+          old: { ringIndex: 9, sectorIndex: 9 },
+        },
+      },
+      graphLayoutSessionByTeam: {
+        'other-team': { mode: 'manual', signature: 'old' },
+      },
+    };
+
+    const transition = ensureTeamGraphLayoutState(stale, 'my-team', [
+      { name: 'alice', agentId: 'agent-alice' },
+    ]);
+    const next = applyTransition(stale, transition);
+
+    expect(next.slotLayoutVersion).toBe('stable-slots-v1');
+    expect(next.slotAssignmentsByTeam).toEqual({
+      'my-team': {
+        'agent-alice': { ringIndex: 0, sectorIndex: 0 },
+      },
+    });
+    expect(next.graphLayoutSessionByTeam).toEqual({
+      'my-team': { mode: 'default', signature: 'agent-alice' },
+    });
+    expect(next.graphLayoutModeByTeam).toBe(stale.graphLayoutModeByTeam);
+    expect(next.gridOwnerOrderByTeam).toBe(stale.gridOwnerOrderByTeam);
+  });
+
+  it('refuses an occupied direct assignment without producing a patch', () => {
+    const state: TeamGraphLayoutState = {
+      ...createInitialTeamGraphLayoutState(),
+      slotAssignmentsByTeam: {
+        'my-team': {
+          alice: { ringIndex: 0, sectorIndex: 0 },
+          bob: { ringIndex: 0, sectorIndex: 1 },
+        },
+      },
+    };
+
+    expect(
+      assignTeamGraphOwnerSlot(state, 'my-team', 'alice', {
+        ringIndex: 0,
+        sectorIndex: 1,
+      })
+    ).toEqual({
+      kind: 'refused',
+      diagnostic: {
+        code: 'occupied-slot-assignment',
+        teamName: 'my-team',
+        stableOwnerId: 'alice',
+        assignment: { ringIndex: 0, sectorIndex: 1 },
+        conflictingStableOwnerId: 'bob',
+      },
+    });
+  });
+
+  it('refuses an incomplete displaced-owner payload', () => {
+    const state: TeamGraphLayoutState = {
+      ...createInitialTeamGraphLayoutState(),
+      slotAssignmentsByTeam: {
+        'my-team': {
+          alice: { ringIndex: 0, sectorIndex: 0 },
+          bob: { ringIndex: 0, sectorIndex: 1 },
+        },
+      },
+    };
+
+    const transition = commitTeamGraphOwnerSlotDrop(
+      state,
+      'my-team',
+      'alice',
+      { ringIndex: 0, sectorIndex: 1 },
+      'bob'
+    );
+
+    expect(transition).toMatchObject({
+      kind: 'refused',
+      diagnostic: { code: 'incomplete-slot-drop-displacement' },
+    });
+    expect(applyTransition(state, transition)).toBe(state);
+  });
+
+  it('refuses stale displaced-owner drops without overwriting a newer pane update', () => {
+    const initial: TeamGraphLayoutState = {
+      ...createInitialTeamGraphLayoutState(),
+      slotAssignmentsByTeam: {
+        'my-team': {
+          alice: { ringIndex: 0, sectorIndex: 0 },
+          bob: { ringIndex: 0, sectorIndex: 1 },
+        },
+      },
+    };
+    const movedByOtherPane = applyTransition(
+      initial,
+      assignTeamGraphOwnerSlot(initial, 'my-team', 'bob', {
+        ringIndex: 0,
+        sectorIndex: 2,
+      })
+    );
+
+    const staleDrop = commitTeamGraphOwnerSlotDrop(
+      movedByOtherPane,
+      'my-team',
+      'alice',
+      { ringIndex: 0, sectorIndex: 1 },
+      'bob',
+      { ringIndex: 0, sectorIndex: 0 }
+    );
+
+    expect(staleDrop).toMatchObject({
+      kind: 'refused',
+      diagnostic: {
+        code: 'inconsistent-slot-drop-displacement',
+        reason: 'stale-displaced-assignment',
+      },
+    });
+    expect(applyTransition(movedByOtherPane, staleDrop)).toBe(movedByOtherPane);
+  });
+
+  it.each([
+    {
+      name: 'only displaced assignment',
+      displacedStableOwnerId: undefined,
+      displacedAssignment: { ringIndex: 0, sectorIndex: 0 },
+      expectedReason: 'incomplete-slot-drop-displacement',
+    },
+    {
+      name: 'same source and displaced owner',
+      displacedStableOwnerId: 'alice',
+      displacedAssignment: { ringIndex: 0, sectorIndex: 0 },
+      expectedReason: 'inconsistent-slot-drop-displacement',
+    },
+    {
+      name: 'unknown displaced owner',
+      displacedStableOwnerId: 'unknown',
+      displacedAssignment: { ringIndex: 0, sectorIndex: 0 },
+      expectedReason: 'inconsistent-slot-drop-displacement',
+    },
+    {
+      name: 'unknown source owner',
+      stableOwnerId: 'unknown',
+      displacedStableOwnerId: 'bob',
+      displacedAssignment: { ringIndex: 0, sectorIndex: 0 },
+      expectedReason: 'inconsistent-slot-drop-displacement',
+    },
+    {
+      name: 'stale source assignment',
+      displacedStableOwnerId: 'bob',
+      displacedAssignment: { ringIndex: 4, sectorIndex: 4 },
+      expectedReason: 'inconsistent-slot-drop-displacement',
+    },
+    {
+      name: 'same final slot',
+      displacedStableOwnerId: 'bob',
+      displacedAssignment: { ringIndex: 0, sectorIndex: 1 },
+      expectedReason: 'inconsistent-slot-drop-displacement',
+    },
+  ])('refuses invalid displacement: $name', (input) => {
+    const state: TeamGraphLayoutState = {
+      ...createInitialTeamGraphLayoutState(),
+      slotAssignmentsByTeam: {
+        'my-team': {
+          alice: { ringIndex: 0, sectorIndex: 0 },
+          bob: { ringIndex: 0, sectorIndex: 1 },
+        },
+      },
+    };
+
+    const transition = commitTeamGraphOwnerSlotDrop(
+      state,
+      'my-team',
+      input.stableOwnerId ?? 'alice',
+      { ringIndex: 0, sectorIndex: 1 },
+      input.displacedStableOwnerId,
+      input.displacedAssignment
+    );
+
+    expect(transition).toMatchObject({
+      kind: 'refused',
+      diagnostic: { code: input.expectedReason },
+    });
+    expect(applyTransition(state, transition)).toBe(state);
+  });
+
+  it('refuses an atomic swap when a third owner occupies either final slot', () => {
+    const state: TeamGraphLayoutState = {
+      ...createInitialTeamGraphLayoutState(),
+      slotAssignmentsByTeam: {
+        'my-team': {
+          alice: { ringIndex: 0, sectorIndex: 0 },
+          bob: { ringIndex: 0, sectorIndex: 1 },
+          tom: { ringIndex: 0, sectorIndex: 1 },
+        },
+      },
+    };
+
+    const transition = commitTeamGraphOwnerSlotDrop(
+      state,
+      'my-team',
+      'alice',
+      { ringIndex: 0, sectorIndex: 1 },
+      'bob',
+      { ringIndex: 0, sectorIndex: 0 }
+    );
+
+    expect(transition).toEqual({
+      kind: 'refused',
+      diagnostic: {
+        code: 'slot-drop-conflict',
+        teamName: 'my-team',
+        stableOwnerId: 'alice',
+        assignment: { ringIndex: 0, sectorIndex: 1 },
+        conflictingStableOwnerId: 'tom',
+      },
+    });
+    expect(applyTransition(state, transition)).toBe(state);
+  });
+
+  it('refuses invalid displaced slot coordinates', () => {
+    const state: TeamGraphLayoutState = {
+      ...createInitialTeamGraphLayoutState(),
+      slotAssignmentsByTeam: {
+        'my-team': {
+          alice: { ringIndex: 0, sectorIndex: 0 },
+          bob: { ringIndex: 0, sectorIndex: 1 },
+        },
+      },
+    };
+    const transition = commitTeamGraphOwnerSlotDrop(
+      state,
+      'my-team',
+      'alice',
+      { ringIndex: 0, sectorIndex: 1 },
+      'bob',
+      { ringIndex: Number.NaN, sectorIndex: 0 }
+    );
+
+    expect(transition).toMatchObject({
+      kind: 'refused',
+      diagnostic: { code: 'invalid-slot-assignment', assignmentRole: 'displaced' },
+    });
+    expect(applyTransition(state, transition)).toBe(state);
+  });
+
+  it.each([
+    { ringIndex: Number.NaN, sectorIndex: 0 },
+    { ringIndex: Number.POSITIVE_INFINITY, sectorIndex: 0 },
+    { ringIndex: -1, sectorIndex: 0 },
+    { ringIndex: 0.5, sectorIndex: 0 },
+    { ringIndex: 0, sectorIndex: Number.NaN },
+    { ringIndex: 0, sectorIndex: -1 },
+    { ringIndex: 0, sectorIndex: 1.5 },
+  ])('refuses invalid slot coordinates: $ringIndex:$sectorIndex', (assignment) => {
+    const state = createInitialTeamGraphLayoutState();
+
+    const direct = assignTeamGraphOwnerSlot(state, 'my-team', 'alice', assignment);
+    const drop = commitTeamGraphOwnerSlotDrop(state, 'my-team', 'alice', assignment);
+
+    expect(direct).toMatchObject({
+      kind: 'refused',
+      diagnostic: { code: 'invalid-slot-assignment', assignmentRole: 'target' },
+    });
+    expect(drop).toMatchObject({
+      kind: 'refused',
+      diagnostic: { code: 'invalid-slot-assignment', assignmentRole: 'target' },
+    });
+    expect(applyTransition(state, direct)).toBe(state);
+    expect(applyTransition(state, drop)).toBe(state);
+  });
+
+  it('clears every stale team before a direct slot mutation adopts the current version', () => {
+    const stale: TeamGraphLayoutState = {
+      ...createInitialTeamGraphLayoutState(),
+      slotLayoutVersion: 'legacy-layout',
+      slotAssignmentsByTeam: {
+        'other-team': { old: { ringIndex: 9, sectorIndex: 9 } },
+      },
+      graphLayoutSessionByTeam: {
+        'other-team': { mode: 'manual', signature: 'old' },
+      },
+    };
+
+    const next = applyTransition(
+      stale,
+      assignTeamGraphOwnerSlot(stale, 'my-team', 'alice', {
+        ringIndex: 0,
+        sectorIndex: 0,
+      })
+    );
+
+    expect(next.slotAssignmentsByTeam).toEqual({
+      'my-team': { alice: { ringIndex: 0, sectorIndex: 0 } },
+    });
+    expect(next.graphLayoutSessionByTeam).toEqual({
+      'my-team': { mode: 'manual', signature: null },
+    });
+  });
+
+  it('commits a displaced-owner swap as one state patch', () => {
+    const state: TeamGraphLayoutState = {
+      ...createInitialTeamGraphLayoutState(),
+      slotAssignmentsByTeam: {
+        'my-team': {
+          alice: { ringIndex: 0, sectorIndex: 0 },
+          bob: { ringIndex: 0, sectorIndex: 1 },
+        },
+      },
+      graphLayoutSessionByTeam: {
+        'my-team': { mode: 'default', signature: 'alice|bob' },
+      },
+    };
+
+    const transition = commitTeamGraphOwnerSlotDrop(
+      state,
+      'my-team',
+      'alice',
+      { ringIndex: 0, sectorIndex: 1 },
+      'bob',
+      { ringIndex: 0, sectorIndex: 0 }
+    );
+    const next = applyTransition(state, transition);
+
+    expect(transition.kind).toBe('updated');
+    expect(next.slotAssignmentsByTeam['my-team']).toEqual({
+      alice: { ringIndex: 0, sectorIndex: 1 },
+      bob: { ringIndex: 0, sectorIndex: 0 },
+    });
+    expect(next.graphLayoutSessionByTeam['my-team']).toEqual({
+      mode: 'manual',
+      signature: 'alice|bob',
+    });
+  });
+
+  it('materializes a first swap from generated slots for current visible owners', () => {
+    const state = createInitialTeamGraphLayoutState();
+    const transition = commitTeamGraphOwnerSlotDrop(
+      state,
+      'my-team',
+      'alice',
+      { ringIndex: 4, sectorIndex: 1 },
+      'bob',
+      { ringIndex: 4, sectorIndex: 0 },
+      ['alice', 'bob']
+    );
+    const next = applyTransition(state, transition);
+
+    expect(transition.kind).toBe('updated');
+    expect(next.slotAssignmentsByTeam['my-team']).toEqual({
+      alice: { ringIndex: 4, sectorIndex: 1 },
+      bob: { ringIndex: 4, sectorIndex: 0 },
+    });
+  });
+
+  it('refuses generated-slot swaps for owners outside the current visible seed', () => {
+    const state = createInitialTeamGraphLayoutState();
+    const transition = commitTeamGraphOwnerSlotDrop(
+      state,
+      'my-team',
+      'alice',
+      { ringIndex: 4, sectorIndex: 1 },
+      'unknown',
+      { ringIndex: 4, sectorIndex: 0 },
+      ['alice', 'bob']
+    );
+
+    expect(transition).toMatchObject({
+      kind: 'refused',
+      diagnostic: {
+        code: 'inconsistent-slot-drop-displacement',
+        reason: 'missing-displaced-owner',
+      },
+    });
+    expect(applyTransition(state, transition)).toBe(state);
+  });
+
+  it('swaps grid order without changing radial assignments', () => {
+    const state: TeamGraphLayoutState = {
+      ...createInitialTeamGraphLayoutState(),
+      gridOwnerOrderByTeam: {
+        'my-team': ['alice', 'bob', 'tom'],
+      },
+      slotAssignmentsByTeam: {
+        'my-team': {
+          alice: { ringIndex: 0, sectorIndex: 2 },
+        },
+      },
+    };
+
+    const next = applyTransition(
+      state,
+      swapTeamGraphGridOwners(state, 'my-team', 'alice', 'tom', ['alice', 'bob', 'tom'])
+    );
+
+    expect(next.gridOwnerOrderByTeam['my-team']).toEqual(['tom', 'bob', 'alice']);
+    expect(next.slotAssignmentsByTeam).toBe(state.slotAssignmentsByTeam);
+  });
+
+  it('swaps radial owners without changing grid or mode state', () => {
+    const state: TeamGraphLayoutState = {
+      ...createInitialTeamGraphLayoutState(),
+      graphLayoutModeByTeam: { 'my-team': 'radial' },
+      gridOwnerOrderByTeam: { 'my-team': ['alice', 'bob'] },
+      slotAssignmentsByTeam: {
+        'my-team': {
+          alice: { ringIndex: 0, sectorIndex: 0 },
+          bob: { ringIndex: 0, sectorIndex: 1 },
+        },
+      },
+    };
+
+    const transition = swapTeamGraphOwnerSlots(state, 'my-team', 'alice', 'bob');
+    const next = applyTransition(state, transition);
+
+    expect(next.slotAssignmentsByTeam['my-team']).toEqual({
+      alice: { ringIndex: 0, sectorIndex: 1 },
+      bob: { ringIndex: 0, sectorIndex: 0 },
+    });
+    expect(next.graphLayoutModeByTeam).toBe(state.graphLayoutModeByTeam);
+    expect(next.gridOwnerOrderByTeam).toBe(state.gridOwnerOrderByTeam);
+    expect(swapTeamGraphOwnerSlots(next, 'my-team', 'alice', 'missing')).toEqual({
+      kind: 'unchanged',
+    });
+  });
+
+  it('changes layout mode independently and returns an explicit no-op when repeated', () => {
+    const state: TeamGraphLayoutState = {
+      ...createInitialTeamGraphLayoutState(),
+      slotAssignmentsByTeam: {
+        'my-team': { alice: { ringIndex: 0, sectorIndex: 0 } },
+      },
+    };
+    const transition = changeTeamGraphLayoutMode(state, 'my-team', 'radial');
+    const next = applyTransition(state, transition);
+
+    expect(next.graphLayoutModeByTeam['my-team']).toBe('radial');
+    expect(next.slotAssignmentsByTeam).toBe(state.slotAssignmentsByTeam);
+    expect(changeTeamGraphLayoutMode(next, 'my-team', 'radial')).toEqual({
+      kind: 'unchanged',
+    });
+  });
+
+  it('clears one team without changing another team or independent layout state', () => {
+    const state: TeamGraphLayoutState = {
+      ...createInitialTeamGraphLayoutState(),
+      graphLayoutModeByTeam: {
+        'my-team': 'grid-under-lead',
+      },
+      gridOwnerOrderByTeam: {
+        'my-team': ['alice'],
+      },
+      slotAssignmentsByTeam: {
+        'my-team': { alice: { ringIndex: 0, sectorIndex: 0 } },
+        'other-team': { bob: { ringIndex: 0, sectorIndex: 1 } },
+      },
+      graphLayoutSessionByTeam: {
+        'my-team': { mode: 'manual', signature: 'alice' },
+        'other-team': { mode: 'manual', signature: 'bob' },
+      },
+    };
+
+    const next = applyTransition(state, clearTeamGraphLayout(state, 'my-team'));
+
+    expect(next.slotAssignmentsByTeam).toEqual({
+      'other-team': { bob: { ringIndex: 0, sectorIndex: 1 } },
+    });
+    expect(next.graphLayoutSessionByTeam).toEqual({
+      'other-team': { mode: 'manual', signature: 'bob' },
+    });
+    expect(next.graphLayoutModeByTeam).toBe(state.graphLayoutModeByTeam);
+    expect(next.gridOwnerOrderByTeam).toBe(state.gridOwnerOrderByTeam);
+  });
+
+  it('resets a manual layout to the supplied deterministic defaults', () => {
+    const state: TeamGraphLayoutState = {
+      ...createInitialTeamGraphLayoutState(),
+      slotAssignmentsByTeam: {
+        'my-team': { alice: { ringIndex: 3, sectorIndex: 2 } },
+      },
+      graphLayoutSessionByTeam: {
+        'my-team': { mode: 'manual', signature: 'alice' },
+      },
+    };
+    const defaultSeed = {
+      orderedVisibleOwnerIds: ['alice'],
+      signature: 'alice',
+      assignments: {
+        alice: { ringIndex: 0, sectorIndex: 0 },
+      },
+      duplicateStableOwnerIds: [],
+    };
+
+    const next = applyTransition(
+      state,
+      resetTeamGraphLayoutToDefaults(state, 'my-team', defaultSeed)
+    );
+
+    expect(next.slotAssignmentsByTeam['my-team']).toEqual(defaultSeed.assignments);
+    expect(next.graphLayoutSessionByTeam['my-team']).toEqual({
+      mode: 'default',
+      signature: 'alice',
+    });
+    expect(resetTeamGraphLayoutToDefaults(next, 'my-team', defaultSeed)).toEqual({
+      kind: 'unchanged',
+    });
+  });
+
+  it('refuses a blank team identifier instead of treating it as a global clear', () => {
+    const state: TeamGraphLayoutState = {
+      ...createInitialTeamGraphLayoutState(),
+      slotAssignmentsByTeam: {
+        'my-team': { alice: { ringIndex: 0, sectorIndex: 0 } },
+      },
+    };
+
+    const transition = clearTeamGraphLayout(state, '');
+
+    expect(transition).toEqual({
+      kind: 'refused',
+      diagnostic: { code: 'invalid-team-name', teamName: '' },
+    });
+    expect(applyTransition(state, transition)).toBe(state);
+  });
+
+  it('globally clears radial layout state without changing grid or mode containers', () => {
+    const state: TeamGraphLayoutState = {
+      ...createInitialTeamGraphLayoutState(),
+      graphLayoutModeByTeam: { 'my-team': 'radial' },
+      gridOwnerOrderByTeam: { 'my-team': ['alice'] },
+      slotAssignmentsByTeam: {
+        'my-team': { alice: { ringIndex: 0, sectorIndex: 0 } },
+      },
+      graphLayoutSessionByTeam: {
+        'my-team': { mode: 'manual', signature: 'alice' },
+      },
+    };
+
+    const next = applyTransition(state, clearTeamGraphLayout(state));
+
+    expect(next.slotAssignmentsByTeam).toEqual({});
+    expect(next.graphLayoutSessionByTeam).toEqual({});
+    expect(next.graphLayoutModeByTeam).toBe(state.graphLayoutModeByTeam);
+    expect(next.gridOwnerOrderByTeam).toBe(state.gridOwnerOrderByTeam);
+  });
+
+  it('refuses duplicate owner identities before changing layout state', () => {
+    const state = createInitialTeamGraphLayoutState();
+    const transition = ensureTeamGraphLayoutState(state, 'my-team', [
+      { name: 'alice', agentId: 'duplicate' },
+      { name: 'bob', agentId: 'duplicate' },
+    ]);
+
+    expect(transition).toEqual({
+      kind: 'refused',
+      diagnostic: {
+        code: 'duplicate-stable-owner-id',
+        teamName: 'my-team',
+        duplicateStableOwnerIds: ['duplicate'],
+      },
+    });
+    expect(applyTransition(state, transition)).toBe(state);
+  });
+});

--- a/test/features/agent-graph/renderer/useTeamGraphSurfaceActions.test.tsx
+++ b/test/features/agent-graph/renderer/useTeamGraphSurfaceActions.test.tsx
@@ -1,0 +1,93 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useTeamGraphSurfaceActions } from '../../../../src/features/agent-graph/renderer/hooks/useTeamGraphSurfaceActions';
+
+const hoisted = vi.hoisted(() => ({
+  getState: vi.fn(),
+}));
+
+vi.mock('@renderer/store', () => ({
+  useStore: {
+    getState: hoisted.getState,
+  },
+}));
+
+type SurfaceActions = ReturnType<typeof useTeamGraphSurfaceActions>;
+
+let surfaceActions: SurfaceActions | null = null;
+
+function Probe(): React.JSX.Element {
+  surfaceActions = useTeamGraphSurfaceActions('my-team');
+  return <div />;
+}
+
+describe('useTeamGraphSurfaceActions', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    surfaceActions = null;
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('routes incomplete and cross-team displacement through the validated commit path', () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    const commitTeamGraphOwnerSlotDrop = vi.fn();
+    const setTeamGraphOwnerSlotAssignment = vi.fn();
+    hoisted.getState.mockReturnValue({
+      graphLayoutModeByTeam: { 'my-team': 'radial' },
+      commitTeamGraphOwnerSlotDrop,
+      setTeamGraphOwnerSlotAssignment,
+    });
+    const host = document.body.appendChild(document.createElement('div'));
+    const root = createRoot(host);
+    act(() => root.render(<Probe />));
+
+    const target = { ringIndex: 0, sectorIndex: 1 };
+    const displaced = { ringIndex: 0, sectorIndex: 0 };
+    surfaceActions!.commitOwnerSlotDrop({
+      nodeId: 'member:my-team:alice',
+      assignment: target,
+      displacedNodeId: 'member:my-team:bob',
+    });
+    surfaceActions!.commitOwnerSlotDrop({
+      nodeId: 'member:my-team:alice',
+      assignment: target,
+      displacedAssignment: displaced,
+    });
+    surfaceActions!.commitOwnerSlotDrop({
+      nodeId: 'member:my-team:alice',
+      assignment: target,
+      displacedNodeId: 'member:other-team:bob',
+      displacedAssignment: displaced,
+    });
+    surfaceActions!.commitOwnerSlotDrop({
+      nodeId: 'member:my-team:alice',
+      assignment: target,
+      displacedNodeId: 'member:other-team:bob',
+    });
+
+    expect(commitTeamGraphOwnerSlotDrop).toHaveBeenNthCalledWith(
+      1,
+      'my-team',
+      'alice',
+      target,
+      'bob',
+      undefined
+    );
+    expect(commitTeamGraphOwnerSlotDrop).toHaveBeenNthCalledWith(
+      2,
+      'my-team',
+      'alice',
+      target,
+      undefined,
+      displaced
+    );
+    expect(commitTeamGraphOwnerSlotDrop).toHaveBeenCalledTimes(2);
+    expect(setTeamGraphOwnerSlotAssignment).not.toHaveBeenCalled();
+
+    act(() => root.unmount());
+  });
+});

--- a/test/renderer/store/teamSlice.test.ts
+++ b/test/renderer/store/teamSlice.test.ts
@@ -1200,6 +1200,14 @@ describe('teamSlice actions', () => {
 
   it('commits owner slot drops in the current session while persistence is disabled', () => {
     const store = createSliceStore();
+    store.setState({
+      slotAssignmentsByTeam: {
+        'my-team': {
+          'agent-alice': { ringIndex: 0, sectorIndex: 1 },
+          'agent-bob': { ringIndex: 0, sectorIndex: 2 },
+        },
+      },
+    });
 
     store
       .getState()


### PR DESCRIPTION
## Summary

- move graph layout state and policies out of the legacy team slice into the agent-graph feature
- keep teamSlice as the renderer composition root with narrow state, seed, and diagnostic ports
- validate slot coordinates, identity collisions, stale multi-pane displacement, and atomic swaps with fail-closed transitions
- preserve Zustand state identity for unchanged and refused transitions
- reduce teamSlice.ts from 5114 to 4682 lines

## Architecture

- browser-safe feature root exports domain and application contracts only
- renderer UI remains behind the renderer entrypoint
- pure transitions own invariants; the application factory maps transitions to injected Zustand and diagnostic ports
- no reverse dependency from feature core into renderer/store

## Verification

- pnpm typecheck
- 517 agent-graph and teamSlice tests
- scoped fast and type-aware lint: 0 errors
- hosted-web feature boundary tests: 8/8
- Node architecture suite: 23/23
- production Electron build
- Radix renderer bundle guard

Full source lint reaches one existing base-branch import-sort error in src/main/services/team/provisioning/TeamProvisioningStopFlow.ts. This PR does not touch that PR252-owned path.

Desktop E2E is intentionally scheduled after the complete teamSlice target reaches less than 800 lines, per the refactor series gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a browser-safe public Agent Graph API via a top-level entrypoint, with expanded public entrypoints for renderer and core usage.
* **Bug Fixes**
  * Improved fail-safe behavior for duplicate stable owner identities in default layouts.
  * Strengthened slot-drop displacement validation and reduced unnecessary state updates while emitting clearer refusal warnings.
* **Documentation**
  * Updated the Agent Graph README with a “Read first” section, clarified entrypoints, and refined responsibility boundaries.
* **Tests**
  * Added/expanded coverage for public exports, transitions, layout actions, duplicate handling, and hook behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactors team graph layout ownership into the agent-graph feature.
- Adds pure layout state, transition, validation, and action-factory APIs.
- Rewires the renderer store and graph hooks through the new feature boundary.
- Adds coverage for layout transitions, diagnostics, exports, and renderer action routing.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no eligible blocking failures remain.

No blocking failures remain.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/features/agent-graph/core/domain/teamGraphLayoutTransitions.ts | Introduces pure, fail-closed transitions for graph layout initialization, assignment, displacement, swapping, clearing, and reset. |
| src/features/agent-graph/core/application/createTeamGraphLayoutActions.ts | Adds a port-driven action factory that maps layout transitions into Zustand updates and diagnostics. |
| src/features/agent-graph/core/domain/teamGraphDefaultLayout.ts | Moves default-layout policy into the feature and adds duplicate stable-owner detection. |
| src/features/agent-graph/renderer/hooks/useTeamGraphSurfaceActions.ts | Routes graph surface interactions through the extracted validated layout actions. |
| src/renderer/store/slices/teamSlice.ts | Replaces inline graph layout state and actions with the agent-graph feature’s initial state and action factory. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  UI[Agent graph renderer hooks] --> Actions[Port-driven layout actions]
  Actions --> Transitions[Pure layout transitions]
  Transitions --> State[Zustand team layout state]
  State --> Adapter[Team graph adapter]
  Adapter --> UI
```

<sub>Reviews (3): Last reviewed commit: ["refactor(agent-graph): isolate layout st..."](https://github.com/777genius/agent-teams-ai/commit/7d7aada4d6f05ede4aaa513aef18cb8fe593a17a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46676590)</sub>

<!-- /greptile_comment -->