### PR TITLE
chore(review): align interaction runtime SHA

### DIFF
--- a/.github/workflows/reviewrouter-interaction.yml
+++ b/.github/workflows/reviewrouter-interaction.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.event_name == 'workflow_dispatch' || ((github.event_name != 'issue_comment' || github.event.issue.pull_request) && github.event.comment.user.type != 'Bot') }}
     env:
-      RR_RUNTIME_REF: "d485d6c0c3914fb1936d23bd52eeb08acb4dcfd4"
+      RR_RUNTIME_REF: "04a450a1d3829c380e77bcb4b07618ee2d16d90b"
       REVIEWROUTER_API_URL: "https://api.reviewrouter.site"
       REVIEWROUTER_OIDC_AUDIENCE: "reviewrouter"
       REVIEWROUTER_RUNTIME_CONFIG_MODE: "oidc"


### PR DESCRIPTION
Pin the managed interaction workflow to the same immutable ReviewRouter runtime as the T0 review workflow. This keeps `/rr review` ingress and execution on one attested release.