### PR TITLE
refactor(review): extract command boundaries

### DIFF
--- a/scripts/ci/source-file-size-legacy.json
+++ b/scripts/ci/source-file-size-legacy.json
@@ -54,7 +54,7 @@
   "src/main/index.ts": 3908,
   "src/main/ipc/config.ts": 1230,
   "src/main/ipc/configValidation.ts": 1050,
-  "src/main/ipc/review.ts": 1943,
+  "src/main/ipc/review.ts": 1538,
   "src/main/services/discovery/ProjectScanner.ts": 2111,
   "src/main/services/infrastructure/CliInstallerService.ts": 1690,
   "src/main/services/infrastructure/ConfigManager.ts": 1503,

--- a/scripts/ci/source-file-size-legacy.json
+++ b/scripts/ci/source-file-size-legacy.json
@@ -54,7 +54,7 @@
   "src/main/index.ts": 3908,
   "src/main/ipc/config.ts": 1230,
   "src/main/ipc/configValidation.ts": 1050,
-  "src/main/ipc/review.ts": 1127,
+  "src/main/ipc/review.ts": 1051,
   "src/main/services/discovery/ProjectScanner.ts": 2111,
   "src/main/services/infrastructure/CliInstallerService.ts": 1690,
   "src/main/services/infrastructure/ConfigManager.ts": 1503,

--- a/scripts/ci/source-file-size-legacy.json
+++ b/scripts/ci/source-file-size-legacy.json
@@ -54,7 +54,7 @@
   "src/main/index.ts": 3908,
   "src/main/ipc/config.ts": 1230,
   "src/main/ipc/configValidation.ts": 1050,
-  "src/main/ipc/review.ts": 1538,
+  "src/main/ipc/review.ts": 1127,
   "src/main/services/discovery/ProjectScanner.ts": 2111,
   "src/main/services/infrastructure/CliInstallerService.ts": 1690,
   "src/main/services/infrastructure/ConfigManager.ts": 1503,

--- a/src/features/change-review/README.md
+++ b/src/features/change-review/README.md
@@ -1,7 +1,7 @@
 # Change Review
 
-This is a thin renderer feature extracted incrementally from the legacy
-`ChangeReviewDialog` shell.
+This feature is extracted incrementally from the legacy renderer dialog and
+main-process review IPC shell.
 
 - `renderer/view-models` owns pure presentation projections.
 - `renderer/utils` owns pure scope and operation-generation policies.
@@ -9,8 +9,12 @@ This is a thin renderer feature extracted incrementally from the legacy
   decision-persistence, keyboard orchestration, and durable Undo/Redo/checkpoint Restore through
   narrow command, state, and view ports.
 - `renderer/ui` owns store-free presentation components.
+- `core/domain` owns pure review scope, rename expectation, and snippet-shape policy.
+- `main/application` owns authoritative scope and path authorization behind narrow ports.
+- `main/infrastructure` owns Node path, filesystem, sensitive-path, and hardlink details.
 - The legacy dialog remains the temporary composition shell for Zustand, editor mutations,
   forward Accept/Reject disk mutations, and outer close coordination while later slices move
   those responsibilities behind focused hooks and use cases.
 
-Production callers import through `@features/change-review/renderer`.
+Production callers import through `@features/change-review/renderer` or
+`@features/change-review/main`.

--- a/src/features/change-review/core/domain/reviewQueryPolicy.ts
+++ b/src/features/change-review/core/domain/reviewQueryPolicy.ts
@@ -1,0 +1,69 @@
+import type { TaskChangeRequestOptions, TeamTaskChangeSummaryRequest } from '@shared/types/review';
+
+const TEAM_TASK_CHANGE_SUMMARY_RAW_REQUEST_LIMIT = 1_000;
+const TEAM_TASK_CHANGE_SUMMARY_UNIQUE_REQUEST_LIMIT = 201;
+
+export function sanitizeTaskChangeOptions(options?: unknown): TaskChangeRequestOptions | undefined {
+  if (!options || typeof options !== 'object') {
+    return undefined;
+  }
+
+  const raw = options as Record<string, unknown>;
+  return {
+    owner: typeof raw.owner === 'string' ? raw.owner : undefined,
+    status: typeof raw.status === 'string' ? raw.status : undefined,
+    since: typeof raw.since === 'string' ? raw.since : undefined,
+    intervals: Array.isArray(raw.intervals)
+      ? (raw.intervals.filter(
+          (interval): interval is { startedAt: string; completedAt?: string } =>
+            Boolean(interval) &&
+            typeof interval === 'object' &&
+            typeof (interval as Record<string, unknown>).startedAt === 'string' &&
+            ((interval as Record<string, unknown>).completedAt === undefined ||
+              typeof (interval as Record<string, unknown>).completedAt === 'string')
+        ) as { startedAt: string; completedAt?: string }[])
+      : undefined,
+    stateBucket:
+      raw.stateBucket === 'approved' ||
+      raw.stateBucket === 'review' ||
+      raw.stateBucket === 'completed' ||
+      raw.stateBucket === 'active'
+        ? raw.stateBucket
+        : undefined,
+    summaryOnly: raw.summaryOnly === true,
+    forceFresh: raw.forceFresh === true,
+  };
+}
+
+export function sanitizeTeamTaskChangeSummaryRequests(
+  requests: unknown
+): TeamTaskChangeSummaryRequest[] {
+  if (!Array.isArray(requests)) {
+    return [];
+  }
+
+  const sanitizedRequests: TeamTaskChangeSummaryRequest[] = [];
+  const seenTaskIds = new Set<string>();
+  for (const request of requests.slice(0, TEAM_TASK_CHANGE_SUMMARY_RAW_REQUEST_LIMIT)) {
+    if (sanitizedRequests.length >= TEAM_TASK_CHANGE_SUMMARY_UNIQUE_REQUEST_LIMIT) {
+      break;
+    }
+    if (!request || typeof request !== 'object') {
+      continue;
+    }
+    const raw = request as Record<string, unknown>;
+    if (typeof raw.taskId !== 'string') {
+      continue;
+    }
+    const taskId = raw.taskId.trim();
+    if (!taskId || seenTaskIds.has(taskId)) {
+      continue;
+    }
+    seenTaskIds.add(taskId);
+    sanitizedRequests.push({
+      taskId,
+      options: sanitizeTaskChangeOptions(raw.options),
+    });
+  }
+  return sanitizedRequests;
+}

--- a/src/features/change-review/core/domain/reviewScopePolicy.ts
+++ b/src/features/change-review/core/domain/reviewScopePolicy.ts
@@ -1,0 +1,223 @@
+import type {
+  FileChangeWithContent,
+  ReviewFileScope,
+  ReviewRenameRecoveryExpectation,
+  SnippetDiff,
+} from '@shared/types/review';
+
+export const MAX_REVIEW_SNIPPETS_PER_FILE = 10_000;
+export const MAX_REVIEW_HUNK_DECISIONS_PER_FILE = 100_000;
+
+export interface ReviewIdentityValidationResult {
+  valid: boolean;
+  value?: string;
+  error?: string;
+}
+
+export interface ReviewIdentityValidators {
+  validateTeamName(value: unknown): ReviewIdentityValidationResult;
+  validateTaskId(value: unknown): ReviewIdentityValidationResult;
+}
+
+export interface ReviewRootConfig {
+  projectPath?: string;
+  members?: readonly { cwd?: string }[];
+}
+
+export function assertNonEmptyString(value: unknown, field: string): asserts value is string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`Invalid ${field}: non-empty string required`);
+  }
+}
+
+export function assertOptionalString(
+  value: unknown,
+  field: string
+): asserts value is string | undefined {
+  if (value !== undefined && typeof value !== 'string') {
+    throw new Error(`Invalid ${field}: string required`);
+  }
+}
+
+export function normalizeReviewIdentity(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
+}
+
+export function parseReviewFileScope(
+  value: unknown,
+  validators: ReviewIdentityValidators
+): ReviewFileScope {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Invalid review scope');
+  }
+  const raw = value as Record<string, unknown>;
+  const team = validators.validateTeamName(raw.teamName);
+  if (!team.valid || !team.value) {
+    throw new Error(team.error ?? 'Invalid teamName');
+  }
+  assertOptionalString(raw.memberName, 'memberName');
+  assertOptionalString(raw.taskId, 'taskId');
+  const memberName = normalizeReviewIdentity(raw.memberName);
+  const taskId = normalizeReviewIdentity(raw.taskId);
+  if (taskId) {
+    const task = validators.validateTaskId(taskId);
+    if (!task.valid || !task.value) {
+      throw new Error(task.error ?? 'Invalid taskId');
+    }
+  }
+  if (memberName && (memberName.length > 256 || memberName.includes('\0'))) {
+    throw new Error('Invalid memberName');
+  }
+  return {
+    teamName: team.value,
+    ...(memberName ? { memberName } : {}),
+    ...(taskId ? { taskId } : {}),
+  };
+}
+
+export function parseReviewRenameRecoveryExpectation(
+  value: unknown
+): ReviewRenameRecoveryExpectation {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Invalid rename recovery expectation');
+  }
+  const raw = value as Record<string, unknown>;
+  const relation = raw.relation;
+  if (!relation || typeof relation !== 'object' || Array.isArray(relation)) {
+    throw new Error('Invalid rename recovery relation');
+  }
+  const relationRaw = relation as Record<string, unknown>;
+  if (
+    typeof raw.eventId !== 'string' ||
+    !raw.eventId ||
+    raw.eventId.length > 512 ||
+    (raw.beforeHash !== null && typeof raw.beforeHash !== 'string') ||
+    (raw.afterHash !== null && typeof raw.afterHash !== 'string') ||
+    relationRaw.kind !== 'rename' ||
+    typeof relationRaw.oldPath !== 'string' ||
+    !relationRaw.oldPath ||
+    relationRaw.oldPath.length > 4096 ||
+    relationRaw.oldPath.includes('\0') ||
+    typeof relationRaw.newPath !== 'string' ||
+    !relationRaw.newPath ||
+    relationRaw.newPath.length > 4096 ||
+    relationRaw.newPath.includes('\0')
+  ) {
+    throw new Error('Invalid rename recovery expectation');
+  }
+  if (
+    (typeof raw.beforeHash === 'string' && raw.beforeHash.length > 512) ||
+    (typeof raw.afterHash === 'string' && raw.afterHash.length > 512)
+  ) {
+    throw new Error('Invalid rename recovery expectation');
+  }
+  return {
+    eventId: raw.eventId,
+    beforeHash: raw.beforeHash,
+    afterHash: raw.afterHash,
+    relation: {
+      kind: 'rename',
+      oldPath: relationRaw.oldPath,
+      newPath: relationRaw.newPath,
+    },
+  };
+}
+
+export function collectReviewRootCandidates(config: ReviewRootConfig): string[] {
+  const roots: string[] = [];
+  const add = (value: unknown): void => {
+    if (typeof value === 'string' && value.trim()) {
+      roots.push(value.trim());
+    }
+  };
+  add(config.projectPath);
+  const members = Array.isArray(config.members)
+    ? (config.members as readonly { cwd?: string }[])
+    : [];
+  for (const member of members) {
+    add(member.cwd);
+  }
+  return roots;
+}
+
+export function assertExpectedAuthoritativeRename(
+  content: FileChangeWithContent,
+  expectation: ReviewRenameRecoveryExpectation
+): void {
+  const renameLedger = content.snippets.find(
+    (snippet) => snippet.ledger?.relation?.kind === 'rename'
+  )?.ledger;
+  const relation = renameLedger?.relation;
+  if (!renameLedger || relation?.kind !== 'rename') {
+    throw new Error('Review file is not an authoritative ledger rename');
+  }
+  if (
+    renameLedger.eventId !== expectation.eventId ||
+    (renameLedger.beforeHash ?? null) !== expectation.beforeHash ||
+    (renameLedger.afterHash ?? null) !== expectation.afterHash ||
+    relation.oldPath !== expectation.relation.oldPath ||
+    relation.newPath !== expectation.relation.newPath
+  ) {
+    throw new Error('Review changes were updated; refusing stale rename recovery');
+  }
+}
+
+export function assertHunkIndices(value: unknown): asserts value is number[] {
+  if (
+    !Array.isArray(value) ||
+    value.length > MAX_REVIEW_HUNK_DECISIONS_PER_FILE ||
+    value.some((index) => !Number.isSafeInteger(index) || index < 0)
+  ) {
+    throw new Error('Invalid hunkIndices');
+  }
+}
+
+export function assertSnippetShapes(value: unknown): asserts value is SnippetDiff[] {
+  if (!Array.isArray(value) || value.length > MAX_REVIEW_SNIPPETS_PER_FILE) {
+    throw new Error('Invalid snippets array');
+  }
+  for (const snippet of value) {
+    if (!snippet || typeof snippet !== 'object' || Array.isArray(snippet)) {
+      throw new Error('Invalid review snippet');
+    }
+    const raw = snippet as Record<string, unknown>;
+    for (const field of [
+      'toolUseId',
+      'filePath',
+      'toolName',
+      'type',
+      'oldString',
+      'newString',
+      'timestamp',
+    ]) {
+      if (typeof raw[field] !== 'string') {
+        throw new Error(`Invalid review snippet ${field}`);
+      }
+    }
+    if (typeof raw.replaceAll !== 'boolean' || typeof raw.isError !== 'boolean') {
+      throw new Error('Invalid review snippet flags');
+    }
+    if (raw.ledger !== undefined) {
+      if (!raw.ledger || typeof raw.ledger !== 'object' || Array.isArray(raw.ledger)) {
+        throw new Error('Invalid review ledger metadata');
+      }
+      const relation = (raw.ledger as Record<string, unknown>).relation;
+      if (relation !== undefined) {
+        if (!relation || typeof relation !== 'object' || Array.isArray(relation)) {
+          throw new Error('Invalid review relation');
+        }
+        const relationRaw = relation as Record<string, unknown>;
+        if (
+          (relationRaw.kind !== 'rename' && relationRaw.kind !== 'copy') ||
+          typeof relationRaw.oldPath !== 'string' ||
+          !relationRaw.oldPath ||
+          typeof relationRaw.newPath !== 'string' ||
+          !relationRaw.newPath
+        ) {
+          throw new Error('Invalid review relation');
+        }
+      }
+    }
+  }
+}

--- a/src/features/change-review/main/application/ReviewQueryApplication.ts
+++ b/src/features/change-review/main/application/ReviewQueryApplication.ts
@@ -1,0 +1,75 @@
+import { assertOptionalString, assertSnippetShapes } from '../../core/domain/reviewScopePolicy';
+
+import type { ReviewQueryDependencies, ReviewQueryGitLogEntry } from './ReviewQueryPorts';
+import type {
+  AgentChangeSet,
+  ChangeStats,
+  FileChangeWithContent,
+  TaskChangeRequestOptions,
+  TaskChangeSetV2,
+  TeamTaskChangeSummariesResponse,
+  TeamTaskChangeSummaryRequest,
+} from '@shared/types/review';
+
+export class ReviewQueryApplication {
+  constructor(private readonly dependencies: ReviewQueryDependencies) {}
+
+  getAgentChanges(teamName: string, memberName: string): Promise<AgentChangeSet> {
+    return this.dependencies.changes.getAgentChanges(teamName, memberName);
+  }
+
+  getTaskChanges(
+    teamName: string,
+    taskId: string,
+    options?: TaskChangeRequestOptions
+  ): Promise<TaskChangeSetV2> {
+    return this.dependencies.changes.getTaskChanges(teamName, taskId, options);
+  }
+
+  getTeamTaskChangeSummaries(
+    teamName: string,
+    requests: TeamTaskChangeSummaryRequest[]
+  ): Promise<TeamTaskChangeSummariesResponse> {
+    return this.dependencies.changes.getTeamTaskChangeSummaries(teamName, requests);
+  }
+
+  invalidateTaskChangeSummaries(teamName: string, taskIds: string[]): Promise<void> {
+    return this.dependencies.changes.invalidateTaskChangeSummaries(
+      teamName,
+      Array.isArray(taskIds) ? taskIds.filter((taskId) => typeof taskId === 'string') : []
+    );
+  }
+
+  getChangeStats(teamName: string, memberName: string): Promise<ChangeStats> {
+    return this.dependencies.changes.getChangeStats(teamName, memberName);
+  }
+
+  async getFileContent(
+    teamNameValue: unknown,
+    memberNameValue: unknown,
+    filePathValue: unknown,
+    snippetsValue: unknown = []
+  ): Promise<FileChangeWithContent> {
+    assertOptionalString(memberNameValue, 'memberName');
+    assertSnippetShapes(snippetsValue);
+    const { scope, authorization } = await this.dependencies.scope.resolve({
+      teamName: teamNameValue,
+      memberName: this.dependencies.scope.normalizeIdentity(memberNameValue),
+    });
+    const filePath = await this.dependencies.scope.validateFilePath(authorization, filePathValue, {
+      requireReviewedFile: false,
+    });
+    await this.dependencies.scope.validateSnippets(authorization, snippetsValue);
+    const content = await this.dependencies.content.getFileContent(
+      scope.teamName,
+      scope.memberName ?? '',
+      filePath,
+      snippetsValue
+    );
+    return this.dependencies.snapshots.register(scope.teamName, filePath, snippetsValue, content);
+  }
+
+  getGitFileLog(projectPath: string, filePath: string): Promise<ReviewQueryGitLogEntry[]> {
+    return this.dependencies.gitHistory.getFileLog(projectPath, filePath);
+  }
+}

--- a/src/features/change-review/main/application/ReviewQueryPorts.ts
+++ b/src/features/change-review/main/application/ReviewQueryPorts.ts
@@ -1,0 +1,76 @@
+import type { ReviewPathAuthorization } from './ReviewScopeAuthorizationPorts';
+import type {
+  AgentChangeSet,
+  ChangeStats,
+  FileChangeWithContent,
+  ReviewFileScope,
+  SnippetDiff,
+  TaskChangeRequestOptions,
+  TaskChangeSetV2,
+  TeamTaskChangeSummariesResponse,
+  TeamTaskChangeSummaryRequest,
+} from '@shared/types/review';
+
+export interface ReviewQueryChangesPort {
+  getAgentChanges(teamName: string, memberName: string): Promise<AgentChangeSet>;
+  getTaskChanges(
+    teamName: string,
+    taskId: string,
+    options?: TaskChangeRequestOptions
+  ): Promise<TaskChangeSetV2>;
+  getTeamTaskChangeSummaries(
+    teamName: string,
+    requests: TeamTaskChangeSummaryRequest[]
+  ): Promise<TeamTaskChangeSummariesResponse>;
+  invalidateTaskChangeSummaries(teamName: string, taskIds: string[]): Promise<void>;
+  getChangeStats(teamName: string, memberName: string): Promise<ChangeStats>;
+}
+
+export interface ReviewQueryScopePort {
+  normalizeIdentity(value: string | undefined): string | undefined;
+  resolve(
+    value: unknown
+  ): Promise<{ scope: ReviewFileScope; authorization: ReviewPathAuthorization }>;
+  validateFilePath(
+    authorization: ReviewPathAuthorization,
+    filePath: unknown,
+    options: { requireReviewedFile: boolean }
+  ): Promise<string>;
+  validateSnippets(authorization: ReviewPathAuthorization, snippets: SnippetDiff[]): Promise<void>;
+}
+
+export interface ReviewQueryContentPort {
+  getFileContent(
+    teamName: string,
+    memberName: string,
+    filePath: string,
+    snippets: SnippetDiff[]
+  ): Promise<FileChangeWithContent>;
+}
+
+export interface ReviewQuerySnapshotPort {
+  register(
+    teamName: string,
+    filePath: string,
+    snippets: SnippetDiff[],
+    content: FileChangeWithContent
+  ): FileChangeWithContent;
+}
+
+export interface ReviewQueryGitLogEntry {
+  hash: string;
+  timestamp: string;
+  message: string;
+}
+
+export interface ReviewQueryGitHistoryPort {
+  getFileLog(projectPath: string, filePath: string): Promise<ReviewQueryGitLogEntry[]>;
+}
+
+export interface ReviewQueryDependencies {
+  changes: ReviewQueryChangesPort;
+  scope: ReviewQueryScopePort;
+  content: ReviewQueryContentPort;
+  snapshots: ReviewQuerySnapshotPort;
+  gitHistory: ReviewQueryGitHistoryPort;
+}

