### PR TITLE
fix(deps): update Fastify security patch

### DIFF
--- a/.codex-handoff/target-image-decision-h2.json
+++ b/.codex-handoff/target-image-decision-h2.json
@@ -36,7 +36,7 @@
     "path": "docs/research/hosted-web/phase-0/auth-artifacts/observed-artifact-scan.json",
     "recordType": "w6-current-commit-artifact-scan",
     "canonicalSourceCommit": "42ec333848e29e97c41699b9fed73ed199740e3f",
-    "semanticSha256": "079e04075c3f2d5bd0bd6cd9f5b7131297c6f14f18b86ff224535e9f1c543256",
+    "semanticSha256": "d91ceece21873f48f23a121cf1a9987534a6197017d350071b7c26a2e70b081c",
     "proofLevel": "targeted_current_commit_build_observed",
     "targetedBuildCompared": true
   },

--- a/docs/research/hosted-web/phase-0/auth-artifacts/evidence.json
+++ b/docs/research/hosted-web/phase-0/auth-artifacts/evidence.json
@@ -218,7 +218,7 @@
         "characterizationAuthority": {
           "authorityPath": "docs/research/hosted-web/phase-0/auth-artifacts/observed-artifact-scan.json",
           "authorityRecordType": "w6-current-commit-artifact-scan",
-          "authoritySha256": "079e04075c3f2d5bd0bd6cd9f5b7131297c6f14f18b86ff224535e9f1c543256",
+          "authoritySha256": "d91ceece21873f48f23a121cf1a9987534a6197017d350071b7c26a2e70b081c",
           "disposition": "rejected_for_hosted_v1"
         },
         "emittedManifest": "observed-artifact-scan.json is the sole exact current-commit standalone characterization authority. historical-rejected-candidate-artifact-scan.json preserves the rejected integration candidate as historical provenance only; all other W6 records carry the current authority's checked semantic-hash projection.",

