### PR TITLE
chore(review): pin ReviewRouter action a0ee0af

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -30,9 +30,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@a982b154f5cb3c56d2cd362a26fdf3421cf4faf7
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@a0ee0af4232326288e81ba91c610047c5b2f7256
     with:
-      runtime_ref: "a982b154f5cb3c56d2cd362a26fdf3421cf4faf7"
+      runtime_ref: "a0ee0af4232326288e81ba91c610047c5b2f7256"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ inputs.pr_number }}
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@a982b154f5cb3c56d2cd362a26fdf3421cf4faf7
+        uses: 777genius/review-router@a0ee0af4232326288e81ba91c610047c5b2f7256
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"


### PR DESCRIPTION
Updates the managed ReviewRouter workflow pin from a982b154 to a0ee0af so workflow_dispatch uses the deployed ReviewRouter action/runtime release.