### PR TITLE
chore(review): pin action v2 runtime

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -30,9 +30,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@04a450a1d3829c380e77bcb4b07618ee2d16d90b
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@a982b154f5cb3c56d2cd362a26fdf3421cf4faf7
     with:
-      runtime_ref: "04a450a1d3829c380e77bcb4b07618ee2d16d90b"
+      runtime_ref: "a982b154f5cb3c56d2cd362a26fdf3421cf4faf7"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ inputs.pr_number }}
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@04a450a1d3829c380e77bcb4b07618ee2d16d90b
+        uses: 777genius/review-router@a982b154f5cb3c56d2cd362a26fdf3421cf4faf7
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"


### PR DESCRIPTION
Pins the managed review, runtime, and interaction paths to the registered immutable ReviewRouter Action v2 release `a982b154f5cb3c56d2cd362a26fdf3421cf4faf7`.