--- a/docs/research/hosted-web/phase-0/auth-artifacts/evidence.json
+++ b/docs/research/hosted-web/phase-0/auth-artifacts/evidence.json
@@ -124,7 +124,7 @@
         "installed": [
           {
             "package": "fastify",
-            "version": "5.8.5",
+            "version": "5.10.0",
             "source": "installed package metadata and pnpm lock"
           },
           {

--- a/docs/research/hosted-web/phase-0/auth-artifacts/observed-artifact-scan.json
+++ b/docs/research/hosted-web/phase-0/auth-artifacts/observed-artifact-scan.json
@@ -21,7 +21,12 @@
   "source": {
     "standaloneInput": "src/main/standalone.ts",
     "rendererOutput": "out/renderer",
-    "externalPackages": ["fastify", "@fastify/cors", "@fastify/static", "agent-teams-controller"],
+    "externalPackages": [
+      "fastify",
+      "@fastify/cors",
+      "@fastify/static",
+      "agent-teams-controller"
+    ],
     "nativeCatchAllEmptyStub": true,
     "broadElectronStub": true,
     "standaloneServiceStubs": true,
@@ -47,7 +52,7 @@
     ],
     "cookiePlugin": null,
     "versions": {
-      "fastify": "^5.8.5",
+      "fastify": "^5.10.0",
       "fastifyCors": "^11.2.0",
       "betterSqlite3": "^12.11.1",
       "electron": "^40.10.0",
@@ -60,29 +65,34 @@
     "observed": true,
     "files": [
       {
-        "path": "dist-standalone/assets/HttpServer-Bqe22d9M.cjs",
-        "bytes": 360996,
-        "sha256": "bc72691427933478a7c5d571c9996ef51e1371ab3679ae6b4b38d0d19a33ddbc"
+        "path": "dist-standalone/assets/ConfigManager-DHkwAl8D.cjs",
+        "bytes": 48442,
+        "sha256": "560bb25e3a8c7d9b88c3da441ae500eff207a330a2b52c64e6c2fdf852f3faa2"
       },
       {
-        "path": "dist-standalone/assets/NotificationManager-B8_AtzLu.cjs",
-        "bytes": 270694,
-        "sha256": "88f99fc01f244cc2f8b06271c57918967142968140d9316985337011bed5105b"
+        "path": "dist-standalone/assets/HttpServer-CRJGIxSZ.cjs",
+        "bytes": 407640,
+        "sha256": "6de16eef37d46039d65a9fa260f3f2fca30e9dcfb0349ef0901640971e7c7d8e"
       },
       {
-        "path": "dist-standalone/assets/ProjectPathResolver-BI-xT66r.cjs",
-        "bytes": 246320,
-        "sha256": "23e747f08c84f1f98b0805371f26d5c64800addf5b6fdf0a48b686723d5a957a"
+        "path": "dist-standalone/assets/NotificationManager-B1U7QO9P.cjs",
+        "bytes": 269952,
+        "sha256": "ad97807e110dd1935d39249f04b534613702b332585673d77811d371985fb068"
       },
       {
-        "path": "dist-standalone/assets/ServiceContext--qE6X1hf.cjs",
-        "bytes": 332256,
-        "sha256": "1d7d7c485d872c43cfad44ec8906db84dd613fb7b85e9a51b5ca9881d59fcef0"
+        "path": "dist-standalone/assets/ProjectPathResolver-10BtGyp0.cjs",
+        "bytes": 218264,
+        "sha256": "6ad72b3e11740bb56c6a68bd7f7677518fc08271d0664bcff4f4abe2e8ea0472"
       },
       {
-        "path": "dist-standalone/assets/index-DiQK2OQV.cjs",
-        "bytes": 5189932,
-        "sha256": "7bee39b2dd444e31819a941276127ce7c25646cba3491005d7d4b3b30ed2a92d"
+        "path": "dist-standalone/assets/ServiceContext-BmtuUHZP.cjs",
+        "bytes": 317760,
+        "sha256": "9d70a1f9bbe3d327b194607af33cb8b877def58c7244139530686ca214d9612f"
+      },
+      {
+        "path": "dist-standalone/assets/index-Ul6_FcQ-.cjs",
+        "bytes": 5848126,
+        "sha256": "9cfa190054f89ab711e7cd1dbcfb44fba213dc8ade219974af797464b281346f"
       },
       {
         "path": "dist-standalone/assets/tokenizer-BIjeYPC0.cjs",
@@ -91,8 +101,8 @@
       },
       {
         "path": "dist-standalone/index.cjs",
-        "bytes": 97537,
-        "sha256": "cd55734bd8996c23b638b20f8652130fae0f0f0b1f11fef7065280cceb7afd65"
+        "bytes": 303347,
+        "sha256": "bfd6d14eb1b2c08c2e6201aba4a1a8a0d17085e0e3ac6827d1b23bfd8b8f8a4b"
       }
     ],
     "internalStorageWorkerPresent": false,

--- a/docs/research/hosted-web/phase-0/auth-artifacts/proposed-hosted-artifact-manifest.json
+++ b/docs/research/hosted-web/phase-0/auth-artifacts/proposed-hosted-artifact-manifest.json
@@ -63,7 +63,7 @@
   "currentStandalone": {
     "authorityPath": "docs/research/hosted-web/phase-0/auth-artifacts/observed-artifact-scan.json",
     "authorityRecordType": "w6-current-commit-artifact-scan",
-    "authoritySha256": "079e04075c3f2d5bd0bd6cd9f5b7131297c6f14f18b86ff224535e9f1c543256",
+    "authoritySha256": "d91ceece21873f48f23a121cf1a9987534a6197017d350071b7c26a2e70b081c",
     "disposition": "rejected_for_hosted_v1"
   },
   "capabilityClaims": {

--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     "drizzle-orm": "^0.45.2",
     "electron-updater": "^6.7.3",
     "fast-json-stringify": "^6.4.0",
-    "fastify": "^5.8.5",
+    "fastify": "^5.10.0",
     "highlight.js": "^11.11.1",
     "i18next": "26.2.0",
     "idb-keyval": "^6.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -336,8 +336,8 @@ importers:
         specifier: ^6.4.0
         version: 6.4.0
       fastify:
-        specifier: ^5.8.5
-        version: 5.8.5
+        specifier: ^5.10.0
+        version: 5.10.0
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
@@ -1474,8 +1474,8 @@ packages:
   '@fastify/error@4.2.0':
     resolution: {integrity: sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==}
 
-  '@fastify/fast-json-stringify-compiler@5.0.3':
-    resolution: {integrity: sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==}
+  '@fastify/fast-json-stringify-compiler@5.1.0':
+    resolution: {integrity: sha512-PxcYtKLbQ8Z+yApiqjK8FwxIwvEj38k2OiLc17u8dkJSlmfi2wHHPaSnaoqBPQqtvF8YVsDgDpP2snDCfFrpfw==}
 
   '@fastify/forwarded@3.0.1':
     resolution: {integrity: sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==}
@@ -5182,6 +5182,9 @@ packages:
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
   alien-signals@3.1.2:
     resolution: {integrity: sha512-d9dYqZTS90WLiU0I5c6DHj/HcKkF8ZyGN3G5x8wSbslulz70KOxaqCT0hQCo9KOyhVqzqGojvNdJXoTumZOtcw==}
 
@@ -5367,8 +5370,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  avvio@9.1.0:
-    resolution: {integrity: sha512-fYASnYi600CsH/j9EQov7lECAniYiBFiiAtBNuZYLA2leLe9qOvZzqYHFjtIj6gD2VMoMLP14834LFWvr4IfDw==}
+  avvio@9.3.0:
+    resolution: {integrity: sha512-g2tQ7LE7oOSqDfwEm3M+ZCMTJc7KiZCdJ4UwyZJb5ckTKyYu50OYmvv0mCFXPuYXoM4zkSt8zM9XQ9KCvxA74A==}
 
   axe-core@4.11.1:
     resolution: {integrity: sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==}
@@ -7009,6 +7012,9 @@ packages:
   fast-json-stringify@6.4.0:
     resolution: {integrity: sha512-ibRCQ0GZKJIQ+P3Et1h0LhPgp3PMTYk0MH8O+kW3lNYsvmaQww5Nn3f1jf73Q0jR1Yz3a1CDP4/NZD3vOajWJQ==}
 
+  fast-json-stringify@7.0.1:
+    resolution: {integrity: sha512-eRSayARSbbwlBjpP4vnTTIRD5QPcIrmihPxDeN1DtKnHPg66UuJLx+8hlK1kaFdjvzyQ/dzALoi4vwAQ+T+iZA==}
+
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
@@ -7034,8 +7040,8 @@ packages:
   fastify-plugin@5.1.0:
     resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
 
-  fastify@5.8.5:
-    resolution: {integrity: sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==}
+  fastify@5.10.0:
+    resolution: {integrity: sha512-A9L0ziuWGQHgEEVgF3davQ9vbD93IuX+lo2IsxapQmu5b/Y/ynn9m9K5JHt9dvyJXOFc5iN0Zk5GHEOqnzhWjg==}
 
   fastmcp@3.35.0:
     resolution: {integrity: sha512-bcyAaVa3Zw5f4xighGg6fNNgEzZoP6tX/O+ZfS2lIhbEULWe/zUWG533JyFEUOjZT7EB+tiZW1ot4eWKmYJ6DA==}
@@ -7096,8 +7102,8 @@ packages:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
 
-  find-my-way@9.4.0:
-    resolution: {integrity: sha512-5Ye4vHsypZRYtS01ob/iwHzGRUDELlsoCftI/OZFhcLs1M0tkGPcXldE80TAZC5yYuJMBPJQQ43UHlqbJWiX2w==}
+  find-my-way@9.7.0:
+    resolution: {integrity: sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==}
     engines: {node: '>=20'}
 
   find-up-simple@1.0.1:
@@ -7677,8 +7683,8 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
-  ipaddr.js@2.3.0:
-    resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
+  ipaddr.js@2.4.0:
+    resolution: {integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==}
     engines: {node: '>= 10'}
 
   iron-webcrypto@1.2.1:
@@ -9760,6 +9766,9 @@ packages:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
 
+  real-require@1.0.0:
+    resolution: {integrity: sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==}
+
   redis-errors@1.2.0:
     resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
     engines: {node: '>=4'}
@@ -9974,8 +9983,9 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
-  safe-regex2@5.0.0:
-    resolution: {integrity: sha512-YwJwe5a51WlK7KbOJREPdjNrpViQBI3p4T50lfwPuDhZnE3XGVTlGvi+aolc5+RvxDD6bnUmjVsU9n1eboLUYw==}
+  safe-regex2@5.1.1:
+    resolution: {integrity: sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==}
+    hasBin: true
 
   safe-regex@2.1.1:
     resolution: {integrity: sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==}
@@ -10039,6 +10049,11 @@ packages:
 
   semver@7.8.0:
     resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -10493,8 +10508,8 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
-  thread-stream@4.0.0:
-    resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
+  thread-stream@4.2.0:
+    resolution: {integrity: sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==}
     engines: {node: '>=20'}
 
   tiny-async-pool@1.3.0:
@@ -10562,6 +10577,10 @@ packages:
   toad-cache@3.7.0:
     resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
     engines: {node: '>=12'}
+
+  toad-cache@3.7.4:
+    resolution: {integrity: sha512-m1TdR/rvT7kgGJZhspNtXdsdYk0fddFpJJFlG5s+UkPFo6lkLoZ3YLOaovPYjq1R75NP5JfeTlSHaOsE09peCg==}
+    engines: {node: '>=20'}
 
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -12504,8 +12523,8 @@ snapshots:
 
   '@fastify/ajv-compiler@4.0.5':
     dependencies:
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
       fast-uri: 3.1.4
 
   '@fastify/cors@11.2.0':
@@ -12515,9 +12534,9 @@ snapshots:
 
   '@fastify/error@4.2.0': {}
 
-  '@fastify/fast-json-stringify-compiler@5.0.3':
+  '@fastify/fast-json-stringify-compiler@5.1.0':
     dependencies:
-      fast-json-stringify: 6.4.0
+      fast-json-stringify: 7.0.1
 
   '@fastify/forwarded@3.0.1': {}
 
@@ -12538,7 +12557,7 @@ snapshots:
   '@fastify/proxy-addr@5.1.0':
     dependencies:
       '@fastify/forwarded': 3.0.1
-      ipaddr.js: 2.3.0
+      ipaddr.js: 2.4.0
 
   '@fastify/send@4.1.0':
     dependencies:
@@ -15883,7 +15902,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.57.1
       debug: 4.4.3
       minimatch: 10.2.3
-      semver: 7.8.0
+      semver: 7.8.5
       tinyglobby: 0.2.16
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -16508,6 +16527,10 @@ snapshots:
     optionalDependencies:
       ajv: 8.18.0
 
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
   ajv-keywords@3.5.2(ajv@6.14.0):
     dependencies:
       ajv: 6.14.0
@@ -16520,6 +16543,13 @@ snapshots:
       uri-js: 4.4.1
 
   ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.4
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 3.1.4
@@ -16779,7 +16809,7 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  avvio@9.1.0:
+  avvio@9.3.0:
     dependencies:
       '@fastify/error': 4.2.0
       fastq: 1.20.1
@@ -18198,7 +18228,7 @@ snapshots:
       eslint-import-context: 0.1.9(unrs-resolver@1.11.1)
       is-glob: 4.0.3
       minimatch: 9.0.7
-      semver: 7.8.0
+      semver: 7.8.5
       stable-hash-x: 0.2.0
       unrs-resolver: 1.11.1
     optionalDependencies:
@@ -18218,7 +18248,7 @@ snapshots:
       eslint-import-context: 0.1.9(unrs-resolver@1.11.1)
       is-glob: 4.0.3
       minimatch: 9.0.7
-      semver: 7.8.0
+      semver: 7.8.5
       stable-hash-x: 0.2.0
       unrs-resolver: 1.11.1
     optionalDependencies:
@@ -18709,6 +18739,15 @@ snapshots:
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
+  fast-json-stringify@7.0.1:
+    dependencies:
+      '@fastify/merge-json-schemas': 0.2.1
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      fast-uri: 3.1.4
+      json-schema-ref-resolver: 3.0.0
+      rfdc: 1.4.1
+
   fast-levenshtein@2.0.6: {}
 
   fast-npm-meta@1.4.2: {}
@@ -18731,23 +18770,23 @@ snapshots:
 
   fastify-plugin@5.1.0: {}
 
-  fastify@5.8.5:
+  fastify@5.10.0:
     dependencies:
       '@fastify/ajv-compiler': 4.0.5
       '@fastify/error': 4.2.0
-      '@fastify/fast-json-stringify-compiler': 5.0.3
+      '@fastify/fast-json-stringify-compiler': 5.1.0
       '@fastify/proxy-addr': 5.1.0
       abstract-logging: 2.0.1
-      avvio: 9.1.0
-      fast-json-stringify: 6.4.0
-      find-my-way: 9.4.0
+      avvio: 9.3.0
+      fast-json-stringify: 7.0.1
+      find-my-way: 9.7.0
       light-my-request: 6.6.0
       pino: 10.3.1
       process-warning: 5.0.0
       rfdc: 1.4.1
       secure-json-parse: 4.1.0
-      semver: 7.7.4
-      toad-cache: 3.7.0
+      semver: 7.8.5
+      toad-cache: 3.7.4
 
   fastmcp@3.35.0(patch_hash=7175182f509e3d149c517648f2b8e6d04a023a3c8fe126ca4ec58426b9d606df):
     dependencies:
@@ -18833,11 +18872,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  find-my-way@9.4.0:
+  find-my-way@9.7.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-querystring: 1.1.2
-      safe-regex2: 5.0.0
+      safe-regex2: 5.1.1
 
   find-up-simple@1.0.1: {}
 
@@ -19552,7 +19591,7 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
-  ipaddr.js@2.3.0: {}
+  ipaddr.js@2.4.0: {}
 
   iron-webcrypto@1.2.1: {}
 
@@ -21486,7 +21525,7 @@ snapshots:
       real-require: 0.2.0
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.1
-      thread-stream: 4.0.0
+      thread-stream: 4.2.0
 
   pipenet@1.4.0:
     dependencies:
@@ -22182,6 +22221,8 @@ snapshots:
 
   real-require@0.2.0: {}
 
+  real-require@1.0.0: {}
+
   redis-errors@1.2.0: {}
 
   redis-parser@3.0.0:
@@ -22474,7 +22515,7 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
-  safe-regex2@5.0.0:
+  safe-regex2@5.1.1:
     dependencies:
       ret: 0.5.0
 
@@ -22529,6 +22570,8 @@ snapshots:
   semver@7.7.4: {}
 
   semver@7.8.0: {}
+
+  semver@7.8.5: {}
 
   send@1.2.1:
     dependencies:
@@ -23083,9 +23126,9 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
-  thread-stream@4.0.0:
+  thread-stream@4.2.0:
     dependencies:
-      real-require: 0.2.0
+      real-require: 1.0.0
 
   tiny-async-pool@1.3.0:
     dependencies:
@@ -23139,6 +23182,8 @@ snapshots:
       reserved-identifiers: 1.2.0
 
   toad-cache@3.7.0: {}
+
+  toad-cache@3.7.4: {}
 
   toidentifier@1.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,7 @@ minimumReleaseAgeExclude:
   - '@esbuild/*'
   - esbuild
   - fast-uri@3.1.4
+  - find-my-way@9.7.0
   - tmp@0.2.6
 strictPeerDependencies: true
 peerDependencyRules:


### PR DESCRIPTION
## Summary
- update Fastify from 5.8.5 to 5.10.0
- update transitive find-my-way from 9.4.0 to patched 9.7.0
- allow the fresh security release through the repository release-age policy

## Verification
- pnpm install --frozen-lockfile --lockfile-only
- pnpm audit --audit-level high
- pnpm typecheck
- focused Fastify and HTTP tests: 65 passed
- git diff --check

This unblocks the required validate check for the sequential refactor PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Fastify framework dependency.
  * Adjusted minimum release-age checks to accommodate the updated dependency.
  * Refreshed research artifact evidence/scan/manifest data and checksums to reflect updated build outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->