### PR TITLE
chore(review): update ReviewRouter runtime on dev

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -30,9 +30,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@d485d6c0c3914fb1936d23bd52eeb08acb4dcfd4
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@04a450a1d3829c380e77bcb4b07618ee2d16d90b
     with:
-      runtime_ref: "d485d6c0c3914fb1936d23bd52eeb08acb4dcfd4"
+      runtime_ref: "04a450a1d3829c380e77bcb4b07618ee2d16d90b"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ inputs.pr_number }}
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@d485d6c0c3914fb1936d23bd52eeb08acb4dcfd4
+        uses: 777genius/review-router@04a450a1d3829c380e77bcb4b07618ee2d16d90b
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"

--- a/.github/workflows/reviewrouter-interaction.yml
+++ b/.github/workflows/reviewrouter-interaction.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.event_name == 'workflow_dispatch' || ((github.event_name != 'issue_comment' || github.event.issue.pull_request) && github.event.comment.user.type != 'Bot') }}
     env:
-      RR_RUNTIME_REF: "d485d6c0c3914fb1936d23bd52eeb08acb4dcfd4"
+      RR_RUNTIME_REF: "04a450a1d3829c380e77bcb4b07618ee2d16d90b"
       REVIEWROUTER_API_URL: "https://api.reviewrouter.site"
       REVIEWROUTER_OIDC_AUDIENCE: "reviewrouter"
       REVIEWROUTER_RUNTIME_CONFIG_MODE: "oidc"


### PR DESCRIPTION
Pins both managed ReviewRouter workflows on `dev` to the deployed immutable Action release `04a450a1d3829c380e77bcb4b07618ee2d16d90b`.

This keeps active review inventory compatible for revision-aware v2 activation.