--- a/src/features/change-review/main/application/ReviewScopeAuthorizationApplication.ts
+++ b/src/features/change-review/main/application/ReviewScopeAuthorizationApplication.ts
@@ -1,0 +1,384 @@
+import {
+  assertExpectedAuthoritativeRename,
+  assertNonEmptyString,
+  assertSnippetShapes,
+  collectReviewRootCandidates,
+  normalizeReviewIdentity,
+  parseReviewFileScope,
+  parseReviewRenameRecoveryExpectation,
+} from '../../core/domain/reviewScopePolicy';
+
+import type {
+  AuthorizedReviewRoot,
+  ReviewPathAuthorization,
+  ReviewScopeAuthorizationDependencies,
+} from './ReviewScopeAuthorizationPorts';
+import type {
+  FileChangeSummary,
+  FileChangeWithContent,
+  ReviewFileScope,
+  ReviewRenameRecoveryExpectation,
+  SnippetDiff,
+} from '@shared/types/review';
+
+export class ReviewScopeAuthorizationApplication {
+  constructor(private readonly dependencies: ReviewScopeAuthorizationDependencies) {}
+
+  normalizeReviewIdentity(value: string | undefined): string | undefined {
+    return normalizeReviewIdentity(value);
+  }
+
+  parseReviewFileScope(value: unknown): ReviewFileScope {
+    return parseReviewFileScope(value, this.dependencies.validators);
+  }
+
+  parseReviewRenameRecoveryExpectation(value: unknown): ReviewRenameRecoveryExpectation {
+    return parseReviewRenameRecoveryExpectation(value);
+  }
+
+  normalizeReviewPathForIdentity(filePath: string): string {
+    return this.dependencies.paths.normalizeIdentity(filePath);
+  }
+
+  async resolveReviewPathAuthorization(
+    scopeValue: unknown,
+    options: { requireIdentity?: boolean } = {}
+  ): Promise<{ scope: ReviewFileScope; authorization: ReviewPathAuthorization }> {
+    const scope = this.parseReviewFileScope(scopeValue);
+    if (options.requireIdentity && !scope.taskId && !scope.memberName) {
+      throw new Error('Review mutation requires taskId or memberName');
+    }
+    const config = await this.dependencies.config.getConfig(scope.teamName);
+    if (!config) {
+      throw new Error(`Review team config is unavailable: ${scope.teamName}`);
+    }
+
+    const rootCandidates = [
+      ...new Set(
+        collectReviewRootCandidates(config).map((root) => this.dependencies.paths.normalize(root))
+      ),
+    ];
+    const roots = (
+      await Promise.all(rootCandidates.map((root) => this.resolveAuthorizedReviewRoot(root)))
+    ).filter((root): root is AuthorizedReviewRoot => Boolean(root));
+    if (roots.length === 0) {
+      throw new Error('Review project/worktree root is unavailable');
+    }
+
+    let reviewedFiles: Map<string, FileChangeSummary> | null = null;
+    let resolutionMemberName = scope.memberName ?? '';
+    if (scope.taskId) {
+      const changeSet = await this.dependencies.changes.getTaskChanges(
+        scope.teamName,
+        scope.taskId
+      );
+      reviewedFiles = this.collectAuthoritativeReviewedFiles(changeSet.files);
+      const authoritativeMemberName = normalizeReviewIdentity(changeSet.scope?.memberName);
+      if (
+        scope.memberName &&
+        authoritativeMemberName &&
+        scope.memberName !== authoritativeMemberName
+      ) {
+        throw new Error('Review memberName does not match the authoritative task scope');
+      }
+      resolutionMemberName = authoritativeMemberName ?? '';
+    } else if (scope.memberName) {
+      const changeSet = await this.dependencies.changes.getAgentChanges(
+        scope.teamName,
+        scope.memberName
+      );
+      reviewedFiles = this.collectAuthoritativeReviewedFiles(changeSet.files);
+    }
+
+    return { scope, authorization: { roots, reviewedFiles, resolutionMemberName } };
+  }
+
+  async validateAuthorizedReviewFilePath(
+    authorization: ReviewPathAuthorization,
+    filePathValue: unknown,
+    options: { requireReviewedFile: boolean; rejectHardlinks?: boolean }
+  ): Promise<string> {
+    assertNonEmptyString(filePathValue, 'filePath');
+    if (!this.dependencies.paths.isAbsolute(filePathValue)) {
+      throw new Error('Review file path must be absolute');
+    }
+    const normalizedPath = this.dependencies.paths.normalize(filePathValue);
+    if (this.dependencies.paths.isSensitive(normalizedPath)) {
+      throw new Error('Access to sensitive files is not allowed');
+    }
+    if (
+      options.requireReviewedFile &&
+      !authorization.reviewedFiles?.has(this.normalizeReviewPathForIdentity(normalizedPath))
+    ) {
+      throw new Error('File is not part of the reviewed scope');
+    }
+
+    let targetRealPath: string;
+    let targetStat: Awaited<
+      ReturnType<ReviewScopeAuthorizationDependencies['files']['lstat']>
+    > | null = null;
+    let resolvedStat: Awaited<
+      ReturnType<ReviewScopeAuthorizationDependencies['files']['stat']>
+    > | null = null;
+    try {
+      targetStat = await this.dependencies.files.lstat(normalizedPath);
+      targetRealPath = this.dependencies.paths.normalize(
+        await this.dependencies.files.realpath(normalizedPath)
+      );
+      resolvedStat =
+        targetStat.kind === 'symbolic-link'
+          ? await this.dependencies.files.stat(targetRealPath)
+          : targetStat;
+      if (resolvedStat.kind !== 'file') {
+        throw new Error('Review target must be a regular file');
+      }
+    } catch (error) {
+      const code = this.getErrorCode(error);
+      if (code !== 'ENOENT' && code !== 'ENOTDIR') {
+        throw error;
+      }
+      targetRealPath = await this.resolveNearestExistingRealPath(
+        this.dependencies.paths.dirname(normalizedPath)
+      );
+    }
+    if (this.dependencies.paths.isSensitive(targetRealPath)) {
+      throw new Error('Access to sensitive files is not allowed');
+    }
+
+    if (!this.isAuthorizedPath(authorization, normalizedPath, targetRealPath)) {
+      throw new Error('Review file path is outside the authoritative project/worktree');
+    }
+    if (options.rejectHardlinks && targetStat && resolvedStat) {
+      if (targetStat.kind !== 'symbolic-link' && resolvedStat.linkCount > 1) {
+        await this.dependencies.files.cleanupOwnedTemporaryLinks(normalizedPath);
+        targetStat = await this.dependencies.files.lstat(normalizedPath);
+        targetRealPath = this.dependencies.paths.normalize(
+          await this.dependencies.files.realpath(normalizedPath)
+        );
+        resolvedStat =
+          targetStat.kind === 'symbolic-link'
+            ? await this.dependencies.files.stat(targetRealPath)
+            : targetStat;
+        const stillAllowed =
+          !this.dependencies.paths.isSensitive(targetRealPath) &&
+          this.isAuthorizedPath(authorization, normalizedPath, targetRealPath);
+        if (!stillAllowed || resolvedStat.kind !== 'file') {
+          throw new Error('Review file path changed during authorization');
+        }
+      }
+      const ownedReviewTransactionLink =
+        targetStat.kind !== 'symbolic-link' &&
+        resolvedStat.linkCount > 1 &&
+        (await this.dependencies.files.isOwnedTransactionHardlink(normalizedPath));
+      if (
+        targetStat.kind === 'symbolic-link' ||
+        (resolvedStat.linkCount > 1 && !ownedReviewTransactionLink)
+      ) {
+        throw new Error('Review mutation refuses symbolic or multiply-linked files');
+      }
+    }
+    return normalizedPath;
+  }
+
+  getAuthoritativeReviewedFile(
+    authorization: ReviewPathAuthorization,
+    filePath: string
+  ): FileChangeSummary {
+    const file = authorization.reviewedFiles?.get(this.normalizeReviewPathForIdentity(filePath));
+    if (!file) {
+      throw new Error('File is not part of the reviewed scope');
+    }
+    return file;
+  }
+
+  async resolveAuthoritativeFileContent(
+    scope: ReviewFileScope,
+    authorization: ReviewPathAuthorization,
+    filePath: string
+  ): Promise<FileChangeWithContent> {
+    const authoritativeFile = this.getAuthoritativeReviewedFile(authorization, filePath);
+    assertSnippetShapes(authoritativeFile.snippets);
+    await this.validateSnippetPaths(authorization, authoritativeFile.snippets, {
+      requireReviewedFile: true,
+    });
+    const resolved = await this.dependencies.content.getFileContent(
+      scope.teamName,
+      authorization.resolutionMemberName,
+      filePath,
+      authoritativeFile.snippets
+    );
+    return {
+      ...resolved,
+      filePath,
+      snippets: authoritativeFile.snippets,
+    };
+  }
+
+  assertExpectedAuthoritativeRename(
+    content: FileChangeWithContent,
+    expectation: ReviewRenameRecoveryExpectation
+  ): void {
+    assertExpectedAuthoritativeRename(content, expectation);
+  }
+
+  invalidateAuthoritativeReviewContent(content: FileChangeWithContent): void {
+    const paths = new Set([content.filePath]);
+    for (const snippet of content.snippets) {
+      paths.add(snippet.filePath);
+      const relation = snippet.ledger?.relation;
+      if (relation) {
+        paths.add(relation.oldPath);
+        paths.add(relation.newPath);
+      }
+    }
+    for (const filePath of paths) {
+      this.dependencies.content.invalidateFile(filePath);
+    }
+  }
+
+  async validateSnippetPaths(
+    authorization: ReviewPathAuthorization,
+    snippets: SnippetDiff[],
+    options: { requireReviewedFile?: boolean; rejectHardlinks?: boolean } = {}
+  ): Promise<void> {
+    const requireReviewedFile = options.requireReviewedFile === true;
+    await Promise.all(
+      snippets.map((snippet) =>
+        this.validateAuthorizedReviewFilePath(authorization, snippet.filePath, {
+          requireReviewedFile,
+          rejectHardlinks: options.rejectHardlinks === true,
+        })
+      )
+    );
+
+    for (const snippet of snippets) {
+      const relation = snippet.ledger?.relation;
+      if (!relation) continue;
+      const slashFilePath = snippet.filePath.replace(/\\/g, '/');
+      const relationPaths = [relation.oldPath, relation.newPath] as const;
+      if (relationPaths.every((relationPath) => this.dependencies.paths.isAbsolute(relationPath))) {
+        for (const relationPath of relationPaths) {
+          await this.validateAuthorizedReviewFilePath(authorization, relationPath, {
+            requireReviewedFile,
+            rejectHardlinks: options.rejectHardlinks === true,
+          });
+        }
+        continue;
+      }
+      if (relationPaths.some((relationPath) => this.dependencies.paths.isAbsolute(relationPath))) {
+        throw new Error('Review relation paths must both be absolute or both be relative');
+      }
+
+      let resolvedRelationPaths: [string, string] | null = null;
+      for (const [anchorRelationPath, targetRelationPath] of [
+        [relation.oldPath, relation.newPath],
+        [relation.newPath, relation.oldPath],
+      ] as const) {
+        const slashAnchor = anchorRelationPath.replace(/\\/g, '/');
+        if (
+          slashFilePath === slashAnchor ||
+          slashFilePath.toLocaleLowerCase().endsWith(`/${slashAnchor.toLocaleLowerCase()}`)
+        ) {
+          const prefix = slashFilePath.slice(0, slashFilePath.length - slashAnchor.length);
+          const anchorPath = this.dependencies.paths.normalize(`${prefix}${slashAnchor}`);
+          const targetPath = this.dependencies.paths.normalize(
+            `${prefix}${targetRelationPath.replace(/\\/g, '/')}`
+          );
+          resolvedRelationPaths =
+            anchorRelationPath === relation.oldPath
+              ? [anchorPath, targetPath]
+              : [targetPath, anchorPath];
+          break;
+        }
+      }
+      if (!resolvedRelationPaths) {
+        throw new Error('Review relation is not anchored to an authoritative snippet path');
+      }
+      for (const relationPath of resolvedRelationPaths) {
+        await this.validateAuthorizedReviewFilePath(authorization, relationPath, {
+          requireReviewedFile,
+          rejectHardlinks: options.rejectHardlinks === true,
+        });
+      }
+    }
+  }
+
+  private collectAuthoritativeReviewedFiles(
+    files: FileChangeSummary[]
+  ): Map<string, FileChangeSummary> {
+    const reviewedFiles = new Map<string, FileChangeSummary>();
+    const add = (filePath: string | null, owner: FileChangeSummary): void => {
+      if (filePath && this.dependencies.paths.isAbsolute(filePath)) {
+        reviewedFiles.set(this.normalizeReviewPathForIdentity(filePath), owner);
+      }
+    };
+    for (const file of files) {
+      add(file.filePath, file);
+      for (const snippet of file.snippets) {
+        add(snippet.filePath, file);
+      }
+    }
+    return reviewedFiles;
+  }
+
+  private async resolveAuthorizedReviewRoot(
+    rootPath: string
+  ): Promise<AuthorizedReviewRoot | null> {
+    if (!this.dependencies.paths.isAbsolute(rootPath)) {
+      return null;
+    }
+    try {
+      const [rootStat, realPath] = await Promise.all([
+        this.dependencies.files.stat(rootPath),
+        this.dependencies.files.realpath(rootPath),
+      ]);
+      if (rootStat.kind !== 'directory') {
+        return null;
+      }
+      return {
+        lexicalPath: this.dependencies.paths.normalize(rootPath),
+        realPath: this.dependencies.paths.normalize(realPath),
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  private async resolveNearestExistingRealPath(filePath: string): Promise<string> {
+    let current = filePath;
+    for (;;) {
+      try {
+        return this.dependencies.paths.normalize(await this.dependencies.files.realpath(current));
+      } catch (error) {
+        const code = this.getErrorCode(error);
+        if (code !== 'ENOENT' && code !== 'ENOTDIR') {
+          throw error;
+        }
+        const parent = this.dependencies.paths.dirname(current);
+        if (parent === current) {
+          throw new Error('No existing ancestor for review file path');
+        }
+        current = parent;
+      }
+    }
+  }
+
+  private isAuthorizedPath(
+    authorization: ReviewPathAuthorization,
+    normalizedPath: string,
+    targetRealPath: string
+  ): boolean {
+    return authorization.roots.some(
+      (root) =>
+        (this.dependencies.paths.isWithinRoot(normalizedPath, root.lexicalPath) ||
+          this.dependencies.paths.isWithinRoot(normalizedPath, root.realPath)) &&
+        this.dependencies.paths.isWithinRoot(targetRealPath, root.realPath)
+    );
+  }
+
+  private getErrorCode(error: unknown): string | undefined {
+    return typeof error === 'object' && error !== null && 'code' in error
+      ? String(error.code)
+      : undefined;
+  }
+}

--- a/src/features/change-review/main/application/ReviewScopeAuthorizationPorts.ts
+++ b/src/features/change-review/main/application/ReviewScopeAuthorizationPorts.ts
@@ -1,0 +1,69 @@
+import type {
+  ReviewIdentityValidators,
+  ReviewRootConfig,
+} from '../../core/domain/reviewScopePolicy';
+import type { FileChangeSummary, FileChangeWithContent, SnippetDiff } from '@shared/types/review';
+
+export interface AuthorizedReviewRoot {
+  lexicalPath: string;
+  realPath: string;
+}
+
+export interface ReviewPathAuthorization {
+  roots: AuthorizedReviewRoot[];
+  reviewedFiles: Map<string, FileChangeSummary> | null;
+  resolutionMemberName: string;
+}
+
+export interface ReviewScopeConfigPort {
+  getConfig(teamName: string): Promise<ReviewRootConfig | null>;
+}
+
+export interface ReviewScopeChangesPort {
+  getTaskChanges(
+    teamName: string,
+    taskId: string
+  ): Promise<{ files: FileChangeSummary[]; scope?: { memberName?: string } }>;
+  getAgentChanges(teamName: string, memberName: string): Promise<{ files: FileChangeSummary[] }>;
+}
+
+export interface ReviewScopeContentPort {
+  getFileContent(
+    teamName: string,
+    memberName: string,
+    filePath: string,
+    snippets: SnippetDiff[]
+  ): Promise<FileChangeWithContent>;
+  invalidateFile(filePath: string): void;
+}
+
+export interface ReviewScopePathPort {
+  normalize(filePath: string): string;
+  dirname(filePath: string): string;
+  isAbsolute(filePath: string): boolean;
+  isWithinRoot(filePath: string, rootPath: string): boolean;
+  isSensitive(filePath: string): boolean;
+  normalizeIdentity(filePath: string): string;
+}
+
+export interface ReviewScopeFileStat {
+  kind: 'directory' | 'file' | 'symbolic-link' | 'other';
+  linkCount: number;
+}
+
+export interface ReviewScopeFileSystemPort {
+  stat(filePath: string): Promise<ReviewScopeFileStat>;
+  lstat(filePath: string): Promise<ReviewScopeFileStat>;
+  realpath(filePath: string): Promise<string>;
+  cleanupOwnedTemporaryLinks(filePath: string): Promise<void>;
+  isOwnedTransactionHardlink(filePath: string): Promise<boolean>;
+}
+
+export interface ReviewScopeAuthorizationDependencies {
+  validators: ReviewIdentityValidators;
+  config: ReviewScopeConfigPort;
+  changes: ReviewScopeChangesPort;
+  content: ReviewScopeContentPort;
+  paths: ReviewScopePathPort;
+  files: ReviewScopeFileSystemPort;
+}

--- a/src/features/change-review/main/composition/createReviewQueryFeature.ts
+++ b/src/features/change-review/main/composition/createReviewQueryFeature.ts
@@ -1,0 +1,9 @@
+import { ReviewQueryApplication } from '../application/ReviewQueryApplication';
+
+import type { ReviewQueryDependencies } from '../application/ReviewQueryPorts';
+
+export function createReviewQueryFeature(
+  dependencies: ReviewQueryDependencies
+): ReviewQueryApplication {
+  return new ReviewQueryApplication(dependencies);
+}

--- a/src/features/change-review/main/composition/createReviewScopeAuthorizationFeature.ts
+++ b/src/features/change-review/main/composition/createReviewScopeAuthorizationFeature.ts
@@ -1,0 +1,22 @@
+import { ReviewScopeAuthorizationApplication } from '../application/ReviewScopeAuthorizationApplication';
+import {
+  nodeReviewScopeFileSystemPort,
+  nodeReviewScopePathPort,
+} from '../infrastructure/nodeReviewScopeAuthorization';
+
+import type { ReviewScopeAuthorizationDependencies } from '../application/ReviewScopeAuthorizationPorts';
+
+export type ReviewScopeAuthorizationFeatureDependencies = Omit<
+  ReviewScopeAuthorizationDependencies,
+  'files' | 'paths'
+>;
+
+export function createReviewScopeAuthorizationFeature(
+  dependencies: ReviewScopeAuthorizationFeatureDependencies
+): ReviewScopeAuthorizationApplication {
+  return new ReviewScopeAuthorizationApplication({
+    ...dependencies,
+    files: nodeReviewScopeFileSystemPort,
+    paths: nodeReviewScopePathPort,
+  });
+}

--- a/src/features/change-review/main/index.ts
+++ b/src/features/change-review/main/index.ts
@@ -1,4 +1,8 @@
 export {
+  sanitizeTaskChangeOptions,
+  sanitizeTeamTaskChangeSummaryRequests,
+} from '../core/domain/reviewQueryPolicy';
+export {
   assertHunkIndices,
   assertNonEmptyString,
   assertOptionalString,
@@ -6,6 +10,16 @@ export {
   MAX_REVIEW_HUNK_DECISIONS_PER_FILE,
   MAX_REVIEW_SNIPPETS_PER_FILE,
 } from '../core/domain/reviewScopePolicy';
+export { ReviewQueryApplication } from './application/ReviewQueryApplication';
+export type {
+  ReviewQueryChangesPort,
+  ReviewQueryContentPort,
+  ReviewQueryDependencies,
+  ReviewQueryGitHistoryPort,
+  ReviewQueryGitLogEntry,
+  ReviewQueryScopePort,
+  ReviewQuerySnapshotPort,
+} from './application/ReviewQueryPorts';
 export { ReviewScopeAuthorizationApplication } from './application/ReviewScopeAuthorizationApplication';
 export type {
   AuthorizedReviewRoot,
@@ -18,6 +32,7 @@ export type {
   ReviewScopeFileSystemPort,
   ReviewScopePathPort,
 } from './application/ReviewScopeAuthorizationPorts';
+export { createReviewQueryFeature } from './composition/createReviewQueryFeature';
 export {
   createReviewScopeAuthorizationFeature,
   type ReviewScopeAuthorizationFeatureDependencies,

--- a/src/features/change-review/main/index.ts
+++ b/src/features/change-review/main/index.ts
@@ -1,0 +1,24 @@
+export {
+  assertHunkIndices,
+  assertNonEmptyString,
+  assertOptionalString,
+  assertSnippetShapes,
+  MAX_REVIEW_HUNK_DECISIONS_PER_FILE,
+  MAX_REVIEW_SNIPPETS_PER_FILE,
+} from '../core/domain/reviewScopePolicy';
+export { ReviewScopeAuthorizationApplication } from './application/ReviewScopeAuthorizationApplication';
+export type {
+  AuthorizedReviewRoot,
+  ReviewPathAuthorization,
+  ReviewScopeAuthorizationDependencies,
+  ReviewScopeChangesPort,
+  ReviewScopeConfigPort,
+  ReviewScopeContentPort,
+  ReviewScopeFileStat,
+  ReviewScopeFileSystemPort,
+  ReviewScopePathPort,
+} from './application/ReviewScopeAuthorizationPorts';
+export {
+  createReviewScopeAuthorizationFeature,
+  type ReviewScopeAuthorizationFeatureDependencies,
+} from './composition/createReviewScopeAuthorizationFeature';

--- a/src/features/change-review/main/infrastructure/nodeReviewScopeAuthorization.ts
+++ b/src/features/change-review/main/infrastructure/nodeReviewScopeAuthorization.ts
@@ -1,0 +1,46 @@
+import {
+  cleanupAtomicCreateTempLinks,
+  isOwnedReviewFileTransactionHardlink,
+} from '@main/utils/atomicWrite';
+import { isPathWithinRoot, matchesSensitivePattern } from '@main/utils/pathValidation';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+import type {
+  ReviewScopeFileStat,
+  ReviewScopeFileSystemPort,
+  ReviewScopePathPort,
+} from '../application/ReviewScopeAuthorizationPorts';
+
+function toReviewFileStat(stat: Awaited<ReturnType<typeof fs.stat>>): ReviewScopeFileStat {
+  return {
+    kind: stat.isSymbolicLink()
+      ? 'symbolic-link'
+      : stat.isDirectory()
+        ? 'directory'
+        : stat.isFile()
+          ? 'file'
+          : 'other',
+    linkCount: Number(stat.nlink),
+  };
+}
+
+export const nodeReviewScopePathPort: ReviewScopePathPort = {
+  normalize: (filePath) => path.resolve(path.normalize(filePath)),
+  dirname: (filePath) => path.dirname(filePath),
+  isAbsolute: (filePath) => path.isAbsolute(path.normalize(filePath)),
+  isWithinRoot: isPathWithinRoot,
+  isSensitive: matchesSensitivePattern,
+  normalizeIdentity: (filePath) => {
+    const normalized = path.resolve(path.normalize(filePath));
+    return process.platform === 'win32' ? normalized.toLocaleLowerCase() : normalized;
+  },
+};
+
+export const nodeReviewScopeFileSystemPort: ReviewScopeFileSystemPort = {
+  stat: async (filePath) => toReviewFileStat(await fs.stat(filePath)),
+  lstat: async (filePath) => toReviewFileStat(await fs.lstat(filePath)),
+  realpath: (filePath) => fs.realpath(filePath),
+  cleanupOwnedTemporaryLinks: cleanupAtomicCreateTempLinks,
+  isOwnedTransactionHardlink: isOwnedReviewFileTransactionHardlink,
+};

--- a/src/features/review-mutations/core/application/ReviewMutationApplyResultError.ts
+++ b/src/features/review-mutations/core/application/ReviewMutationApplyResultError.ts
@@ -1,0 +1,7 @@
+import type { ApplyReviewResult } from '@shared/types/review';
+
+export class ReviewMutationApplyResultError extends Error {
+  constructor(readonly result: ApplyReviewResult) {
+    super(result.errors[0]?.error ?? 'Review mutation could not be applied safely');
+  }
+}

--- a/src/features/review-mutations/core/domain/reviewDecisionCommandPolicy.ts
+++ b/src/features/review-mutations/core/domain/reviewDecisionCommandPolicy.ts
@@ -1,0 +1,172 @@
+import { isDurableReviewEqual } from './durableReviewValue';
+import { getReviewActionDiskSnapshots } from './reviewHistoryDiskSteps';
+
+import type {
+  FileChangeSummary,
+  FileReviewDecision,
+  HunkDecision,
+  ReviewPersistedStateSnapshot,
+} from '@shared/types/review';
+
+export interface ReviewDecisionCommandCurrentState extends ReviewPersistedStateSnapshot {
+  revision: number;
+}
+
+export interface ReviewDecisionCommandPolicyContext {
+  resolveFile(filePath: string): FileChangeSummary;
+  normalizePath(filePath: string): string;
+}
+
+export function assertCurrentReviewDecisionRevision(
+  current: ReviewDecisionCommandCurrentState | null,
+  expectedRevision: number
+): void {
+  if ((current?.revision ?? 0) !== expectedRevision) {
+    throw new Error('Review decisions changed; refusing stale state overwrite');
+  }
+}
+
+export function assertExactApplyReviewHistoryTransition(
+  state: ReviewPersistedStateSnapshot,
+  current: ReviewDecisionCommandCurrentState | null,
+  decisions: readonly (FileReviewDecision & { reviewKey: string })[],
+  context: ReviewDecisionCommandPolicyContext
+): void {
+  const previousActions = current?.reviewActionHistory ?? [];
+  const nextActions = state.reviewActionHistory ?? [];
+  const action = nextActions.at(-1);
+  const currentRedo = current?.reviewRedoHistory ?? [];
+  const knownIds = new Set([
+    ...previousActions.map((entry) => entry.id),
+    ...currentRedo.map((entry) => entry.action.id),
+  ]);
+  if (
+    !action ||
+    action.kind === 'hunk' ||
+    knownIds.has(action.id) ||
+    nextActions.length !== previousActions.length + 1 ||
+    !isDurableReviewEqual(nextActions.slice(0, -1), previousActions) ||
+    (state.reviewRedoHistory?.length ?? 0) !== 0
+  ) {
+    throw new Error('Durable Reject requires exactly one new disk history action');
+  }
+
+  const filesByPath = new Map(
+    decisions.map((decision) => {
+      const file = context.resolveFile(decision.filePath);
+      const canonicalKey = file.changeKey ?? file.filePath;
+      if (decision.reviewKey !== canonicalKey) {
+        throw new Error('Durable reviewKey does not match the authoritative review identity');
+      }
+      return [context.normalizePath(file.filePath), file] as const;
+    })
+  );
+  const actionPaths = getReviewActionDiskSnapshots(action).map((snapshot) =>
+    context.normalizePath(snapshot.filePath)
+  );
+  if (
+    actionPaths.length !== filesByPath.size ||
+    new Set(actionPaths).size !== actionPaths.length ||
+    actionPaths.some((filePath) => !filesByPath.has(filePath))
+  ) {
+    throw new Error('Durable Reject history does not match the requested files');
+  }
+  if ((decisions.length === 1) !== (action.kind === 'disk')) {
+    throw new Error('Durable Reject history action kind does not match the decision batch');
+  }
+  if (action.descriptor) {
+    const descriptor = action.descriptor;
+    let descriptorMatches = false;
+    if (action.kind === 'bulk') {
+      descriptorMatches =
+        descriptor.intent === 'reject-all' && descriptor.fileCount === filesByPath.size;
+    } else if (action.action.originalIndex !== undefined) {
+      descriptorMatches =
+        descriptor.intent === 'reject-hunk' &&
+        descriptor.hunkIndex === action.action.originalIndex &&
+        context.normalizePath(descriptor.filePath) ===
+          context.normalizePath(action.action.snapshot.filePath);
+    } else {
+      descriptorMatches =
+        descriptor.intent === 'reject-file' &&
+        context.normalizePath(descriptor.filePath) ===
+          context.normalizePath(action.action.snapshot.filePath);
+    }
+    if (!descriptorMatches) {
+      throw new Error('Durable Reject history descriptor does not match the decision transition');
+    }
+  }
+
+  const currentDecisions = {
+    hunkDecisions: current?.hunkDecisions ?? {},
+    fileDecisions: current?.fileDecisions ?? {},
+  };
+  const allowedFileKeys = new Set(decisions.map((decision) => decision.reviewKey));
+  const allowedHunkKeys = new Set<string>();
+  for (const decision of decisions) {
+    for (const index of Object.keys(decision.hunkDecisions)) {
+      allowedHunkKeys.add(`${decision.reviewKey}:${index}`);
+    }
+  }
+  const changedKeys = (
+    previous: Record<string, HunkDecision>,
+    next: Record<string, HunkDecision>,
+    allowed: ReadonlySet<string>
+  ): string[] => {
+    const changed = [...new Set([...Object.keys(previous), ...Object.keys(next)])].filter(
+      (key) => previous[key] !== next[key]
+    );
+    if (changed.some((key) => !allowed.has(key))) {
+      throw new Error('Durable Reject state changes decisions outside the requested files');
+    }
+    return changed;
+  };
+  const changedHunks = changedKeys(
+    currentDecisions.hunkDecisions,
+    state.hunkDecisions,
+    allowedHunkKeys
+  );
+  const changedFiles = changedKeys(
+    currentDecisions.fileDecisions,
+    state.fileDecisions,
+    allowedFileKeys
+  );
+  if (changedHunks.length + changedFiles.length === 0) {
+    throw new Error('Durable Reject history has no matching decision transition');
+  }
+
+  if (action.kind === 'bulk') {
+    if (
+      !isDurableReviewEqual(action.decisionSnapshot, currentDecisions) ||
+      decisions.some((decision) => decision.fileDecision !== 'rejected')
+    ) {
+      throw new Error('Durable bulk Reject history has invalid decision metadata');
+    }
+    return;
+  }
+
+  const decision = decisions[0];
+  if (!decision) throw new Error('Durable Reject decision is unavailable');
+  const originalIndex = action.action.originalIndex;
+  if (originalIndex !== undefined) {
+    const decisionKey = `${decision.reviewKey}:${originalIndex}`;
+    if (
+      changedHunks.length !== 1 ||
+      changedHunks[0] !== decisionKey ||
+      changedFiles.length !== 0 ||
+      decision.fileDecision !== 'pending' ||
+      decision.hunkDecisions[originalIndex] !== 'rejected' ||
+      state.hunkDecisions[decisionKey] !== 'rejected'
+    ) {
+      throw new Error('Durable hunk Reject history index does not match the decision transition');
+    }
+    return;
+  }
+
+  if (
+    decision.fileDecision !== 'rejected' ||
+    !isDurableReviewEqual(action.action.decisionSnapshot, currentDecisions)
+  ) {
+    throw new Error('Durable file Reject history has invalid decision metadata');
+  }
+}

--- a/src/features/review-mutations/index.ts
+++ b/src/features/review-mutations/index.ts
@@ -1,6 +1,12 @@
 export * from './contracts';
 export { isDurableReviewEqual } from './core/domain/durableReviewValue';
 export {
+  assertCurrentReviewDecisionRevision,
+  assertExactApplyReviewHistoryTransition,
+  type ReviewDecisionCommandCurrentState,
+  type ReviewDecisionCommandPolicyContext,
+} from './core/domain/reviewDecisionCommandPolicy';
+export {
   buildReviewExternalReloadState,
   buildReviewHistoryRestorePlan,
   buildReviewRestoreDecisionState,

--- a/src/features/review-mutations/main/application/ReviewDecisionBatchApplication.ts
+++ b/src/features/review-mutations/main/application/ReviewDecisionBatchApplication.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 
 import { threeWayTextMerge } from '@shared/utils/threeWayTextMerge';
 
+import { ReviewMutationApplyResultError } from '../../core/application/ReviewMutationApplyResultError';
 import {
   assertPersistedStateIncludesDecisions,
   composeReviewDiskTransitions,
@@ -25,12 +26,6 @@ import type {
   ReviewMutationDiskPostimage,
   ReviewPersistedStateSnapshot,
 } from '@shared/types/review';
-
-export class ReviewMutationApplyResultError extends Error {
-  constructor(readonly result: ApplyReviewResult) {
-    super(result.errors[0]?.error ?? 'Review mutation could not be applied safely');
-  }
-}
 
 export class ReviewDecisionBatchApplication {
   constructor(private readonly dependencies: ReviewDecisionBatchDependencies) {}

--- a/src/features/review-mutations/main/application/ReviewDecisionCommandApplication.ts
+++ b/src/features/review-mutations/main/application/ReviewDecisionCommandApplication.ts
@@ -1,0 +1,393 @@
+import { ReviewMutationApplyResultError } from '../../core/application/ReviewMutationApplyResultError';
+import { mergeReviewMutationDiskPostimages } from '../../core/domain/reviewDecisionBatch';
+import {
+  assertCurrentReviewDecisionRevision,
+  assertExactApplyReviewHistoryTransition,
+} from '../../core/domain/reviewDecisionCommandPolicy';
+
+import type { ReviewDecisionCommandDependencies } from './ReviewDecisionCommandPorts';
+import type { ReviewMutationPathAuthorization } from './ReviewMutationRecoveryPorts';
+import type {
+  ApplyReviewRequest,
+  ApplyReviewResult,
+  ConflictCheckResult,
+  FileChangeWithContent,
+  FileReviewDecision,
+  RejectResult,
+  ReviewDecisionPersistenceScope,
+  ReviewFileScope,
+  ReviewMutationDiskPostimage,
+  ReviewPersistedStateSnapshot,
+  SnippetDiff,
+} from '@shared/types/review';
+
+interface DisplayedReviewSnapshot {
+  teamName: string;
+  filePath: string;
+  snippetFingerprint: string;
+  content: FileChangeWithContent;
+  expiresAt: number;
+}
+
+const REVIEW_SNAPSHOT_TTL_MS = 60 * 60 * 1000;
+const MAX_DISPLAYED_REVIEW_SNAPSHOTS = 2_000;
+
+export class ReviewDecisionCommandApplication {
+  private readonly displayedReviewSnapshots = new Map<string, DisplayedReviewSnapshot>();
+
+  constructor(private readonly dependencies: ReviewDecisionCommandDependencies) {}
+
+  registerDisplayedReviewSnapshot(
+    teamName: string,
+    filePath: string,
+    snippets: SnippetDiff[],
+    content: FileChangeWithContent
+  ): FileChangeWithContent {
+    const now = this.dependencies.snapshots.now();
+    for (const [token, snapshot] of this.displayedReviewSnapshots) {
+      if (snapshot.expiresAt <= now) this.displayedReviewSnapshots.delete(token);
+    }
+    while (this.displayedReviewSnapshots.size >= MAX_DISPLAYED_REVIEW_SNAPSHOTS) {
+      const oldestToken = this.displayedReviewSnapshots.keys().next().value;
+      if (!oldestToken) break;
+      this.displayedReviewSnapshots.delete(oldestToken);
+    }
+
+    const token = this.dependencies.snapshots.createToken();
+    const snapshotContent = { ...content, reviewSnapshotToken: token };
+    this.displayedReviewSnapshots.set(token, {
+      teamName,
+      filePath: this.dependencies.scope.normalizeIdentityPath(filePath),
+      snippetFingerprint: this.dependencies.snapshots.fingerprintSnippets(snippets),
+      content: snapshotContent,
+      expiresAt: now + REVIEW_SNAPSHOT_TTL_MS,
+    });
+    return snapshotContent;
+  }
+
+  async checkConflict(
+    scopeValue: unknown,
+    filePathValue: unknown,
+    expectedModified: string
+  ): Promise<ConflictCheckResult> {
+    const { authorization } = await this.dependencies.scope.resolve(scopeValue, {
+      requireIdentity: true,
+    });
+    const filePath = await this.dependencies.scope.validateFilePath(authorization, filePathValue, {
+      requireReviewedFile: true,
+      rejectHardlinks: true,
+    });
+    return this.dependencies.applier.checkConflict(filePath, expectedModified);
+  }
+
+  async rejectHunks(
+    scopeValue: unknown,
+    filePathValue: unknown,
+    hunkIndices: number[]
+  ): Promise<RejectResult> {
+    const { scope, authorization } = await this.dependencies.scope.resolve(scopeValue, {
+      requireIdentity: true,
+    });
+    const filePath = await this.dependencies.scope.validateFilePath(authorization, filePathValue, {
+      requireReviewedFile: true,
+      rejectHardlinks: true,
+    });
+    const authoritativeContent = await this.requireAuthoritativeContents(
+      scope,
+      authorization,
+      filePath
+    );
+    return this.dependencies.applier.rejectHunks(
+      scope.teamName,
+      filePath,
+      authoritativeContent.originalFullContent,
+      authoritativeContent.modifiedFullContent,
+      hunkIndices,
+      authoritativeContent.snippets
+    );
+  }
+
+  async rejectFile(scopeValue: unknown, filePathValue: unknown): Promise<RejectResult> {
+    const { scope, authorization } = await this.dependencies.scope.resolve(scopeValue, {
+      requireIdentity: true,
+    });
+    const filePath = await this.dependencies.scope.validateFilePath(authorization, filePathValue, {
+      requireReviewedFile: true,
+      rejectHardlinks: true,
+    });
+    const authoritativeContent = await this.requireAuthoritativeContents(
+      scope,
+      authorization,
+      filePath
+    );
+    return this.dependencies.applier.rejectFile(
+      scope.teamName,
+      filePath,
+      authoritativeContent.originalFullContent,
+      authoritativeContent.modifiedFullContent
+    );
+  }
+
+  previewReject(
+    filePath: string,
+    original: string,
+    modified: string,
+    hunkIndices: number[],
+    snippets: SnippetDiff[]
+  ): Promise<{ preview: string; hasConflicts: boolean }> {
+    return this.dependencies.applier.previewReject(
+      filePath,
+      original,
+      modified,
+      hunkIndices,
+      snippets
+    );
+  }
+
+  async applyDecisions(request: ApplyReviewRequest): Promise<ApplyReviewResult> {
+    const { scope, authorization } = await this.dependencies.scope.resolve(request, {
+      requireIdentity: true,
+    });
+    const persistenceScope = this.dependencies.scope.parsePersistenceScope(
+      request.decisionPersistenceScope,
+      scope
+    );
+    const validatedDecisions: FileReviewDecision[] = [];
+    const fileContents = new Map<string, FileChangeWithContent>();
+    const decisionPaths = new Set<string>();
+    const decisionReviewKeys = new Set<string>();
+    for (const decision of request.decisions) {
+      this.dependencies.scope.assertDecisionShape(decision);
+      const filePath = await this.dependencies.scope.validateFilePath(
+        authorization,
+        decision.filePath,
+        { requireReviewedFile: true, rejectHardlinks: true }
+      );
+      const authoritativeFile = this.dependencies.scope.getAuthoritativeFile(
+        authorization,
+        filePath
+      );
+      const authoritativeReviewKey = authoritativeFile.changeKey ?? authoritativeFile.filePath;
+      const normalizedDecisionPath = this.dependencies.scope.normalizeIdentityPath(filePath);
+      if (
+        decisionPaths.has(normalizedDecisionPath) ||
+        decisionReviewKeys.has(authoritativeReviewKey)
+      ) {
+        throw new Error('Duplicate reviewed file in Apply decisions');
+      }
+      decisionPaths.add(normalizedDecisionPath);
+      decisionReviewKeys.add(authoritativeReviewKey);
+      if (persistenceScope && decision.reviewKey !== authoritativeReviewKey) {
+        throw new Error('Durable reviewKey does not match the authoritative review identity');
+      }
+      this.dependencies.scope.assertSnippetShapes(authoritativeFile.snippets);
+      await this.dependencies.scope.validateSnippets(authorization, authoritativeFile.snippets, {
+        requireReviewedFile: true,
+        rejectHardlinks: true,
+      });
+      const hasLedgerSnapshot = authoritativeFile.snippets.some(
+        (snippet) => !!snippet.ledger && !snippet.isError
+      );
+      fileContents.set(
+        filePath,
+        hasLedgerSnapshot
+          ? await this.dependencies.scope.resolveAuthoritativeContent(
+              scope,
+              authorization,
+              filePath
+            )
+          : this.resolveDisplayedReviewSnapshot(
+              decision.contentSnapshotToken,
+              scope.teamName,
+              filePath,
+              authoritativeFile.snippets
+            )
+      );
+      validatedDecisions.push({
+        filePath,
+        ...(decision.reviewKey ? { reviewKey: decision.reviewKey } : {}),
+        fileDecision: decision.fileDecision,
+        hunkDecisions: decision.hunkDecisions,
+        ...(decision.hunkContextHashes ? { hunkContextHashes: decision.hunkContextHashes } : {}),
+      });
+    }
+    const validatedRequest: ApplyReviewRequest = {
+      teamName: scope.teamName,
+      ...(scope.taskId ? { taskId: scope.taskId } : {}),
+      ...(authorization.resolutionMemberName
+        ? { memberName: authorization.resolutionMemberName }
+        : {}),
+      ...(persistenceScope ? { decisionPersistenceScope: persistenceScope } : {}),
+      decisions: validatedDecisions,
+    };
+
+    let result: ApplyReviewResult;
+    if (!persistenceScope) {
+      result = await this.dependencies.applier.applyReviewDecisions(validatedRequest, fileContents);
+    } else {
+      if (validatedDecisions.some((decision) => !decision.reviewKey)) {
+        throw new Error('Durable review mutation requires a stable reviewKey');
+      }
+      if (!request.persistedState) {
+        throw new Error('Durable review mutation requires an exact post-operation state');
+      }
+      if (
+        !Number.isSafeInteger(request.expectedDecisionRevision) ||
+        request.expectedDecisionRevision! < 0
+      ) {
+        throw new Error('Durable review mutation requires an exact decision revision');
+      }
+      this.dependencies.persistence.assertValidSnapshot(request.persistedState);
+      this.dependencies.batch.assertPersistedStateIncludesDecisions(
+        request.persistedState,
+        validatedDecisions
+      );
+      result = await this.applyDecisionsWithDurableJournal(
+        scope,
+        authorization,
+        persistenceScope,
+        validatedDecisions as (FileReviewDecision & { reviewKey: string })[],
+        fileContents,
+        request.persistedState,
+        request.expectedDecisionRevision!
+      );
+    }
+
+    try {
+      for (const decision of validatedRequest.decisions) {
+        this.dependencies.cache.invalidateFile(decision.filePath);
+      }
+    } catch (error) {
+      this.dependencies.logger.debug('applyDecisions cache invalidation failed:', error);
+    }
+    return result;
+  }
+
+  private resolveDisplayedReviewSnapshot(
+    token: string | undefined,
+    teamName: string,
+    filePath: string,
+    authoritativeSnippets: SnippetDiff[]
+  ): FileChangeWithContent {
+    if (!token) {
+      throw new Error('Displayed review snapshot is unavailable; reload Changes before rejecting.');
+    }
+    const snapshot = this.displayedReviewSnapshots.get(token);
+    if (
+      !snapshot ||
+      snapshot.expiresAt <= this.dependencies.snapshots.now() ||
+      snapshot.teamName !== teamName ||
+      snapshot.filePath !== this.dependencies.scope.normalizeIdentityPath(filePath) ||
+      snapshot.snippetFingerprint !==
+        this.dependencies.snapshots.fingerprintSnippets(authoritativeSnippets)
+    ) {
+      this.displayedReviewSnapshots.delete(token);
+      throw new Error('Displayed review snapshot is stale; reload Changes before rejecting.');
+    }
+    snapshot.expiresAt = this.dependencies.snapshots.now() + REVIEW_SNAPSHOT_TTL_MS;
+    return {
+      ...snapshot.content,
+      filePath,
+      snippets: authoritativeSnippets,
+    };
+  }
+
+  private async requireAuthoritativeContents(
+    scope: ReviewFileScope,
+    authorization: ReviewMutationPathAuthorization,
+    filePath: string
+  ): Promise<FileChangeWithContent & { originalFullContent: string; modifiedFullContent: string }> {
+    const content = await this.dependencies.scope.resolveAuthoritativeContent(
+      scope,
+      authorization,
+      filePath
+    );
+    if (content.originalFullContent === null || content.modifiedFullContent === null) {
+      throw new Error('Authoritative review contents are unavailable');
+    }
+    return content as FileChangeWithContent & {
+      originalFullContent: string;
+      modifiedFullContent: string;
+    };
+  }
+
+  private async applyDecisionsWithDurableJournal(
+    scope: ReviewFileScope,
+    authorization: ReviewMutationPathAuthorization,
+    persistenceScope: ReviewDecisionPersistenceScope,
+    decisions: (FileReviewDecision & { reviewKey: string })[],
+    fileContents: Map<string, FileChangeWithContent>,
+    persistedState: ReviewPersistedStateSnapshot,
+    expectedDecisionRevision: number
+  ): Promise<ApplyReviewResult> {
+    const normalizePath = (filePath: string): string =>
+      this.dependencies.scope.normalizeIdentityPath(filePath);
+    return this.dependencies.persistence.withLock(scope.teamName, persistenceScope, async () => {
+      const diskPostimages = new Map<string, ReviewMutationDiskPostimage>();
+      try {
+        await this.dependencies.recovery.recoverPending(scope.teamName, persistenceScope);
+        const revisionSnapshot = await this.dependencies.persistence.load(
+          scope.teamName,
+          persistenceScope
+        );
+        assertCurrentReviewDecisionRevision(revisionSnapshot, expectedDecisionRevision);
+        const current = await this.dependencies.persistence.load(scope.teamName, persistenceScope);
+        assertExactApplyReviewHistoryTransition(persistedState, current, decisions, {
+          resolveFile: (filePath) =>
+            this.dependencies.scope.getAuthoritativeFile(authorization, filePath),
+          normalizePath,
+        });
+        const boundPersistedState = await this.dependencies.history.bindNewHistorySnapshots(
+          persistedState,
+          current,
+          scope,
+          authorization
+        );
+        let result: ApplyReviewResult | null = null;
+        await this.dependencies.coordinator.execute(
+          {
+            teamName: scope.teamName,
+            persistenceScope,
+            reviewScope: scope,
+            kind: decisions.length > 1 ? 'bulk' : 'reject',
+            decisions,
+            fileContents: decisions.map((decision) => {
+              const content = fileContents.get(decision.filePath);
+              if (!content) throw new Error('Review mutation content is unavailable');
+              return content;
+            }),
+            persistedState: boundPersistedState,
+            expectedDecisionRevision,
+          },
+          {
+            applyDisk: (record) =>
+              this.dependencies.batch.applyDisk(
+                record,
+                (nextResult) => {
+                  result = nextResult;
+                },
+                (postimages) =>
+                  mergeReviewMutationDiskPostimages(diskPostimages, postimages, normalizePath)
+              ),
+            commitDecisions: (record) => this.dependencies.batch.commit(record),
+          }
+        );
+        const committed = await this.dependencies.persistence.load(
+          scope.teamName,
+          persistenceScope
+        );
+        return {
+          ...(result ?? { applied: 0, skipped: 0, conflicts: 0, errors: [] }),
+          decisionRevision: committed?.revision ?? expectedDecisionRevision,
+          committedReviewAction: committed?.reviewActionHistory.at(-1),
+          diskPostimages: [...diskPostimages.values()],
+        };
+      } catch (error) {
+        if (error instanceof ReviewMutationApplyResultError) {
+          return { ...error.result, diskPostimages: [...diskPostimages.values()] };
+        }
+        throw error;
+      }
+    });
+  }
+}

--- a/src/features/review-mutations/main/application/ReviewDecisionCommandPorts.ts
+++ b/src/features/review-mutations/main/application/ReviewDecisionCommandPorts.ts
@@ -1,0 +1,156 @@
+import type { ReviewMutationSteps } from '../../core/application/ReviewMutationCoordinator';
+import type {
+  PrepareReviewMutationInput,
+  ReviewMutationJournalRecord,
+} from '../../core/application/ReviewMutationJournalTypes';
+import type { ReviewDecisionCommandCurrentState } from '../../core/domain/reviewDecisionCommandPolicy';
+import type { ReviewMutationPathAuthorization } from './ReviewMutationRecoveryPorts';
+import type {
+  ApplyReviewRequest,
+  ApplyReviewResult,
+  ConflictCheckResult,
+  FileChangeSummary,
+  FileChangeWithContent,
+  FileReviewDecision,
+  RejectResult,
+  ReviewDecisionPersistenceScope,
+  ReviewFileScope,
+  ReviewMutationDiskPostimage,
+  ReviewPersistedStateSnapshot,
+  SnippetDiff,
+} from '@shared/types/review';
+
+export interface ReviewDecisionCommandScopePort {
+  resolve(
+    value: unknown,
+    options: { requireIdentity: true }
+  ): Promise<{ scope: ReviewFileScope; authorization: ReviewMutationPathAuthorization }>;
+  parsePersistenceScope(
+    value: unknown,
+    scope: ReviewFileScope
+  ): ReviewDecisionPersistenceScope | null;
+  validateFilePath(
+    authorization: ReviewMutationPathAuthorization,
+    filePath: unknown,
+    options: { requireReviewedFile: boolean; rejectHardlinks: boolean }
+  ): Promise<string>;
+  validateSnippets(
+    authorization: ReviewMutationPathAuthorization,
+    snippets: SnippetDiff[],
+    options: { requireReviewedFile: boolean; rejectHardlinks: boolean }
+  ): Promise<void>;
+  assertDecisionShape(value: unknown): asserts value is FileReviewDecision;
+  assertSnippetShapes(value: unknown): asserts value is SnippetDiff[];
+  getAuthoritativeFile(
+    authorization: ReviewMutationPathAuthorization,
+    filePath: string
+  ): FileChangeSummary;
+  resolveAuthoritativeContent(
+    scope: ReviewFileScope,
+    authorization: ReviewMutationPathAuthorization,
+    filePath: string
+  ): Promise<FileChangeWithContent>;
+  normalizeIdentityPath(filePath: string): string;
+}
+
+export interface ReviewDecisionCommandApplierPort {
+  checkConflict(filePath: string, expectedModified: string): Promise<ConflictCheckResult>;
+  rejectHunks(
+    teamName: string,
+    filePath: string,
+    original: string,
+    modified: string,
+    hunkIndices: number[],
+    snippets: SnippetDiff[]
+  ): Promise<RejectResult>;
+  rejectFile(
+    teamName: string,
+    filePath: string,
+    original: string,
+    modified: string
+  ): Promise<RejectResult>;
+  previewReject(
+    filePath: string,
+    original: string,
+    modified: string,
+    hunkIndices: number[],
+    snippets: SnippetDiff[]
+  ): Promise<{ preview: string; hasConflicts: boolean }>;
+  applyReviewDecisions(
+    request: ApplyReviewRequest,
+    fileContents: Map<string, FileChangeWithContent>
+  ): Promise<ApplyReviewResult>;
+}
+
+export interface ReviewDecisionCommandPersistencePort {
+  withLock<T>(
+    teamName: string,
+    persistenceScope: ReviewDecisionPersistenceScope,
+    operation: () => Promise<T>
+  ): Promise<T>;
+  assertValidSnapshot(value: ReviewPersistedStateSnapshot): void;
+  load(
+    teamName: string,
+    persistenceScope: ReviewDecisionPersistenceScope
+  ): Promise<ReviewDecisionCommandCurrentState | null>;
+}
+
+export interface ReviewDecisionCommandBatchPort {
+  assertPersistedStateIncludesDecisions(
+    state: ReviewPersistedStateSnapshot,
+    decisions: readonly FileReviewDecision[]
+  ): void;
+  applyDisk(
+    record: ReviewMutationJournalRecord,
+    onResult?: (result: ApplyReviewResult) => void,
+    onPostimages?: (postimages: readonly ReviewMutationDiskPostimage[]) => void
+  ): Promise<ReviewMutationJournalRecord>;
+  commit(record: ReviewMutationJournalRecord): Promise<void>;
+}
+
+export interface ReviewDecisionCommandHistoryPort {
+  bindNewHistorySnapshots(
+    state: ReviewPersistedStateSnapshot,
+    current: ReviewDecisionCommandCurrentState | null,
+    scope: ReviewFileScope,
+    authorization: ReviewMutationPathAuthorization
+  ): Promise<ReviewPersistedStateSnapshot>;
+}
+
+export interface ReviewDecisionCommandRecoveryPort {
+  recoverPending(teamName: string, persistenceScope: ReviewDecisionPersistenceScope): Promise<void>;
+}
+
+export interface ReviewDecisionCommandCoordinatorPort {
+  execute(
+    input: PrepareReviewMutationInput,
+    steps: ReviewMutationSteps<ReviewMutationJournalRecord>
+  ): Promise<ReviewMutationJournalRecord>;
+}
+
+export interface ReviewDecisionCommandSnapshotIdentityPort {
+  now(): number;
+  createToken(): string;
+  fingerprintSnippets(snippets: SnippetDiff[]): string;
+}
+
+export interface ReviewDecisionCommandCachePort {
+  invalidateFile(filePath: string): void;
+}
+
+export interface ReviewDecisionCommandLoggerPort {
+  debug(message: string, error: unknown): void;
+}
+
+export interface ReviewDecisionCommandDependencies {
+  scope: ReviewDecisionCommandScopePort;
+  applier: ReviewDecisionCommandApplierPort;
+  persistence: ReviewDecisionCommandPersistencePort;
+  batch: ReviewDecisionCommandBatchPort;
+  history: ReviewDecisionCommandHistoryPort;
+  recovery: ReviewDecisionCommandRecoveryPort;
+  coordinator: ReviewDecisionCommandCoordinatorPort;
+  snapshots: ReviewDecisionCommandSnapshotIdentityPort;
+  cache: ReviewDecisionCommandCachePort;
+  logger: ReviewDecisionCommandLoggerPort;
+}

--- a/src/features/review-mutations/main/composition/createReviewDecisionCommandFeature.ts
+++ b/src/features/review-mutations/main/composition/createReviewDecisionCommandFeature.ts
@@ -1,0 +1,18 @@
+import { ReviewDecisionCommandApplication } from '../application/ReviewDecisionCommandApplication';
+import { nodeReviewDecisionCommandSnapshotIdentity } from '../infrastructure/nodeReviewDecisionCommandSnapshotIdentity';
+
+import type { ReviewDecisionCommandDependencies } from '../application/ReviewDecisionCommandPorts';
+
+export type ReviewDecisionCommandFeatureDependencies = Omit<
+  ReviewDecisionCommandDependencies,
+  'snapshots'
+>;
+
+export function createReviewDecisionCommandFeature(
+  dependencies: ReviewDecisionCommandFeatureDependencies
+): ReviewDecisionCommandApplication {
+  return new ReviewDecisionCommandApplication({
+    ...dependencies,
+    snapshots: nodeReviewDecisionCommandSnapshotIdentity,
+  });
+}

--- a/src/features/review-mutations/main/index.ts
+++ b/src/features/review-mutations/main/index.ts
@@ -1,3 +1,4 @@
+export { ReviewMutationApplyResultError } from '../core/application/ReviewMutationApplyResultError';
 export {
   ReviewMutationCoordinator,
   type ReviewMutationJournalPort,
@@ -18,6 +19,12 @@ export {
   mergeReviewApplyResults,
   mergeReviewMutationDiskPostimages,
 } from '../core/domain/reviewDecisionBatch';
+export {
+  assertCurrentReviewDecisionRevision,
+  assertExactApplyReviewHistoryTransition,
+  type ReviewDecisionCommandCurrentState,
+  type ReviewDecisionCommandPolicyContext,
+} from '../core/domain/reviewDecisionCommandPolicy';
 export {
   buildReviewExternalReloadState,
   buildReviewHistoryRestorePlan,
@@ -58,10 +65,21 @@ export {
   removeReviewMutationRecoveryIpc,
   type ReviewMutationIpcHandlerWrapper,
 } from './adapters/input/ipc/registerReviewMutationRecoveryIpc';
-export {
-  ReviewDecisionBatchApplication,
-  ReviewMutationApplyResultError,
-} from './application/ReviewDecisionBatchApplication';
+export { ReviewDecisionBatchApplication } from './application/ReviewDecisionBatchApplication';
+export { ReviewDecisionCommandApplication } from './application/ReviewDecisionCommandApplication';
+export type {
+  ReviewDecisionCommandApplierPort,
+  ReviewDecisionCommandBatchPort,
+  ReviewDecisionCommandCachePort,
+  ReviewDecisionCommandCoordinatorPort,
+  ReviewDecisionCommandDependencies,
+  ReviewDecisionCommandHistoryPort,
+  ReviewDecisionCommandLoggerPort,
+  ReviewDecisionCommandPersistencePort,
+  ReviewDecisionCommandRecoveryPort,
+  ReviewDecisionCommandScopePort,
+  ReviewDecisionCommandSnapshotIdentityPort,
+} from './application/ReviewDecisionCommandPorts';
 export { ReviewDirectMutationDiskService } from './application/ReviewDirectMutationDiskService';
 export { ReviewHistoryMutationApplication } from './application/ReviewHistoryMutationApplication';
 export type {
@@ -99,6 +117,10 @@ export {
   createReviewDecisionBatchFeature,
   type ReviewDecisionBatchFeatureDependencies,
 } from './composition/createReviewDecisionBatchFeature';
+export {
+  createReviewDecisionCommandFeature,
+  type ReviewDecisionCommandFeatureDependencies,
+} from './composition/createReviewDecisionCommandFeature';
 export {
   createReviewHistoryMutationFeature,
   type ReviewHistoryMutationFeatureDependencies,

--- a/src/features/review-mutations/main/infrastructure/nodeReviewDecisionCommandSnapshotIdentity.ts
+++ b/src/features/review-mutations/main/infrastructure/nodeReviewDecisionCommandSnapshotIdentity.ts
@@ -1,0 +1,11 @@
+import { createHash, randomUUID } from 'node:crypto';
+
+import type { ReviewDecisionCommandSnapshotIdentityPort } from '../application/ReviewDecisionCommandPorts';
+
+export const nodeReviewDecisionCommandSnapshotIdentity: ReviewDecisionCommandSnapshotIdentityPort =
+  {
+    now: Date.now,
+    createToken: randomUUID,
+    fingerprintSnippets: (snippets) =>
+      createHash('sha256').update(JSON.stringify(snippets)).digest('hex'),
+  };

--- a/src/main/ipc/review.ts
+++ b/src/main/ipc/review.ts
@@ -5,6 +5,14 @@
  */
 
 import {
+  assertHunkIndices,
+  assertNonEmptyString,
+  assertOptionalString,
+  assertSnippetShapes,
+  createReviewScopeAuthorizationFeature,
+  MAX_REVIEW_HUNK_DECISIONS_PER_FILE,
+} from '@features/change-review/main';
+import {
   createReviewDecisionHistoryFeature,
   createReviewDraftHistoryFeature,
   registerReviewDecisionHistoryIpc,
@@ -34,12 +42,7 @@ import {
   withReviewPersistenceScopeLock,
 } from '@main/services/team/ReviewPersistenceScopeLock';
 import { TeamConfigReader } from '@main/services/team/TeamConfigReader';
-import {
-  cleanupAtomicCreateTempLinks,
-  inspectReviewFileTransaction,
-  isOwnedReviewFileTransactionHardlink,
-} from '@main/utils/atomicWrite';
-import { isPathWithinRoot, matchesSensitivePattern } from '@main/utils/pathValidation';
+import { inspectReviewFileTransaction } from '@main/utils/atomicWrite';
 import { safeSendToRenderer } from '@main/utils/safeWebContentsSend';
 import {
   REVIEW_APPLY_DECISIONS,
@@ -68,11 +71,11 @@ import { createHash, randomUUID } from 'crypto';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 
+import type { ReviewPathAuthorization } from '@features/change-review/main';
 import type {
   ReviewDecisionAuthorization,
   ReviewDraftHistoryAuthorization,
 } from '@features/change-review-history/main';
-import type { ReviewMutationPathAuthorization } from '@features/review-mutations/main';
 import type { ChangeExtractorService } from '@main/services/team/ChangeExtractorService';
 import type { FileContentResolver } from '@main/services/team/FileContentResolver';
 import type { GitDiffFallback } from '@main/services/team/GitDiffFallback';
@@ -100,7 +103,6 @@ import type {
   TeamTaskChangeSummariesResponse,
   TeamTaskChangeSummaryRequest,
 } from '@shared/types/review';
-import type { TeamConfig } from '@shared/types/team';
 import type { BrowserWindow, IpcMain, IpcMainInvokeEvent } from 'electron';
 
 const wrapReviewHandler = createIpcWrapper('IPC:review');
@@ -108,8 +110,6 @@ const logger = createLogger('IPC:review');
 const TEAM_TASK_CHANGE_SUMMARY_IPC_RAW_REQUEST_LIMIT = 1_000;
 const TEAM_TASK_CHANGE_SUMMARY_IPC_UNIQUE_REQUEST_LIMIT = 201;
 const MAX_REVIEW_DECISIONS = 2_000;
-const MAX_REVIEW_SNIPPETS_PER_FILE = 10_000;
-const MAX_REVIEW_HUNK_DECISIONS_PER_FILE = 100_000;
 
 // --- Module-level state ---
 
@@ -253,498 +253,93 @@ function getContentResolver(): FileContentResolver {
   return fileContentResolver;
 }
 
-interface AuthorizedReviewRoot {
-  lexicalPath: string;
-  realPath: string;
-}
-
-type ReviewPathAuthorization = ReviewMutationPathAuthorization;
-
-function assertNonEmptyString(value: unknown, field: string): asserts value is string {
-  if (typeof value !== 'string' || value.trim().length === 0) {
-    throw new Error(`Invalid ${field}: non-empty string required`);
-  }
-}
-
-function assertOptionalString(value: unknown, field: string): asserts value is string | undefined {
-  if (value !== undefined && typeof value !== 'string') {
-    throw new Error(`Invalid ${field}: string required`);
-  }
-}
+const reviewScopeAuthorizationFeature = createReviewScopeAuthorizationFeature({
+  validators: { validateTeamName, validateTaskId },
+  config: {
+    getConfig: (teamName) => reviewConfigReader.getConfig(teamName),
+  },
+  changes: {
+    getTaskChanges: (teamName, taskId) => getChangeExtractor().getTaskChanges(teamName, taskId),
+    getAgentChanges: (teamName, memberName) =>
+      getChangeExtractor().getAgentChanges(teamName, memberName),
+  },
+  content: {
+    getFileContent: (...args) => getContentResolver().getFileContent(...args),
+    invalidateFile: (filePath) => getContentResolver().invalidateFile(filePath),
+  },
+});
 
 function normalizeReviewIdentity(value: string | undefined): string | undefined {
-  const normalized = value?.trim();
-  return normalized ? normalized : undefined;
+  return reviewScopeAuthorizationFeature.normalizeReviewIdentity(value);
 }
 
 function parseReviewFileScope(value: unknown): ReviewFileScope {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    throw new Error('Invalid review scope');
-  }
-  const raw = value as Record<string, unknown>;
-  const team = validateTeamName(raw.teamName);
-  if (!team.valid || !team.value) {
-    throw new Error(team.error ?? 'Invalid teamName');
-  }
-  assertOptionalString(raw.memberName, 'memberName');
-  assertOptionalString(raw.taskId, 'taskId');
-  const memberName = normalizeReviewIdentity(raw.memberName);
-  const taskId = normalizeReviewIdentity(raw.taskId);
-  if (taskId) {
-    const task = validateTaskId(taskId);
-    if (!task.valid || !task.value) {
-      throw new Error(task.error ?? 'Invalid taskId');
-    }
-  }
-  if (memberName && (memberName.length > 256 || memberName.includes('\0'))) {
-    throw new Error('Invalid memberName');
-  }
-  return {
-    teamName: team.value,
-    ...(memberName ? { memberName } : {}),
-    ...(taskId ? { taskId } : {}),
-  };
+  return reviewScopeAuthorizationFeature.parseReviewFileScope(value);
 }
 
 function parseReviewRenameRecoveryExpectation(value: unknown): ReviewRenameRecoveryExpectation {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    throw new Error('Invalid rename recovery expectation');
-  }
-  const raw = value as Record<string, unknown>;
-  const relation = raw.relation;
-  if (!relation || typeof relation !== 'object' || Array.isArray(relation)) {
-    throw new Error('Invalid rename recovery relation');
-  }
-  const relationRaw = relation as Record<string, unknown>;
-  if (
-    typeof raw.eventId !== 'string' ||
-    !raw.eventId ||
-    raw.eventId.length > 512 ||
-    (raw.beforeHash !== null && typeof raw.beforeHash !== 'string') ||
-    (raw.afterHash !== null && typeof raw.afterHash !== 'string') ||
-    relationRaw.kind !== 'rename' ||
-    typeof relationRaw.oldPath !== 'string' ||
-    !relationRaw.oldPath ||
-    relationRaw.oldPath.length > 4096 ||
-    relationRaw.oldPath.includes('\0') ||
-    typeof relationRaw.newPath !== 'string' ||
-    !relationRaw.newPath ||
-    relationRaw.newPath.length > 4096 ||
-    relationRaw.newPath.includes('\0')
-  ) {
-    throw new Error('Invalid rename recovery expectation');
-  }
-  if (
-    (typeof raw.beforeHash === 'string' && raw.beforeHash.length > 512) ||
-    (typeof raw.afterHash === 'string' && raw.afterHash.length > 512)
-  ) {
-    throw new Error('Invalid rename recovery expectation');
-  }
-  return {
-    eventId: raw.eventId,
-    beforeHash: raw.beforeHash,
-    afterHash: raw.afterHash,
-    relation: {
-      kind: 'rename',
-      oldPath: relationRaw.oldPath,
-      newPath: relationRaw.newPath,
-    },
-  };
-}
-
-function collectConfiguredReviewRoots(config: TeamConfig): string[] {
-  const roots: string[] = [];
-  const add = (value: unknown): void => {
-    if (typeof value === 'string' && value.trim()) {
-      roots.push(value.trim());
-    }
-  };
-  add(config.projectPath);
-
-  const members = Array.isArray(config.members) ? config.members : [];
-  for (const member of members) {
-    add(member.cwd);
-  }
-  return [...new Set(roots.map((root) => path.resolve(path.normalize(root))))];
-}
-
-async function resolveAuthorizedReviewRoot(rootPath: string): Promise<AuthorizedReviewRoot | null> {
-  if (!path.isAbsolute(rootPath)) {
-    return null;
-  }
-  try {
-    const [rootStat, realPath] = await Promise.all([fs.stat(rootPath), fs.realpath(rootPath)]);
-    if (!rootStat.isDirectory()) {
-      return null;
-    }
-    return {
-      lexicalPath: path.resolve(path.normalize(rootPath)),
-      realPath: path.resolve(path.normalize(realPath)),
-    };
-  } catch {
-    return null;
-  }
+  return reviewScopeAuthorizationFeature.parseReviewRenameRecoveryExpectation(value);
 }
 
 function normalizeReviewPathForIdentity(filePath: string): string {
-  const normalized = path.resolve(path.normalize(filePath));
-  return process.platform === 'win32' ? normalized.toLocaleLowerCase() : normalized;
+  return reviewScopeAuthorizationFeature.normalizeReviewPathForIdentity(filePath);
 }
 
-function collectAuthoritativeReviewedFiles(
-  files: FileChangeSummary[]
-): Map<string, FileChangeSummary> {
-  const reviewedFiles = new Map<string, FileChangeSummary>();
-  const add = (filePath: string | null, owner: FileChangeSummary): void => {
-    if (filePath && path.isAbsolute(path.normalize(filePath))) {
-      reviewedFiles.set(normalizeReviewPathForIdentity(filePath), owner);
-    }
-  };
-
-  for (const file of files) {
-    add(file.filePath, file);
-    for (const snippet of file.snippets) {
-      add(snippet.filePath, file);
-    }
-  }
-  return reviewedFiles;
-}
-
-async function resolveReviewPathAuthorization(
+function resolveReviewPathAuthorization(
   scopeValue: unknown,
   options: { requireIdentity?: boolean } = {}
 ): Promise<{ scope: ReviewFileScope; authorization: ReviewPathAuthorization }> {
-  const scope = parseReviewFileScope(scopeValue);
-  if (options.requireIdentity && !scope.taskId && !scope.memberName) {
-    throw new Error('Review mutation requires taskId or memberName');
-  }
-  const config = await reviewConfigReader.getConfig(scope.teamName);
-  if (!config) {
-    throw new Error(`Review team config is unavailable: ${scope.teamName}`);
-  }
-
-  const roots = (
-    await Promise.all(collectConfiguredReviewRoots(config).map(resolveAuthorizedReviewRoot))
-  ).filter((root): root is AuthorizedReviewRoot => Boolean(root));
-  if (roots.length === 0) {
-    throw new Error('Review project/worktree root is unavailable');
-  }
-
-  let reviewedFiles: Map<string, FileChangeSummary> | null = null;
-  let resolutionMemberName = scope.memberName ?? '';
-  if (scope.taskId) {
-    const changeSet = await getChangeExtractor().getTaskChanges(scope.teamName, scope.taskId);
-    reviewedFiles = collectAuthoritativeReviewedFiles(changeSet.files);
-    const authoritativeMemberName = normalizeReviewIdentity(changeSet.scope?.memberName);
-    if (
-      scope.memberName &&
-      authoritativeMemberName &&
-      scope.memberName !== authoritativeMemberName
-    ) {
-      throw new Error('Review memberName does not match the authoritative task scope');
-    }
-    resolutionMemberName = authoritativeMemberName ?? '';
-  } else if (scope.memberName) {
-    const changeSet = await getChangeExtractor().getAgentChanges(scope.teamName, scope.memberName);
-    reviewedFiles = collectAuthoritativeReviewedFiles(changeSet.files);
-  }
-
-  return { scope, authorization: { roots, reviewedFiles, resolutionMemberName } };
+  return reviewScopeAuthorizationFeature.resolveReviewPathAuthorization(scopeValue, options);
 }
 
-async function resolveNearestExistingRealPath(filePath: string): Promise<string> {
-  let current = filePath;
-  for (;;) {
-    try {
-      return path.resolve(path.normalize(await fs.realpath(current)));
-    } catch (error) {
-      const code = (error as NodeJS.ErrnoException).code;
-      if (code !== 'ENOENT' && code !== 'ENOTDIR') {
-        throw error;
-      }
-      const parent = path.dirname(current);
-      if (parent === current) {
-        throw new Error('No existing ancestor for review file path');
-      }
-      current = parent;
-    }
-  }
-}
-
-async function validateAuthorizedReviewFilePath(
+function validateAuthorizedReviewFilePath(
   authorization: ReviewPathAuthorization,
   filePathValue: unknown,
   options: { requireReviewedFile: boolean; rejectHardlinks?: boolean }
 ): Promise<string> {
-  assertNonEmptyString(filePathValue, 'filePath');
-  if (!path.isAbsolute(path.normalize(filePathValue))) {
-    throw new Error('Review file path must be absolute');
-  }
-  const normalizedPath = path.resolve(path.normalize(filePathValue));
-  if (matchesSensitivePattern(normalizedPath)) {
-    throw new Error('Access to sensitive files is not allowed');
-  }
-  if (
-    options.requireReviewedFile &&
-    !authorization.reviewedFiles?.has(normalizeReviewPathForIdentity(normalizedPath))
-  ) {
-    throw new Error('File is not part of the reviewed scope');
-  }
-
-  let targetRealPath: string;
-  let targetStat: Awaited<ReturnType<typeof fs.lstat>> | null = null;
-  let resolvedStat: Awaited<ReturnType<typeof fs.stat>> | null = null;
-  try {
-    targetStat = await fs.lstat(normalizedPath);
-    targetRealPath = path.resolve(path.normalize(await fs.realpath(normalizedPath)));
-    resolvedStat = targetStat.isSymbolicLink() ? await fs.stat(targetRealPath) : targetStat;
-    if (!resolvedStat.isFile()) {
-      throw new Error('Review target must be a regular file');
-    }
-  } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code;
-    if (code !== 'ENOENT' && code !== 'ENOTDIR') {
-      throw error;
-    }
-    targetRealPath = await resolveNearestExistingRealPath(path.dirname(normalizedPath));
-  }
-  if (matchesSensitivePattern(targetRealPath)) {
-    throw new Error('Access to sensitive files is not allowed');
-  }
-
-  const allowed = authorization.roots.some(
-    (root) =>
-      (isPathWithinRoot(normalizedPath, root.lexicalPath) ||
-        isPathWithinRoot(normalizedPath, root.realPath)) &&
-      isPathWithinRoot(targetRealPath, root.realPath)
+  return reviewScopeAuthorizationFeature.validateAuthorizedReviewFilePath(
+    authorization,
+    filePathValue,
+    options
   );
-  if (!allowed) {
-    throw new Error('Review file path is outside the authoritative project/worktree');
-  }
-  if (options.rejectHardlinks && targetStat && resolvedStat) {
-    if (!targetStat.isSymbolicLink() && resolvedStat.nlink > 1) {
-      await cleanupAtomicCreateTempLinks(normalizedPath);
-      targetStat = await fs.lstat(normalizedPath);
-      targetRealPath = path.resolve(path.normalize(await fs.realpath(normalizedPath)));
-      resolvedStat = targetStat.isSymbolicLink() ? await fs.stat(targetRealPath) : targetStat;
-      const stillAllowed =
-        !matchesSensitivePattern(targetRealPath) &&
-        authorization.roots.some(
-          (root) =>
-            (isPathWithinRoot(normalizedPath, root.lexicalPath) ||
-              isPathWithinRoot(normalizedPath, root.realPath)) &&
-            isPathWithinRoot(targetRealPath, root.realPath)
-        );
-      if (!stillAllowed || !resolvedStat.isFile()) {
-        throw new Error('Review file path changed during authorization');
-      }
-    }
-    const ownedReviewTransactionLink =
-      !targetStat.isSymbolicLink() &&
-      resolvedStat.nlink > 1 &&
-      (await isOwnedReviewFileTransactionHardlink(normalizedPath));
-    if (targetStat.isSymbolicLink() || (resolvedStat.nlink > 1 && !ownedReviewTransactionLink)) {
-      throw new Error('Review mutation refuses symbolic or multiply-linked files');
-    }
-  }
-  return normalizedPath;
 }
 
 function getAuthoritativeReviewedFile(
   authorization: ReviewPathAuthorization,
   filePath: string
 ): FileChangeSummary {
-  const file = authorization.reviewedFiles?.get(normalizeReviewPathForIdentity(filePath));
-  if (!file) {
-    throw new Error('File is not part of the reviewed scope');
-  }
-  return file;
+  return reviewScopeAuthorizationFeature.getAuthoritativeReviewedFile(authorization, filePath);
 }
 
-async function resolveAuthoritativeFileContent(
+function resolveAuthoritativeFileContent(
   scope: ReviewFileScope,
   authorization: ReviewPathAuthorization,
   filePath: string
 ): Promise<FileChangeWithContent> {
-  const authoritativeFile = getAuthoritativeReviewedFile(authorization, filePath);
-  assertSnippetShapes(authoritativeFile.snippets);
-  await validateSnippetPaths(authorization, authoritativeFile.snippets, {
-    requireReviewedFile: true,
-  });
-  const resolved = await getContentResolver().getFileContent(
-    scope.teamName,
-    authorization.resolutionMemberName,
-    filePath,
-    authoritativeFile.snippets
+  return reviewScopeAuthorizationFeature.resolveAuthoritativeFileContent(
+    scope,
+    authorization,
+    filePath
   );
-  return {
-    ...resolved,
-    filePath,
-    snippets: authoritativeFile.snippets,
-  };
 }
 
 function assertExpectedAuthoritativeRename(
   content: FileChangeWithContent,
   expectation: ReviewRenameRecoveryExpectation
 ): void {
-  const renameLedger = content.snippets.find(
-    (snippet) => snippet.ledger?.relation?.kind === 'rename'
-  )?.ledger;
-  const relation = renameLedger?.relation;
-  if (!renameLedger || relation?.kind !== 'rename') {
-    throw new Error('Review file is not an authoritative ledger rename');
-  }
-  if (
-    renameLedger.eventId !== expectation.eventId ||
-    (renameLedger.beforeHash ?? null) !== expectation.beforeHash ||
-    (renameLedger.afterHash ?? null) !== expectation.afterHash ||
-    relation.oldPath !== expectation.relation.oldPath ||
-    relation.newPath !== expectation.relation.newPath
-  ) {
-    throw new Error('Review changes were updated; refusing stale rename recovery');
-  }
+  reviewScopeAuthorizationFeature.assertExpectedAuthoritativeRename(content, expectation);
 }
 
 function invalidateAuthoritativeReviewContent(content: FileChangeWithContent): void {
-  const paths = new Set([content.filePath]);
-  for (const snippet of content.snippets) {
-    paths.add(snippet.filePath);
-    const relation = snippet.ledger?.relation;
-    if (relation) {
-      paths.add(relation.oldPath);
-      paths.add(relation.newPath);
-    }
-  }
-  for (const filePath of paths) {
-    getContentResolver().invalidateFile(filePath);
-  }
+  reviewScopeAuthorizationFeature.invalidateAuthoritativeReviewContent(content);
 }
 
-function assertHunkIndices(value: unknown): asserts value is number[] {
-  if (
-    !Array.isArray(value) ||
-    value.length > MAX_REVIEW_HUNK_DECISIONS_PER_FILE ||
-    value.some((index) => !Number.isSafeInteger(index) || index < 0)
-  ) {
-    throw new Error('Invalid hunkIndices');
-  }
-}
-
-function assertSnippetShapes(value: unknown): asserts value is SnippetDiff[] {
-  if (!Array.isArray(value) || value.length > MAX_REVIEW_SNIPPETS_PER_FILE) {
-    throw new Error('Invalid snippets array');
-  }
-  for (const snippet of value) {
-    if (!snippet || typeof snippet !== 'object' || Array.isArray(snippet)) {
-      throw new Error('Invalid review snippet');
-    }
-    const raw = snippet as Record<string, unknown>;
-    for (const field of [
-      'toolUseId',
-      'filePath',
-      'toolName',
-      'type',
-      'oldString',
-      'newString',
-      'timestamp',
-    ]) {
-      if (typeof raw[field] !== 'string') {
-        throw new Error(`Invalid review snippet ${field}`);
-      }
-    }
-    if (typeof raw.replaceAll !== 'boolean' || typeof raw.isError !== 'boolean') {
-      throw new Error('Invalid review snippet flags');
-    }
-    if (raw.ledger !== undefined) {
-      if (!raw.ledger || typeof raw.ledger !== 'object' || Array.isArray(raw.ledger)) {
-        throw new Error('Invalid review ledger metadata');
-      }
-      const relation = (raw.ledger as Record<string, unknown>).relation;
-      if (relation !== undefined) {
-        if (!relation || typeof relation !== 'object' || Array.isArray(relation)) {
-          throw new Error('Invalid review relation');
-        }
-        const relationRaw = relation as Record<string, unknown>;
-        if (
-          (relationRaw.kind !== 'rename' && relationRaw.kind !== 'copy') ||
-          typeof relationRaw.oldPath !== 'string' ||
-          !relationRaw.oldPath ||
-          typeof relationRaw.newPath !== 'string' ||
-          !relationRaw.newPath
-        ) {
-          throw new Error('Invalid review relation');
-        }
-      }
-    }
-  }
-}
-
-async function validateSnippetPaths(
+function validateSnippetPaths(
   authorization: ReviewPathAuthorization,
   snippets: SnippetDiff[],
   options: { requireReviewedFile?: boolean; rejectHardlinks?: boolean } = {}
 ): Promise<void> {
-  const requireReviewedFile = options.requireReviewedFile === true;
-  await Promise.all(
-    snippets.map((snippet) =>
-      validateAuthorizedReviewFilePath(authorization, snippet.filePath, {
-        requireReviewedFile,
-        rejectHardlinks: options.rejectHardlinks === true,
-      })
-    )
-  );
-
-  for (const snippet of snippets) {
-    const relation = snippet.ledger?.relation;
-    if (!relation) continue;
-    const slashFilePath = snippet.filePath.replace(/\\/g, '/');
-    const relationPaths = [relation.oldPath, relation.newPath] as const;
-    if (relationPaths.every((relationPath) => path.isAbsolute(path.normalize(relationPath)))) {
-      for (const relationPath of relationPaths) {
-        await validateAuthorizedReviewFilePath(authorization, relationPath, {
-          requireReviewedFile,
-          rejectHardlinks: options.rejectHardlinks === true,
-        });
-      }
-      continue;
-    }
-    if (relationPaths.some((relationPath) => path.isAbsolute(path.normalize(relationPath)))) {
-      throw new Error('Review relation paths must both be absolute or both be relative');
-    }
-
-    let resolvedRelationPaths: [string, string] | null = null;
-    for (const [anchorRelationPath, targetRelationPath] of [
-      [relation.oldPath, relation.newPath],
-      [relation.newPath, relation.oldPath],
-    ] as const) {
-      const slashAnchor = anchorRelationPath.replace(/\\/g, '/');
-      if (
-        slashFilePath === slashAnchor ||
-        slashFilePath.toLocaleLowerCase().endsWith(`/${slashAnchor.toLocaleLowerCase()}`)
-      ) {
-        const prefix = slashFilePath.slice(0, slashFilePath.length - slashAnchor.length);
-        const anchorPath = path.resolve(path.normalize(`${prefix}${slashAnchor}`));
-        const targetPath = path.resolve(
-          path.normalize(`${prefix}${targetRelationPath.replace(/\\/g, '/')}`)
-        );
-        resolvedRelationPaths =
-          anchorRelationPath === relation.oldPath
-            ? [anchorPath, targetPath]
-            : [targetPath, anchorPath];
-        break;
-      }
-    }
-    if (!resolvedRelationPaths) {
-      throw new Error('Review relation is not anchored to an authoritative snippet path');
-    }
-    for (const relationPath of resolvedRelationPaths) {
-      await validateAuthorizedReviewFilePath(authorization, relationPath, {
-        requireReviewedFile,
-        rejectHardlinks: options.rejectHardlinks === true,
-      });
-    }
-  }
+  return reviewScopeAuthorizationFeature.validateSnippetPaths(authorization, snippets, options);
 }
 
 function assertReviewDecisionShape(value: unknown): asserts value is FileReviewDecision {

--- a/src/main/ipc/review.ts
+++ b/src/main/ipc/review.ts
@@ -7,10 +7,12 @@
 import {
   assertHunkIndices,
   assertNonEmptyString,
-  assertOptionalString,
   assertSnippetShapes,
+  createReviewQueryFeature,
   createReviewScopeAuthorizationFeature,
   MAX_REVIEW_HUNK_DECISIONS_PER_FILE,
+  sanitizeTaskChangeOptions,
+  sanitizeTeamTaskChangeSummaryRequests,
 } from '@features/change-review/main';
 import {
   createReviewDecisionHistoryFeature,
@@ -92,17 +94,13 @@ import type {
   ReviewFileScope,
   ReviewRenameRecoveryExpectation,
   SnippetDiff,
-  TaskChangeRequestOptions,
   TaskChangeSetV2,
   TeamTaskChangeSummariesResponse,
-  TeamTaskChangeSummaryRequest,
 } from '@shared/types/review';
 import type { BrowserWindow, IpcMain, IpcMainInvokeEvent } from 'electron';
 
 const wrapReviewHandler = createIpcWrapper('IPC:review');
 const logger = createLogger('IPC:review');
-const TEAM_TASK_CHANGE_SUMMARY_IPC_RAW_REQUEST_LIMIT = 1_000;
-const TEAM_TASK_CHANGE_SUMMARY_IPC_UNIQUE_REQUEST_LIMIT = 201;
 const MAX_REVIEW_DECISIONS = 2_000;
 
 // --- Module-level state ---
@@ -160,20 +158,6 @@ async function withReviewDecisionPersistenceLock<T>(
   }
 }
 
-function registerDisplayedReviewSnapshot(
-  teamName: string,
-  filePath: string,
-  snippets: SnippetDiff[],
-  content: FileChangeWithContent
-): FileChangeWithContent {
-  return reviewDecisionCommandFeature.registerDisplayedReviewSnapshot(
-    teamName,
-    filePath,
-    snippets,
-    content
-  );
-}
-
 function getChangeExtractor(): ChangeExtractorService {
   if (!changeExtractor) throw new Error('Review handlers not initialized');
   return changeExtractor;
@@ -204,10 +188,6 @@ const reviewScopeAuthorizationFeature = createReviewScopeAuthorizationFeature({
     invalidateFile: (filePath) => getContentResolver().invalidateFile(filePath),
   },
 });
-
-function normalizeReviewIdentity(value: string | undefined): string | undefined {
-  return reviewScopeAuthorizationFeature.normalizeReviewIdentity(value);
-}
 
 function parseReviewFileScope(value: unknown): ReviewFileScope {
   return reviewScopeAuthorizationFeature.parseReviewFileScope(value);
@@ -483,71 +463,8 @@ async function handleGetAgentChanges(
   memberName: string
 ): Promise<IpcResult<AgentChangeSet>> {
   return wrapReviewHandler('getAgentChanges', () =>
-    getChangeExtractor().getAgentChanges(teamName, memberName)
+    reviewQueryFeature.getAgentChanges(teamName, memberName)
   );
-}
-
-function sanitizeTaskChangeOptions(options?: unknown): TaskChangeRequestOptions | undefined {
-  if (!options || typeof options !== 'object') {
-    return undefined;
-  }
-
-  const raw = options as Record<string, unknown>;
-  return {
-    owner: typeof raw.owner === 'string' ? raw.owner : undefined,
-    status: typeof raw.status === 'string' ? raw.status : undefined,
-    since: typeof raw.since === 'string' ? raw.since : undefined,
-    intervals: Array.isArray(raw.intervals)
-      ? (raw.intervals.filter(
-          (i): i is { startedAt: string; completedAt?: string } =>
-            Boolean(i) &&
-            typeof i === 'object' &&
-            typeof (i as Record<string, unknown>).startedAt === 'string' &&
-            ((i as Record<string, unknown>).completedAt === undefined ||
-              typeof (i as Record<string, unknown>).completedAt === 'string')
-        ) as { startedAt: string; completedAt?: string }[])
-      : undefined,
-    stateBucket:
-      raw.stateBucket === 'approved' ||
-      raw.stateBucket === 'review' ||
-      raw.stateBucket === 'completed' ||
-      raw.stateBucket === 'active'
-        ? raw.stateBucket
-        : undefined,
-    summaryOnly: raw.summaryOnly === true,
-    forceFresh: raw.forceFresh === true,
-  };
-}
-
-function sanitizeTeamTaskChangeSummaryRequests(requests: unknown): TeamTaskChangeSummaryRequest[] {
-  if (!Array.isArray(requests)) {
-    return [];
-  }
-
-  const sanitizedRequests: TeamTaskChangeSummaryRequest[] = [];
-  const seenTaskIds = new Set<string>();
-  for (const request of requests.slice(0, TEAM_TASK_CHANGE_SUMMARY_IPC_RAW_REQUEST_LIMIT)) {
-    if (sanitizedRequests.length >= TEAM_TASK_CHANGE_SUMMARY_IPC_UNIQUE_REQUEST_LIMIT) {
-      break;
-    }
-    if (!request || typeof request !== 'object') {
-      continue;
-    }
-    const raw = request as Record<string, unknown>;
-    if (typeof raw.taskId !== 'string') {
-      continue;
-    }
-    const taskId = raw.taskId.trim();
-    if (!taskId || seenTaskIds.has(taskId)) {
-      continue;
-    }
-    seenTaskIds.add(taskId);
-    sanitizedRequests.push({
-      taskId,
-      options: sanitizeTaskChangeOptions(raw.options),
-    });
-  }
-  return sanitizedRequests;
 }
 
 async function handleGetTaskChanges(
@@ -559,7 +476,7 @@ async function handleGetTaskChanges(
   const opts = sanitizeTaskChangeOptions(options);
 
   return wrapReviewHandler('getTaskChanges', () =>
-    getChangeExtractor().getTaskChanges(teamName, taskId, opts)
+    reviewQueryFeature.getTaskChanges(teamName, taskId, opts)
   );
 }
 
@@ -571,7 +488,7 @@ async function handleGetTeamTaskChangeSummaries(
   const sanitizedRequests = sanitizeTeamTaskChangeSummaryRequests(requests);
 
   return wrapReviewHandler('getTeamTaskChangeSummaries', () =>
-    getChangeExtractor().getTeamTaskChangeSummaries(teamName, sanitizedRequests)
+    reviewQueryFeature.getTeamTaskChangeSummaries(teamName, sanitizedRequests)
   );
 }
 
@@ -580,12 +497,9 @@ async function handleInvalidateTaskChangeSummaries(
   teamName: string,
   taskIds: string[]
 ): Promise<IpcResult<void>> {
-  return wrapReviewHandler('invalidateTaskChangeSummaries', async () => {
-    await getChangeExtractor().invalidateTaskChangeSummaries(
-      teamName,
-      Array.isArray(taskIds) ? taskIds.filter((taskId) => typeof taskId === 'string') : []
-    );
-  });
+  return wrapReviewHandler('invalidateTaskChangeSummaries', () =>
+    reviewQueryFeature.invalidateTaskChangeSummaries(teamName, taskIds)
+  );
 }
 
 async function handleGetChangeStats(
@@ -594,7 +508,7 @@ async function handleGetChangeStats(
   memberName: string
 ): Promise<IpcResult<ChangeStats>> {
   return wrapReviewHandler('getChangeStats', () =>
-    getChangeExtractor().getChangeStats(teamName, memberName)
+    reviewQueryFeature.getChangeStats(teamName, memberName)
   );
 }
 
@@ -869,6 +783,35 @@ const reviewDecisionCommandFeature = createReviewDecisionCommandFeature({
   },
 });
 
+const reviewQueryFeature = createReviewQueryFeature({
+  changes: {
+    getAgentChanges: (...args) => getChangeExtractor().getAgentChanges(...args),
+    getTaskChanges: (...args) => getChangeExtractor().getTaskChanges(...args),
+    getTeamTaskChangeSummaries: (...args) =>
+      getChangeExtractor().getTeamTaskChangeSummaries(...args),
+    invalidateTaskChangeSummaries: (...args) =>
+      getChangeExtractor().invalidateTaskChangeSummaries(...args),
+    getChangeStats: (...args) => getChangeExtractor().getChangeStats(...args),
+  },
+  scope: {
+    normalizeIdentity: (value) => reviewScopeAuthorizationFeature.normalizeReviewIdentity(value),
+    resolve: (value) => resolveReviewPathAuthorization(value),
+    validateFilePath: (authorization, filePath, options) =>
+      validateAuthorizedReviewFilePath(authorization, filePath, options),
+    validateSnippets: (authorization, snippets) => validateSnippetPaths(authorization, snippets),
+  },
+  content: {
+    getFileContent: (...args) => getContentResolver().getFileContent(...args),
+  },
+  snapshots: {
+    register: (...args) => reviewDecisionCommandFeature.registerDisplayedReviewSnapshot(...args),
+  },
+  gitHistory: {
+    getFileLog: (projectPath, filePath) =>
+      gitDiffFallback ? gitDiffFallback.getFileLog(projectPath, filePath) : Promise.resolve([]),
+  },
+});
+
 const reviewDecisionHistoryFeature = createReviewDecisionHistoryFeature({
   lock: { run: withReviewDecisionPersistenceLock },
   authorization: { authorize: authorizeReviewDecisionHistoryScope },
@@ -910,25 +853,9 @@ async function handleGetFileContent(
   filePathValue: unknown,
   snippetsValue: unknown = []
 ): Promise<IpcResult<FileChangeWithContent>> {
-  return wrapReviewHandler('getFileContent', async () => {
-    assertOptionalString(memberNameValue, 'memberName');
-    assertSnippetShapes(snippetsValue);
-    const { scope, authorization } = await resolveReviewPathAuthorization({
-      teamName: teamNameValue,
-      memberName: normalizeReviewIdentity(memberNameValue),
-    });
-    const filePath = await validateAuthorizedReviewFilePath(authorization, filePathValue, {
-      requireReviewedFile: false,
-    });
-    await validateSnippetPaths(authorization, snippetsValue);
-    const content = await getContentResolver().getFileContent(
-      scope.teamName,
-      scope.memberName ?? '',
-      filePath,
-      snippetsValue
-    );
-    return registerDisplayedReviewSnapshot(scope.teamName, filePath, snippetsValue, content);
-  });
+  return wrapReviewHandler('getFileContent', () =>
+    reviewQueryFeature.getFileContent(teamNameValue, memberNameValue, filePathValue, snippetsValue)
+  );
 }
 
 // --- Editable diff Handlers ---
@@ -1118,10 +1045,7 @@ async function handleGetGitFileLog(
   projectPath: string,
   filePath: string
 ): Promise<IpcResult<{ hash: string; timestamp: string; message: string }[]>> {
-  return wrapReviewHandler('getGitFileLog', async () => {
-    if (!gitDiffFallback) {
-      return [];
-    }
-    return gitDiffFallback.getFileLog(projectPath, filePath);
-  });
+  return wrapReviewHandler('getGitFileLog', () =>
+    reviewQueryFeature.getGitFileLog(projectPath, filePath)
+  );
 }

--- a/src/main/ipc/review.ts
+++ b/src/main/ipc/review.ts
@@ -21,15 +21,13 @@ import {
   removeReviewDraftHistoryIpc,
 } from '@features/change-review-history/main';
 import {
+  assertCurrentReviewDecisionRevision,
   createReviewDecisionBatchFeature,
+  createReviewDecisionCommandFeature,
   createReviewHistoryMutationFeature,
   createReviewMutationRecoveryFeature,
-  getReviewActionDiskSnapshots,
-  isDurableReviewEqual,
-  mergeReviewMutationDiskPostimages,
   registerReviewMutationRecoveryIpc,
   removeReviewMutationRecoveryIpc,
-  ReviewMutationApplyResultError,
   ReviewMutationCoordinator,
 } from '@features/review-mutations/main';
 import { validateTaskId, validateTeamName } from '@main/ipc/guards';
@@ -67,7 +65,6 @@ import {
   // eslint-disable-next-line boundaries/element-types -- IPC channel constants are shared between main and preload by design
 } from '@preload/constants/ipcChannels';
 import { createLogger } from '@shared/utils/logger';
-import { createHash, randomUUID } from 'crypto';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 
@@ -90,12 +87,9 @@ import type {
   FileChangeSummary,
   FileChangeWithContent,
   FileReviewDecision,
-  HunkDecision,
   RejectResult,
   ReviewDecisionPersistenceScope,
   ReviewFileScope,
-  ReviewMutationDiskPostimage,
-  ReviewPersistedStateSnapshot,
   ReviewRenameRecoveryExpectation,
   SnippetDiff,
   TaskChangeRequestOptions,
@@ -166,76 +160,18 @@ async function withReviewDecisionPersistenceLock<T>(
   }
 }
 
-interface DisplayedReviewSnapshot {
-  teamName: string;
-  filePath: string;
-  snippetFingerprint: string;
-  content: FileChangeWithContent;
-  expiresAt: number;
-}
-
-const displayedReviewSnapshots = new Map<string, DisplayedReviewSnapshot>();
-const REVIEW_SNAPSHOT_TTL_MS = 60 * 60 * 1000;
-const MAX_DISPLAYED_REVIEW_SNAPSHOTS = 2_000;
-
-function fingerprintReviewSnippets(snippets: SnippetDiff[]): string {
-  return createHash('sha256').update(JSON.stringify(snippets)).digest('hex');
-}
-
 function registerDisplayedReviewSnapshot(
   teamName: string,
   filePath: string,
   snippets: SnippetDiff[],
   content: FileChangeWithContent
 ): FileChangeWithContent {
-  const now = Date.now();
-  for (const [token, snapshot] of displayedReviewSnapshots) {
-    if (snapshot.expiresAt <= now) displayedReviewSnapshots.delete(token);
-  }
-  while (displayedReviewSnapshots.size >= MAX_DISPLAYED_REVIEW_SNAPSHOTS) {
-    const oldestToken = displayedReviewSnapshots.keys().next().value;
-    if (!oldestToken) break;
-    displayedReviewSnapshots.delete(oldestToken);
-  }
-
-  const token = randomUUID();
-  const snapshotContent = { ...content, reviewSnapshotToken: token };
-  displayedReviewSnapshots.set(token, {
+  return reviewDecisionCommandFeature.registerDisplayedReviewSnapshot(
     teamName,
-    filePath: normalizeReviewPathForIdentity(filePath),
-    snippetFingerprint: fingerprintReviewSnippets(snippets),
-    content: snapshotContent,
-    expiresAt: now + REVIEW_SNAPSHOT_TTL_MS,
-  });
-  return snapshotContent;
-}
-
-function resolveDisplayedReviewSnapshot(
-  token: string | undefined,
-  teamName: string,
-  filePath: string,
-  authoritativeSnippets: SnippetDiff[]
-): FileChangeWithContent {
-  if (!token) {
-    throw new Error('Displayed review snapshot is unavailable; reload Changes before rejecting.');
-  }
-  const snapshot = displayedReviewSnapshots.get(token);
-  if (
-    !snapshot ||
-    snapshot.expiresAt <= Date.now() ||
-    snapshot.teamName !== teamName ||
-    snapshot.filePath !== normalizeReviewPathForIdentity(filePath) ||
-    snapshot.snippetFingerprint !== fingerprintReviewSnippets(authoritativeSnippets)
-  ) {
-    displayedReviewSnapshots.delete(token);
-    throw new Error('Displayed review snapshot is stale; reload Changes before rejecting.');
-  }
-  snapshot.expiresAt = Date.now() + REVIEW_SNAPSHOT_TTL_MS;
-  return {
-    ...snapshot.content,
     filePath,
-    snippets: authoritativeSnippets,
-  };
+    snippets,
+    content
+  );
 }
 
 function getChangeExtractor(): ChangeExtractorService {
@@ -670,18 +606,11 @@ async function handleCheckConflict(
   filePathValue: unknown,
   expectedModified: unknown
 ): Promise<IpcResult<ConflictCheckResult>> {
-  return wrapReviewHandler('checkConflict', async () => {
+  return wrapReviewHandler('checkConflict', () => {
     if (typeof expectedModified !== 'string') {
       throw new Error('Invalid expectedModified');
     }
-    const { authorization } = await resolveReviewPathAuthorization(scopeValue, {
-      requireIdentity: true,
-    });
-    const filePath = await validateAuthorizedReviewFilePath(authorization, filePathValue, {
-      requireReviewedFile: true,
-      rejectHardlinks: true,
-    });
-    return getApplier().checkConflict(filePath, expectedModified);
+    return reviewDecisionCommandFeature.checkConflict(scopeValue, filePathValue, expectedModified);
   });
 }
 
@@ -691,34 +620,9 @@ async function handleRejectHunks(
   filePathValue: unknown,
   hunkIndices: unknown
 ): Promise<IpcResult<RejectResult>> {
-  return wrapReviewHandler('rejectHunks', async () => {
+  return wrapReviewHandler('rejectHunks', () => {
     assertHunkIndices(hunkIndices);
-    const { scope, authorization } = await resolveReviewPathAuthorization(scopeValue, {
-      requireIdentity: true,
-    });
-    const filePath = await validateAuthorizedReviewFilePath(authorization, filePathValue, {
-      requireReviewedFile: true,
-      rejectHardlinks: true,
-    });
-    const authoritativeContent = await resolveAuthoritativeFileContent(
-      scope,
-      authorization,
-      filePath
-    );
-    if (
-      authoritativeContent.originalFullContent === null ||
-      authoritativeContent.modifiedFullContent === null
-    ) {
-      throw new Error('Authoritative review contents are unavailable');
-    }
-    return getApplier().rejectHunks(
-      scope.teamName,
-      filePath,
-      authoritativeContent.originalFullContent,
-      authoritativeContent.modifiedFullContent,
-      hunkIndices,
-      authoritativeContent.snippets
-    );
+    return reviewDecisionCommandFeature.rejectHunks(scopeValue, filePathValue, hunkIndices);
   });
 }
 
@@ -727,32 +631,9 @@ async function handleRejectFile(
   scopeValue: unknown,
   filePathValue: unknown
 ): Promise<IpcResult<RejectResult>> {
-  return wrapReviewHandler('rejectFile', async () => {
-    const { scope, authorization } = await resolveReviewPathAuthorization(scopeValue, {
-      requireIdentity: true,
-    });
-    const filePath = await validateAuthorizedReviewFilePath(authorization, filePathValue, {
-      requireReviewedFile: true,
-      rejectHardlinks: true,
-    });
-    const authoritativeContent = await resolveAuthoritativeFileContent(
-      scope,
-      authorization,
-      filePath
-    );
-    if (
-      authoritativeContent.originalFullContent === null ||
-      authoritativeContent.modifiedFullContent === null
-    ) {
-      throw new Error('Authoritative review contents are unavailable');
-    }
-    return getApplier().rejectFile(
-      scope.teamName,
-      filePath,
-      authoritativeContent.originalFullContent,
-      authoritativeContent.modifiedFullContent
-    );
-  });
+  return wrapReviewHandler('rejectFile', () =>
+    reviewDecisionCommandFeature.rejectFile(scopeValue, filePathValue)
+  );
 }
 
 async function handlePreviewReject(
@@ -764,7 +645,7 @@ async function handlePreviewReject(
   snippets: SnippetDiff[]
 ): Promise<IpcResult<{ preview: string; hasConflicts: boolean }>> {
   return wrapReviewHandler('previewReject', () =>
-    getApplier().previewReject(filePath, original, modified, hunkIndices, snippets)
+    reviewDecisionCommandFeature.previewReject(filePath, original, modified, hunkIndices, snippets)
   );
 }
 
@@ -779,276 +660,9 @@ async function handleApplyDecisions(
   if (!Array.isArray(request.decisions) || request.decisions.length > MAX_REVIEW_DECISIONS) {
     return { success: false, error: 'Invalid request: decisions array required' };
   }
-  return wrapReviewHandler('applyDecisions', async () => {
-    const { scope, authorization } = await resolveReviewPathAuthorization(request, {
-      requireIdentity: true,
-    });
-    const persistenceScope = parseDecisionPersistenceScope(request.decisionPersistenceScope, scope);
-    const validatedDecisions: FileReviewDecision[] = [];
-    const fileContents = new Map<string, FileChangeWithContent>();
-    const decisionPaths = new Set<string>();
-    const decisionReviewKeys = new Set<string>();
-    for (const decision of request.decisions) {
-      assertReviewDecisionShape(decision);
-      const filePath = await validateAuthorizedReviewFilePath(authorization, decision.filePath, {
-        requireReviewedFile: true,
-        rejectHardlinks: true,
-      });
-      const authoritativeFile = getAuthoritativeReviewedFile(authorization, filePath);
-      const authoritativeReviewKey = authoritativeFile.changeKey ?? authoritativeFile.filePath;
-      const normalizedDecisionPath = normalizeReviewPathForIdentity(filePath);
-      if (
-        decisionPaths.has(normalizedDecisionPath) ||
-        decisionReviewKeys.has(authoritativeReviewKey)
-      ) {
-        throw new Error('Duplicate reviewed file in Apply decisions');
-      }
-      decisionPaths.add(normalizedDecisionPath);
-      decisionReviewKeys.add(authoritativeReviewKey);
-      if (persistenceScope && decision.reviewKey !== authoritativeReviewKey) {
-        throw new Error('Durable reviewKey does not match the authoritative review identity');
-      }
-      assertSnippetShapes(authoritativeFile.snippets);
-      await validateSnippetPaths(authorization, authoritativeFile.snippets, {
-        requireReviewedFile: true,
-        rejectHardlinks: true,
-      });
-      const hasLedgerSnapshot = authoritativeFile.snippets.some(
-        (snippet) => !!snippet.ledger && !snippet.isError
-      );
-      fileContents.set(
-        filePath,
-        hasLedgerSnapshot
-          ? await resolveAuthoritativeFileContent(scope, authorization, filePath)
-          : resolveDisplayedReviewSnapshot(
-              decision.contentSnapshotToken,
-              scope.teamName,
-              filePath,
-              authoritativeFile.snippets
-            )
-      );
-      validatedDecisions.push({
-        filePath,
-        ...(decision.reviewKey ? { reviewKey: decision.reviewKey } : {}),
-        fileDecision: decision.fileDecision,
-        hunkDecisions: decision.hunkDecisions,
-        ...(decision.hunkContextHashes ? { hunkContextHashes: decision.hunkContextHashes } : {}),
-      });
-    }
-    const validatedRequest: ApplyReviewRequest = {
-      teamName: scope.teamName,
-      ...(scope.taskId ? { taskId: scope.taskId } : {}),
-      ...(authorization.resolutionMemberName
-        ? { memberName: authorization.resolutionMemberName }
-        : {}),
-      ...(persistenceScope ? { decisionPersistenceScope: persistenceScope } : {}),
-      decisions: validatedDecisions,
-    };
-
-    let result: ApplyReviewResult;
-    if (!persistenceScope) {
-      result = await getApplier().applyReviewDecisions(validatedRequest, fileContents);
-    } else {
-      if (validatedDecisions.some((decision) => !decision.reviewKey)) {
-        throw new Error('Durable review mutation requires a stable reviewKey');
-      }
-      if (!request.persistedState) {
-        throw new Error('Durable review mutation requires an exact post-operation state');
-      }
-      if (
-        !Number.isSafeInteger(request.expectedDecisionRevision) ||
-        request.expectedDecisionRevision! < 0
-      ) {
-        throw new Error('Durable review mutation requires an exact decision revision');
-      }
-      reviewDecisionStore.assertValidSnapshot(request.persistedState);
-      reviewDecisionBatchFeature.assertPersistedStateIncludesDecisions(
-        request.persistedState,
-        validatedDecisions
-      );
-      result = await applyDecisionsWithDurableJournal(
-        scope,
-        authorization,
-        persistenceScope,
-        validatedDecisions as (FileReviewDecision & { reviewKey: string })[],
-        fileContents,
-        request.persistedState,
-        request.expectedDecisionRevision!
-      );
-    }
-
-    // Invalidate resolved file content cache after applying decisions so subsequent
-    // diff operations read the latest disk state (avoids "stuck" decisions in instant-apply flows).
-    try {
-      for (const d of validatedRequest.decisions) {
-        getContentResolver().invalidateFile(d.filePath);
-      }
-    } catch (error) {
-      logger.debug('applyDecisions cache invalidation failed:', error);
-    }
-
-    return result;
-  });
-}
-
-async function assertCurrentReviewDecisionRevision(
-  teamName: string,
-  persistenceScope: ReviewDecisionPersistenceScope,
-  expectedRevision: number
-): Promise<void> {
-  const current = await reviewDecisionStore.load(
-    teamName,
-    persistenceScope.scopeKey,
-    persistenceScope.scopeToken
+  return wrapReviewHandler('applyDecisions', () =>
+    reviewDecisionCommandFeature.applyDecisions(request)
   );
-  if ((current?.revision ?? 0) !== expectedRevision) {
-    throw new Error('Review decisions changed; refusing stale state overwrite');
-  }
-}
-
-function assertExactApplyReviewHistoryTransition(
-  state: ReviewPersistedStateSnapshot,
-  current: Awaited<ReturnType<ReviewDecisionStore['load']>>,
-  decisions: readonly (FileReviewDecision & { reviewKey: string })[],
-  authorization: ReviewPathAuthorization
-): void {
-  const previousActions = current?.reviewActionHistory ?? [];
-  const nextActions = state.reviewActionHistory ?? [];
-  const action = nextActions.at(-1);
-  const currentRedo = current?.reviewRedoHistory ?? [];
-  const knownIds = new Set([
-    ...previousActions.map((entry) => entry.id),
-    ...currentRedo.map((entry) => entry.action.id),
-  ]);
-  if (
-    !action ||
-    action.kind === 'hunk' ||
-    knownIds.has(action.id) ||
-    nextActions.length !== previousActions.length + 1 ||
-    !isDurableReviewEqual(nextActions.slice(0, -1), previousActions) ||
-    (state.reviewRedoHistory?.length ?? 0) !== 0
-  ) {
-    throw new Error('Durable Reject requires exactly one new disk history action');
-  }
-
-  const filesByPath = new Map(
-    decisions.map((decision) => {
-      const file = getAuthoritativeReviewedFile(authorization, decision.filePath);
-      const canonicalKey = file.changeKey ?? file.filePath;
-      if (decision.reviewKey !== canonicalKey) {
-        throw new Error('Durable reviewKey does not match the authoritative review identity');
-      }
-      return [normalizeReviewPathForIdentity(file.filePath), file] as const;
-    })
-  );
-  const actionPaths = getReviewActionDiskSnapshots(action).map((snapshot) =>
-    normalizeReviewPathForIdentity(snapshot.filePath)
-  );
-  if (
-    actionPaths.length !== filesByPath.size ||
-    new Set(actionPaths).size !== actionPaths.length ||
-    actionPaths.some((filePath) => !filesByPath.has(filePath))
-  ) {
-    throw new Error('Durable Reject history does not match the requested files');
-  }
-  if ((decisions.length === 1) !== (action.kind === 'disk')) {
-    throw new Error('Durable Reject history action kind does not match the decision batch');
-  }
-  if (action.descriptor) {
-    const descriptor = action.descriptor;
-    let descriptorMatches = false;
-    if (action.kind === 'bulk') {
-      descriptorMatches =
-        descriptor.intent === 'reject-all' && descriptor.fileCount === filesByPath.size;
-    } else if (action.action.originalIndex !== undefined) {
-      descriptorMatches =
-        descriptor.intent === 'reject-hunk' &&
-        descriptor.hunkIndex === action.action.originalIndex &&
-        normalizeReviewPathForIdentity(descriptor.filePath) ===
-          normalizeReviewPathForIdentity(action.action.snapshot.filePath);
-    } else {
-      descriptorMatches =
-        descriptor.intent === 'reject-file' &&
-        normalizeReviewPathForIdentity(descriptor.filePath) ===
-          normalizeReviewPathForIdentity(action.action.snapshot.filePath);
-    }
-    if (!descriptorMatches) {
-      throw new Error('Durable Reject history descriptor does not match the decision transition');
-    }
-  }
-
-  const currentDecisions = {
-    hunkDecisions: current?.hunkDecisions ?? {},
-    fileDecisions: current?.fileDecisions ?? {},
-  };
-  const allowedFileKeys = new Set(decisions.map((decision) => decision.reviewKey));
-  const allowedHunkKeys = new Set<string>();
-  for (const decision of decisions) {
-    for (const index of Object.keys(decision.hunkDecisions)) {
-      allowedHunkKeys.add(`${decision.reviewKey}:${index}`);
-    }
-  }
-  const changedKeys = (
-    previous: Record<string, HunkDecision>,
-    next: Record<string, HunkDecision>,
-    allowed: ReadonlySet<string>
-  ): string[] => {
-    const changed = [...new Set([...Object.keys(previous), ...Object.keys(next)])].filter(
-      (key) => previous[key] !== next[key]
-    );
-    if (changed.some((key) => !allowed.has(key))) {
-      throw new Error('Durable Reject state changes decisions outside the requested files');
-    }
-    return changed;
-  };
-  const changedHunks = changedKeys(
-    currentDecisions.hunkDecisions,
-    state.hunkDecisions,
-    allowedHunkKeys
-  );
-  const changedFiles = changedKeys(
-    currentDecisions.fileDecisions,
-    state.fileDecisions,
-    allowedFileKeys
-  );
-  if (changedHunks.length + changedFiles.length === 0) {
-    throw new Error('Durable Reject history has no matching decision transition');
-  }
-
-  if (action.kind === 'bulk') {
-    if (
-      !isDurableReviewEqual(action.decisionSnapshot, currentDecisions) ||
-      decisions.some((decision) => decision.fileDecision !== 'rejected')
-    ) {
-      throw new Error('Durable bulk Reject history has invalid decision metadata');
-    }
-    return;
-  }
-
-  const decision = decisions[0];
-  if (!decision) throw new Error('Durable Reject decision is unavailable');
-  const originalIndex = action.action.originalIndex;
-  if (originalIndex !== undefined) {
-    const decisionKey = `${decision.reviewKey}:${originalIndex}`;
-    if (
-      changedHunks.length !== 1 ||
-      changedHunks[0] !== decisionKey ||
-      changedFiles.length !== 0 ||
-      decision.fileDecision !== 'pending' ||
-      decision.hunkDecisions[originalIndex] !== 'rejected' ||
-      state.hunkDecisions[decisionKey] !== 'rejected'
-    ) {
-      throw new Error('Durable hunk Reject history index does not match the decision transition');
-    }
-    return;
-  }
-
-  if (
-    decision.fileDecision !== 'rejected' ||
-    !isDurableReviewEqual(action.action.decisionSnapshot, currentDecisions)
-  ) {
-    throw new Error('Durable file Reject history has invalid decision metadata');
-  }
 }
 
 function parseReviewScopeKey(teamName: string, scopeKey: string): ReviewFileScope {
@@ -1154,7 +768,14 @@ const reviewMutationRecoveryFeature = createReviewMutationRecoveryFeature({
   decisions: {
     withLock: withReviewDecisionPersistenceLock,
     assertValidSnapshot: (value) => reviewDecisionStore.assertValidSnapshot(value),
-    assertCurrentRevision: assertCurrentReviewDecisionRevision,
+    assertCurrentRevision: async (teamName, persistenceScope, expectedRevision) => {
+      const current = await reviewDecisionStore.load(
+        teamName,
+        persistenceScope.scopeKey,
+        persistenceScope.scopeToken
+      );
+      assertCurrentReviewDecisionRevision(current, expectedRevision);
+    },
     load: (teamName, persistenceScope) =>
       reviewDecisionStore.load(teamName, persistenceScope.scopeKey, persistenceScope.scopeToken),
     commit: (record) => reviewDecisionBatchFeature.commit(record),
@@ -1197,6 +818,57 @@ const reviewMutationRecoveryFeature = createReviewMutationRecoveryFeature({
   },
 });
 
+const reviewDecisionCommandFeature = createReviewDecisionCommandFeature({
+  scope: {
+    resolve: resolveReviewPathAuthorization,
+    parsePersistenceScope: parseDecisionPersistenceScope,
+    validateFilePath: validateAuthorizedReviewFilePath,
+    validateSnippets: validateSnippetPaths,
+    assertDecisionShape: assertReviewDecisionShape,
+    assertSnippetShapes,
+    getAuthoritativeFile: getAuthoritativeReviewedFile,
+    resolveAuthoritativeContent: resolveAuthoritativeFileContent,
+    normalizeIdentityPath: normalizeReviewPathForIdentity,
+  },
+  applier: {
+    checkConflict: (...args) => getApplier().checkConflict(...args),
+    rejectHunks: (...args) => getApplier().rejectHunks(...args),
+    rejectFile: (...args) => getApplier().rejectFile(...args),
+    previewReject: (...args) => getApplier().previewReject(...args),
+    applyReviewDecisions: (...args) => getApplier().applyReviewDecisions(...args),
+  },
+  persistence: {
+    withLock: withReviewDecisionPersistenceLock,
+    assertValidSnapshot: (value) => reviewDecisionStore.assertValidSnapshot(value),
+    load: (teamName, persistenceScope) =>
+      reviewDecisionStore.load(teamName, persistenceScope.scopeKey, persistenceScope.scopeToken),
+  },
+  batch: {
+    assertPersistedStateIncludesDecisions: (state, decisions) =>
+      reviewDecisionBatchFeature.assertPersistedStateIncludesDecisions(state, decisions),
+    applyDisk: (record, onResult, onPostimages) =>
+      reviewDecisionBatchFeature.applyDisk(record, onResult, onPostimages),
+    commit: (record) => reviewDecisionBatchFeature.commit(record),
+  },
+  history: {
+    bindNewHistorySnapshots: (state, current, scope, authorization) =>
+      reviewHistoryMutationFeature.bindNewHistorySnapshots(state, current, scope, authorization),
+  },
+  recovery: {
+    recoverPending: (teamName, persistenceScope) =>
+      reviewMutationRecoveryFeature.recoverPending(teamName, persistenceScope),
+  },
+  coordinator: {
+    execute: (input, steps) => reviewMutationCoordinator.execute(input, steps),
+  },
+  cache: {
+    invalidateFile: (filePath) => getContentResolver().invalidateFile(filePath),
+  },
+  logger: {
+    debug: (message, error) => logger.debug(message, error),
+  },
+});
+
 const reviewDecisionHistoryFeature = createReviewDecisionHistoryFeature({
   lock: { run: withReviewDecisionPersistenceLock },
   authorization: { authorize: authorizeReviewDecisionHistoryScope },
@@ -1230,89 +902,6 @@ const reviewDraftHistoryFeature = createReviewDraftHistoryFeature({
   lock: { run: withReviewDecisionPersistenceLock },
   authorization: { authorize: authorizeReviewDraftHistoryScope },
 });
-
-async function applyDecisionsWithDurableJournal(
-  scope: ReviewFileScope,
-  authorization: ReviewPathAuthorization,
-  persistenceScope: ReviewDecisionPersistenceScope,
-  decisions: (FileReviewDecision & { reviewKey: string })[],
-  fileContents: Map<string, FileChangeWithContent>,
-  persistedState: ReviewPersistedStateSnapshot,
-  expectedDecisionRevision: number
-): Promise<ApplyReviewResult> {
-  return withReviewDecisionPersistenceLock(scope.teamName, persistenceScope, async () => {
-    const diskPostimages = new Map<string, ReviewMutationDiskPostimage>();
-    try {
-      await reviewMutationRecoveryFeature.recoverPending(scope.teamName, persistenceScope);
-      await assertCurrentReviewDecisionRevision(
-        scope.teamName,
-        persistenceScope,
-        expectedDecisionRevision
-      );
-      const current = await reviewDecisionStore.load(
-        scope.teamName,
-        persistenceScope.scopeKey,
-        persistenceScope.scopeToken
-      );
-      assertExactApplyReviewHistoryTransition(persistedState, current, decisions, authorization);
-      const boundPersistedState = await reviewHistoryMutationFeature.bindNewHistorySnapshots(
-        persistedState,
-        current,
-        scope,
-        authorization
-      );
-      let result: ApplyReviewResult | null = null;
-      await reviewMutationCoordinator.execute(
-        {
-          teamName: scope.teamName,
-          persistenceScope,
-          reviewScope: scope,
-          kind: decisions.length > 1 ? 'bulk' : 'reject',
-          decisions,
-          fileContents: decisions.map((decision) => {
-            const content = fileContents.get(decision.filePath);
-            if (!content) throw new Error('Review mutation content is unavailable');
-            return content;
-          }),
-          persistedState: boundPersistedState,
-          expectedDecisionRevision,
-        },
-        {
-          applyDisk: (record) =>
-            reviewDecisionBatchFeature.applyDisk(
-              record,
-              (nextResult) => {
-                result = nextResult;
-              },
-              (postimages) =>
-                mergeReviewMutationDiskPostimages(
-                  diskPostimages,
-                  postimages,
-                  normalizeReviewPathForIdentity
-                )
-            ),
-          commitDecisions: (record) => reviewDecisionBatchFeature.commit(record),
-        }
-      );
-      const committed = await reviewDecisionStore.load(
-        scope.teamName,
-        persistenceScope.scopeKey,
-        persistenceScope.scopeToken
-      );
-      return {
-        ...(result ?? { applied: 0, skipped: 0, conflicts: 0, errors: [] }),
-        decisionRevision: committed?.revision ?? expectedDecisionRevision,
-        committedReviewAction: committed?.reviewActionHistory.at(-1),
-        diskPostimages: [...diskPostimages.values()],
-      };
-    } catch (error) {
-      if (error instanceof ReviewMutationApplyResultError) {
-        return { ...error.result, diskPostimages: [...diskPostimages.values()] };
-      }
-      throw error;
-    }
-  });
-}
 
 async function handleGetFileContent(
   _event: IpcMainInvokeEvent,

--- a/test/architecture/hosted-web/phase-3/review-decision-command-boundaries.test.ts
+++ b/test/architecture/hosted-web/phase-3/review-decision-command-boundaries.test.ts
@@ -1,0 +1,63 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '../../../..');
+
+function readSource(relativePath: string): string {
+  // Paths are fixed repository-owned test fixtures.
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  return readFileSync(resolve(ROOT, relativePath), 'utf8');
+}
+
+describe('review decision command architecture boundary', () => {
+  it('keeps durable Reject and CAS policy free of runtime dependencies', () => {
+    const source = readSource(
+      'src/features/review-mutations/core/domain/reviewDecisionCommandPolicy.ts'
+    );
+    const imports = [...source.matchAll(/from\s+['"]([^'"]+)['"]/g)].map((match) => match[1]);
+
+    expect(
+      imports.some(
+        (specifier) =>
+          specifier === 'electron' ||
+          specifier.startsWith('node:') ||
+          specifier.startsWith('@main/')
+      )
+    ).toBe(false);
+    expect(source).not.toMatch(/\b(readFile|writeFile|ipcMain|ReviewDecisionStore)\b/);
+  });
+
+  it('owns orchestration behind focused ports and isolates Node snapshot identity', () => {
+    const application = readSource(
+      'src/features/review-mutations/main/application/ReviewDecisionCommandApplication.ts'
+    );
+    const ports = readSource(
+      'src/features/review-mutations/main/application/ReviewDecisionCommandPorts.ts'
+    );
+    const infrastructure = readSource(
+      'src/features/review-mutations/main/infrastructure/nodeReviewDecisionCommandSnapshotIdentity.ts'
+    );
+
+    expect(application).not.toMatch(/from\s+['"](?:electron|node:|fs|@main\/)/);
+    expect(application).not.toContain('ipcMain');
+    expect(application).not.toContain("from './ReviewDecisionBatchApplication'");
+    expect(ports).toContain('export interface ReviewDecisionCommandScopePort');
+    expect(ports).toContain('export interface ReviewDecisionCommandPersistencePort');
+    expect(ports).toContain('export interface ReviewDecisionCommandCoordinatorPort');
+    expect(infrastructure).toContain("from 'node:crypto'");
+  });
+
+  it('leaves review IPC as exact registration, transport validation, and delegation', () => {
+    const shell = readSource('src/main/ipc/review.ts');
+
+    expect(shell).toContain('createReviewDecisionCommandFeature({');
+    expect(shell).toContain('reviewDecisionCommandFeature.applyDecisions(request)');
+    expect(shell).toContain('ipcMain.handle(REVIEW_APPLY_DECISIONS, handleApplyDecisions)');
+    expect(shell).toContain('ipcMain.removeHandler(REVIEW_APPLY_DECISIONS)');
+    expect(shell).not.toContain('function applyDecisionsWithDurableJournal');
+    expect(shell).not.toContain('function assertExactApplyReviewHistoryTransition');
+    expect(shell).not.toContain('const displayedReviewSnapshots = new Map');
+  });
+});

--- a/test/architecture/hosted-web/phase-3/review-query-boundaries.test.ts
+++ b/test/architecture/hosted-web/phase-3/review-query-boundaries.test.ts
@@ -1,0 +1,63 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '../../../..');
+
+function readSource(relativePath: string): string {
+  // Paths are fixed repository-owned test fixtures.
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  return readFileSync(resolve(ROOT, relativePath), 'utf8');
+}
+
+describe('review query architecture boundary', () => {
+  it('keeps renderer query sanitization in a pure domain policy', () => {
+    const policy = readSource('src/features/change-review/core/domain/reviewQueryPolicy.ts');
+    const imports = [...policy.matchAll(/from\s+['"]([^'"]+)['"]/g)].map((match) => match[1]);
+
+    expect(
+      imports.some(
+        (specifier) =>
+          specifier === 'electron' ||
+          specifier.startsWith('node:') ||
+          specifier.startsWith('@main/')
+      )
+    ).toBe(false);
+    expect(policy).not.toMatch(/\b(ipcMain|readFile|writeFile)\b/);
+  });
+
+  it('owns query orchestration behind focused application ports', () => {
+    const application = readSource(
+      'src/features/change-review/main/application/ReviewQueryApplication.ts'
+    );
+    const ports = readSource('src/features/change-review/main/application/ReviewQueryPorts.ts');
+    const composition = readSource(
+      'src/features/change-review/main/composition/createReviewQueryFeature.ts'
+    );
+
+    expect(application).not.toMatch(/from\s+['"](?:electron|node:|fs|@main\/)/);
+    expect(application).not.toContain('ipcMain');
+    expect(ports).toContain('export interface ReviewQueryChangesPort');
+    expect(ports).toContain('export interface ReviewQueryScopePort');
+    expect(ports).toContain('export interface ReviewQueryGitHistoryPort');
+    expect(composition).toContain('return new ReviewQueryApplication(dependencies)');
+  });
+
+  it('leaves review IPC as exact registration, transport policy, and delegation', () => {
+    const shell = readSource('src/main/ipc/review.ts');
+
+    expect(shell).toContain('createReviewQueryFeature({');
+    expect(shell).toContain('reviewQueryFeature.getTaskChanges(teamName, taskId, opts)');
+    expect(shell).toContain(
+      'reviewQueryFeature.getTeamTaskChangeSummaries(teamName, sanitizedRequests)'
+    );
+    expect(shell).toContain('reviewQueryFeature.getFileContent(');
+    expect(shell).toContain('reviewQueryFeature.getGitFileLog(projectPath, filePath)');
+    expect(shell).toContain('ipcMain.handle(REVIEW_GET_FILE_CONTENT, handleGetFileContent)');
+    expect(shell).toContain('ipcMain.removeHandler(REVIEW_GET_FILE_CONTENT)');
+    expect(shell).not.toContain('function sanitizeTaskChangeOptions');
+    expect(shell).not.toContain('function sanitizeTeamTaskChangeSummaryRequests');
+    expect(shell).not.toContain('function registerDisplayedReviewSnapshot');
+  });
+});

--- a/test/architecture/hosted-web/phase-3/review-scope-authorization-boundaries.test.ts
+++ b/test/architecture/hosted-web/phase-3/review-scope-authorization-boundaries.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '../../../..');
+
+function readSource(relativePath: string): string {
+  // Paths are fixed repository-owned test fixtures.
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  return readFileSync(resolve(ROOT, relativePath), 'utf8');
+}
+
+describe('review scope authorization architecture boundary', () => {
+  it('keeps review scope and transport-shape policy free of runtime dependencies', () => {
+    const source = readSource('src/features/change-review/core/domain/reviewScopePolicy.ts');
+    const imports = [...source.matchAll(/from\s+['"]([^'"]+)['"]/g)].map((match) => match[1]);
+
+    expect(
+      imports.some(
+        (specifier) =>
+          specifier === 'electron' ||
+          specifier.startsWith('node:') ||
+          specifier.startsWith('@main/')
+      )
+    ).toBe(false);
+    expect(source).not.toMatch(/\b(fs|ipcMain|process|ReviewDecisionStore)\b/);
+  });
+
+  it('isolates Node filesystem and path security behind feature-owned ports', () => {
+    const application = readSource(
+      'src/features/change-review/main/application/ReviewScopeAuthorizationApplication.ts'
+    );
+    const ports = readSource(
+      'src/features/change-review/main/application/ReviewScopeAuthorizationPorts.ts'
+    );
+    const infrastructure = readSource(
+      'src/features/change-review/main/infrastructure/nodeReviewScopeAuthorization.ts'
+    );
+
+    expect(application).not.toMatch(/from\s+['"](?:node:|fs|path|@main\/)/);
+    expect(ports).toContain('export interface ReviewScopePathPort');
+    expect(ports).toContain('export interface ReviewScopeFileSystemPort');
+    expect(ports).toContain('export interface ReviewScopeChangesPort');
+    expect(infrastructure).toContain('isOwnedReviewFileTransactionHardlink');
+    expect(infrastructure).toContain('matchesSensitivePattern');
+  });
+
+  it('leaves the IPC shell as composition without legacy path-security implementations', () => {
+    const shell = readSource('src/main/ipc/review.ts');
+
+    expect(shell).toContain('createReviewScopeAuthorizationFeature({');
+    expect(shell).toContain('reviewScopeAuthorizationFeature.validateAuthorizedReviewFilePath(');
+    expect(shell).toContain('reviewScopeAuthorizationFeature.resolveReviewPathAuthorization(');
+    expect(shell).not.toContain('function resolveAuthorizedReviewRoot');
+    expect(shell).not.toContain('function resolveNearestExistingRealPath');
+    expect(shell).not.toContain('function collectAuthoritativeReviewedFiles');
+  });
+});

--- a/test/features/change-review/core/reviewQueryPolicy.test.ts
+++ b/test/features/change-review/core/reviewQueryPolicy.test.ts
@@ -1,0 +1,93 @@
+import {
+  sanitizeTaskChangeOptions,
+  sanitizeTeamTaskChangeSummaryRequests,
+} from '@features/change-review/main';
+import { describe, expect, it } from 'vitest';
+
+describe('review query policy', () => {
+  it('rejects malformed task options without inventing defaults', () => {
+    expect(sanitizeTaskChangeOptions()).toBeUndefined();
+    expect(sanitizeTaskChangeOptions(null)).toBeUndefined();
+    expect(sanitizeTaskChangeOptions('owner')).toBeUndefined();
+  });
+
+  it('keeps only supported task option fields and valid intervals', () => {
+    expect(
+      sanitizeTaskChangeOptions({
+        owner: 'worker',
+        status: 'completed',
+        since: '2026-07-24T10:00:00.000Z',
+        intervals: [
+          { startedAt: '2026-07-24T10:00:00.000Z' },
+          {
+            startedAt: '2026-07-24T11:00:00.000Z',
+            completedAt: '2026-07-24T12:00:00.000Z',
+          },
+          { startedAt: 123 },
+          { startedAt: 'valid', completedAt: false },
+          null,
+        ],
+        stateBucket: 'approved',
+        summaryOnly: true,
+        forceFresh: 'yes',
+        ignored: 'value',
+      })
+    ).toEqual({
+      owner: 'worker',
+      status: 'completed',
+      since: '2026-07-24T10:00:00.000Z',
+      intervals: [
+        { startedAt: '2026-07-24T10:00:00.000Z' },
+        {
+          startedAt: '2026-07-24T11:00:00.000Z',
+          completedAt: '2026-07-24T12:00:00.000Z',
+        },
+      ],
+      stateBucket: 'approved',
+      summaryOnly: true,
+      forceFresh: false,
+    });
+  });
+
+  it('trims, de-duplicates, and bounds team summary requests exactly', () => {
+    const requests = [
+      null,
+      { taskId: 42 },
+      { taskId: '   ' },
+      { taskId: ' task-1 ', options: { summaryOnly: true } },
+      { taskId: 'task-1', options: { forceFresh: true } },
+      ...Array.from({ length: 205 }, (_, index) => ({
+        taskId: `task-${index + 2}`,
+      })),
+    ];
+
+    const sanitized = sanitizeTeamTaskChangeSummaryRequests(requests);
+
+    expect(sanitized).toHaveLength(201);
+    expect(sanitized[0]).toEqual({
+      taskId: 'task-1',
+      options: {
+        owner: undefined,
+        status: undefined,
+        since: undefined,
+        intervals: undefined,
+        stateBucket: undefined,
+        summaryOnly: true,
+        forceFresh: false,
+      },
+    });
+    expect(sanitized.at(-1)).toEqual({
+      taskId: 'task-201',
+      options: undefined,
+    });
+  });
+
+  it('inspects no more than the first 1,000 raw summary requests', () => {
+    const requests = [
+      ...Array.from({ length: 1_000 }, () => null),
+      { taskId: 'outside-raw-limit' },
+    ];
+
+    expect(sanitizeTeamTaskChangeSummaryRequests(requests)).toEqual([]);
+  });
+});

--- a/test/features/change-review/core/reviewScopePolicy.test.ts
+++ b/test/features/change-review/core/reviewScopePolicy.test.ts
@@ -1,0 +1,95 @@
+import {
+  assertExpectedAuthoritativeRename,
+  assertHunkIndices,
+  assertSnippetShapes,
+  parseReviewFileScope,
+  parseReviewRenameRecoveryExpectation,
+} from '@features/change-review/core/domain/reviewScopePolicy';
+import { describe, expect, it } from 'vitest';
+
+import type { FileChangeWithContent, SnippetDiff } from '@shared/types/review';
+
+const validators = {
+  validateTeamName: (value: unknown) =>
+    value === 'safe-team'
+      ? { valid: true, value: 'safe-team' }
+      : { valid: false, error: 'Invalid teamName' },
+  validateTaskId: (value: unknown) =>
+    value === 'task-1'
+      ? { valid: true, value: 'task-1' }
+      : { valid: false, error: 'Invalid taskId' },
+};
+
+function createRenameSnippet(): SnippetDiff {
+  return {
+    toolUseId: 'rename-1',
+    filePath: '/sandbox/new.ts',
+    toolName: 'Bash',
+    type: 'shell-snapshot',
+    oldString: 'before\n',
+    newString: 'after\n',
+    replaceAll: false,
+    timestamp: '2026-07-24T00:00:00.000Z',
+    isError: false,
+    ledger: {
+      eventId: 'event-1',
+      source: 'ledger-exact',
+      confidence: 'exact',
+      originalFullContent: 'before\n',
+      modifiedFullContent: 'after\n',
+      beforeHash: 'before-hash',
+      afterHash: 'after-hash',
+      relation: { kind: 'rename', oldPath: '/sandbox/old.ts', newPath: '/sandbox/new.ts' },
+    },
+  };
+}
+
+describe('review scope policy', () => {
+  it('normalizes a valid task scope through injected identity validators', () => {
+    expect(
+      parseReviewFileScope(
+        { teamName: 'safe-team', taskId: ' task-1 ', memberName: ' worker ' },
+        validators
+      )
+    ).toEqual({ teamName: 'safe-team', taskId: 'task-1', memberName: 'worker' });
+  });
+
+  it('preserves task validation errors and rejects malformed hunk indices', () => {
+    expect(() =>
+      parseReviewFileScope({ teamName: 'safe-team', taskId: 'forged' }, validators)
+    ).toThrow('Invalid taskId');
+    expect(() => assertHunkIndices([0, -1])).toThrow('Invalid hunkIndices');
+  });
+
+  it('validates rename recovery metadata and rejects stale authoritative evidence', () => {
+    const snippet = createRenameSnippet();
+    const content: FileChangeWithContent = {
+      filePath: snippet.filePath,
+      relativePath: 'new.ts',
+      snippets: [snippet],
+      linesAdded: 1,
+      linesRemoved: 1,
+      isNewFile: false,
+      originalFullContent: 'before\n',
+      modifiedFullContent: 'after\n',
+      contentSource: 'ledger-exact',
+    };
+    const expectation = parseReviewRenameRecoveryExpectation({
+      eventId: 'event-1',
+      beforeHash: 'before-hash',
+      afterHash: 'after-hash',
+      relation: snippet.ledger?.relation,
+    });
+
+    expect(() => assertExpectedAuthoritativeRename(content, expectation)).not.toThrow();
+    expect(() =>
+      assertExpectedAuthoritativeRename(content, { ...expectation, eventId: 'stale-event' })
+    ).toThrow('Review changes were updated; refusing stale rename recovery');
+  });
+
+  it('rejects renderer snippets with incomplete transport shapes', () => {
+    expect(() => assertSnippetShapes([{ filePath: '/sandbox/file.ts' }])).toThrow(
+      'Invalid review snippet toolUseId'
+    );
+  });
+});

--- a/test/features/change-review/main/ReviewQueryApplication.test.ts
+++ b/test/features/change-review/main/ReviewQueryApplication.test.ts
@@ -1,0 +1,236 @@
+import {
+  createReviewQueryFeature,
+  type ReviewQueryDependencies,
+} from '@features/change-review/main';
+import { describe, expect, it, vi } from 'vitest';
+
+import type {
+  AgentChangeSet,
+  FileChangeWithContent,
+  SnippetDiff,
+  TaskChangeSetV2,
+  TeamTaskChangeSummariesResponse,
+} from '@shared/types/review';
+
+const PROJECT_PATH = '/review-query-safe-root';
+const REVIEWED_FILE_PATH = `${PROJECT_PATH}/query-reviewed.ts`;
+const GIT_FILE_PATH = `${PROJECT_PATH}/file.ts`;
+
+function createDependencies() {
+  const agentChanges = { kind: 'agent-changes' } as unknown as AgentChangeSet;
+  const taskChanges = { kind: 'task-changes' } as unknown as TaskChangeSetV2;
+  const summaries = {
+    kind: 'team-task-change-summaries',
+  } as unknown as TeamTaskChangeSummariesResponse;
+  const stats = { linesAdded: 3, linesRemoved: 2, filesChanged: 1 };
+  const content = {
+    filePath: REVIEWED_FILE_PATH,
+    relativePath: 'query-reviewed.ts',
+    snippets: [],
+    linesAdded: 1,
+    linesRemoved: 1,
+    isNewFile: false,
+    originalFullContent: 'before\n',
+    modifiedFullContent: 'after\n',
+    contentSource: 'ledger-exact',
+  } satisfies FileChangeWithContent;
+  const displayedContent = {
+    ...content,
+    reviewSnapshotToken: 'snapshot-token',
+  } satisfies FileChangeWithContent;
+  const authorization = {
+    roots: [],
+    reviewedFiles: null,
+    resolutionMemberName: 'worker',
+  };
+
+  const dependencies = {
+    changes: {
+      getAgentChanges: vi.fn(() => Promise.resolve(agentChanges)),
+      getTaskChanges: vi.fn(() => Promise.resolve(taskChanges)),
+      getTeamTaskChangeSummaries: vi.fn(() => Promise.resolve(summaries)),
+      invalidateTaskChangeSummaries: vi.fn(() => Promise.resolve()),
+      getChangeStats: vi.fn(() => Promise.resolve(stats)),
+    },
+    scope: {
+      normalizeIdentity: vi.fn((value: string | undefined) => value?.trim()),
+      resolve: vi.fn(() =>
+        Promise.resolve({
+          scope: { teamName: 'safe-team', memberName: 'worker' },
+          authorization,
+        })
+      ),
+      validateFilePath: vi.fn(() => Promise.resolve(REVIEWED_FILE_PATH)),
+      validateSnippets: vi.fn(() => Promise.resolve()),
+    },
+    content: {
+      getFileContent: vi.fn(() => Promise.resolve(content)),
+    },
+    snapshots: {
+      register: vi.fn(() => displayedContent),
+    },
+    gitHistory: {
+      getFileLog: vi.fn(() =>
+        Promise.resolve([
+          { hash: 'abc123', timestamp: '2026-07-24T10:00:00.000Z', message: 'query' },
+        ])
+      ),
+    },
+  } satisfies ReviewQueryDependencies;
+
+  return {
+    dependencies,
+    agentChanges,
+    taskChanges,
+    summaries,
+    stats,
+    content,
+    displayedContent,
+    authorization,
+  };
+}
+
+describe('ReviewQueryApplication', () => {
+  it('delegates change and history queries without altering valid input', async () => {
+    const harness = createDependencies();
+    const feature = createReviewQueryFeature(harness.dependencies);
+    const options = { owner: 'worker', summaryOnly: true };
+    const requests = [{ taskId: 'task-1', options }];
+
+    await expect(feature.getAgentChanges('safe-team', 'worker')).resolves.toBe(
+      harness.agentChanges
+    );
+    await expect(feature.getTaskChanges('safe-team', 'task-1', options)).resolves.toBe(
+      harness.taskChanges
+    );
+    await expect(feature.getTeamTaskChangeSummaries('safe-team', requests)).resolves.toBe(
+      harness.summaries
+    );
+    await expect(feature.getChangeStats('safe-team', 'worker')).resolves.toBe(harness.stats);
+    await expect(feature.getGitFileLog(PROJECT_PATH, GIT_FILE_PATH)).resolves.toEqual([
+      { hash: 'abc123', timestamp: '2026-07-24T10:00:00.000Z', message: 'query' },
+    ]);
+
+    expect(harness.dependencies.changes.getAgentChanges).toHaveBeenCalledWith(
+      'safe-team',
+      'worker'
+    );
+    expect(harness.dependencies.changes.getTaskChanges).toHaveBeenCalledWith(
+      'safe-team',
+      'task-1',
+      options
+    );
+    expect(harness.dependencies.changes.getTeamTaskChangeSummaries).toHaveBeenCalledWith(
+      'safe-team',
+      requests
+    );
+    expect(harness.dependencies.changes.getChangeStats).toHaveBeenCalledWith('safe-team', 'worker');
+    expect(harness.dependencies.gitHistory.getFileLog).toHaveBeenCalledWith(
+      PROJECT_PATH,
+      GIT_FILE_PATH
+    );
+  });
+
+  it('preserves the existing string-only invalidation filter', async () => {
+    const harness = createDependencies();
+    const feature = createReviewQueryFeature(harness.dependencies);
+
+    await feature.invalidateTaskChangeSummaries('safe-team', [
+      'task-1',
+      17,
+      '',
+      'task-1',
+    ] as unknown as string[]);
+    await feature.invalidateTaskChangeSummaries('safe-team', null as unknown as string[]);
+
+    expect(harness.dependencies.changes.invalidateTaskChangeSummaries).toHaveBeenNthCalledWith(
+      1,
+      'safe-team',
+      ['task-1', '', 'task-1']
+    );
+    expect(harness.dependencies.changes.invalidateTaskChangeSummaries).toHaveBeenNthCalledWith(
+      2,
+      'safe-team',
+      []
+    );
+  });
+
+  it('authorizes, reads, and snapshot-binds file content in the original order', async () => {
+    const harness = createDependencies();
+    const events: string[] = [];
+    const snippets: SnippetDiff[] = [];
+    harness.dependencies.scope.normalizeIdentity.mockImplementation((value) => {
+      events.push('normalize');
+      return value?.trim();
+    });
+    harness.dependencies.scope.resolve.mockImplementation(() => {
+      events.push('resolve');
+      return Promise.resolve({
+        scope: { teamName: 'safe-team', memberName: 'worker' },
+        authorization: harness.authorization,
+      });
+    });
+    harness.dependencies.scope.validateFilePath.mockImplementation(() => {
+      events.push('validate-file');
+      return Promise.resolve(REVIEWED_FILE_PATH);
+    });
+    harness.dependencies.scope.validateSnippets.mockImplementation(() => {
+      events.push('validate-snippets');
+      return Promise.resolve();
+    });
+    harness.dependencies.content.getFileContent.mockImplementation(() => {
+      events.push('read-content');
+      return Promise.resolve(harness.content);
+    });
+    harness.dependencies.snapshots.register.mockImplementation(() => {
+      events.push('bind-snapshot');
+      return harness.displayedContent;
+    });
+    const feature = createReviewQueryFeature(harness.dependencies);
+
+    await expect(
+      feature.getFileContent('renderer-team', ' worker ', '/renderer/file.ts', snippets)
+    ).resolves.toBe(harness.displayedContent);
+
+    expect(events).toEqual([
+      'normalize',
+      'resolve',
+      'validate-file',
+      'validate-snippets',
+      'read-content',
+      'bind-snapshot',
+    ]);
+    expect(harness.dependencies.scope.resolve).toHaveBeenCalledWith({
+      teamName: 'renderer-team',
+      memberName: 'worker',
+    });
+    expect(harness.dependencies.scope.validateFilePath).toHaveBeenCalledWith(
+      harness.authorization,
+      '/renderer/file.ts',
+      { requireReviewedFile: false }
+    );
+    expect(harness.dependencies.content.getFileContent).toHaveBeenCalledWith(
+      'safe-team',
+      'worker',
+      REVIEWED_FILE_PATH,
+      snippets
+    );
+    expect(harness.dependencies.snapshots.register).toHaveBeenCalledWith(
+      'safe-team',
+      REVIEWED_FILE_PATH,
+      snippets,
+      harness.content
+    );
+  });
+
+  it('keeps member validation ahead of snippet validation and all dependencies', async () => {
+    const harness = createDependencies();
+    const feature = createReviewQueryFeature(harness.dependencies);
+
+    await expect(
+      feature.getFileContent('safe-team', 42, REVIEWED_FILE_PATH, 'bad')
+    ).rejects.toThrow('Invalid memberName');
+    expect(harness.dependencies.scope.normalizeIdentity).not.toHaveBeenCalled();
+    expect(harness.dependencies.scope.resolve).not.toHaveBeenCalled();
+  });
+});

--- a/test/features/change-review/main/ReviewScopeAuthorizationApplication.test.ts
+++ b/test/features/change-review/main/ReviewScopeAuthorizationApplication.test.ts
@@ -1,0 +1,174 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+
+import { createReviewScopeAuthorizationFeature } from '@features/change-review/main';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { FileChangeSummary, FileChangeWithContent } from '@shared/types/review';
+
+const temporaryRoots: string[] = [];
+
+function createFile(filePath: string): FileChangeSummary {
+  return {
+    filePath,
+    relativePath: 'src/reviewed.ts',
+    snippets: [],
+    linesAdded: 1,
+    linesRemoved: 1,
+    isNewFile: false,
+    changeKey: 'reviewed-change',
+  };
+}
+
+function createContent(file: FileChangeSummary): FileChangeWithContent {
+  return {
+    ...file,
+    originalFullContent: 'before\n',
+    modifiedFullContent: 'after\n',
+    contentSource: 'ledger-exact',
+  };
+}
+
+function createHarness(root: string, files: FileChangeSummary[]) {
+  const getFileContent = vi.fn((_team, _member, filePath: string) => {
+    const file = files.find((candidate) => candidate.filePath === filePath);
+    if (!file) throw new Error('Missing test file');
+    return Promise.resolve(createContent(file));
+  });
+  return {
+    feature: createReviewScopeAuthorizationFeature({
+      validators: {
+        validateTeamName: (value) =>
+          value === 'safe-team'
+            ? { valid: true, value: 'safe-team' }
+            : { valid: false, error: 'Invalid teamName' },
+        validateTaskId: (value) =>
+          value === 'task-1'
+            ? { valid: true, value: 'task-1' }
+            : { valid: false, error: 'Invalid taskId' },
+      },
+      config: {
+        getConfig: vi.fn(() => Promise.resolve({ projectPath: root, members: [{ cwd: root }] })),
+      },
+      changes: {
+        getTaskChanges: vi.fn(() =>
+          Promise.resolve({
+            files,
+            scope: { memberName: 'worker' },
+          })
+        ),
+        getAgentChanges: vi.fn(() => Promise.resolve({ files })),
+      },
+      content: {
+        getFileContent,
+        invalidateFile: vi.fn(),
+      },
+    }),
+    getFileContent,
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((root) => rm(root, { recursive: true, force: true }))
+  );
+});
+
+describe('ReviewScopeAuthorizationApplication', () => {
+  it('binds a task scope to configured roots and authoritative reviewed files', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'review-scope-'));
+    temporaryRoots.push(root);
+    const filePath = path.join(root, 'src', 'reviewed.ts');
+    // Path is derived from a fresh test-only temporary directory.
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    await mkdir(path.dirname(filePath), { recursive: true });
+    // Path is derived from a fresh test-only temporary directory.
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    await writeFile(filePath, 'current\n', { encoding: 'utf8', flag: 'w' });
+    const file = createFile(filePath);
+    const { feature, getFileContent } = createHarness(root, [file]);
+
+    const { scope, authorization } = await feature.resolveReviewPathAuthorization({
+      teamName: 'safe-team',
+      taskId: 'task-1',
+    });
+    const authorizedPath = await feature.validateAuthorizedReviewFilePath(authorization, filePath, {
+      requireReviewedFile: true,
+      rejectHardlinks: true,
+    });
+    const content = await feature.resolveAuthoritativeFileContent(
+      scope,
+      authorization,
+      authorizedPath
+    );
+
+    expect(scope).toEqual({ teamName: 'safe-team', taskId: 'task-1' });
+    expect(authorization.resolutionMemberName).toBe('worker');
+    expect(feature.getAuthoritativeReviewedFile(authorization, filePath)).toBe(file);
+    expect(content).toMatchObject({ filePath, snippets: [], contentSource: 'ledger-exact' });
+    expect(getFileContent).toHaveBeenCalledWith('safe-team', 'worker', filePath, []);
+  });
+
+  it('rejects existing files outside every authoritative project root', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'review-scope-root-'));
+    const outside = await mkdtemp(path.join(tmpdir(), 'review-scope-outside-'));
+    temporaryRoots.push(root, outside);
+    const outsideFile = path.join(outside, 'outside.ts');
+    // Path is derived from a fresh test-only temporary directory.
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    await writeFile(outsideFile, 'outside\n', 'utf8');
+    const { feature } = createHarness(root, []);
+    const { authorization } = await feature.resolveReviewPathAuthorization({
+      teamName: 'safe-team',
+      memberName: 'worker',
+    });
+
+    await expect(
+      feature.validateAuthorizedReviewFilePath(authorization, outsideFile, {
+        requireReviewedFile: false,
+      })
+    ).rejects.toThrow('Review file path is outside the authoritative project/worktree');
+  });
+
+  it('refuses a reviewed symlink even when its target remains inside the project root', async () => {
+    if (process.platform === 'win32') return;
+    const root = await mkdtemp(path.join(tmpdir(), 'review-scope-link-'));
+    temporaryRoots.push(root);
+    const targetPath = path.join(root, 'target.ts');
+    const linkPath = path.join(root, 'reviewed.ts');
+    // Paths are derived from a fresh test-only temporary directory.
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    await writeFile(targetPath, 'target\n', 'utf8');
+    // Paths are derived from a fresh test-only temporary directory.
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    await symlink(targetPath, linkPath);
+    const file = createFile(linkPath);
+    const { feature } = createHarness(root, [file]);
+    const { authorization } = await feature.resolveReviewPathAuthorization({
+      teamName: 'safe-team',
+      memberName: 'worker',
+    });
+
+    await expect(
+      feature.validateAuthorizedReviewFilePath(authorization, linkPath, {
+        requireReviewedFile: true,
+        rejectHardlinks: true,
+      })
+    ).rejects.toThrow('Review mutation refuses symbolic or multiply-linked files');
+  });
+
+  it('rejects a renderer member that conflicts with authoritative task ownership', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'review-scope-owner-'));
+    temporaryRoots.push(root);
+    const { feature } = createHarness(root, []);
+
+    await expect(
+      feature.resolveReviewPathAuthorization({
+        teamName: 'safe-team',
+        taskId: 'task-1',
+        memberName: 'other-worker',
+      })
+    ).rejects.toThrow('Review memberName does not match the authoritative task scope');
+  });
+});

--- a/test/features/review-mutations/core/reviewDecisionCommandPolicy.test.ts
+++ b/test/features/review-mutations/core/reviewDecisionCommandPolicy.test.ts
@@ -1,0 +1,127 @@
+import {
+  assertCurrentReviewDecisionRevision,
+  assertExactApplyReviewHistoryTransition,
+} from '@features/review-mutations/main';
+import { describe, expect, it } from 'vitest';
+
+import type {
+  FileChangeSummary,
+  FileReviewDecision,
+  ReviewPersistedStateSnapshot,
+  ReviewUndoAction,
+} from '@shared/types/review';
+
+const FILE_PATH = '/sandbox/fixture.ts';
+const REVIEW_KEY = 'fixture-change';
+
+const file: FileChangeSummary = {
+  filePath: FILE_PATH,
+  relativePath: 'fixture.ts',
+  snippets: [],
+  linesAdded: 1,
+  linesRemoved: 1,
+  isNewFile: false,
+  changeKey: REVIEW_KEY,
+};
+
+const current = {
+  hunkDecisions: {},
+  fileDecisions: {},
+  hunkContextHashesByFile: {},
+  reviewActionHistory: [],
+  reviewRedoHistory: [],
+  revision: 4,
+};
+
+const decision: FileReviewDecision & { reviewKey: string } = {
+  filePath: FILE_PATH,
+  reviewKey: REVIEW_KEY,
+  fileDecision: 'rejected',
+  hunkDecisions: {},
+};
+
+function createAction(id = 'action-1'): Extract<ReviewUndoAction, { kind: 'disk' }> {
+  return {
+    id,
+    createdAt: '2026-07-24T00:00:00.000Z',
+    kind: 'disk',
+    descriptor: { intent: 'reject-file', filePath: FILE_PATH },
+    action: {
+      snapshot: {
+        filePath: FILE_PATH,
+        beforeContent: 'after\n',
+        afterContent: 'before\n',
+      },
+      decisionSnapshot: {
+        hunkDecisions: current.hunkDecisions,
+        fileDecisions: current.fileDecisions,
+      },
+    },
+  };
+}
+
+function createState(action = createAction()): ReviewPersistedStateSnapshot {
+  return {
+    hunkDecisions: {},
+    fileDecisions: { [REVIEW_KEY]: 'rejected' },
+    hunkContextHashesByFile: {},
+    reviewActionHistory: [action],
+    reviewRedoHistory: [],
+  };
+}
+
+const context = {
+  resolveFile: () => file,
+  normalizePath: (filePath: string) => filePath,
+};
+
+describe('review decision command policy', () => {
+  it('accepts an exact file Reject transition at the expected revision', () => {
+    expect(() => assertCurrentReviewDecisionRevision(current, 4)).not.toThrow();
+    expect(() =>
+      assertExactApplyReviewHistoryTransition(createState(), current, [decision], context)
+    ).not.toThrow();
+  });
+
+  it('rejects a stale revision and a reused durable action id', () => {
+    expect(() => assertCurrentReviewDecisionRevision(current, 3)).toThrow(
+      'Review decisions changed; refusing stale state overwrite'
+    );
+
+    const reused = createAction('known-action');
+    expect(() =>
+      assertExactApplyReviewHistoryTransition(
+        createState(reused),
+        { ...current, reviewRedoHistory: [{ action: reused, decisionSnapshot: current }] },
+        [decision],
+        context
+      )
+    ).toThrow('Durable Reject requires exactly one new disk history action');
+  });
+
+  it('rejects off-scope decision changes and a forged action descriptor', () => {
+    expect(() =>
+      assertExactApplyReviewHistoryTransition(
+        {
+          ...createState(),
+          fileDecisions: { [REVIEW_KEY]: 'rejected', 'other-change': 'accepted' },
+        },
+        current,
+        [decision],
+        context
+      )
+    ).toThrow('Durable Reject state changes decisions outside the requested files');
+
+    expect(() =>
+      assertExactApplyReviewHistoryTransition(
+        createState({
+          ...createAction(),
+          descriptor: { intent: 'reject-file', filePath: '/sandbox/other.ts' },
+        }),
+        current,
+        [decision],
+        context
+      )
+    ).toThrow('Durable Reject history descriptor does not match the decision transition');
+  });
+});

--- a/test/features/review-mutations/main/ReviewDecisionCommandApplication.test.ts
+++ b/test/features/review-mutations/main/ReviewDecisionCommandApplication.test.ts
@@ -1,0 +1,423 @@
+import {
+  ReviewDecisionCommandApplication,
+  ReviewMutationApplyResultError,
+} from '@features/review-mutations/main';
+import { describe, expect, it, vi } from 'vitest';
+
+import type {
+  ReviewDecisionCommandCurrentState,
+  ReviewDecisionCommandDependencies,
+  ReviewMutationJournalRecord,
+} from '@features/review-mutations/main';
+import type {
+  ApplyReviewRequest,
+  FileChangeSummary,
+  FileChangeWithContent,
+  ReviewDecisionPersistenceScope,
+  ReviewPersistedStateSnapshot,
+  ReviewUndoAction,
+  SnippetDiff,
+} from '@shared/types/review';
+
+const FILE_PATH = '/sandbox/fixture.ts';
+const REVIEW_KEY = 'fixture-change';
+const SCOPE = { teamName: 'safe-team', memberName: 'worker' };
+const PERSISTENCE_SCOPE: ReviewDecisionPersistenceScope = {
+  scopeKey: 'agent-worker',
+  scopeToken: 'scope-token',
+};
+
+function createSnippet(withLedger = false): SnippetDiff {
+  return {
+    toolUseId: 'tool-1',
+    filePath: FILE_PATH,
+    toolName: 'Edit',
+    type: 'edit',
+    oldString: 'before\n',
+    newString: 'after\n',
+    replaceAll: false,
+    timestamp: '2026-07-24T00:00:00.000Z',
+    isError: false,
+    ...(withLedger
+      ? {
+          ledger: {
+            eventId: 'event-1',
+            source: 'ledger-exact' as const,
+            confidence: 'exact' as const,
+            originalFullContent: 'ledger-before\n',
+            modifiedFullContent: 'ledger-after\n',
+            beforeHash: 'before-hash',
+            afterHash: 'after-hash',
+          },
+        }
+      : {}),
+  };
+}
+
+function createFile(withLedger = false): FileChangeSummary {
+  return {
+    filePath: FILE_PATH,
+    relativePath: 'fixture.ts',
+    snippets: [createSnippet(withLedger)],
+    linesAdded: 1,
+    linesRemoved: 1,
+    isNewFile: false,
+    changeKey: REVIEW_KEY,
+  };
+}
+
+function createContent(
+  originalFullContent: string,
+  modifiedFullContent: string,
+  snippets = createFile().snippets
+): FileChangeWithContent {
+  return {
+    ...createFile(),
+    snippets,
+    originalFullContent,
+    modifiedFullContent,
+    contentSource: 'snippet-reconstruction',
+  };
+}
+
+function createDecisionRequest(
+  contentSnapshotToken: string,
+  durable?: {
+    persistedState: ReviewPersistedStateSnapshot;
+    expectedDecisionRevision: number;
+  }
+): ApplyReviewRequest {
+  return {
+    ...SCOPE,
+    ...(durable ? { decisionPersistenceScope: PERSISTENCE_SCOPE, ...durable } : {}),
+    decisions: [
+      {
+        filePath: FILE_PATH,
+        reviewKey: REVIEW_KEY,
+        fileDecision: 'rejected',
+        hunkDecisions: {},
+        contentSnapshotToken,
+      },
+    ],
+  };
+}
+
+function createHarness(options: {
+  file?: FileChangeSummary;
+  authoritativeContent?: FileChangeWithContent;
+  persistenceScope?: ReviewDecisionPersistenceScope | null;
+  loadStates?: (ReviewDecisionCommandCurrentState | null)[];
+}) {
+  const file = options.file ?? createFile();
+  const events: string[] = [];
+  let now = 1_000;
+  let tokenIndex = 0;
+  const loadStates = [...(options.loadStates ?? [])];
+  const authorization = {
+    roots: [{ lexicalPath: '/sandbox', realPath: '/sandbox' }],
+    reviewedFiles: new Map([[FILE_PATH, file]]),
+    resolutionMemberName: 'worker',
+  };
+  const applyReviewDecisions: ReviewDecisionCommandDependencies['applier']['applyReviewDecisions'] =
+    vi.fn(() => Promise.resolve({ applied: 1, skipped: 0, conflicts: 0, errors: [] }));
+  const resolveAuthoritativeContent = vi.fn(() =>
+    Promise.resolve(
+      options.authoritativeContent ??
+        createContent('authoritative-before\n', 'authoritative-after\n', file.snippets)
+    )
+  );
+  const invalidateFile = vi.fn();
+  const applyDisk: ReviewDecisionCommandDependencies['batch']['applyDisk'] = vi.fn(
+    (record, onResult, onPostimages) => {
+      events.push('apply-disk');
+      onResult?.({ applied: 1, skipped: 0, conflicts: 0, errors: [] });
+      onPostimages?.([{ filePath: FILE_PATH, content: 'before\n' }]);
+      return Promise.resolve(record);
+    }
+  );
+  const assertSnippetShapes = (value: unknown): asserts value is SnippetDiff[] => {
+    if (!Array.isArray(value)) throw new Error('Invalid snippets');
+  };
+  const assertDecisionShape: ReviewDecisionCommandDependencies['scope']['assertDecisionShape'] = (
+    value
+  ): asserts value is ApplyReviewRequest['decisions'][number] => {
+    events.push('validate-decision');
+    if (!value || typeof value !== 'object') throw new Error('Invalid decision');
+  };
+  const dependencies: ReviewDecisionCommandDependencies = {
+    scope: {
+      resolve: () => {
+        events.push('resolve-scope');
+        return Promise.resolve({ scope: SCOPE, authorization });
+      },
+      parsePersistenceScope: () => {
+        events.push('parse-persistence');
+        return options.persistenceScope ?? null;
+      },
+      validateFilePath: (_authorization, filePath) => Promise.resolve(String(filePath)),
+      validateSnippets: () => Promise.resolve(),
+      assertDecisionShape,
+      assertSnippetShapes,
+      getAuthoritativeFile: () => file,
+      resolveAuthoritativeContent,
+      normalizeIdentityPath: (filePath) => filePath,
+    },
+    applier: {
+      checkConflict: vi.fn(() =>
+        Promise.resolve({
+          hasConflict: false,
+          conflictContent: null,
+          currentContent: 'after\n',
+          originalContent: 'before\n',
+        })
+      ),
+      rejectHunks: vi.fn(() =>
+        Promise.resolve({
+          success: true,
+          newContent: 'before\n',
+          hadConflicts: false,
+        })
+      ),
+      rejectFile: vi.fn(() =>
+        Promise.resolve({
+          success: true,
+          newContent: 'before\n',
+          hadConflicts: false,
+        })
+      ),
+      previewReject: vi.fn(() => Promise.resolve({ preview: '', hasConflicts: false })),
+      applyReviewDecisions,
+    },
+    persistence: {
+      withLock: (_teamName, _scope, operation) => {
+        events.push('lock');
+        return operation();
+      },
+      assertValidSnapshot: () => events.push('validate-state'),
+      load: () => {
+        events.push(`load-${loadStates.length}`);
+        return Promise.resolve(loadStates.shift() ?? null);
+      },
+    },
+    batch: {
+      assertPersistedStateIncludesDecisions: () => events.push('validate-decisions'),
+      applyDisk,
+      commit: () => {
+        events.push('commit');
+        return Promise.resolve();
+      },
+    },
+    history: {
+      bindNewHistorySnapshots: (state) => {
+        events.push('bind-history');
+        return Promise.resolve(state);
+      },
+    },
+    recovery: {
+      recoverPending: () => {
+        events.push('recover');
+        return Promise.resolve();
+      },
+    },
+    coordinator: {
+      execute: async (_input, steps) => {
+        events.push('coordinate');
+        const record = {} as ReviewMutationJournalRecord;
+        const applied = (await steps.applyDisk(record)) ?? record;
+        await steps.commitDecisions(applied);
+        return applied;
+      },
+    },
+    snapshots: {
+      now: () => now,
+      createToken: () => `snapshot-${++tokenIndex}`,
+      fingerprintSnippets: (snippets) => JSON.stringify(snippets),
+    },
+    cache: { invalidateFile },
+    logger: { debug: vi.fn() },
+  };
+  return {
+    application: new ReviewDecisionCommandApplication(dependencies),
+    applyDisk,
+    applyReviewDecisions,
+    events,
+    invalidateFile,
+    resolveAuthoritativeContent,
+    setNow: (value: number) => {
+      now = value;
+    },
+  };
+}
+
+describe('ReviewDecisionCommandApplication', () => {
+  it('binds non-ledger Apply to the immutable displayed snapshot and rejects stale tokens', async () => {
+    const harness = createHarness({});
+    const displayed = harness.application.registerDisplayedReviewSnapshot(
+      SCOPE.teamName,
+      FILE_PATH,
+      createFile().snippets,
+      createContent('displayed-before\n', 'displayed-after\n')
+    );
+
+    await harness.application.applyDecisions(createDecisionRequest(displayed.reviewSnapshotToken!));
+
+    const [, contents] = vi.mocked(harness.applyReviewDecisions).mock.calls[0];
+    expect(contents.get(FILE_PATH)).toMatchObject({
+      originalFullContent: 'displayed-before\n',
+      modifiedFullContent: 'displayed-after\n',
+    });
+    expect(harness.resolveAuthoritativeContent).not.toHaveBeenCalled();
+    expect(harness.invalidateFile).toHaveBeenCalledWith(FILE_PATH);
+
+    harness.setNow(1_000 + 60 * 60 * 1_000 + 1);
+    await expect(
+      harness.application.applyDecisions(createDecisionRequest(displayed.reviewSnapshotToken!))
+    ).rejects.toThrow('Displayed review snapshot is stale; reload Changes before rejecting.');
+  });
+
+  it('uses authoritative ledger content without trusting a displayed token', async () => {
+    const file = createFile(true);
+    const authoritativeContent = createContent('ledger-before\n', 'ledger-after\n', file.snippets);
+    const harness = createHarness({ file, authoritativeContent });
+
+    await harness.application.applyDecisions(createDecisionRequest('forged-token'));
+
+    const [, contents] = vi.mocked(harness.applyReviewDecisions).mock.calls[0];
+    expect(contents.get(FILE_PATH)).toBe(authoritativeContent);
+    expect(harness.resolveAuthoritativeContent).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves lock, recovery, CAS, history binding, WAL, commit, and result ordering', async () => {
+    const current: ReviewDecisionCommandCurrentState = {
+      hunkDecisions: {},
+      fileDecisions: {},
+      hunkContextHashesByFile: {},
+      reviewActionHistory: [],
+      reviewRedoHistory: [],
+      revision: 7,
+    };
+    const action: Extract<ReviewUndoAction, { kind: 'disk' }> = {
+      id: 'action-1',
+      createdAt: '2026-07-24T00:00:00.000Z',
+      kind: 'disk',
+      descriptor: { intent: 'reject-file', filePath: FILE_PATH },
+      action: {
+        snapshot: {
+          filePath: FILE_PATH,
+          beforeContent: 'after\n',
+          afterContent: 'before\n',
+        },
+        decisionSnapshot: { hunkDecisions: {}, fileDecisions: {} },
+      },
+    };
+    const persistedState: ReviewPersistedStateSnapshot = {
+      hunkDecisions: {},
+      fileDecisions: { [REVIEW_KEY]: 'rejected' },
+      hunkContextHashesByFile: {},
+      reviewActionHistory: [action],
+      reviewRedoHistory: [],
+    };
+    const committed = { ...persistedState, revision: 8 };
+    const harness = createHarness({
+      persistenceScope: PERSISTENCE_SCOPE,
+      loadStates: [current, current, committed],
+    });
+    const displayed = harness.application.registerDisplayedReviewSnapshot(
+      SCOPE.teamName,
+      FILE_PATH,
+      createFile().snippets,
+      createContent('after\n', 'before\n')
+    );
+
+    const result = await harness.application.applyDecisions(
+      createDecisionRequest(displayed.reviewSnapshotToken!, {
+        persistedState,
+        expectedDecisionRevision: 7,
+      })
+    );
+
+    expect(harness.events).toEqual([
+      'resolve-scope',
+      'parse-persistence',
+      'validate-decision',
+      'validate-state',
+      'validate-decisions',
+      'lock',
+      'recover',
+      'load-3',
+      'load-2',
+      'bind-history',
+      'coordinate',
+      'apply-disk',
+      'commit',
+      'load-1',
+    ]);
+    expect(result).toMatchObject({
+      applied: 1,
+      decisionRevision: 8,
+      committedReviewAction: action,
+      diskPostimages: [{ filePath: FILE_PATH, content: 'before\n' }],
+    });
+  });
+
+  it('returns an exact clean-conflict result while preserving collected postimages', async () => {
+    const current: ReviewDecisionCommandCurrentState = {
+      hunkDecisions: {},
+      fileDecisions: {},
+      reviewActionHistory: [],
+      reviewRedoHistory: [],
+      revision: 0,
+    };
+    const action: Extract<ReviewUndoAction, { kind: 'disk' }> = {
+      id: 'action-conflict',
+      createdAt: '2026-07-24T00:00:00.000Z',
+      kind: 'disk',
+      action: {
+        snapshot: { filePath: FILE_PATH, beforeContent: 'after\n', afterContent: 'before\n' },
+        decisionSnapshot: { hunkDecisions: {}, fileDecisions: {} },
+      },
+    };
+    const persistedState: ReviewPersistedStateSnapshot = {
+      hunkDecisions: {},
+      fileDecisions: { [REVIEW_KEY]: 'rejected' },
+      reviewActionHistory: [action],
+      reviewRedoHistory: [],
+    };
+    const harness = createHarness({
+      persistenceScope: PERSISTENCE_SCOPE,
+      loadStates: [current, current],
+    });
+    const displayed = harness.application.registerDisplayedReviewSnapshot(
+      SCOPE.teamName,
+      FILE_PATH,
+      createFile().snippets,
+      createContent('after\n', 'before\n')
+    );
+    vi.mocked(harness.applyDisk).mockImplementationOnce((_record, _onResult, onPostimages) => {
+      onPostimages?.([{ filePath: FILE_PATH, content: null }]);
+      return Promise.reject(
+        new ReviewMutationApplyResultError({
+          applied: 0,
+          skipped: 0,
+          conflicts: 1,
+          errors: [{ filePath: FILE_PATH, error: 'external edit' }],
+        })
+      );
+    });
+
+    await expect(
+      harness.application.applyDecisions(
+        createDecisionRequest(displayed.reviewSnapshotToken!, {
+          persistedState,
+          expectedDecisionRevision: 0,
+        })
+      )
+    ).resolves.toEqual({
+      applied: 0,
+      skipped: 0,
+      conflicts: 1,
+      errors: [{ filePath: FILE_PATH, error: 'external edit' }],
+      diskPostimages: [{ filePath: FILE_PATH, content: null }],
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- extracts authoritative review scope/path authorization into change-review core and main ports
- extracts Reject/Apply decision orchestration and displayed-snapshot ownership into review-mutations
- extracts review query sanitization and orchestration behind focused ports
- keeps review IPC as transport registration, validation, composition, editable mutations, watcher lifecycle, and persistence wiring

## Size

- `src/main/ipc/review.ts`: 1,943 -> 1,051 physical lines (-892, -45.9%)
- legacy cap ratcheted exactly to 1,051
- all 16 new production files are below 800 LOC; the largest is 393 LOC

## Responsibilities and invariants

- preserves existing IPC channel names, positional arguments, response envelopes, and error semantics
- keeps project and path authorization in a feature-owned application boundary with Node infrastructure behind explicit ports
- keeps decision policies and query policies free of Electron and filesystem dependencies
- preserves decision snapshot identity, recovery ordering, and batch mutation contracts established by the previous slice
- keeps dependencies created in composition roots and passed explicitly

## Verification

- focused scope, decision-command, query, IPC, and boundary suites: 10 files, 105 tests passed
- global node architecture/source-size suite: 31 tests passed
- `pnpm typecheck`
- `pnpm lint:fast:files` for every changed TypeScript file
- type-aware ESLint for every changed production TypeScript file
- `pnpm guard:source-file-size`
- Prettier check and `git diff --check`

## E2E evidence

Desktop/live review E2E remains deferred until the final `review.ts` slice. No runtime, agent flow, or real user project was opened.

## Remaining work

1. extract editable mutations
2. extract watcher lifecycle and decision persistence
3. reduce `review.ts` to 783 LOC, remove its legacy exception, and run the full fresh-sandbox desktop review E2E with restart and SIGKILL recovery

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured change-review querying for agent, task, team summary, statistics, file content, and Git history data.
  * Added secure review-scope authorization, including path, snippet, symlink, hardlink, and rename validation.
  * Added review decision commands for conflict checks, hunk/file rejection, previews, and durable decision application.

* **Bug Fixes**
  * Improved protection against stale snapshots, conflicting revisions, forged transitions, and unauthorized file access.

* **Documentation**
  * Updated change-review architecture and integration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->