### PR TITLE
refactor(architecture): restore source size boundaries

### DIFF
--- a/src/features/internal-storage/main/infrastructure/InternalStorageWorkerClient.ts
+++ b/src/features/internal-storage/main/infrastructure/InternalStorageWorkerClient.ts
@@ -1,6 +1,3 @@
-import * as fs from 'node:fs';
-import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { Worker } from 'node:worker_threads';
 
 import { createLogger } from '@shared/utils/logger';
@@ -15,6 +12,11 @@ import {
   type TeamRosterSnapshotRecord,
   type TeamRosterStorageGateway,
 } from '../../contracts/teamRosterStorageContracts';
+
+import {
+  getInternalStorageWorkerPathCandidates,
+  resolveInternalStorageWorkerPath,
+} from './internalStorageWorkerPath';
 
 import type {
   CommentJournalEntryRecord,
@@ -106,7 +108,6 @@ type InternalStorageWorkerPayloadFor<TOp extends InternalStorageWorkerRequest['o
       : Extract<InternalStorageWorkerRequest, { op: TOp }>['payload'];
 
 const WORKER_CALL_TIMEOUT_MS = 20_000;
-const WORKER_FILENAME = 'internal-storage-worker.cjs';
 
 interface PendingEntry {
   resolve: (value: unknown) => void;
@@ -125,32 +126,6 @@ function makeId(): string {
   return `${Date.now()}-${crypto.randomUUID().slice(0, 12)}`;
 }
 
-function resolveWorkerPath(): string | null {
-  // Same candidate strategy as team-fs-worker: co-located with the bundled
-  // main output first, then the dev dist folder.
-  const baseDir =
-    typeof __dirname === 'string' && __dirname.length > 0
-      ? __dirname
-      : path.dirname(fileURLToPath(import.meta.url));
-
-  const candidates = [
-    path.join(baseDir, WORKER_FILENAME),
-    path.join(process.cwd(), 'dist-electron', 'main', WORKER_FILENAME),
-  ];
-
-  for (const candidate of candidates) {
-    try {
-      if (fs.existsSync(candidate)) {
-        return candidate;
-      }
-    } catch {
-      // ignore
-    }
-  }
-
-  return null;
-}
-
 /**
  * Async facade over the internal-storage worker thread. Requests run one at a
  * time (SQLite access is serialized anyway); a timeout or worker crash rejects
@@ -167,7 +142,7 @@ export class InternalStorageWorkerClient
     CoordinationDurabilityStorageGateway
 {
   private worker: Worker | null = null;
-  private readonly workerPath: string | null = resolveWorkerPath();
+  private readonly workerPath: string | null = resolveInternalStorageWorkerPath();
   private pending = new Map<string, PendingEntry>();
   private queue: QueuedEntry[] = [];
   private activeCallId: string | null = null;
@@ -181,14 +156,7 @@ export class InternalStorageWorkerClient
   }
 
   getWorkerPathCandidatesForDiagnostics(): string[] {
-    const baseDir =
-      typeof __dirname === 'string' && __dirname.length > 0
-        ? __dirname
-        : path.dirname(fileURLToPath(import.meta.url));
-    return [
-      path.join(baseDir, WORKER_FILENAME),
-      path.join(process.cwd(), 'dist-electron', 'main', WORKER_FILENAME),
-    ];
+    return getInternalStorageWorkerPathCandidates();
   }
 
   async ping(): Promise<InternalStorageBackendInfo> {

--- a/src/features/internal-storage/main/infrastructure/internalStorageWorkerPath.ts
+++ b/src/features/internal-storage/main/infrastructure/internalStorageWorkerPath.ts
@@ -1,0 +1,27 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const WORKER_FILENAME = 'internal-storage-worker.cjs';
+
+export function getInternalStorageWorkerPathCandidates(): string[] {
+  const baseDir =
+    typeof __dirname === 'string' && __dirname.length > 0
+      ? __dirname
+      : path.dirname(fileURLToPath(import.meta.url));
+  return [
+    path.join(baseDir, WORKER_FILENAME),
+    path.join(process.cwd(), 'dist-electron', 'main', WORKER_FILENAME),
+  ];
+}
+
+export function resolveInternalStorageWorkerPath(): string | null {
+  for (const candidate of getInternalStorageWorkerPathCandidates()) {
+    try {
+      if (fs.existsSync(candidate)) return candidate;
+    } catch {
+      // An inaccessible candidate is unavailable; the next packaged/dev path may still work.
+    }
+  }
+  return null;
+}

--- a/src/features/internal-storage/main/infrastructure/worker/internalStorageBackupTables.ts
+++ b/src/features/internal-storage/main/infrastructure/worker/internalStorageBackupTables.ts
@@ -1,0 +1,14 @@
+export const INTERNAL_STORAGE_REQUIRED_BACKUP_TABLES = Object.freeze([
+  'coordination_backup_runs',
+  'coordination_backup_writer_fences',
+  'coordination_event_journal',
+  'coordination_event_journal_metadata',
+  'durable_application_command_outbox',
+  'durable_application_commands',
+  'snapshot_retention_leases',
+  'team_identity_records',
+  'team_identity_storage_metadata',
+  'team_roster_members',
+  'team_roster_storage_metadata',
+  'team_rosters',
+] as const);

--- a/src/features/internal-storage/main/infrastructure/worker/internalStorageMigrations.ts
+++ b/src/features/internal-storage/main/infrastructure/worker/internalStorageMigrations.ts
@@ -8,24 +8,12 @@ import {
 
 import type DatabaseConstructor from 'better-sqlite3';
 
+export { INTERNAL_STORAGE_REQUIRED_BACKUP_TABLES } from './internalStorageBackupTables';
+
 type SqliteDatabase = InstanceType<typeof DatabaseConstructor>;
 
 /** "ATAI" in big-endian ASCII. Backups reject databases owned by another application. */
 export const INTERNAL_STORAGE_APPLICATION_ID = 0x41544149;
-export const INTERNAL_STORAGE_REQUIRED_BACKUP_TABLES = Object.freeze([
-  'coordination_backup_runs',
-  'coordination_backup_writer_fences',
-  'coordination_event_journal',
-  'coordination_event_journal_metadata',
-  'durable_application_command_outbox',
-  'durable_application_commands',
-  'snapshot_retention_leases',
-  'team_identity_records',
-  'team_identity_storage_metadata',
-  'team_roster_members',
-  'team_roster_storage_metadata',
-  'team_rosters',
-] as const);
 
 interface InternalStorageMigration {
   version: number;

--- a/src/features/team-runtime-control/core/application/planning/CompositeRuntimePlanValidationError.ts
+++ b/src/features/team-runtime-control/core/application/planning/CompositeRuntimePlanValidationError.ts
@@ -1,0 +1,30 @@
+export type CompositeRuntimePlanErrorCode =
+  | 'case_fold_ambiguity'
+  | 'credential_exposure_missing'
+  | 'credential_exposure_widened'
+  | 'credential_metadata_only'
+  | 'duplicate_execution_unit_id'
+  | 'duplicate_lane_id'
+  | 'duplicate_legacy_member_key'
+  | 'duplicate_member_id'
+  | 'invalid_field'
+  | 'lane_plan_mismatch'
+  | 'lane_plan_rejected'
+  | 'missing_lane_binding'
+  | 'missing_member_binding'
+  | 'persisted_roster_mismatch'
+  | 'persisted_roster_missing'
+  | 'persisted_plan_invalid'
+  | 'plan_hash_mismatch'
+  | 'unsupported_topology'
+  | 'unstable_ordering';
+
+export class CompositeRuntimePlanValidationError extends TypeError {
+  readonly code: CompositeRuntimePlanErrorCode;
+
+  constructor(code: CompositeRuntimePlanErrorCode, message: string) {
+    super(message);
+    this.name = 'CompositeRuntimePlanValidationError';
+    this.code = code;
+  }
+}

--- a/src/features/team-runtime-control/core/application/planning/createCompositeRuntimePlan.ts
+++ b/src/features/team-runtime-control/core/application/planning/createCompositeRuntimePlan.ts
@@ -45,6 +45,11 @@ import {
 import { credentialExposureSetsOverlap, credentialRefKey } from '../../domain/ProcessExecutionUnit';
 import { isRuntimeExecutionBackend } from '../../domain/RuntimeExecutionBackend';
 
+import {
+  type CompositeRuntimePlanErrorCode,
+  CompositeRuntimePlanValidationError,
+} from './CompositeRuntimePlanValidationError';
+
 import type {
   PlannedRuntimeMember,
   TeamRuntimeLanePlan,
@@ -52,36 +57,10 @@ import type {
 } from '@features/team-runtime-lanes';
 import type { TeamProviderId } from '@shared/types';
 
-export type CompositeRuntimePlanErrorCode =
-  | 'case_fold_ambiguity'
-  | 'credential_exposure_missing'
-  | 'credential_exposure_widened'
-  | 'credential_metadata_only'
-  | 'duplicate_execution_unit_id'
-  | 'duplicate_lane_id'
-  | 'duplicate_legacy_member_key'
-  | 'duplicate_member_id'
-  | 'invalid_field'
-  | 'lane_plan_mismatch'
-  | 'lane_plan_rejected'
-  | 'missing_lane_binding'
-  | 'missing_member_binding'
-  | 'persisted_roster_mismatch'
-  | 'persisted_roster_missing'
-  | 'persisted_plan_invalid'
-  | 'plan_hash_mismatch'
-  | 'unsupported_topology'
-  | 'unstable_ordering';
-
-export class CompositeRuntimePlanValidationError extends TypeError {
-  readonly code: CompositeRuntimePlanErrorCode;
-
-  constructor(code: CompositeRuntimePlanErrorCode, message: string) {
-    super(message);
-    this.name = 'CompositeRuntimePlanValidationError';
-    this.code = code;
-  }
-}
+export {
+  type CompositeRuntimePlanErrorCode,
+  CompositeRuntimePlanValidationError,
+} from './CompositeRuntimePlanValidationError';
 
 export interface ResolvedRuntimeLaneCredentialFact {
   readonly laneId: LaneId;

--- a/src/features/team-runtime-control/main/adapters/output/process-supervision/AnchorProcessSupervisorAdapter.ts
+++ b/src/features/team-runtime-control/main/adapters/output/process-supervision/AnchorProcessSupervisorAdapter.ts
@@ -50,6 +50,7 @@ import {
   mapAnchorDrainProof,
   mapAnchorReadyProof,
 } from './AnchorProtocolFrames';
+import { exactStartRequestKey, waitForCallerCancellation } from './startRequestCoordination';
 
 import type { ProcessExecutionUnit, Sha256Hash } from '../../../../contracts/runtimePlan';
 import type {
@@ -717,52 +718,6 @@ export class AnchorProcessSupervisorAdapter
       // The original typed failure is returned; store-unavailable is never treated as cleanup proof.
     }
   }
-}
-
-function exactStartRequestKey(request: StartProcessExecutionUnitRequest): Sha256Hash {
-  // Cancellation belongs to one caller waiting on this semantic operation. It must neither split
-  // the durable start identity nor let a retry replace the cancellation owner of an existing start.
-  return computeCanonicalPolicyDigest({
-    executionUnit: request.executionUnit,
-    launchSpec: request.launchSpec,
-  });
-}
-
-async function waitForCallerCancellation(
-  inFlight: Promise<StartProcessExecutionUnitResult>,
-  cancellation: StartProcessExecutionUnitRequest['cancellation']
-): Promise<StartProcessExecutionUnitResult> {
-  if (isCancellationRequested(cancellation)) {
-    return { status: 'rejected', reason: 'cancelled' };
-  }
-
-  return await new Promise<StartProcessExecutionUnitResult>((resolve, reject) => {
-    let settled = false;
-    const settle = (callback: () => void): void => {
-      if (settled) return;
-      settled = true;
-      clearInterval(cancellationPoll);
-      callback();
-    };
-    const cancellationPoll = setInterval(() => {
-      if (isCancellationRequested(cancellation)) {
-        settle(() => resolve({ status: 'rejected', reason: 'cancelled' }));
-      }
-    }, 5);
-
-    void inFlight.then(
-      (result) =>
-        settle(() =>
-          resolve(
-            isCancellationRequested(cancellation)
-              ? { status: 'rejected', reason: 'cancelled' }
-              : result
-          )
-        ),
-      (error: unknown) =>
-        settle(() => reject(error instanceof Error ? error : new Error('in-flight-start-rejected')))
-    );
-  });
 }
 
 function isExactLaunchSpec(

--- a/src/features/team-runtime-control/main/adapters/output/process-supervision/startRequestCoordination.ts
+++ b/src/features/team-runtime-control/main/adapters/output/process-supervision/startRequestCoordination.ts
@@ -1,0 +1,53 @@
+import { isCancellationRequested } from '../../../../core/application/process-supervision';
+import { computeCanonicalPolicyDigest } from '../../../../core/domain/process-supervision';
+
+import type { Sha256Hash } from '../../../../contracts/runtimePlan';
+import type {
+  StartProcessExecutionUnitRequest,
+  StartProcessExecutionUnitResult,
+} from '../../../../core/application/ports';
+
+export function exactStartRequestKey(request: StartProcessExecutionUnitRequest): Sha256Hash {
+  // Cancellation belongs to one caller, not to the semantic durable-start identity.
+  return computeCanonicalPolicyDigest({
+    executionUnit: request.executionUnit,
+    launchSpec: request.launchSpec,
+  });
+}
+
+export async function waitForCallerCancellation(
+  inFlight: Promise<StartProcessExecutionUnitResult>,
+  cancellation: StartProcessExecutionUnitRequest['cancellation']
+): Promise<StartProcessExecutionUnitResult> {
+  if (isCancellationRequested(cancellation)) {
+    return { status: 'rejected', reason: 'cancelled' };
+  }
+
+  return await new Promise<StartProcessExecutionUnitResult>((resolve, reject) => {
+    let settled = false;
+    const settle = (callback: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearInterval(cancellationPoll);
+      callback();
+    };
+    const cancellationPoll = setInterval(() => {
+      if (isCancellationRequested(cancellation)) {
+        settle(() => resolve({ status: 'rejected', reason: 'cancelled' }));
+      }
+    }, 5);
+
+    void inFlight.then(
+      (result) =>
+        settle(() =>
+          resolve(
+            isCancellationRequested(cancellation)
+              ? { status: 'rejected', reason: 'cancelled' }
+              : result
+          )
+        ),
+      (error: unknown) =>
+        settle(() => reject(error instanceof Error ? error : new Error('in-flight-start-rejected')))
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- extract internal-storage worker path resolution and backup table ownership
- extract composite runtime validation taxonomy while preserving the existing public re-export and `instanceof` behavior
- extract coalesced start request coordination from the anchor process supervisor
- restore every live-base source-size violation without raising a legacy cap or adding a new exception

## Source size
- `InternalStorageWorkerClient.ts`: 949 -> 917 (cap 919)
- `internalStorageMigrations.ts`: 886 -> 874 (cap 874)
- `createCompositeRuntimePlan.ts`: 1216 -> 1195 (cap 1214)
- `AnchorProcessSupervisorAdapter.ts`: 839 -> 794 (new-file limit 800, no exception)
- new modules: 14-53 lines

## Verification
- `pnpm typecheck`
- 7 focused Vitest files, 81 tests
- architecture boundaries, 24 tests total across the targeted suites
- fast lint for all changed production files
- type-aware ESLint for all changed and new files, no errors and no warnings in new files
- `git diff --check`

Behavior is intentionally unchanged. This PR unblocks the source-file-size ratchet without weakening its policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved reliability when locating the internal storage worker across packaged and development environments.
  - Added structured validation errors for composite runtime plans.
  - Added cancellation-aware coordination for concurrent process-start requests.
  - Defined required internal storage backup tables for consistent backup handling.

- **Refactor**
  - Centralized worker path discovery, runtime-plan errors, and process-start coordination into dedicated modules while preserving existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->