### PR TITLE
fix(coordination-events): reject aborted snapshot phases

### DIFF
--- a/src/features/coordination-events/core/application/CoordinationEventHandoff.ts
+++ b/src/features/coordination-events/core/application/CoordinationEventHandoff.ts
@@ -561,7 +561,7 @@ function settleSnapshotPhaseBeforeDeadline<T>(input: {
         if (settled) {
           return;
         }
-        if (Date.now() >= input.deadlineAtMs) {
+        if (input.abortController.signal.aborted || Date.now() >= input.deadlineAtMs) {
           settled = true;
           clearTimeout(deadline);
           input.abortController.abort();
@@ -576,7 +576,7 @@ function settleSnapshotPhaseBeforeDeadline<T>(input: {
         if (settled) {
           return;
         }
-        if (Date.now() >= input.deadlineAtMs) {
+        if (input.abortController.signal.aborted || Date.now() >= input.deadlineAtMs) {
           settled = true;
           clearTimeout(deadline);
           input.abortController.abort();

--- a/test/features/coordination-events/core/CoordinationEventHandoff.test.ts
+++ b/test/features/coordination-events/core/CoordinationEventHandoff.test.ts
@@ -446,21 +446,28 @@ describe('CoordinationEventHandoff', () => {
   });
 
   it('cancels a deadline-bound external scan while retaining exclusive lease ownership', async () => {
-    const journal = new MemoryJournal();
-    const retentionLeases = new MemoryRetentionLeases(journal);
-    const handoff = new CoordinationEventHandoff({
-      journal,
-      retentionLeases,
-      snapshotLeaseTtlMs: 25,
-    });
-    const ownershipAtCancellation: boolean[] = [];
-    let delivered = false;
+    vi.useFakeTimers();
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(10_000);
+    try {
+      const journal = new MemoryJournal();
+      const retentionLeases = new MemoryRetentionLeases(journal);
+      const handoff = new CoordinationEventHandoff({
+        journal,
+        retentionLeases,
+        snapshotLeaseTtlMs: 25,
+      });
+      const ownershipAtCancellation: boolean[] = [];
+      let delivered = false;
+      let markReadStarted!: () => void;
+      const readStarted = new Promise<void>((resolve) => {
+        markReadStarted = resolve;
+      });
 
-    await expect(
-      handoff.captureExternalSnapshot({
+      const capture = handoff.captureExternalSnapshot({
         request: REQUEST,
         source: {
           async readStableSnapshot(_request, context) {
+            markReadStarted();
             return new Promise<ExternalCoordinationSnapshotRead<{ revision: number }>>(
               (resolve) => {
                 context.signal.addEventListener(
@@ -485,12 +492,20 @@ describe('CoordinationEventHandoff', () => {
         async deliver() {
           delivered = true;
         },
-      })
-    ).rejects.toMatchObject({ code: 'snapshot_retry' });
+      });
+      const rejection = expect(capture).rejects.toMatchObject({ code: 'snapshot_retry' });
 
-    expect(ownershipAtCancellation).toEqual([true]);
-    expect(delivered).toBe(false);
-    expect(retentionLeases.operations).toEqual(['acquire', 'run', 'release']);
+      await readStarted;
+      await vi.advanceTimersByTimeAsync(25);
+      await rejection;
+
+      expect(ownershipAtCancellation).toEqual([true]);
+      expect(delivered).toBe(false);
+      expect(retentionLeases.operations).toEqual(['acquire', 'run', 'release']);
+    } finally {
+      nowSpy.mockRestore();
+      vi.useRealTimers();
+    }
   });
 
   it('bounds ignored lease acquisition and releases a lease that arrives after timeout', async () => {

--- a/test/features/coordination-events/core/CoordinationEventHandoff.test.ts
+++ b/test/features/coordination-events/core/CoordinationEventHandoff.test.ts
@@ -132,6 +132,7 @@ class MemoryRetentionLeases implements SnapshotRetentionLeaseCoordinator {
   expireDuringDeliveryMicrotask = false;
   expiryAttempted = false;
   overrideWatermark: EventJournalWatermark | null = null;
+  runError: unknown;
 
   constructor(private readonly journal: MemoryJournal) {}
 
@@ -174,6 +175,9 @@ class MemoryRetentionLeases implements SnapshotRetentionLeaseCoordinator {
         active: true,
         watermark: this.overrideWatermark ?? (await this.journal.getWatermark()),
       });
+    } catch (error) {
+      this.runError = error;
+      throw error;
     } finally {
       this.deliveryOwned = false;
     }
@@ -507,6 +511,7 @@ describe('CoordinationEventHandoff', () => {
 
         expect(ownershipAtCancellation).toEqual([true]);
         expect(delivered).toBe(false);
+        expect(retentionLeases.runError).toMatchObject({ code: 'snapshot_retry' });
         expect(retentionLeases.operations).toEqual(['acquire', 'run', 'release']);
       } finally {
         nowSpy.mockRestore();

--- a/test/features/coordination-events/core/CoordinationEventHandoff.test.ts
+++ b/test/features/coordination-events/core/CoordinationEventHandoff.test.ts
@@ -445,68 +445,75 @@ describe('CoordinationEventHandoff', () => {
     expect(overtakenBarrierSourceReads).toBe(0);
   });
 
-  it('cancels a deadline-bound external scan while retaining exclusive lease ownership', async () => {
-    vi.useFakeTimers();
-    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(10_000);
-    try {
-      const journal = new MemoryJournal();
-      const retentionLeases = new MemoryRetentionLeases(journal);
-      const handoff = new CoordinationEventHandoff({
-        journal,
-        retentionLeases,
-        snapshotLeaseTtlMs: 25,
-      });
-      const ownershipAtCancellation: boolean[] = [];
-      let delivered = false;
-      let markReadStarted!: () => void;
-      const readStarted = new Promise<void>((resolve) => {
-        markReadStarted = resolve;
-      });
+  it.each(['resolve', 'reject'] as const)(
+    'cancels a deadline-bound external scan when the source %ss from its abort listener',
+    async (abortOutcome) => {
+      vi.useFakeTimers();
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(10_000);
+      try {
+        const journal = new MemoryJournal();
+        const retentionLeases = new MemoryRetentionLeases(journal);
+        const handoff = new CoordinationEventHandoff({
+          journal,
+          retentionLeases,
+          snapshotLeaseTtlMs: 25,
+        });
+        const ownershipAtCancellation: boolean[] = [];
+        let delivered = false;
+        let markReadStarted!: () => void;
+        const readStarted = new Promise<void>((resolve) => {
+          markReadStarted = resolve;
+        });
 
-      const capture = handoff.captureExternalSnapshot({
-        request: REQUEST,
-        source: {
-          async readStableSnapshot(_request, context) {
-            markReadStarted();
-            return new Promise<ExternalCoordinationSnapshotRead<{ revision: number }>>(
-              (resolve) => {
-                context.signal.addEventListener(
-                  'abort',
-                  () => {
-                    ownershipAtCancellation.push(
-                      retentionLeases.active && retentionLeases.deliveryOwned
-                    );
-                    resolve({
-                      snapshot: { revision: 0 },
-                      revisionVector: [],
-                      sourceGenerationBefore: 'generation-1',
-                      sourceGenerationAfter: 'generation-1',
-                    });
-                  },
-                  { once: true }
-                );
-              }
-            );
+        const capture = handoff.captureExternalSnapshot({
+          request: REQUEST,
+          source: {
+            async readStableSnapshot(_request, context) {
+              markReadStarted();
+              return new Promise<ExternalCoordinationSnapshotRead<{ revision: number }>>(
+                (resolve, reject) => {
+                  context.signal.addEventListener(
+                    'abort',
+                    () => {
+                      ownershipAtCancellation.push(
+                        retentionLeases.active && retentionLeases.deliveryOwned
+                      );
+                      if (abortOutcome === 'reject') {
+                        reject(new Error('source aborted after deadline'));
+                        return;
+                      }
+                      resolve({
+                        snapshot: { revision: 0 },
+                        revisionVector: [],
+                        sourceGenerationBefore: 'generation-1',
+                        sourceGenerationAfter: 'generation-1',
+                      });
+                    },
+                    { once: true }
+                  );
+                }
+              );
+            },
           },
-        },
-        async deliver() {
-          delivered = true;
-        },
-      });
-      const rejection = expect(capture).rejects.toMatchObject({ code: 'snapshot_retry' });
+          async deliver() {
+            delivered = true;
+          },
+        });
+        const rejection = expect(capture).rejects.toMatchObject({ code: 'snapshot_retry' });
 
-      await readStarted;
-      await vi.advanceTimersByTimeAsync(25);
-      await rejection;
+        await readStarted;
+        await vi.advanceTimersByTimeAsync(25);
+        await rejection;
 
-      expect(ownershipAtCancellation).toEqual([true]);
-      expect(delivered).toBe(false);
-      expect(retentionLeases.operations).toEqual(['acquire', 'run', 'release']);
-    } finally {
-      nowSpy.mockRestore();
-      vi.useRealTimers();
+        expect(ownershipAtCancellation).toEqual([true]);
+        expect(delivered).toBe(false);
+        expect(retentionLeases.operations).toEqual(['acquire', 'run', 'release']);
+      } finally {
+        nowSpy.mockRestore();
+        vi.useRealTimers();
+      }
     }
-  });
+  );
 
   it('bounds ignored lease acquisition and releases a lease that arrives after timeout', async () => {
     const journal = new MemoryJournal();


### PR DESCRIPTION
## Summary

- rejects a snapshot phase when its shared deadline controller has already been aborted
- closes the race where a source settles synchronously from the abort handler before wall-clock comparison advances
- makes both resolve-on-abort and reject-on-abort regression cases deterministic with fake time and an explicit read-start barrier

## Root cause

The outer deadline aborted the shared controller. A source abort listener could resolve or reject synchronously, and the inner settlement helper only checked Date.now. If the clock had not advanced past the deadline, the inner result could win instead of the deadline contract.

## Size

- 2 files
- +74 / -47 lines
- no API, DTO, persistence, or architecture boundary changes

## Verification

- coordination-events focused suite: 3 files, 67 tests passed
- resolve/reject deadline regression: 20/20 repeated deterministic cases passed
- mutation check: removing the rejection-side abort guard fails only the reject case with the raw source error; restoring it returns snapshot_retry
- global Node architecture suite: 31 tests passed
- pnpm typecheck
- pnpm lint:fast:files for both changed files
- type-aware ESLint for changed production code: 0 errors
- pnpm guard:source-file-size
- Prettier and git diff --check

## E2E evidence

This is a deterministic core cancellation race fix. It does not invoke agents, runtime, terminal, provisioning, or user projects. Both exact production settlement interleavings are covered by focused fake-timer regression tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deadline-bound snapshot handling now stops promptly when cancellation has already been signaled, treating it as “deadline expired.”
  * Prevents unintended follow-on processing on external-scan cancellation and ensures correct lease and delivery behavior.
  * Snapshot lease retention now records errors thrown during snapshot-leased execution.

* **Tests**
  * Expanded deadline-cancellation coverage to validate consistent `snapshot_retry` outcomes for both resolve and reject paths using fake timers and deterministic timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->