### PR TITLE
test(internal-storage): complete v8 migration fixture

### DIFF
--- a/test/features/internal-storage/memberWorkSyncWorkerOps.test.ts
+++ b/test/features/internal-storage/memberWorkSyncWorkerOps.test.ts
@@ -593,5 +593,8 @@ function createV8MemberWorkSyncSchema(database: InstanceType<typeof Database>): 
       event_json TEXT NOT NULL,
       PRIMARY KEY (team_name, id)
     );
+    CREATE TABLE coordination_backup_writer_fences (
+      status TEXT NOT NULL
+    );
   `);
 }

--- a/test/features/internal-storage/memberWorkSyncWorkerOps.test.ts
+++ b/test/features/internal-storage/memberWorkSyncWorkerOps.test.ts
@@ -593,8 +593,29 @@ function createV8MemberWorkSyncSchema(database: InstanceType<typeof Database>): 
       event_json TEXT NOT NULL,
       PRIMARY KEY (team_name, id)
     );
+    CREATE TABLE coordination_backup_runs (
+      backup_run_id TEXT PRIMARY KEY,
+      deployment_id TEXT NOT NULL,
+      state TEXT NOT NULL,
+      revision INTEGER NOT NULL CHECK (revision > 0),
+      fence_completion_status TEXT,
+      record_json TEXT NOT NULL CHECK (json_valid(record_json)),
+      requested_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
     CREATE TABLE coordination_backup_writer_fences (
-      status TEXT NOT NULL
+      deployment_id TEXT PRIMARY KEY,
+      generation INTEGER NOT NULL CHECK (generation > 0),
+      admitted_run_id TEXT NOT NULL,
+      lease_id TEXT NOT NULL UNIQUE,
+      status TEXT NOT NULL CHECK (status IN ('active', 'released', 'operator_required')),
+      disposition TEXT CHECK (disposition IN ('committed', 'aborted', 'operator_required')),
+      acquired_at TEXT NOT NULL,
+      completed_at TEXT,
+      FOREIGN KEY (admitted_run_id) REFERENCES coordination_backup_runs(backup_run_id)
+        ON DELETE RESTRICT ON UPDATE RESTRICT,
+      CHECK ((status = 'active' AND disposition IS NULL AND completed_at IS NULL)
+        OR (status <> 'active' AND disposition IS NOT NULL AND completed_at IS NOT NULL))
     );
   `);
 }


### PR DESCRIPTION
## Summary

- completes the focused member-work-sync v8 fixture with the real backup-run and backup-writer-fence DDL from production v8
- lets the newly added v11 ownership migration guard evaluate the fixture without weakening its fail-closed production behavior
- preserves required columns, checks, uniqueness, and the backup-run foreign key
- changes test setup only; no runtime or migration code changes

## Root cause

Canonical commit `2f424b384` added a v11 pre-migration query against `coordination_backup_writer_fences`. The focused test declared `user_version = 8` but built only the member-work-sync subset of v8, so the guard failed before the v9 assertion ran.

This reproduces on exact canonical without PR #341: 6/7 tests pass and the migration test fails with `no such table: coordination_backup_writer_fences`.

## Verification

- `memberWorkSyncWorkerOps.test.ts`: 7/7 passed after the fixture correction
- fast ESLint on the changed test file
- Prettier check
- `git diff --check`
- CodeRabbit schema-alignment nitpick addressed by mirroring both production backup tables

No agent runtime, provisioning, terminal flow, or real user project was used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated migration/schema test setup to align with the v8 schema bootstrap by creating the additional coordination backup tables, including the backup runs store and the backup writer fence records with their constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->