### PR TITLE
fix(change-review): stabilize draft hydration scope

### DIFF
--- a/src/features/change-review/renderer/hooks/useChangeReviewDraftHistoryController.ts
+++ b/src/features/change-review/renderer/hooks/useChangeReviewDraftHistoryController.ts
@@ -127,6 +127,14 @@ export function useChangeReviewDraftHistoryController({
   const writeErrorsRef = useRef(new Map<string, unknown>());
   const persistedVersionsRef = useRef(new Map<string, DraftHistoryVersion>());
   const suppressedFilesRef = useRef(new Set<string>());
+  const stableReviewScope = useMemo(
+    () => ({
+      teamName: reviewScope.teamName,
+      taskId: reviewScope.taskId,
+      memberName: reviewScope.memberName,
+    }),
+    [reviewScope.memberName, reviewScope.taskId, reviewScope.teamName]
+  );
   const persistenceScope = useMemo(
     () =>
       decisionScopeToken
@@ -253,7 +261,7 @@ export function useChangeReviewDraftHistoryController({
           if (file?.filePath !== entry.filePath) continue;
           const baselineKey = normalizePathForComparison(file.filePath);
           const conflict = await port.checkConflict({
-            reviewScope,
+            reviewScope: stableReviewScope,
             filePath: file.filePath,
             expectedModified: entry.diskBaseline ?? '',
           });
@@ -310,7 +318,7 @@ export function useChangeReviewDraftHistoryController({
     replaceEntries,
     reportError,
     retryNonce,
-    reviewScope,
+    stableReviewScope,
     setHydration,
   ]);
 

--- a/test/features/change-review/renderer/useChangeReviewDraftHistoryController.test.tsx
+++ b/test/features/change-review/renderer/useChangeReviewDraftHistoryController.test.tsx
@@ -140,6 +140,7 @@ interface ProbeProps {
   hydrationKey: string;
   scopeToken: string;
   changeSetEpoch: number;
+  recreateReviewScope: boolean;
   expectedHydrationKey: () => string;
   operationScope: () => ReviewOperationScopeToken;
   port: ChangeReviewDraftHistoryPort;
@@ -180,7 +181,7 @@ function DraftHistoryProbe(props: Readonly<ProbeProps>): React.JSX.Element {
     decisionScopeToken: props.scopeToken,
     decisionHydrationKey: props.hydrationKey,
     draftHistoryHydrationReady: true,
-    reviewScope,
+    reviewScope: props.recreateReviewScope ? { ...reviewScope } : reviewScope,
     draftHistoryConflictCandidates: [],
     setHydration: props.setHydration,
     isExpectedHydrationKey,
@@ -211,7 +212,8 @@ function createHarness(port = createPortHarness().port) {
   const render = async (
     hydrationKey = expectedHydrationKey,
     scopeToken = `token-${hydrationKey}`,
-    changeSetEpoch = 1
+    changeSetEpoch = 1,
+    recreateReviewScope = false
   ) => {
     await act(async () => {
       root.render(
@@ -219,6 +221,7 @@ function createHarness(port = createPortHarness().port) {
           hydrationKey={hydrationKey}
           scopeToken={scopeToken}
           changeSetEpoch={changeSetEpoch}
+          recreateReviewScope={recreateReviewScope}
           expectedHydrationKey={getExpectedHydrationKey}
           operationScope={getOperationScope}
           port={port}
@@ -309,6 +312,28 @@ describe('useChangeReviewDraftHistoryController', () => {
 
     expect(harness.commitHydratedDrafts).toHaveBeenCalledOnce();
     expect(latestController!.getEntry('/Project/Case.ts')?.editorState.doc).toBe('current draft');
+    await flushReact(() => harness.root.unmount());
+  });
+
+  it('does not restart hydration when an equivalent review scope object is recreated', async () => {
+    const { port, load } = createPortHarness();
+    const pending = deferred<ReviewDraftHistorySnapshot | null>();
+    load.mockReturnValue(pending.promise);
+    const harness = createHarness(port);
+
+    await harness.render('scope-a', 'token-a', 1, true);
+    expect(load).toHaveBeenCalledOnce();
+
+    await harness.render('scope-a', 'token-a', 1, true);
+    expect(load).toHaveBeenCalledOnce();
+
+    pending.resolve(null);
+    await settle();
+
+    expect(harness.setHydration).toHaveBeenLastCalledWith({
+      key: 'scope-a',
+      status: 'loaded',
+    });
     await flushReact(() => harness.root.unmount());
   });
 


### PR DESCRIPTION
## Summary

- Stabilizes the logical review scope passed to draft-history hydration.
- Prevents hydration state updates from recreating an equivalent scope and restarting the load effect forever.
- Adds a regression test proving an equivalent recreated scope does not issue a second load.

## Root cause

`setHydration({ status: 'loading' })` updated the scope projection. The projection recreated `reviewScope`, which was an effect dependency, so the in-flight draft-history load was cancelled and restarted continuously. The dialog stayed on Reading task ledger even though task changes and decision hydration had completed.

## Verification

- 48 focused renderer tests passed
- TypeScript typecheck passed
- Fast and type-aware ESLint passed
- Prettier and diff checks passed
- Source-size guard passed, production hook is 676 lines
- Architecture gate passed, 31/31
- Fresh sandbox desktop Electron E2E passed end to end:
  - Accept All
  - Reject file
  - Restore back and forward across restart
  - Undo to start
  - stale branch reload and reversible recovery
  - discard backup and prior snapshot
  - blocked response
  - SIGKILL recovery
  - exact Undo

No agent runtime, provisioning, task assignment, or real user project was used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented draft hydration and conflict checks from restarting when an equivalent review scope is recreated.
  * Improved stability when navigating or rendering review changes with unchanged scope details.

* **Tests**
  * Added coverage confirming that recreating an equivalent review scope does not trigger unnecessary hydration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->