### PR TITLE
refactor(review): extract final boundaries

### DIFF
--- a/scripts/ci/source-file-size-legacy.json
+++ b/scripts/ci/source-file-size-legacy.json
@@ -54,7 +54,6 @@
   "src/main/index.ts": 3908,
   "src/main/ipc/config.ts": 1230,
   "src/main/ipc/configValidation.ts": 1050,
-  "src/main/ipc/review.ts": 991,
   "src/main/services/discovery/ProjectScanner.ts": 2111,
   "src/main/services/infrastructure/CliInstallerService.ts": 1690,
   "src/main/services/infrastructure/ConfigManager.ts": 1503,

--- a/scripts/ci/source-file-size-legacy.json
+++ b/scripts/ci/source-file-size-legacy.json
@@ -54,7 +54,7 @@
   "src/main/index.ts": 3908,
   "src/main/ipc/config.ts": 1230,
   "src/main/ipc/configValidation.ts": 1050,
-  "src/main/ipc/review.ts": 1051,
+  "src/main/ipc/review.ts": 991,
   "src/main/services/discovery/ProjectScanner.ts": 2111,
   "src/main/services/infrastructure/CliInstallerService.ts": 1690,
   "src/main/services/infrastructure/ConfigManager.ts": 1503,

--- a/src/features/change-review/README.md
+++ b/src/features/change-review/README.md
@@ -9,9 +9,12 @@ main-process review IPC shell.
   decision-persistence, keyboard orchestration, and durable Undo/Redo/checkpoint Restore through
   narrow command, state, and view ports.
 - `renderer/ui` owns store-free presentation components.
-- `core/domain` owns pure review scope, rename expectation, and snippet-shape policy.
-- `main/application` owns authoritative scope and path authorization behind narrow ports.
-- `main/infrastructure` owns Node path, filesystem, sensitive-path, and hardlink details.
+- `core/domain` owns pure review scope, rename expectation, snippet-shape, watcher-input, and
+  decision-persistence policy.
+- `main/application` owns authoritative scope/path authorization, review watcher lifecycle, and
+  decision-persistence coordination behind narrow ports.
+- `main/infrastructure` owns Node path, filesystem, sensitive-path, hardlink, and watcher-root
+  validation details.
 - The legacy dialog remains the temporary composition shell for Zustand, editor mutations,
   forward Accept/Reject disk mutations, and outer close coordination while later slices move
   those responsibilities behind focused hooks and use cases.

--- a/src/features/change-review/core/domain/reviewDecisionPersistencePolicy.ts
+++ b/src/features/change-review/core/domain/reviewDecisionPersistencePolicy.ts
@@ -1,0 +1,125 @@
+import {
+  assertNonEmptyString,
+  assertSnippetShapes,
+  MAX_REVIEW_HUNK_DECISIONS_PER_FILE,
+} from './reviewScopePolicy';
+
+import type {
+  FileReviewDecision,
+  ReviewDecisionPersistenceScope,
+  ReviewFileScope,
+} from '@shared/types/review';
+
+export type ReviewHistoryScopeIdentity = { taskId: string } | { memberName: string };
+
+export function assertReviewDecisionShape(value: unknown): asserts value is FileReviewDecision {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Invalid review decision');
+  }
+  const raw = value as Record<string, unknown>;
+  assertNonEmptyString(raw.filePath, 'decision.filePath');
+  if (
+    raw.reviewKey !== undefined &&
+    (typeof raw.reviewKey !== 'string' ||
+      raw.reviewKey.length === 0 ||
+      raw.reviewKey.length > 32_768 ||
+      raw.reviewKey.includes('\0'))
+  ) {
+    throw new Error('Invalid decision.reviewKey');
+  }
+  if (!['accepted', 'rejected', 'pending'].includes(String(raw.fileDecision))) {
+    throw new Error('Invalid fileDecision');
+  }
+  if (
+    !raw.hunkDecisions ||
+    typeof raw.hunkDecisions !== 'object' ||
+    Array.isArray(raw.hunkDecisions) ||
+    Object.keys(raw.hunkDecisions).length > MAX_REVIEW_HUNK_DECISIONS_PER_FILE
+  ) {
+    throw new Error('Invalid hunkDecisions');
+  }
+  for (const [index, decision] of Object.entries(raw.hunkDecisions)) {
+    const numericIndex = Number(index);
+    if (
+      !/^\d+$/.test(index) ||
+      !Number.isSafeInteger(numericIndex) ||
+      numericIndex >= MAX_REVIEW_HUNK_DECISIONS_PER_FILE ||
+      !['accepted', 'rejected', 'pending'].includes(String(decision))
+    ) {
+      throw new Error('Invalid hunk decision');
+    }
+  }
+  if (raw.hunkContextHashes !== undefined) {
+    if (
+      !raw.hunkContextHashes ||
+      typeof raw.hunkContextHashes !== 'object' ||
+      Array.isArray(raw.hunkContextHashes) ||
+      Object.keys(raw.hunkContextHashes).length > MAX_REVIEW_HUNK_DECISIONS_PER_FILE
+    ) {
+      throw new Error('Invalid hunkContextHashes');
+    }
+    for (const [index, hash] of Object.entries(raw.hunkContextHashes)) {
+      const numericIndex = Number(index);
+      if (
+        !/^\d+$/.test(index) ||
+        !Number.isSafeInteger(numericIndex) ||
+        numericIndex >= MAX_REVIEW_HUNK_DECISIONS_PER_FILE ||
+        typeof hash !== 'string' ||
+        hash.length === 0 ||
+        hash.length > 256
+      ) {
+        throw new Error('Invalid hunk context hash');
+      }
+    }
+  }
+  if (
+    raw.contentSnapshotToken !== undefined &&
+    (typeof raw.contentSnapshotToken !== 'string' || raw.contentSnapshotToken.length > 200)
+  ) {
+    throw new Error('Invalid contentSnapshotToken');
+  }
+  if (raw.snippets !== undefined) assertSnippetShapes(raw.snippets);
+  for (const field of ['originalFullContent', 'modifiedFullContent']) {
+    if (raw[field] !== undefined && raw[field] !== null && typeof raw[field] !== 'string') {
+      throw new Error(`Invalid ${field}`);
+    }
+  }
+  if (raw.isNewFile !== undefined && typeof raw.isNewFile !== 'boolean') {
+    throw new Error('Invalid isNewFile');
+  }
+}
+
+export function parseReviewDecisionPersistenceScope(
+  value: unknown,
+  scope: ReviewFileScope
+): ReviewDecisionPersistenceScope | null {
+  if (value === undefined) return null;
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Invalid decision persistence scope');
+  }
+  const raw = value as Record<string, unknown>;
+  assertNonEmptyString(raw.scopeKey, 'decisionPersistenceScope.scopeKey');
+  assertNonEmptyString(raw.scopeToken, 'decisionPersistenceScope.scopeToken');
+  if (raw.scopeToken.length > 32 * 1024 * 1024 || raw.scopeToken.includes('\0')) {
+    throw new Error('Invalid decision persistence scope token');
+  }
+  const expectedScopeKey = scope.taskId
+    ? `task-${scope.taskId}`
+    : scope.memberName
+      ? `agent-${scope.memberName}`
+      : null;
+  if (!expectedScopeKey || raw.scopeKey !== expectedScopeKey) {
+    throw new Error('Decision persistence scope does not match the authoritative review');
+  }
+  return { scopeKey: raw.scopeKey, scopeToken: raw.scopeToken };
+}
+
+export function parseReviewHistoryScopeIdentity(scopeKey: string): ReviewHistoryScopeIdentity {
+  if (scopeKey.startsWith('task-')) {
+    return { taskId: scopeKey.slice('task-'.length) };
+  }
+  if (scopeKey.startsWith('agent-')) {
+    return { memberName: scopeKey.slice('agent-'.length) };
+  }
+  throw new Error('Review decision scope cannot authorize history');
+}

--- a/src/features/change-review/core/domain/reviewFileWatchPolicy.ts
+++ b/src/features/change-review/core/domain/reviewFileWatchPolicy.ts
@@ -1,3 +1,5 @@
 export function normalizeReviewWatchedFiles(filePaths: unknown): string[] {
-  return Array.isArray(filePaths) ? (filePaths as string[]) : [];
+  return Array.isArray(filePaths)
+    ? filePaths.filter((filePath): filePath is string => typeof filePath === 'string')
+    : [];
 }

--- a/src/features/change-review/core/domain/reviewFileWatchPolicy.ts
+++ b/src/features/change-review/core/domain/reviewFileWatchPolicy.ts
@@ -1,0 +1,3 @@
+export function normalizeReviewWatchedFiles(filePaths: unknown): string[] {
+  return Array.isArray(filePaths) ? (filePaths as string[]) : [];
+}

--- a/src/features/change-review/main/adapters/output/presenters/ReviewFileWatchEventPresenter.ts
+++ b/src/features/change-review/main/adapters/output/presenters/ReviewFileWatchEventPresenter.ts
@@ -1,0 +1,17 @@
+import { safeSendToRenderer } from '@main/utils/safeWebContentsSend';
+import { REVIEW_FILE_CHANGE } from '@preload/constants/ipcChannels';
+
+import type { EditorFileChangeEvent } from '@shared/types/editor';
+import type { BrowserWindow } from 'electron';
+
+export class ReviewFileWatchEventPresenter {
+  private mainWindow: BrowserWindow | null = null;
+
+  setMainWindow(window: BrowserWindow | null): void {
+    this.mainWindow = window;
+  }
+
+  present(event: EditorFileChangeEvent): void {
+    safeSendToRenderer(this.mainWindow, REVIEW_FILE_CHANGE, event);
+  }
+}

--- a/src/features/change-review/main/application/ReviewDecisionPersistenceApplication.ts
+++ b/src/features/change-review/main/application/ReviewDecisionPersistenceApplication.ts
@@ -1,0 +1,113 @@
+import {
+  assertReviewDecisionShape,
+  parseReviewDecisionPersistenceScope,
+  parseReviewHistoryScopeIdentity,
+} from '../../core/domain/reviewDecisionPersistencePolicy';
+
+import type {
+  ReviewDecisionHistoryScopeAuthorization,
+  ReviewDecisionPersistenceDependencies,
+  ReviewDraftHistoryScopeAuthorization,
+} from './ReviewDecisionPersistencePorts';
+import type { ReviewPathAuthorization } from './ReviewScopeAuthorizationPorts';
+import type {
+  FileReviewDecision,
+  ReviewDecisionPersistenceScope,
+  ReviewFileScope,
+} from '@shared/types/review';
+
+export class ReviewDecisionPersistenceApplication {
+  private readonly queues = new Map<string, Promise<void>>();
+
+  constructor(private readonly dependencies: ReviewDecisionPersistenceDependencies) {}
+
+  assertDecisionShape(value: unknown): asserts value is FileReviewDecision {
+    assertReviewDecisionShape(value);
+  }
+
+  parsePersistenceScope(
+    value: unknown,
+    scope: ReviewFileScope
+  ): ReviewDecisionPersistenceScope | null {
+    return parseReviewDecisionPersistenceScope(value, scope);
+  }
+
+  async withLock<T>(
+    teamName: string,
+    persistenceScope: ReviewDecisionPersistenceScope,
+    operation: () => Promise<T>
+  ): Promise<T> {
+    const key = `${teamName}:${persistenceScope.scopeKey}`;
+    const previous = this.queues.get(key) ?? Promise.resolve();
+    let release = (): void => undefined;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const queueTail = previous.then(
+      () => current,
+      () => current
+    );
+    this.queues.set(key, queueTail);
+
+    await previous.catch(() => undefined);
+    try {
+      return await this.dependencies.locks.withLogicalScopeLock(
+        teamName,
+        persistenceScope.scopeKey,
+        () =>
+          this.dependencies.locks.withPersistenceScopeLock(teamName, persistenceScope, operation)
+      );
+    } finally {
+      release();
+      if (this.queues.get(key) === queueTail) {
+        this.queues.delete(key);
+      }
+    }
+  }
+
+  async authorizeDraftHistoryScope(
+    teamName: string,
+    scopeKey: string
+  ): Promise<ReviewDraftHistoryScopeAuthorization> {
+    const authorization = await this.resolveHistoryAuthorization(teamName, scopeKey);
+    return {
+      isCurrentReviewedFile: (filePath) =>
+        this.dependencies.paths.isAbsoluteNormalized(filePath) &&
+        Boolean(
+          authorization.reviewedFiles?.has(this.dependencies.scope.normalizeIdentityPath(filePath))
+        ),
+      assertCurrentReviewedFile: async (filePath) => {
+        await this.dependencies.scope.validateFilePath(authorization, filePath, {
+          requireReviewedFile: true,
+        });
+      },
+    };
+  }
+
+  async authorizeDecisionHistoryScope(
+    teamName: string,
+    scopeKey: string
+  ): Promise<ReviewDecisionHistoryScopeAuthorization> {
+    const authorization = await this.resolveHistoryAuthorization(teamName, scopeKey);
+    return {
+      files: authorization.reviewedFiles ? [...authorization.reviewedFiles.values()] : null,
+      normalizePath: (filePath) => this.dependencies.scope.normalizeIdentityPath(filePath),
+      resolveFile: (filePath) =>
+        this.dependencies.scope.getAuthoritativeFile(authorization, filePath),
+    };
+  }
+
+  private async resolveHistoryAuthorization(
+    teamName: string,
+    scopeKey: string
+  ): Promise<ReviewPathAuthorization> {
+    const scope = this.dependencies.scope.parse({
+      teamName,
+      ...parseReviewHistoryScopeIdentity(scopeKey),
+    });
+    const { authorization } = await this.dependencies.scope.resolve(scope, {
+      requireIdentity: true,
+    });
+    return authorization;
+  }
+}

--- a/src/features/change-review/main/application/ReviewDecisionPersistencePorts.ts
+++ b/src/features/change-review/main/application/ReviewDecisionPersistencePorts.ts
@@ -1,0 +1,55 @@
+import type { ReviewPathAuthorization } from './ReviewScopeAuthorizationPorts';
+import type {
+  FileChangeSummary,
+  ReviewDecisionPersistenceScope,
+  ReviewFileScope,
+} from '@shared/types/review';
+
+export interface ReviewDecisionPersistenceScopePort {
+  parse(value: unknown): ReviewFileScope;
+  resolve(
+    value: unknown,
+    options: { requireIdentity: true }
+  ): Promise<{ scope: ReviewFileScope; authorization: ReviewPathAuthorization }>;
+  normalizeIdentityPath(filePath: string): string;
+  validateFilePath(
+    authorization: ReviewPathAuthorization,
+    filePath: unknown,
+    options: { requireReviewedFile: true }
+  ): Promise<string>;
+  getAuthoritativeFile(authorization: ReviewPathAuthorization, filePath: string): FileChangeSummary;
+}
+
+export interface ReviewDecisionPersistencePathPort {
+  isAbsoluteNormalized(filePath: string): boolean;
+}
+
+export interface ReviewDecisionPersistenceLockPort {
+  withLogicalScopeLock<T>(
+    teamName: string,
+    scopeKey: string,
+    operation: () => Promise<T>
+  ): Promise<T>;
+  withPersistenceScopeLock<T>(
+    teamName: string,
+    persistenceScope: ReviewDecisionPersistenceScope,
+    operation: () => Promise<T>
+  ): Promise<T>;
+}
+
+export interface ReviewDecisionPersistenceDependencies {
+  scope: ReviewDecisionPersistenceScopePort;
+  paths: ReviewDecisionPersistencePathPort;
+  locks: ReviewDecisionPersistenceLockPort;
+}
+
+export interface ReviewDraftHistoryScopeAuthorization {
+  isCurrentReviewedFile(filePath: string): boolean;
+  assertCurrentReviewedFile(filePath: string): Promise<void>;
+}
+
+export interface ReviewDecisionHistoryScopeAuthorization {
+  files: FileChangeSummary[] | null;
+  normalizePath(filePath: string): string;
+  resolveFile(filePath: string): FileChangeSummary;
+}

--- a/src/features/change-review/main/application/ReviewFileWatchApplication.ts
+++ b/src/features/change-review/main/application/ReviewFileWatchApplication.ts
@@ -1,0 +1,70 @@
+import { normalizeReviewWatchedFiles } from '../../core/domain/reviewFileWatchPolicy';
+
+import type {
+  ReviewFileWatchConfiguration,
+  ReviewFileWatchDependencies,
+  ReviewFileWatcherPort,
+  ReviewFileWatchOperation,
+  ReviewProjectPathValidator,
+} from './ReviewFileWatchPorts';
+
+export class ReviewFileWatchApplication {
+  private fileWatcher: ReviewFileWatcherPort;
+  private projectPathValidator: ReviewProjectPathValidator;
+  private projectRoot: string | null = null;
+  private requestGeneration = 0;
+
+  constructor(private readonly dependencies: ReviewFileWatchDependencies) {
+    this.fileWatcher = dependencies.defaultWatcher;
+    this.projectPathValidator = dependencies.defaultProjectPathValidator;
+  }
+
+  supersedePendingRequests(): void {
+    this.requestGeneration += 1;
+  }
+
+  configure(configuration: ReviewFileWatchConfiguration): void {
+    const nextFileWatcher = configuration.fileWatcher ?? this.dependencies.defaultWatcher;
+    if (this.fileWatcher !== nextFileWatcher) {
+      this.fileWatcher.stop();
+      this.projectRoot = null;
+      this.fileWatcher = nextFileWatcher;
+    }
+    this.projectPathValidator =
+      configuration.projectPathValidator ?? this.dependencies.defaultProjectPathValidator;
+  }
+
+  prepareWatch(projectPath: string, filePaths: unknown): ReviewFileWatchOperation {
+    const requestGeneration = ++this.requestGeneration;
+    return async () => {
+      const normalizedProjectPath = await this.projectPathValidator(projectPath);
+      if (requestGeneration !== this.requestGeneration) return;
+      const shouldRestart =
+        this.projectRoot !== normalizedProjectPath || !this.fileWatcher.isWatching();
+
+      if (shouldRestart) {
+        this.fileWatcher.stop();
+        this.projectRoot = normalizedProjectPath;
+        this.fileWatcher.start(normalizedProjectPath, (event) => {
+          this.dependencies.events.present(event);
+        });
+      }
+
+      this.fileWatcher.setWatchedFiles(normalizeReviewWatchedFiles(filePaths));
+    };
+  }
+
+  prepareUnwatch(): ReviewFileWatchOperation {
+    this.requestGeneration += 1;
+    return async () => {
+      this.fileWatcher.stop();
+      this.projectRoot = null;
+    };
+  }
+
+  dispose(): void {
+    this.fileWatcher.stop();
+    this.projectRoot = null;
+    this.requestGeneration += 1;
+  }
+}

--- a/src/features/change-review/main/application/ReviewFileWatchPorts.ts
+++ b/src/features/change-review/main/application/ReviewFileWatchPorts.ts
@@ -1,0 +1,27 @@
+import type { EditorFileChangeEvent } from '@shared/types/editor';
+
+export interface ReviewFileWatcherPort {
+  isWatching(): boolean;
+  setWatchedFiles(filePaths: string[]): void;
+  start(projectRoot: string, onChange: (event: EditorFileChangeEvent) => void): void;
+  stop(): void;
+}
+
+export type ReviewProjectPathValidator = (projectPath: string) => Promise<string>;
+
+export interface ReviewFileWatchEventPort {
+  present(event: EditorFileChangeEvent): void;
+}
+
+export interface ReviewFileWatchDependencies {
+  defaultWatcher: ReviewFileWatcherPort;
+  defaultProjectPathValidator: ReviewProjectPathValidator;
+  events: ReviewFileWatchEventPort;
+}
+
+export interface ReviewFileWatchConfiguration {
+  fileWatcher?: ReviewFileWatcherPort;
+  projectPathValidator?: ReviewProjectPathValidator;
+}
+
+export type ReviewFileWatchOperation = () => Promise<void>;

--- a/src/features/change-review/main/composition/createReviewDecisionPersistenceFeature.ts
+++ b/src/features/change-review/main/composition/createReviewDecisionPersistenceFeature.ts
@@ -1,0 +1,11 @@
+import { ReviewDecisionPersistenceApplication } from '../application/ReviewDecisionPersistenceApplication';
+
+import type { ReviewDecisionPersistenceDependencies } from '../application/ReviewDecisionPersistencePorts';
+
+export type ReviewDecisionPersistenceFeatureDependencies = ReviewDecisionPersistenceDependencies;
+
+export function createReviewDecisionPersistenceFeature(
+  dependencies: ReviewDecisionPersistenceFeatureDependencies
+): ReviewDecisionPersistenceApplication {
+  return new ReviewDecisionPersistenceApplication(dependencies);
+}

--- a/src/features/change-review/main/composition/createReviewFileWatchFeature.ts
+++ b/src/features/change-review/main/composition/createReviewFileWatchFeature.ts
@@ -1,0 +1,41 @@
+import { EditorFileWatcher } from '@main/services/editor';
+
+import { ReviewFileWatchEventPresenter } from '../adapters/output/presenters/ReviewFileWatchEventPresenter';
+import { ReviewFileWatchApplication } from '../application/ReviewFileWatchApplication';
+import { validateReviewWatchProjectPath } from '../infrastructure/validateReviewWatchProjectPath';
+
+import type {
+  ReviewFileWatchConfiguration,
+  ReviewFileWatchOperation,
+} from '../application/ReviewFileWatchPorts';
+import type { BrowserWindow } from 'electron';
+
+export interface ReviewFileWatchFeature {
+  supersedePendingRequests(): void;
+  configure(configuration: ReviewFileWatchConfiguration): void;
+  prepareWatch(projectPath: string, filePaths: unknown): ReviewFileWatchOperation;
+  prepareUnwatch(): ReviewFileWatchOperation;
+  dispose(): void;
+  setMainWindow(window: BrowserWindow | null): void;
+}
+
+export function createReviewFileWatchFeature(): ReviewFileWatchFeature {
+  // Review is backed by a point-in-time diff. Ignoring startup changes can miss
+  // an external write and make Undo unsafe.
+  const defaultWatcher = new EditorFileWatcher({ ignoreStartupChanges: false });
+  const presenter = new ReviewFileWatchEventPresenter();
+  const application = new ReviewFileWatchApplication({
+    defaultWatcher,
+    defaultProjectPathValidator: validateReviewWatchProjectPath,
+    events: presenter,
+  });
+
+  return {
+    supersedePendingRequests: () => application.supersedePendingRequests(),
+    configure: (configuration) => application.configure(configuration),
+    prepareWatch: (projectPath, filePaths) => application.prepareWatch(projectPath, filePaths),
+    prepareUnwatch: () => application.prepareUnwatch(),
+    dispose: () => application.dispose(),
+    setMainWindow: (window) => presenter.setMainWindow(window),
+  };
+}

--- a/src/features/change-review/main/index.ts
+++ b/src/features/change-review/main/index.ts
@@ -1,4 +1,11 @@
 export {
+  assertReviewDecisionShape,
+  parseReviewDecisionPersistenceScope,
+  parseReviewHistoryScopeIdentity,
+  type ReviewHistoryScopeIdentity,
+} from '../core/domain/reviewDecisionPersistencePolicy';
+export { normalizeReviewWatchedFiles } from '../core/domain/reviewFileWatchPolicy';
+export {
   sanitizeTaskChangeOptions,
   sanitizeTeamTaskChangeSummaryRequests,
 } from '../core/domain/reviewQueryPolicy';
@@ -10,6 +17,24 @@ export {
   MAX_REVIEW_HUNK_DECISIONS_PER_FILE,
   MAX_REVIEW_SNIPPETS_PER_FILE,
 } from '../core/domain/reviewScopePolicy';
+export { ReviewDecisionPersistenceApplication } from './application/ReviewDecisionPersistenceApplication';
+export type {
+  ReviewDecisionHistoryScopeAuthorization,
+  ReviewDecisionPersistenceDependencies,
+  ReviewDecisionPersistenceLockPort,
+  ReviewDecisionPersistencePathPort,
+  ReviewDecisionPersistenceScopePort,
+  ReviewDraftHistoryScopeAuthorization,
+} from './application/ReviewDecisionPersistencePorts';
+export { ReviewFileWatchApplication } from './application/ReviewFileWatchApplication';
+export type {
+  ReviewFileWatchConfiguration,
+  ReviewFileWatchDependencies,
+  ReviewFileWatcherPort,
+  ReviewFileWatchEventPort,
+  ReviewFileWatchOperation,
+  ReviewProjectPathValidator,
+} from './application/ReviewFileWatchPorts';
 export { ReviewQueryApplication } from './application/ReviewQueryApplication';
 export type {
   ReviewQueryChangesPort,
@@ -32,6 +57,14 @@ export type {
   ReviewScopeFileSystemPort,
   ReviewScopePathPort,
 } from './application/ReviewScopeAuthorizationPorts';
+export {
+  createReviewDecisionPersistenceFeature,
+  type ReviewDecisionPersistenceFeatureDependencies,
+} from './composition/createReviewDecisionPersistenceFeature';
+export {
+  createReviewFileWatchFeature,
+  type ReviewFileWatchFeature,
+} from './composition/createReviewFileWatchFeature';
 export { createReviewQueryFeature } from './composition/createReviewQueryFeature';
 export {
   createReviewScopeAuthorizationFeature,

--- a/src/features/change-review/main/infrastructure/validateReviewWatchProjectPath.ts
+++ b/src/features/change-review/main/infrastructure/validateReviewWatchProjectPath.ts
@@ -1,0 +1,19 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+export async function validateReviewWatchProjectPath(projectPath: string): Promise<string> {
+  if (!projectPath || typeof projectPath !== 'string') {
+    throw new Error('Invalid project path');
+  }
+
+  if (!path.isAbsolute(projectPath)) {
+    throw new Error('Project path must be absolute');
+  }
+
+  const normalized = path.resolve(path.normalize(projectPath));
+  const stat = await fs.stat(normalized);
+  if (!stat.isDirectory()) {
+    throw new Error('Project path is not a directory');
+  }
+  return normalized;
+}

--- a/src/features/review-mutations/core/domain/reviewEditableMutationPolicy.ts
+++ b/src/features/review-mutations/core/domain/reviewEditableMutationPolicy.ts
@@ -5,7 +5,7 @@ export interface SaveEditedFileInput {
 }
 
 export interface DeleteEditedFileInput {
-  filePath: unknown;
+  filePath: string;
   expectedCurrentContent: string;
 }
 
@@ -28,5 +28,7 @@ export function parseDeleteEditedFileInput(
   filePath: unknown,
   expectedCurrentContent: unknown
 ): DeleteEditedFileInput | null {
-  return typeof expectedCurrentContent === 'string' ? { filePath, expectedCurrentContent } : null;
+  return typeof filePath === 'string' && typeof expectedCurrentContent === 'string'
+    ? { filePath, expectedCurrentContent }
+    : null;
 }

--- a/src/features/review-mutations/core/domain/reviewEditableMutationPolicy.ts
+++ b/src/features/review-mutations/core/domain/reviewEditableMutationPolicy.ts
@@ -1,0 +1,32 @@
+export interface SaveEditedFileInput {
+  filePath: string;
+  content: string;
+  expectedCurrentContent: string | null;
+}
+
+export interface DeleteEditedFileInput {
+  filePath: unknown;
+  expectedCurrentContent: string;
+}
+
+export function parseSaveEditedFileInput(
+  filePath: unknown,
+  content: unknown,
+  expectedCurrentContent: unknown
+): SaveEditedFileInput | null {
+  if (
+    typeof filePath !== 'string' ||
+    typeof content !== 'string' ||
+    (expectedCurrentContent !== null && typeof expectedCurrentContent !== 'string')
+  ) {
+    return null;
+  }
+  return { filePath, content, expectedCurrentContent };
+}
+
+export function parseDeleteEditedFileInput(
+  filePath: unknown,
+  expectedCurrentContent: unknown
+): DeleteEditedFileInput | null {
+  return typeof expectedCurrentContent === 'string' ? { filePath, expectedCurrentContent } : null;
+}

--- a/src/features/review-mutations/main/application/ReviewDecisionCommandApplication.ts
+++ b/src/features/review-mutations/main/application/ReviewDecisionCommandApplication.ts
@@ -326,12 +326,8 @@ export class ReviewDecisionCommandApplication {
       const diskPostimages = new Map<string, ReviewMutationDiskPostimage>();
       try {
         await this.dependencies.recovery.recoverPending(scope.teamName, persistenceScope);
-        const revisionSnapshot = await this.dependencies.persistence.load(
-          scope.teamName,
-          persistenceScope
-        );
-        assertCurrentReviewDecisionRevision(revisionSnapshot, expectedDecisionRevision);
         const current = await this.dependencies.persistence.load(scope.teamName, persistenceScope);
+        assertCurrentReviewDecisionRevision(current, expectedDecisionRevision);
         assertExactApplyReviewHistoryTransition(persistedState, current, decisions, {
           resolveFile: (filePath) =>
             this.dependencies.scope.getAuthoritativeFile(authorization, filePath),

--- a/src/features/review-mutations/main/application/ReviewEditableMutationApplication.ts
+++ b/src/features/review-mutations/main/application/ReviewEditableMutationApplication.ts
@@ -1,0 +1,132 @@
+import type {
+  DeleteEditedFileInput,
+  SaveEditedFileInput,
+} from '../../core/domain/reviewEditableMutationPolicy';
+import type { ReviewEditableMutationDependencies } from './ReviewEditableMutationPorts';
+import type { FileChangeWithContent } from '@shared/types/review';
+
+interface AuthorizedRenameMutation {
+  filePath: string;
+  content: FileChangeWithContent;
+}
+
+export class ReviewEditableMutationApplication {
+  constructor(private readonly dependencies: ReviewEditableMutationDependencies) {}
+
+  async saveEditedFile(
+    scopeValue: unknown,
+    input: SaveEditedFileInput
+  ): Promise<{ success: boolean }> {
+    const filePath = await this.authorizeMutableFile(scopeValue, input.filePath);
+    const result = await this.dependencies.applier.saveEditedFile(
+      filePath,
+      input.content,
+      input.expectedCurrentContent
+    );
+    this.dependencies.content.invalidateFile(filePath);
+    return result;
+  }
+
+  async deleteEditedFile(
+    scopeValue: unknown,
+    input: DeleteEditedFileInput
+  ): Promise<{ success: boolean }> {
+    const filePath = await this.authorizeMutableFile(scopeValue, input.filePath);
+    const result = await this.dependencies.applier.deleteEditedFile(
+      filePath,
+      input.expectedCurrentContent
+    );
+    this.dependencies.content.invalidateFile(filePath);
+    return result;
+  }
+
+  async restoreRejectedRename(
+    scopeValue: unknown,
+    filePathValue: unknown,
+    expectationValue: unknown
+  ): Promise<{ success: boolean }> {
+    const authorized = await this.authorizeRenameMutation(
+      scopeValue,
+      filePathValue,
+      expectationValue
+    );
+    try {
+      return await this.dependencies.applier.restoreRejectedRename(
+        authorized.filePath,
+        authorized.content.originalFullContent,
+        authorized.content.modifiedFullContent,
+        authorized.content.snippets
+      );
+    } finally {
+      this.dependencies.scope.invalidateAuthoritativeReviewContent(authorized.content);
+    }
+  }
+
+  async reapplyRejectedRename(
+    scopeValue: unknown,
+    filePathValue: unknown,
+    expectationValue: unknown
+  ): Promise<{ success: boolean }> {
+    const authorized = await this.authorizeRenameMutation(
+      scopeValue,
+      filePathValue,
+      expectationValue
+    );
+    try {
+      return await this.dependencies.applier.reapplyRejectedRename(
+        authorized.filePath,
+        authorized.content.originalFullContent,
+        authorized.content.snippets
+      );
+    } finally {
+      this.dependencies.scope.invalidateAuthoritativeReviewContent(authorized.content);
+    }
+  }
+
+  private async authorizeMutableFile(scopeValue: unknown, filePathValue: unknown): Promise<string> {
+    const { authorization } = await this.dependencies.scope.resolveReviewPathAuthorization(
+      scopeValue,
+      {
+        requireIdentity: true,
+      }
+    );
+    return this.dependencies.scope.validateAuthorizedReviewFilePath(authorization, filePathValue, {
+      requireReviewedFile: true,
+      rejectHardlinks: true,
+    });
+  }
+
+  private async authorizeRenameMutation(
+    scopeValue: unknown,
+    filePathValue: unknown,
+    expectationValue: unknown
+  ): Promise<AuthorizedRenameMutation> {
+    const expectation =
+      this.dependencies.scope.parseReviewRenameRecoveryExpectation(expectationValue);
+    const { scope, authorization } = await this.dependencies.scope.resolveReviewPathAuthorization(
+      scopeValue,
+      {
+        requireIdentity: true,
+      }
+    );
+    const filePath = await this.dependencies.scope.validateAuthorizedReviewFilePath(
+      authorization,
+      filePathValue,
+      {
+        requireReviewedFile: true,
+        rejectHardlinks: true,
+      }
+    );
+    const content = await this.dependencies.scope.resolveAuthoritativeFileContent(
+      scope,
+      authorization,
+      filePath
+    );
+    await this.dependencies.scope.validateSnippetPaths(authorization, content.snippets, {
+      requireReviewedFile: true,
+      rejectHardlinks: true,
+    });
+    this.dependencies.scope.assertExpectedAuthoritativeRename(content, expectation);
+    return { filePath, content };
+  }
+}

--- a/src/features/review-mutations/main/application/ReviewEditableMutationPorts.ts
+++ b/src/features/review-mutations/main/application/ReviewEditableMutationPorts.ts
@@ -1,0 +1,65 @@
+import type { ReviewMutationPathAuthorization } from './ReviewMutationRecoveryPorts';
+import type {
+  FileChangeWithContent,
+  ReviewFileScope,
+  ReviewRenameRecoveryExpectation,
+  SnippetDiff,
+} from '@shared/types/review';
+
+export interface ReviewEditableMutationScopePort {
+  parseReviewRenameRecoveryExpectation(value: unknown): ReviewRenameRecoveryExpectation;
+  resolveReviewPathAuthorization(
+    value: unknown,
+    options: { requireIdentity: true }
+  ): Promise<{ scope: ReviewFileScope; authorization: ReviewMutationPathAuthorization }>;
+  validateAuthorizedReviewFilePath(
+    authorization: ReviewMutationPathAuthorization,
+    filePath: unknown,
+    options: { requireReviewedFile: true; rejectHardlinks: true }
+  ): Promise<string>;
+  resolveAuthoritativeFileContent(
+    scope: ReviewFileScope,
+    authorization: ReviewMutationPathAuthorization,
+    filePath: string
+  ): Promise<FileChangeWithContent>;
+  validateSnippetPaths(
+    authorization: ReviewMutationPathAuthorization,
+    snippets: SnippetDiff[],
+    options: { requireReviewedFile: true; rejectHardlinks: true }
+  ): Promise<void>;
+  assertExpectedAuthoritativeRename(
+    content: FileChangeWithContent,
+    expectation: ReviewRenameRecoveryExpectation
+  ): void;
+  invalidateAuthoritativeReviewContent(content: FileChangeWithContent): void;
+}
+
+export interface ReviewEditableMutationApplierPort {
+  saveEditedFile(
+    filePath: string,
+    content: string,
+    expectedCurrentContent: string | null
+  ): Promise<{ success: boolean }>;
+  deleteEditedFile(filePath: string, expectedCurrentContent: string): Promise<{ success: boolean }>;
+  restoreRejectedRename(
+    filePath: string,
+    original: string | null,
+    modified: string | null,
+    snippets: SnippetDiff[]
+  ): Promise<{ success: boolean }>;
+  reapplyRejectedRename(
+    filePath: string,
+    original: string | null,
+    snippets: SnippetDiff[]
+  ): Promise<{ success: boolean }>;
+}
+
+export interface ReviewEditableMutationContentPort {
+  invalidateFile(filePath: string): void;
+}
+
+export interface ReviewEditableMutationDependencies {
+  scope: ReviewEditableMutationScopePort;
+  applier: ReviewEditableMutationApplierPort;
+  content: ReviewEditableMutationContentPort;
+}

--- a/src/features/review-mutations/main/composition/createReviewEditableMutationFeature.ts
+++ b/src/features/review-mutations/main/composition/createReviewEditableMutationFeature.ts
@@ -1,0 +1,11 @@
+import { ReviewEditableMutationApplication } from '../application/ReviewEditableMutationApplication';
+
+import type { ReviewEditableMutationDependencies } from '../application/ReviewEditableMutationPorts';
+
+export type ReviewEditableMutationFeatureDependencies = ReviewEditableMutationDependencies;
+
+export function createReviewEditableMutationFeature(
+  dependencies: ReviewEditableMutationFeatureDependencies
+): ReviewEditableMutationApplication {
+  return new ReviewEditableMutationApplication(dependencies);
+}

--- a/src/features/review-mutations/main/index.ts
+++ b/src/features/review-mutations/main/index.ts
@@ -26,6 +26,12 @@ export {
   type ReviewDecisionCommandPolicyContext,
 } from '../core/domain/reviewDecisionCommandPolicy';
 export {
+  type DeleteEditedFileInput,
+  parseDeleteEditedFileInput,
+  parseSaveEditedFileInput,
+  type SaveEditedFileInput,
+} from '../core/domain/reviewEditableMutationPolicy';
+export {
   buildReviewExternalReloadState,
   buildReviewHistoryRestorePlan,
   buildReviewRestoreDecisionState,
@@ -81,6 +87,13 @@ export type {
   ReviewDecisionCommandSnapshotIdentityPort,
 } from './application/ReviewDecisionCommandPorts';
 export { ReviewDirectMutationDiskService } from './application/ReviewDirectMutationDiskService';
+export { ReviewEditableMutationApplication } from './application/ReviewEditableMutationApplication';
+export type {
+  ReviewEditableMutationApplierPort,
+  ReviewEditableMutationContentPort,
+  ReviewEditableMutationDependencies,
+  ReviewEditableMutationScopePort,
+} from './application/ReviewEditableMutationPorts';
 export { ReviewHistoryMutationApplication } from './application/ReviewHistoryMutationApplication';
 export type {
   ReviewHistoryMutationCurrentState,
@@ -121,6 +134,10 @@ export {
   createReviewDecisionCommandFeature,
   type ReviewDecisionCommandFeatureDependencies,
 } from './composition/createReviewDecisionCommandFeature';
+export {
+  createReviewEditableMutationFeature,
+  type ReviewEditableMutationFeatureDependencies,
+} from './composition/createReviewEditableMutationFeature';
 export {
   createReviewHistoryMutationFeature,
   type ReviewHistoryMutationFeatureDependencies,

--- a/src/main/ipc/review.ts
+++ b/src/main/ipc/review.ts
@@ -6,11 +6,11 @@
 
 import {
   assertHunkIndices,
-  assertNonEmptyString,
   assertSnippetShapes,
+  createReviewDecisionPersistenceFeature,
+  createReviewFileWatchFeature,
   createReviewQueryFeature,
   createReviewScopeAuthorizationFeature,
-  MAX_REVIEW_HUNK_DECISIONS_PER_FILE,
   sanitizeTaskChangeOptions,
   sanitizeTeamTaskChangeSummaryRequests,
 } from '@features/change-review/main';
@@ -37,21 +37,15 @@ import {
 } from '@features/review-mutations/main';
 import { validateTaskId, validateTeamName } from '@main/ipc/guards';
 import { createIpcWrapper } from '@main/ipc/ipcWrapper';
-import { EditorFileWatcher } from '@main/services/editor';
 import { ReviewDecisionStore } from '@main/services/team/ReviewDecisionStore';
 import { ReviewMutationJournalStore } from '@main/services/team/ReviewMutationJournalStore';
-import {
-  withReviewPersistenceLogicalScopeLock,
-  withReviewPersistenceScopeLock,
-} from '@main/services/team/ReviewPersistenceScopeLock';
+import * as reviewPersistenceLocks from '@main/services/team/ReviewPersistenceScopeLock';
 import { TeamConfigReader } from '@main/services/team/TeamConfigReader';
 import { inspectReviewFileTransaction } from '@main/utils/atomicWrite';
-import { safeSendToRenderer } from '@main/utils/safeWebContentsSend';
 import {
   REVIEW_APPLY_DECISIONS,
   REVIEW_CHECK_CONFLICT,
   REVIEW_DELETE_EDITED_FILE,
-  REVIEW_FILE_CHANGE,
   REVIEW_GET_AGENT_CHANGES,
   REVIEW_GET_CHANGE_STATS,
   REVIEW_GET_FILE_CONTENT,
@@ -73,11 +67,7 @@ import { createLogger } from '@shared/utils/logger';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 
-import type { ReviewPathAuthorization } from '@features/change-review/main';
-import type {
-  ReviewDecisionAuthorization,
-  ReviewDraftHistoryAuthorization,
-} from '@features/change-review-history/main';
+import type { ReviewFileWatcherPort, ReviewPathAuthorization } from '@features/change-review/main';
 import type { ChangeExtractorService } from '@main/services/team/ChangeExtractorService';
 import type { FileContentResolver } from '@main/services/team/FileContentResolver';
 import type { GitDiffFallback } from '@main/services/team/GitDiffFallback';
@@ -91,9 +81,7 @@ import type {
   ConflictCheckResult,
   FileChangeSummary,
   FileChangeWithContent,
-  FileReviewDecision,
   RejectResult,
-  ReviewDecisionPersistenceScope,
   ReviewFileScope,
   ReviewRenameRecoveryExpectation,
   SnippetDiff,
@@ -116,50 +104,8 @@ let reviewConfigReader: Pick<TeamConfigReader, 'getConfig'> = new TeamConfigRead
 const reviewDecisionStore = new ReviewDecisionStore();
 const reviewMutationJournal = new ReviewMutationJournalStore();
 const reviewMutationCoordinator = new ReviewMutationCoordinator(reviewMutationJournal);
-const reviewDecisionPersistenceQueues = new Map<string, Promise<void>>();
-// Review is backed by a point-in-time diff. Unlike the editor watcher, ignoring
-// the first few seconds can silently miss an external write and make Undo unsafe.
-export type ReviewFileWatcher = Pick<
-  EditorFileWatcher,
-  'isWatching' | 'setWatchedFiles' | 'start' | 'stop'
->;
-const defaultReviewFileWatcher = new EditorFileWatcher({ ignoreStartupChanges: false });
-let reviewFileWatcher: ReviewFileWatcher = defaultReviewFileWatcher;
-let reviewWatcherProjectRoot: string | null = null;
-let reviewWatcherRequestGeneration = 0;
-let reviewMainWindowRef: BrowserWindow | null = null;
-let reviewProjectPathValidator: (projectPath: string) => Promise<string> =
-  validateReviewProjectPath;
-
-async function withReviewDecisionPersistenceLock<T>(
-  teamName: string,
-  persistenceScope: ReviewDecisionPersistenceScope,
-  operation: () => Promise<T>
-): Promise<T> {
-  const key = `${teamName}:${persistenceScope.scopeKey}`;
-  const previous = reviewDecisionPersistenceQueues.get(key) ?? Promise.resolve();
-  let release = (): void => undefined;
-  const current = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  const queueTail = previous.then(
-    () => current,
-    () => current
-  );
-  reviewDecisionPersistenceQueues.set(key, queueTail);
-
-  await previous.catch(() => undefined);
-  try {
-    return await withReviewPersistenceLogicalScopeLock(teamName, persistenceScope.scopeKey, () =>
-      withReviewPersistenceScopeLock(teamName, persistenceScope, operation)
-    );
-  } finally {
-    release();
-    if (reviewDecisionPersistenceQueues.get(key) === queueTail) {
-      reviewDecisionPersistenceQueues.delete(key);
-    }
-  }
-}
+export type ReviewFileWatcher = ReviewFileWatcherPort;
+const reviewFileWatchFeature = createReviewFileWatchFeature();
 
 function getChangeExtractor(): ChangeExtractorService {
   if (!changeExtractor) throw new Error('Review handlers not initialized');
@@ -261,107 +207,22 @@ function validateSnippetPaths(
   return reviewScopeAuthorizationFeature.validateSnippetPaths(authorization, snippets, options);
 }
 
-function assertReviewDecisionShape(value: unknown): asserts value is FileReviewDecision {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    throw new Error('Invalid review decision');
-  }
-  const raw = value as Record<string, unknown>;
-  assertNonEmptyString(raw.filePath, 'decision.filePath');
-  if (
-    raw.reviewKey !== undefined &&
-    (typeof raw.reviewKey !== 'string' ||
-      raw.reviewKey.length === 0 ||
-      raw.reviewKey.length > 32_768 ||
-      raw.reviewKey.includes('\0'))
-  ) {
-    throw new Error('Invalid decision.reviewKey');
-  }
-  if (!['accepted', 'rejected', 'pending'].includes(String(raw.fileDecision))) {
-    throw new Error('Invalid fileDecision');
-  }
-  if (
-    !raw.hunkDecisions ||
-    typeof raw.hunkDecisions !== 'object' ||
-    Array.isArray(raw.hunkDecisions) ||
-    Object.keys(raw.hunkDecisions).length > MAX_REVIEW_HUNK_DECISIONS_PER_FILE
-  ) {
-    throw new Error('Invalid hunkDecisions');
-  }
-  for (const [index, decision] of Object.entries(raw.hunkDecisions)) {
-    const numericIndex = Number(index);
-    if (
-      !/^\d+$/.test(index) ||
-      !Number.isSafeInteger(numericIndex) ||
-      numericIndex >= MAX_REVIEW_HUNK_DECISIONS_PER_FILE ||
-      !['accepted', 'rejected', 'pending'].includes(String(decision))
-    ) {
-      throw new Error('Invalid hunk decision');
-    }
-  }
-  if (raw.hunkContextHashes !== undefined) {
-    if (
-      !raw.hunkContextHashes ||
-      typeof raw.hunkContextHashes !== 'object' ||
-      Array.isArray(raw.hunkContextHashes) ||
-      Object.keys(raw.hunkContextHashes).length > MAX_REVIEW_HUNK_DECISIONS_PER_FILE
-    ) {
-      throw new Error('Invalid hunkContextHashes');
-    }
-    for (const [index, hash] of Object.entries(raw.hunkContextHashes)) {
-      const numericIndex = Number(index);
-      if (
-        !/^\d+$/.test(index) ||
-        !Number.isSafeInteger(numericIndex) ||
-        numericIndex >= MAX_REVIEW_HUNK_DECISIONS_PER_FILE ||
-        typeof hash !== 'string' ||
-        hash.length === 0 ||
-        hash.length > 256
-      ) {
-        throw new Error('Invalid hunk context hash');
-      }
-    }
-  }
-  if (
-    raw.contentSnapshotToken !== undefined &&
-    (typeof raw.contentSnapshotToken !== 'string' || raw.contentSnapshotToken.length > 200)
-  ) {
-    throw new Error('Invalid contentSnapshotToken');
-  }
-  if (raw.snippets !== undefined) assertSnippetShapes(raw.snippets);
-  for (const field of ['originalFullContent', 'modifiedFullContent']) {
-    if (raw[field] !== undefined && raw[field] !== null && typeof raw[field] !== 'string') {
-      throw new Error(`Invalid ${field}`);
-    }
-  }
-  if (raw.isNewFile !== undefined && typeof raw.isNewFile !== 'boolean') {
-    throw new Error('Invalid isNewFile');
-  }
-}
-
-function parseDecisionPersistenceScope(
-  value: unknown,
-  scope: ReviewFileScope
-): ReviewDecisionPersistenceScope | null {
-  if (value === undefined) return null;
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    throw new Error('Invalid decision persistence scope');
-  }
-  const raw = value as Record<string, unknown>;
-  assertNonEmptyString(raw.scopeKey, 'decisionPersistenceScope.scopeKey');
-  assertNonEmptyString(raw.scopeToken, 'decisionPersistenceScope.scopeToken');
-  if (raw.scopeToken.length > 32 * 1024 * 1024 || raw.scopeToken.includes('\0')) {
-    throw new Error('Invalid decision persistence scope token');
-  }
-  const expectedScopeKey = scope.taskId
-    ? `task-${scope.taskId}`
-    : scope.memberName
-      ? `agent-${scope.memberName}`
-      : null;
-  if (!expectedScopeKey || raw.scopeKey !== expectedScopeKey) {
-    throw new Error('Decision persistence scope does not match the authoritative review');
-  }
-  return { scopeKey: raw.scopeKey, scopeToken: raw.scopeToken };
-}
+const reviewDecisionPersistenceFeature = createReviewDecisionPersistenceFeature({
+  scope: {
+    parse: parseReviewFileScope,
+    resolve: resolveReviewPathAuthorization,
+    normalizeIdentityPath: normalizeReviewPathForIdentity,
+    validateFilePath: validateAuthorizedReviewFilePath,
+    getAuthoritativeFile: getAuthoritativeReviewedFile,
+  },
+  paths: {
+    isAbsoluteNormalized: (filePath) => path.isAbsolute(path.normalize(filePath)),
+  },
+  locks: {
+    withLogicalScopeLock: reviewPersistenceLocks.withReviewPersistenceLogicalScopeLock,
+    withPersistenceScopeLock: reviewPersistenceLocks.withReviewPersistenceScopeLock,
+  },
+});
 
 // --- Forward-compatible config object ---
 
@@ -378,19 +239,16 @@ export interface ReviewHandlerDeps {
 export function initializeReviewHandlers(deps: ReviewHandlerDeps): void {
   // Handler reinitialization supersedes validation still pending from the
   // previous registration, even when both registrations reuse one watcher.
-  reviewWatcherRequestGeneration += 1;
+  reviewFileWatchFeature.supersedePendingRequests();
   changeExtractor = deps.extractor;
   if (deps.applier) reviewApplier = deps.applier;
   if (deps.contentResolver) fileContentResolver = deps.contentResolver;
   if (deps.gitFallback) gitDiffFallback = deps.gitFallback;
   reviewConfigReader = deps.configReader ?? new TeamConfigReader();
-  const nextFileWatcher = deps.fileWatcher ?? defaultReviewFileWatcher;
-  if (reviewFileWatcher !== nextFileWatcher) {
-    reviewFileWatcher.stop();
-    reviewWatcherProjectRoot = null;
-    reviewFileWatcher = nextFileWatcher;
-  }
-  reviewProjectPathValidator = deps.projectPathValidator ?? validateReviewProjectPath;
+  reviewFileWatchFeature.configure({
+    fileWatcher: deps.fileWatcher,
+    projectPathValidator: deps.projectPathValidator,
+  });
 }
 
 export function registerReviewHandlers(ipcMain: IpcMain): void {
@@ -449,13 +307,11 @@ export function removeReviewHandlers(ipcMain: IpcMain): void {
   removeReviewMutationRecoveryIpc(ipcMain);
   removeReviewDecisionHistoryIpc(ipcMain);
   removeReviewDraftHistoryIpc(ipcMain);
-  reviewFileWatcher.stop();
-  reviewWatcherProjectRoot = null;
-  reviewWatcherRequestGeneration += 1;
+  reviewFileWatchFeature.dispose();
 }
 
 export function setReviewMainWindow(win: BrowserWindow | null): void {
-  reviewMainWindowRef = win;
+  reviewFileWatchFeature.setMainWindow(win);
 }
 
 // --- Phase 1 Handlers ---
@@ -582,51 +438,6 @@ async function handleApplyDecisions(
   );
 }
 
-function parseReviewScopeKey(teamName: string, scopeKey: string): ReviewFileScope {
-  if (scopeKey.startsWith('task-')) {
-    return parseReviewFileScope({ teamName, taskId: scopeKey.slice('task-'.length) });
-  }
-  if (scopeKey.startsWith('agent-')) {
-    return parseReviewFileScope({ teamName, memberName: scopeKey.slice('agent-'.length) });
-  }
-  throw new Error('Review decision scope cannot authorize history');
-}
-
-async function authorizeReviewDraftHistoryScope(
-  teamName: string,
-  scopeKey: string
-): Promise<ReviewDraftHistoryAuthorization> {
-  const { authorization } = await resolveReviewPathAuthorization(
-    parseReviewScopeKey(teamName, scopeKey),
-    { requireIdentity: true }
-  );
-  return {
-    isCurrentReviewedFile: (filePath) =>
-      path.isAbsolute(path.normalize(filePath)) &&
-      Boolean(authorization.reviewedFiles?.has(normalizeReviewPathForIdentity(filePath))),
-    assertCurrentReviewedFile: async (filePath) => {
-      await validateAuthorizedReviewFilePath(authorization, filePath, {
-        requireReviewedFile: true,
-      });
-    },
-  };
-}
-
-async function authorizeReviewDecisionHistoryScope(
-  teamName: string,
-  scopeKey: string
-): Promise<ReviewDecisionAuthorization> {
-  const { authorization } = await resolveReviewPathAuthorization(
-    parseReviewScopeKey(teamName, scopeKey),
-    { requireIdentity: true }
-  );
-  return {
-    files: authorization.reviewedFiles ? [...authorization.reviewedFiles.values()] : null,
-    normalizePath: normalizeReviewPathForIdentity,
-    resolveFile: (filePath) => getAuthoritativeReviewedFile(authorization, filePath),
-  };
-}
-
 const reviewDecisionBatchFeature = createReviewDecisionBatchFeature({
   scope: {
     parse: parseReviewFileScope,
@@ -683,20 +494,22 @@ const reviewMutationRecoveryFeature = createReviewMutationRecoveryFeature({
   scope: {
     parse: parseReviewFileScope,
     resolve: resolveReviewPathAuthorization,
-    parsePersistenceScope: parseDecisionPersistenceScope,
+    parsePersistenceScope: (value, scope) =>
+      reviewDecisionPersistenceFeature.parsePersistenceScope(value, scope),
     validateFilePath: validateAuthorizedReviewFilePath,
     validateSnippets: validateSnippetPaths,
     resolveAuthoritativeContent: resolveAuthoritativeFileContent,
     assertExpectedRename: assertExpectedAuthoritativeRename,
     parseRenameExpectation: parseReviewRenameRecoveryExpectation,
-    assertDecisionShape: assertReviewDecisionShape,
+    assertDecisionShape: (value) => reviewDecisionPersistenceFeature.assertDecisionShape(value),
     assertSnippetShapes,
     getAuthoritativeFile: getAuthoritativeReviewedFile,
     normalizeIdentityPath: normalizeReviewPathForIdentity,
     normalizeFilesystemPath: (filePath) => path.resolve(path.normalize(filePath)),
   },
   decisions: {
-    withLock: withReviewDecisionPersistenceLock,
+    withLock: (teamName, persistenceScope, operation) =>
+      reviewDecisionPersistenceFeature.withLock(teamName, persistenceScope, operation),
     assertValidSnapshot: (value) => reviewDecisionStore.assertValidSnapshot(value),
     assertCurrentRevision: async (teamName, persistenceScope, expectedRevision) => {
       const current = await reviewDecisionStore.load(
@@ -751,10 +564,11 @@ const reviewMutationRecoveryFeature = createReviewMutationRecoveryFeature({
 const reviewDecisionCommandFeature = createReviewDecisionCommandFeature({
   scope: {
     resolve: resolveReviewPathAuthorization,
-    parsePersistenceScope: parseDecisionPersistenceScope,
+    parsePersistenceScope: (value, scope) =>
+      reviewDecisionPersistenceFeature.parsePersistenceScope(value, scope),
     validateFilePath: validateAuthorizedReviewFilePath,
     validateSnippets: validateSnippetPaths,
-    assertDecisionShape: assertReviewDecisionShape,
+    assertDecisionShape: (value) => reviewDecisionPersistenceFeature.assertDecisionShape(value),
     assertSnippetShapes,
     getAuthoritativeFile: getAuthoritativeReviewedFile,
     resolveAuthoritativeContent: resolveAuthoritativeFileContent,
@@ -768,7 +582,8 @@ const reviewDecisionCommandFeature = createReviewDecisionCommandFeature({
     applyReviewDecisions: (...args) => getApplier().applyReviewDecisions(...args),
   },
   persistence: {
-    withLock: withReviewDecisionPersistenceLock,
+    withLock: (teamName, persistenceScope, operation) =>
+      reviewDecisionPersistenceFeature.withLock(teamName, persistenceScope, operation),
     assertValidSnapshot: (value) => reviewDecisionStore.assertValidSnapshot(value),
     load: (teamName, persistenceScope) =>
       reviewDecisionStore.load(teamName, persistenceScope.scopeKey, persistenceScope.scopeToken),
@@ -829,8 +644,14 @@ const reviewQueryFeature = createReviewQueryFeature({
 });
 
 const reviewDecisionHistoryFeature = createReviewDecisionHistoryFeature({
-  lock: { run: withReviewDecisionPersistenceLock },
-  authorization: { authorize: authorizeReviewDecisionHistoryScope },
+  lock: {
+    run: (teamName, persistenceScope, operation) =>
+      reviewDecisionPersistenceFeature.withLock(teamName, persistenceScope, operation),
+  },
+  authorization: {
+    authorize: (teamName, scopeKey) =>
+      reviewDecisionPersistenceFeature.authorizeDecisionHistoryScope(teamName, scopeKey),
+  },
   queries: reviewDecisionStore,
   mutations: reviewDecisionStore,
   validation: reviewDecisionStore,
@@ -858,8 +679,14 @@ const reviewDecisionHistoryFeature = createReviewDecisionHistoryFeature({
 });
 
 const reviewDraftHistoryFeature = createReviewDraftHistoryFeature({
-  lock: { run: withReviewDecisionPersistenceLock },
-  authorization: { authorize: authorizeReviewDraftHistoryScope },
+  lock: {
+    run: (teamName, persistenceScope, operation) =>
+      reviewDecisionPersistenceFeature.withLock(teamName, persistenceScope, operation),
+  },
+  authorization: {
+    authorize: (teamName, scopeKey) =>
+      reviewDecisionPersistenceFeature.authorizeDraftHistoryScope(teamName, scopeKey),
+  },
 });
 
 async function handleGetFileContent(
@@ -934,51 +761,16 @@ async function handleWatchReviewFiles(
   projectPath: string,
   filePaths: string[]
 ): Promise<IpcResult<void>> {
-  const requestGeneration = ++reviewWatcherRequestGeneration;
-  return wrapReviewHandler('watchFiles', async () => {
-    const normalizedProjectPath = await reviewProjectPathValidator(projectPath);
-    if (requestGeneration !== reviewWatcherRequestGeneration) return;
-    const shouldRestart =
-      reviewWatcherProjectRoot !== normalizedProjectPath || !reviewFileWatcher.isWatching();
-
-    if (shouldRestart) {
-      reviewFileWatcher.stop();
-      reviewWatcherProjectRoot = normalizedProjectPath;
-      reviewFileWatcher.start(normalizedProjectPath, (event) => {
-        safeSendToRenderer(reviewMainWindowRef, REVIEW_FILE_CHANGE, event);
-      });
-    }
-
-    reviewFileWatcher.setWatchedFiles(Array.isArray(filePaths) ? filePaths : []);
-  });
+  const operation = reviewFileWatchFeature.prepareWatch(projectPath, filePaths);
+  return wrapReviewHandler('watchFiles', operation);
 }
 
 async function handleUnwatchReviewFiles(): Promise<IpcResult<void>> {
-  reviewWatcherRequestGeneration += 1;
-  return wrapReviewHandler('unwatchFiles', async () => {
-    reviewFileWatcher.stop();
-    reviewWatcherProjectRoot = null;
-  });
+  const operation = reviewFileWatchFeature.prepareUnwatch();
+  return wrapReviewHandler('unwatchFiles', operation);
 }
 
 // --- Phase 4 Handlers ---
-
-async function validateReviewProjectPath(projectPath: string): Promise<string> {
-  if (!projectPath || typeof projectPath !== 'string') {
-    throw new Error('Invalid project path');
-  }
-
-  if (!path.isAbsolute(projectPath)) {
-    throw new Error('Project path must be absolute');
-  }
-
-  const normalized = path.resolve(path.normalize(projectPath));
-  const stat = await fs.stat(normalized);
-  if (!stat.isDirectory()) {
-    throw new Error('Project path is not a directory');
-  }
-  return normalized;
-}
 
 async function handleGetGitFileLog(
   _event: IpcMainInvokeEvent,

--- a/src/main/ipc/review.ts
+++ b/src/main/ipc/review.ts
@@ -26,8 +26,11 @@ import {
   assertCurrentReviewDecisionRevision,
   createReviewDecisionBatchFeature,
   createReviewDecisionCommandFeature,
+  createReviewEditableMutationFeature,
   createReviewHistoryMutationFeature,
   createReviewMutationRecoveryFeature,
+  parseDeleteEditedFileInput,
+  parseSaveEditedFileInput,
   registerReviewMutationRecoveryIpc,
   removeReviewMutationRecoveryIpc,
   ReviewMutationCoordinator,
@@ -663,6 +666,19 @@ const reviewHistoryMutationFeature = createReviewHistoryMutationFeature({
   },
 });
 
+const reviewEditableMutationFeature = createReviewEditableMutationFeature({
+  scope: reviewScopeAuthorizationFeature,
+  applier: {
+    saveEditedFile: (...args) => getApplier().saveEditedFile(...args),
+    deleteEditedFile: (...args) => getApplier().deleteEditedFile(...args),
+    restoreRejectedRename: (...args) => getApplier().restoreRejectedRename(...args),
+    reapplyRejectedRename: (...args) => getApplier().reapplyRejectedRename(...args),
+  },
+  content: {
+    invalidateFile: (filePath) => getContentResolver().invalidateFile(filePath),
+  },
+});
+
 const reviewMutationRecoveryFeature = createReviewMutationRecoveryFeature({
   scope: {
     parse: parseReviewFileScope,
@@ -867,26 +883,13 @@ async function handleSaveEditedFile(
   content: unknown,
   expectedCurrentContent: string | null | undefined
 ): Promise<IpcResult<{ success: boolean }>> {
-  if (
-    typeof filePathValue !== 'string' ||
-    typeof content !== 'string' ||
-    (expectedCurrentContent !== null && typeof expectedCurrentContent !== 'string')
-  ) {
+  const input = parseSaveEditedFileInput(filePathValue, content, expectedCurrentContent);
+  if (!input) {
     return { success: false, error: 'Invalid parameters' };
   }
-  return wrapReviewHandler('saveEditedFile', async () => {
-    const { authorization } = await resolveReviewPathAuthorization(scopeValue, {
-      requireIdentity: true,
-    });
-    const filePath = await validateAuthorizedReviewFilePath(authorization, filePathValue, {
-      requireReviewedFile: true,
-      rejectHardlinks: true,
-    });
-    const result = await getApplier().saveEditedFile(filePath, content, expectedCurrentContent);
-    // Invalidate cached content so next fetch reads the saved version from disk
-    getContentResolver().invalidateFile(filePath);
-    return result;
-  });
+  return wrapReviewHandler('saveEditedFile', () =>
+    reviewEditableMutationFeature.saveEditedFile(scopeValue, input)
+  );
 }
 
 async function handleDeleteEditedFile(
@@ -895,21 +898,13 @@ async function handleDeleteEditedFile(
   filePathValue: unknown,
   expectedCurrentContent: unknown
 ): Promise<IpcResult<{ success: boolean }>> {
-  if (typeof expectedCurrentContent !== 'string') {
+  const input = parseDeleteEditedFileInput(filePathValue, expectedCurrentContent);
+  if (!input) {
     return { success: false, error: 'Invalid parameters' };
   }
-  return wrapReviewHandler('deleteEditedFile', async () => {
-    const { authorization } = await resolveReviewPathAuthorization(scopeValue, {
-      requireIdentity: true,
-    });
-    const filePath = await validateAuthorizedReviewFilePath(authorization, filePathValue, {
-      requireReviewedFile: true,
-      rejectHardlinks: true,
-    });
-    const result = await getApplier().deleteEditedFile(filePath, expectedCurrentContent);
-    getContentResolver().invalidateFile(filePath);
-    return result;
-  });
+  return wrapReviewHandler('deleteEditedFile', () =>
+    reviewEditableMutationFeature.deleteEditedFile(scopeValue, input)
+  );
 }
 
 async function handleRestoreRejectedRename(
@@ -918,37 +913,9 @@ async function handleRestoreRejectedRename(
   filePathValue: unknown,
   expectationValue: unknown
 ): Promise<IpcResult<{ success: boolean }>> {
-  return wrapReviewHandler('restoreRejectedRename', async () => {
-    const expectation = parseReviewRenameRecoveryExpectation(expectationValue);
-    const { scope, authorization } = await resolveReviewPathAuthorization(scopeValue, {
-      requireIdentity: true,
-    });
-    const filePath = await validateAuthorizedReviewFilePath(authorization, filePathValue, {
-      requireReviewedFile: true,
-      rejectHardlinks: true,
-    });
-    const authoritativeContent = await resolveAuthoritativeFileContent(
-      scope,
-      authorization,
-      filePath
-    );
-    await validateSnippetPaths(authorization, authoritativeContent.snippets, {
-      requireReviewedFile: true,
-      rejectHardlinks: true,
-    });
-    assertExpectedAuthoritativeRename(authoritativeContent, expectation);
-
-    try {
-      return await getApplier().restoreRejectedRename(
-        filePath,
-        authoritativeContent.originalFullContent,
-        authoritativeContent.modifiedFullContent,
-        authoritativeContent.snippets
-      );
-    } finally {
-      invalidateAuthoritativeReviewContent(authoritativeContent);
-    }
-  });
+  return wrapReviewHandler('restoreRejectedRename', () =>
+    reviewEditableMutationFeature.restoreRejectedRename(scopeValue, filePathValue, expectationValue)
+  );
 }
 
 async function handleReapplyRejectedRename(
@@ -957,36 +924,9 @@ async function handleReapplyRejectedRename(
   filePathValue: unknown,
   expectationValue: unknown
 ): Promise<IpcResult<{ success: boolean }>> {
-  return wrapReviewHandler('reapplyRejectedRename', async () => {
-    const expectation = parseReviewRenameRecoveryExpectation(expectationValue);
-    const { scope, authorization } = await resolveReviewPathAuthorization(scopeValue, {
-      requireIdentity: true,
-    });
-    const filePath = await validateAuthorizedReviewFilePath(authorization, filePathValue, {
-      requireReviewedFile: true,
-      rejectHardlinks: true,
-    });
-    const authoritativeContent = await resolveAuthoritativeFileContent(
-      scope,
-      authorization,
-      filePath
-    );
-    await validateSnippetPaths(authorization, authoritativeContent.snippets, {
-      requireReviewedFile: true,
-      rejectHardlinks: true,
-    });
-    assertExpectedAuthoritativeRename(authoritativeContent, expectation);
-
-    try {
-      return await getApplier().reapplyRejectedRename(
-        filePath,
-        authoritativeContent.originalFullContent,
-        authoritativeContent.snippets
-      );
-    } finally {
-      invalidateAuthoritativeReviewContent(authoritativeContent);
-    }
-  });
+  return wrapReviewHandler('reapplyRejectedRename', () =>
+    reviewEditableMutationFeature.reapplyRejectedRename(scopeValue, filePathValue, expectationValue)
+  );
 }
 
 async function handleWatchReviewFiles(

--- a/test/architecture/hosted-web/phase-3/review-editable-mutation-boundaries.test.ts
+++ b/test/architecture/hosted-web/phase-3/review-editable-mutation-boundaries.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '../../../..');
+
+function readSource(relativePath: string): string {
+  // Paths are fixed repository-owned test fixtures.
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  return readFileSync(resolve(ROOT, relativePath), 'utf8');
+}
+
+describe('review editable mutation architecture boundary', () => {
+  it('keeps direct edit input policy free of runtime dependencies', () => {
+    const policy = readSource(
+      'src/features/review-mutations/core/domain/reviewEditableMutationPolicy.ts'
+    );
+    const imports = [...policy.matchAll(/from\s+['"]([^'"]+)['"]/g)].map((match) => match[1]);
+
+    expect(
+      imports.some(
+        (specifier) =>
+          specifier === 'electron' ||
+          specifier.startsWith('node:') ||
+          specifier.startsWith('@main/')
+      )
+    ).toBe(false);
+    expect(policy).not.toMatch(/\b(ipcMain|readFile|writeFile)\b/);
+  });
+
+  it('owns editable mutation orchestration behind focused ports', () => {
+    const application = readSource(
+      'src/features/review-mutations/main/application/ReviewEditableMutationApplication.ts'
+    );
+    const ports = readSource(
+      'src/features/review-mutations/main/application/ReviewEditableMutationPorts.ts'
+    );
+    const composition = readSource(
+      'src/features/review-mutations/main/composition/createReviewEditableMutationFeature.ts'
+    );
+
+    expect(application).not.toMatch(/from\s+['"](?:electron|node:|fs|@main\/)/);
+    expect(application).not.toContain('ipcMain');
+    expect(ports).toContain('export interface ReviewEditableMutationScopePort');
+    expect(ports).toContain('export interface ReviewEditableMutationApplierPort');
+    expect(ports).toContain('export interface ReviewEditableMutationContentPort');
+    expect(composition).toContain('return new ReviewEditableMutationApplication(dependencies)');
+  });
+
+  it('leaves editable review IPC as exact validation and delegation', () => {
+    const shell = readSource('src/main/ipc/review.ts');
+    const handlers = shell.slice(
+      shell.indexOf('// --- Editable diff Handlers ---'),
+      shell.indexOf('async function handleWatchReviewFiles')
+    );
+
+    expect(shell).toContain('createReviewEditableMutationFeature({');
+    expect(shell).toContain('ipcMain.handle(REVIEW_SAVE_EDITED_FILE, handleSaveEditedFile)');
+    expect(shell).toContain('ipcMain.removeHandler(REVIEW_SAVE_EDITED_FILE)');
+    expect(handlers).toContain('parseSaveEditedFileInput(');
+    expect(handlers).toContain('parseDeleteEditedFileInput(');
+    expect(handlers).toContain('reviewEditableMutationFeature.restoreRejectedRename(');
+    expect(handlers).toContain('reviewEditableMutationFeature.reapplyRejectedRename(');
+    expect(handlers).not.toContain('resolveReviewPathAuthorization(');
+    expect(handlers).not.toContain('validateAuthorizedReviewFilePath(');
+    expect(handlers).not.toContain('getApplier()');
+    expect(handlers).not.toContain('invalidateAuthoritativeReviewContent(');
+  });
+});

--- a/test/architecture/hosted-web/phase-3/review-watcher-persistence-boundaries.test.ts
+++ b/test/architecture/hosted-web/phase-3/review-watcher-persistence-boundaries.test.ts
@@ -1,0 +1,79 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '../../../..');
+
+function readSource(relativePath: string): string {
+  // Paths are fixed repository-owned test fixtures.
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  return readFileSync(resolve(ROOT, relativePath), 'utf8');
+}
+
+describe('review watcher and persistence architecture boundaries', () => {
+  it('keeps watcher policy and orchestration runtime-free behind focused ports', () => {
+    const policy = readSource('src/features/change-review/core/domain/reviewFileWatchPolicy.ts');
+    const application = readSource(
+      'src/features/change-review/main/application/ReviewFileWatchApplication.ts'
+    );
+    const ports = readSource('src/features/change-review/main/application/ReviewFileWatchPorts.ts');
+
+    expect(policy).not.toMatch(/from\s+['"](?:electron|node:|fs|@main\/)/);
+    expect(application).not.toMatch(/from\s+['"](?:electron|node:|fs|@main\/)/);
+    expect(application).not.toContain('ipcMain');
+    expect(ports).toContain('export interface ReviewFileWatcherPort');
+    expect(ports).toContain('export interface ReviewFileWatchEventPort');
+    expect(ports).toContain('export type ReviewProjectPathValidator');
+  });
+
+  it('isolates watcher runtime details in main adapters, infrastructure, and composition', () => {
+    const presenter = readSource(
+      'src/features/change-review/main/adapters/output/presenters/ReviewFileWatchEventPresenter.ts'
+    );
+    const validator = readSource(
+      'src/features/change-review/main/infrastructure/validateReviewWatchProjectPath.ts'
+    );
+    const composition = readSource(
+      'src/features/change-review/main/composition/createReviewFileWatchFeature.ts'
+    );
+
+    expect(presenter).toContain('safeSendToRenderer(');
+    expect(presenter).toContain('REVIEW_FILE_CHANGE');
+    expect(validator).toContain("import * as fs from 'fs/promises'");
+    expect(validator).toContain('path.resolve(path.normalize(projectPath))');
+    expect(composition).toContain('new EditorFileWatcher({ ignoreStartupChanges: false })');
+  });
+
+  it('keeps decision persistence policy and application runtime-free', () => {
+    const policy = readSource(
+      'src/features/change-review/core/domain/reviewDecisionPersistencePolicy.ts'
+    );
+    const application = readSource(
+      'src/features/change-review/main/application/ReviewDecisionPersistenceApplication.ts'
+    );
+    const ports = readSource(
+      'src/features/change-review/main/application/ReviewDecisionPersistencePorts.ts'
+    );
+
+    expect(policy).not.toMatch(/from\s+['"](?:electron|node:|fs|@main\/)/);
+    expect(application).not.toMatch(/from\s+['"](?:electron|node:|fs|@main\/)/);
+    expect(application).not.toContain('ipcMain');
+    expect(ports).toContain('export interface ReviewDecisionPersistenceScopePort');
+    expect(ports).toContain('export interface ReviewDecisionPersistenceLockPort');
+  });
+
+  it('leaves IPC registration and wrapper boundaries exact while delegating lifecycle', () => {
+    const shell = readSource('src/main/ipc/review.ts');
+
+    expect(shell).toContain('ipcMain.handle(REVIEW_WATCH_FILES, handleWatchReviewFiles)');
+    expect(shell).toContain('ipcMain.removeHandler(REVIEW_WATCH_FILES)');
+    expect(shell).toContain("wrapReviewHandler('watchFiles', operation)");
+    expect(shell).toContain("wrapReviewHandler('unwatchFiles', operation)");
+    expect(shell).toContain('reviewFileWatchFeature.prepareWatch(projectPath, filePaths)');
+    expect(shell).toContain('reviewDecisionPersistenceFeature.withLock(');
+    expect(shell).not.toContain('let reviewWatcherRequestGeneration');
+    expect(shell).not.toContain('function assertReviewDecisionShape');
+    expect(shell).not.toContain('function withReviewDecisionPersistenceLock');
+  });
+});

--- a/test/features/change-review/core/reviewDecisionPersistencePolicy.test.ts
+++ b/test/features/change-review/core/reviewDecisionPersistencePolicy.test.ts
@@ -1,0 +1,82 @@
+import {
+  assertReviewDecisionShape,
+  parseReviewDecisionPersistenceScope,
+  parseReviewHistoryScopeIdentity,
+} from '@features/change-review/main';
+import { describe, expect, it } from 'vitest';
+
+describe('review decision persistence policy', () => {
+  it('accepts the persisted decision shape used by review history', () => {
+    const value = {
+      filePath: '/safe/file.ts',
+      reviewKey: 'review-key',
+      fileDecision: 'rejected',
+      hunkDecisions: { 0: 'accepted' },
+      hunkContextHashes: { 0: 'hash' },
+      contentSnapshotToken: 'snapshot',
+      snippets: [],
+      originalFullContent: 'before',
+      modifiedFullContent: null,
+      isNewFile: false,
+    };
+
+    expect(() => assertReviewDecisionShape(value)).not.toThrow();
+  });
+
+  it.each([
+    [{}, 'decision.filePath'],
+    [
+      {
+        filePath: '/safe/file.ts',
+        fileDecision: 'invalid',
+        hunkDecisions: {},
+      },
+      'Invalid fileDecision',
+    ],
+    [
+      {
+        filePath: '/safe/file.ts',
+        fileDecision: 'pending',
+        hunkDecisions: { '-1': 'pending' },
+      },
+      'Invalid hunk decision',
+    ],
+    [
+      {
+        filePath: '/safe/file.ts',
+        fileDecision: 'pending',
+        hunkDecisions: {},
+        contentSnapshotToken: 42,
+      },
+      'Invalid contentSnapshotToken',
+    ],
+  ])('rejects an invalid decision with the legacy error', (value, error) => {
+    expect(() => assertReviewDecisionShape(value)).toThrow(error);
+  });
+
+  it('parses an exact task persistence scope and preserves undefined as null', () => {
+    const scope = { teamName: 'safe-team', taskId: 'task-1' };
+
+    expect(parseReviewDecisionPersistenceScope(undefined, scope)).toBeNull();
+    expect(
+      parseReviewDecisionPersistenceScope({ scopeKey: 'task-task-1', scopeToken: 'token' }, scope)
+    ).toEqual({ scopeKey: 'task-task-1', scopeToken: 'token' });
+  });
+
+  it('rejects a persistence scope that is not authoritative for the review', () => {
+    expect(() =>
+      parseReviewDecisionPersistenceScope(
+        { scopeKey: 'agent-worker', scopeToken: 'token' },
+        { teamName: 'safe-team', taskId: 'task-1' }
+      )
+    ).toThrow('Decision persistence scope does not match the authoritative review');
+  });
+
+  it('parses task and agent history identities without widening accepted prefixes', () => {
+    expect(parseReviewHistoryScopeIdentity('task-task-1')).toEqual({ taskId: 'task-1' });
+    expect(parseReviewHistoryScopeIdentity('agent-worker')).toEqual({ memberName: 'worker' });
+    expect(() => parseReviewHistoryScopeIdentity('team-safe-team')).toThrow(
+      'Review decision scope cannot authorize history'
+    );
+  });
+});

--- a/test/features/change-review/core/reviewFileWatchPolicy.test.ts
+++ b/test/features/change-review/core/reviewFileWatchPolicy.test.ts
@@ -2,10 +2,10 @@ import { normalizeReviewWatchedFiles } from '@features/change-review/main';
 import { describe, expect, it } from 'vitest';
 
 describe('review file watch policy', () => {
-  it('preserves array inputs without filtering renderer values', () => {
+  it('keeps only string paths from renderer arrays', () => {
     const values = ['/safe/a.ts', 42] as unknown[];
 
-    expect(normalizeReviewWatchedFiles(values)).toBe(values);
+    expect(normalizeReviewWatchedFiles(values)).toEqual(['/safe/a.ts']);
   });
 
   it.each([undefined, null, 'file.ts', { filePath: 'file.ts' }])(

--- a/test/features/change-review/core/reviewFileWatchPolicy.test.ts
+++ b/test/features/change-review/core/reviewFileWatchPolicy.test.ts
@@ -1,0 +1,17 @@
+import { normalizeReviewWatchedFiles } from '@features/change-review/main';
+import { describe, expect, it } from 'vitest';
+
+describe('review file watch policy', () => {
+  it('preserves array inputs without filtering renderer values', () => {
+    const values = ['/safe/a.ts', 42] as unknown[];
+
+    expect(normalizeReviewWatchedFiles(values)).toBe(values);
+  });
+
+  it.each([undefined, null, 'file.ts', { filePath: 'file.ts' }])(
+    'normalizes non-array input %j to an empty list',
+    (value) => {
+      expect(normalizeReviewWatchedFiles(value)).toEqual([]);
+    }
+  );
+});

--- a/test/features/change-review/main/ReviewDecisionPersistenceApplication.test.ts
+++ b/test/features/change-review/main/ReviewDecisionPersistenceApplication.test.ts
@@ -1,0 +1,141 @@
+import {
+  createReviewDecisionPersistenceFeature,
+  type ReviewDecisionPersistenceDependencies,
+} from '@features/change-review/main';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { FileChangeSummary } from '@shared/types/review';
+
+const REVIEWED_PATH = '/safe/reviewed.ts';
+
+function createHarness() {
+  const reviewedFile = {
+    filePath: REVIEWED_PATH,
+    relativePath: 'reviewed.ts',
+    snippets: [],
+    linesAdded: 1,
+    linesRemoved: 0,
+    isNewFile: false,
+  } satisfies FileChangeSummary;
+  const authorization = {
+    roots: [],
+    reviewedFiles: new Map([[REVIEWED_PATH, reviewedFile]]),
+    resolutionMemberName: 'worker',
+  };
+  const dependencies = {
+    scope: {
+      parse: vi.fn((value: unknown) => value as { teamName: string; taskId?: string }),
+      resolve: vi.fn(() =>
+        Promise.resolve({
+          scope: { teamName: 'safe-team', taskId: 'task-1' },
+          authorization,
+        })
+      ),
+      normalizeIdentityPath: vi.fn((filePath: string) => filePath),
+      validateFilePath: vi.fn(() => Promise.resolve(REVIEWED_PATH)),
+      getAuthoritativeFile: vi.fn(() => reviewedFile),
+    },
+    paths: {
+      isAbsoluteNormalized: vi.fn((filePath: string) => filePath.startsWith('/')),
+    },
+    locks: {
+      withLogicalScopeLock: async <T>(
+        _teamName: string,
+        _scopeKey: string,
+        operation: () => Promise<T>
+      ): Promise<T> => operation(),
+      withPersistenceScopeLock: async <T>(
+        _teamName: string,
+        _scope: { scopeKey: string; scopeToken: string },
+        operation: () => Promise<T>
+      ): Promise<T> => operation(),
+    },
+  } satisfies ReviewDecisionPersistenceDependencies;
+
+  return { dependencies, authorization, reviewedFile };
+}
+
+describe('ReviewDecisionPersistenceApplication', () => {
+  it('authorizes draft and decision history from the same exact task scope', async () => {
+    const harness = createHarness();
+    const feature = createReviewDecisionPersistenceFeature(harness.dependencies);
+
+    const draft = await feature.authorizeDraftHistoryScope('safe-team', 'task-task-1');
+    expect(harness.dependencies.scope.parse).toHaveBeenCalledWith({
+      teamName: 'safe-team',
+      taskId: 'task-1',
+    });
+    expect(harness.dependencies.scope.resolve).toHaveBeenCalledWith(
+      { teamName: 'safe-team', taskId: 'task-1' },
+      { requireIdentity: true }
+    );
+    expect(draft.isCurrentReviewedFile(REVIEWED_PATH)).toBe(true);
+    expect(draft.isCurrentReviewedFile('relative.ts')).toBe(false);
+    await draft.assertCurrentReviewedFile('/renderer/file.ts');
+    expect(harness.dependencies.scope.validateFilePath).toHaveBeenCalledWith(
+      harness.authorization,
+      '/renderer/file.ts',
+      { requireReviewedFile: true }
+    );
+
+    const decision = await feature.authorizeDecisionHistoryScope('safe-team', 'task-task-1');
+    expect(decision.files).toEqual([harness.reviewedFile]);
+    expect(decision.normalizePath(REVIEWED_PATH)).toBe(REVIEWED_PATH);
+    expect(decision.resolveFile(REVIEWED_PATH)).toBe(harness.reviewedFile);
+  });
+
+  it('serializes the same persistence scope while allowing another scope to proceed', async () => {
+    const harness = createHarness();
+    const feature = createReviewDecisionPersistenceFeature(harness.dependencies);
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const events: string[] = [];
+    const first = feature.withLock(
+      'safe-team',
+      { scopeKey: 'task-a', scopeToken: 'token-a' },
+      async () => {
+        events.push('first:start');
+        await firstGate;
+        events.push('first:end');
+      }
+    );
+    const second = feature.withLock(
+      'safe-team',
+      { scopeKey: 'task-a', scopeToken: 'token-a' },
+      () => {
+        events.push('second');
+        return Promise.resolve();
+      }
+    );
+    const independent = feature.withLock(
+      'safe-team',
+      { scopeKey: 'task-b', scopeToken: 'token-b' },
+      () => {
+        events.push('independent');
+        return Promise.resolve();
+      }
+    );
+
+    await vi.waitFor(() => expect(events).toContain('independent'));
+    expect(events).not.toContain('second');
+    releaseFirst();
+    await Promise.all([first, second, independent]);
+
+    expect(events).toEqual(['first:start', 'independent', 'first:end', 'second']);
+  });
+
+  it('releases the queue after a rejected operation', async () => {
+    const harness = createHarness();
+    const feature = createReviewDecisionPersistenceFeature(harness.dependencies);
+    const scope = { scopeKey: 'task-a', scopeToken: 'token-a' };
+
+    await expect(
+      feature.withLock('safe-team', scope, () => Promise.reject(new Error('write failed')))
+    ).rejects.toThrow('write failed');
+    await expect(feature.withLock('safe-team', scope, () => Promise.resolve('next'))).resolves.toBe(
+      'next'
+    );
+  });
+});

--- a/test/features/change-review/main/ReviewFileWatchApplication.test.ts
+++ b/test/features/change-review/main/ReviewFileWatchApplication.test.ts
@@ -1,0 +1,132 @@
+import {
+  ReviewFileWatchApplication,
+  type ReviewFileWatcherPort,
+} from '@features/change-review/main';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { EditorFileChangeEvent } from '@shared/types/editor';
+
+function createWatcher(events: string[], name = 'watcher') {
+  let watching = false;
+  let emitChange: ((event: EditorFileChangeEvent) => void) | null = null;
+  const watcher = {
+    isWatching: vi.fn(() => watching),
+    setWatchedFiles: vi.fn((filePaths: string[]) => {
+      events.push(`${name}:files:${filePaths.join(',')}`);
+    }),
+    start: vi.fn((projectRoot: string, onChange: (event: EditorFileChangeEvent) => void) => {
+      events.push(`${name}:start:${projectRoot}`);
+      watching = true;
+      emitChange = onChange;
+    }),
+    stop: vi.fn(() => {
+      events.push(`${name}:stop`);
+      watching = false;
+    }),
+  } satisfies ReviewFileWatcherPort;
+
+  return {
+    watcher,
+    emit(event: EditorFileChangeEvent): void {
+      if (!emitChange) throw new Error('watcher was not started');
+      emitChange(event);
+    },
+  };
+}
+
+describe('ReviewFileWatchApplication', () => {
+  it('restarts only when required, preserves watched inputs, and forwards events', async () => {
+    const events: string[] = [];
+    const defaultWatcher = createWatcher(events);
+    const present = vi.fn();
+    const validate = vi.fn(() => Promise.resolve('/normalized/project'));
+    const application = new ReviewFileWatchApplication({
+      defaultWatcher: defaultWatcher.watcher,
+      defaultProjectPathValidator: validate,
+      events: { present },
+    });
+
+    const firstOperation = application.prepareWatch('/raw/project', ['/normalized/project/a.ts']);
+    expect(validate).not.toHaveBeenCalled();
+    await firstOperation();
+
+    expect(events).toEqual([
+      'watcher:stop',
+      'watcher:start:/normalized/project',
+      'watcher:files:/normalized/project/a.ts',
+    ]);
+    const change = { type: 'change', path: '/normalized/project/a.ts' } as const;
+    defaultWatcher.emit(change);
+    expect(present).toHaveBeenCalledWith(change);
+
+    await application.prepareWatch('/same/project', false)();
+
+    expect(defaultWatcher.watcher.start).toHaveBeenCalledTimes(1);
+    expect(defaultWatcher.watcher.stop).toHaveBeenCalledTimes(1);
+    expect(defaultWatcher.watcher.setWatchedFiles).toHaveBeenLastCalledWith([]);
+  });
+
+  it('ignores a late validation after unwatch and a newer subscription', async () => {
+    const events: string[] = [];
+    const defaultWatcher = createWatcher(events);
+    let resolveOldProject!: (projectPath: string) => void;
+    const oldValidation = new Promise<string>((resolve) => {
+      resolveOldProject = resolve;
+    });
+    const validate = vi.fn((projectPath: string) =>
+      projectPath === '/old' ? oldValidation : Promise.resolve('/new')
+    );
+    const application = new ReviewFileWatchApplication({
+      defaultWatcher: defaultWatcher.watcher,
+      defaultProjectPathValidator: validate,
+      events: { present: vi.fn() },
+    });
+
+    const lateOldWatch = application.prepareWatch('/old', ['/old/a.ts'])();
+    await vi.waitFor(() => expect(validate).toHaveBeenCalledWith('/old'));
+    await application.prepareUnwatch()();
+    await application.prepareWatch('/new', ['/new/b.ts'])();
+    resolveOldProject('/old');
+    await lateOldWatch;
+
+    expect(defaultWatcher.watcher.start).toHaveBeenCalledTimes(1);
+    expect(defaultWatcher.watcher.start).toHaveBeenCalledWith('/new', expect.any(Function));
+    expect(defaultWatcher.watcher.setWatchedFiles).toHaveBeenCalledTimes(1);
+    expect(defaultWatcher.watcher.setWatchedFiles).toHaveBeenCalledWith(['/new/b.ts']);
+  });
+
+  it('supersedes pending work on reconfigure and owns replacement and cleanup order', async () => {
+    const events: string[] = [];
+    const defaultWatcher = createWatcher(events, 'default');
+    const replacementWatcher = createWatcher(events, 'replacement');
+    let resolvePending!: (projectPath: string) => void;
+    const pendingValidation = new Promise<string>((resolve) => {
+      resolvePending = resolve;
+    });
+    const application = new ReviewFileWatchApplication({
+      defaultWatcher: defaultWatcher.watcher,
+      defaultProjectPathValidator: () => pendingValidation,
+      events: { present: vi.fn() },
+    });
+
+    const pendingWatch = application.prepareWatch('/pending', ['/pending/a.ts'])();
+    application.supersedePendingRequests();
+    application.configure({
+      fileWatcher: replacementWatcher.watcher,
+      projectPathValidator: () => Promise.resolve('/replacement'),
+    });
+    resolvePending('/pending');
+    await pendingWatch;
+    await application.prepareWatch('/replacement', ['/replacement/b.ts'])();
+    application.dispose();
+
+    expect(events).toEqual([
+      'default:stop',
+      'replacement:stop',
+      'replacement:start:/replacement',
+      'replacement:files:/replacement/b.ts',
+      'replacement:stop',
+    ]);
+    expect(defaultWatcher.watcher.setWatchedFiles).not.toHaveBeenCalled();
+  });
+});

--- a/test/features/review-mutations/core/reviewEditableMutationPolicy.test.ts
+++ b/test/features/review-mutations/core/reviewEditableMutationPolicy.test.ts
@@ -27,11 +27,15 @@ describe('review editable mutation policy', () => {
     expect(parseSaveEditedFileInput(filePath, content, expected)).toBeNull();
   });
 
-  it('preserves delete file-path validation for the authorization layer', () => {
-    expect(parseDeleteEditedFileInput({ renderer: 'value' }, 'before\n')).toEqual({
-      filePath: { renderer: 'value' },
+  it('accepts exact delete inputs', () => {
+    expect(parseDeleteEditedFileInput('/review-root/file.ts', 'before\n')).toEqual({
+      filePath: '/review-root/file.ts',
       expectedCurrentContent: 'before\n',
     });
+  });
+
+  it('rejects a non-string delete path before authorization', () => {
+    expect(parseDeleteEditedFileInput({ renderer: 'value' }, 'before\n')).toBeNull();
   });
 
   it.each([null, undefined, false, 42])(

--- a/test/features/review-mutations/core/reviewEditableMutationPolicy.test.ts
+++ b/test/features/review-mutations/core/reviewEditableMutationPolicy.test.ts
@@ -1,0 +1,43 @@
+import {
+  parseDeleteEditedFileInput,
+  parseSaveEditedFileInput,
+} from '@features/review-mutations/main';
+import { describe, expect, it } from 'vitest';
+
+describe('review editable mutation policy', () => {
+  it('accepts exact save inputs, including a missing-file compare-and-set', () => {
+    expect(parseSaveEditedFileInput('/review-root/file.ts', 'after\n', 'before\n')).toEqual({
+      filePath: '/review-root/file.ts',
+      content: 'after\n',
+      expectedCurrentContent: 'before\n',
+    });
+    expect(parseSaveEditedFileInput('/review-root/new.ts', 'created\n', null)).toEqual({
+      filePath: '/review-root/new.ts',
+      content: 'created\n',
+      expectedCurrentContent: null,
+    });
+  });
+
+  it.each([
+    [42, 'after\n', 'before\n'],
+    ['/review-root/file.ts', null, 'before\n'],
+    ['/review-root/file.ts', 'after\n', undefined],
+    ['/review-root/file.ts', 'after\n', false],
+  ])('rejects an invalid save input without coercion', (filePath, content, expected) => {
+    expect(parseSaveEditedFileInput(filePath, content, expected)).toBeNull();
+  });
+
+  it('preserves delete file-path validation for the authorization layer', () => {
+    expect(parseDeleteEditedFileInput({ renderer: 'value' }, 'before\n')).toEqual({
+      filePath: { renderer: 'value' },
+      expectedCurrentContent: 'before\n',
+    });
+  });
+
+  it.each([null, undefined, false, 42])(
+    'rejects a non-string delete compare-and-set value',
+    (expected) => {
+      expect(parseDeleteEditedFileInput('/review-root/file.ts', expected)).toBeNull();
+    }
+  );
+});

--- a/test/features/review-mutations/main/ReviewDecisionCommandApplication.test.ts
+++ b/test/features/review-mutations/main/ReviewDecisionCommandApplication.test.ts
@@ -320,7 +320,7 @@ describe('ReviewDecisionCommandApplication', () => {
     const committed = { ...persistedState, revision: 8 };
     const harness = createHarness({
       persistenceScope: PERSISTENCE_SCOPE,
-      loadStates: [current, current, committed],
+      loadStates: [current, committed],
     });
     const displayed = harness.application.registerDisplayedReviewSnapshot(
       SCOPE.teamName,
@@ -344,7 +344,6 @@ describe('ReviewDecisionCommandApplication', () => {
       'validate-decisions',
       'lock',
       'recover',
-      'load-3',
       'load-2',
       'bind-history',
       'coordinate',
@@ -385,7 +384,7 @@ describe('ReviewDecisionCommandApplication', () => {
     };
     const harness = createHarness({
       persistenceScope: PERSISTENCE_SCOPE,
-      loadStates: [current, current],
+      loadStates: [current],
     });
     const displayed = harness.application.registerDisplayedReviewSnapshot(
       SCOPE.teamName,

--- a/test/features/review-mutations/main/ReviewEditableMutationApplication.test.ts
+++ b/test/features/review-mutations/main/ReviewEditableMutationApplication.test.ts
@@ -1,0 +1,286 @@
+import {
+  createReviewEditableMutationFeature,
+  type ReviewEditableMutationDependencies,
+} from '@features/review-mutations/main';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { FileChangeWithContent, SnippetDiff } from '@shared/types/review';
+
+const REVIEWED_FILE_PATH = '/review-editable-safe-root/reviewed.ts';
+const RENAMED_FILE_PATH = '/review-editable-safe-root/renamed.ts';
+
+function createSnippet(): SnippetDiff {
+  return {
+    toolUseId: 'rename-event',
+    filePath: REVIEWED_FILE_PATH,
+    toolName: 'Bash',
+    type: 'shell-snapshot',
+    oldString: 'before\n',
+    newString: 'after\n',
+    replaceAll: false,
+    timestamp: '2026-07-24T10:00:00.000Z',
+    isError: false,
+  };
+}
+
+function createHarness() {
+  const authorization = {
+    roots: [],
+    reviewedFiles: null,
+    resolutionMemberName: 'worker',
+  };
+  const expectation = {
+    eventId: 'rename-event',
+    beforeHash: null,
+    afterHash: null,
+    relation: {
+      kind: 'rename' as const,
+      oldPath: REVIEWED_FILE_PATH,
+      newPath: RENAMED_FILE_PATH,
+    },
+  };
+  const content = {
+    filePath: RENAMED_FILE_PATH,
+    relativePath: 'renamed.ts',
+    snippets: [createSnippet()],
+    linesAdded: 1,
+    linesRemoved: 1,
+    isNewFile: false,
+    originalFullContent: 'before\n',
+    modifiedFullContent: 'after\n',
+    contentSource: 'ledger-exact',
+  } satisfies FileChangeWithContent;
+
+  const dependencies = {
+    scope: {
+      parseReviewRenameRecoveryExpectation: vi.fn(() => expectation),
+      resolveReviewPathAuthorization: vi.fn(() =>
+        Promise.resolve({
+          scope: { teamName: 'safe-team', memberName: 'worker' },
+          authorization,
+        })
+      ),
+      validateAuthorizedReviewFilePath: vi.fn(() => Promise.resolve(RENAMED_FILE_PATH)),
+      resolveAuthoritativeFileContent: vi.fn(() => Promise.resolve(content)),
+      validateSnippetPaths: vi.fn(() => Promise.resolve()),
+      assertExpectedAuthoritativeRename: vi.fn(),
+      invalidateAuthoritativeReviewContent: vi.fn(),
+    },
+    applier: {
+      saveEditedFile: vi.fn(() => Promise.resolve({ success: true })),
+      deleteEditedFile: vi.fn(() => Promise.resolve({ success: true })),
+      restoreRejectedRename: vi.fn(() => Promise.resolve({ success: true })),
+      reapplyRejectedRename: vi.fn(() => Promise.resolve({ success: true })),
+    },
+    content: {
+      invalidateFile: vi.fn(),
+    },
+  } satisfies ReviewEditableMutationDependencies;
+
+  return { dependencies, authorization, expectation, content };
+}
+
+describe('ReviewEditableMutationApplication', () => {
+  it('authorizes save and delete before applying and invalidating content', async () => {
+    const harness = createHarness();
+    const events: string[] = [];
+    harness.dependencies.scope.resolveReviewPathAuthorization.mockImplementation(() => {
+      events.push('resolve');
+      return Promise.resolve({
+        scope: { teamName: 'safe-team', memberName: 'worker' },
+        authorization: harness.authorization,
+      });
+    });
+    harness.dependencies.scope.validateAuthorizedReviewFilePath.mockImplementation(() => {
+      events.push('validate-file');
+      return Promise.resolve(REVIEWED_FILE_PATH);
+    });
+    harness.dependencies.applier.saveEditedFile.mockImplementation(() => {
+      events.push('save');
+      return Promise.resolve({ success: true });
+    });
+    harness.dependencies.applier.deleteEditedFile.mockImplementation(() => {
+      events.push('delete');
+      return Promise.resolve({ success: true });
+    });
+    harness.dependencies.content.invalidateFile.mockImplementation(() => {
+      events.push('invalidate');
+    });
+    const feature = createReviewEditableMutationFeature(harness.dependencies);
+
+    await expect(
+      feature.saveEditedFile(
+        { teamName: 'renderer-team', memberName: 'worker' },
+        {
+          filePath: '/renderer/file.ts',
+          content: 'after\n',
+          expectedCurrentContent: 'before\n',
+        }
+      )
+    ).resolves.toEqual({ success: true });
+    expect(events).toEqual(['resolve', 'validate-file', 'save', 'invalidate']);
+    expect(harness.dependencies.scope.resolveReviewPathAuthorization).toHaveBeenLastCalledWith(
+      { teamName: 'renderer-team', memberName: 'worker' },
+      { requireIdentity: true }
+    );
+    expect(harness.dependencies.scope.validateAuthorizedReviewFilePath).toHaveBeenLastCalledWith(
+      harness.authorization,
+      '/renderer/file.ts',
+      {
+        requireReviewedFile: true,
+        rejectHardlinks: true,
+      }
+    );
+    expect(harness.dependencies.applier.saveEditedFile).toHaveBeenCalledWith(
+      REVIEWED_FILE_PATH,
+      'after\n',
+      'before\n'
+    );
+
+    events.length = 0;
+    await expect(
+      feature.deleteEditedFile(
+        { teamName: 'renderer-team', memberName: 'worker' },
+        { filePath: '/renderer/file.ts', expectedCurrentContent: 'after\n' }
+      )
+    ).resolves.toEqual({ success: true });
+    expect(events).toEqual(['resolve', 'validate-file', 'delete', 'invalidate']);
+    expect(harness.dependencies.applier.deleteEditedFile).toHaveBeenCalledWith(
+      REVIEWED_FILE_PATH,
+      'after\n'
+    );
+    expect(harness.dependencies.content.invalidateFile).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not invalidate a direct edit whose applier rejects it', async () => {
+    const harness = createHarness();
+    harness.dependencies.applier.saveEditedFile.mockRejectedValueOnce(
+      new Error('compare-and-set failed')
+    );
+    const feature = createReviewEditableMutationFeature(harness.dependencies);
+
+    await expect(
+      feature.saveEditedFile(
+        { teamName: 'safe-team', memberName: 'worker' },
+        {
+          filePath: REVIEWED_FILE_PATH,
+          content: 'after\n',
+          expectedCurrentContent: 'before\n',
+        }
+      )
+    ).rejects.toThrow('compare-and-set failed');
+    expect(harness.dependencies.content.invalidateFile).not.toHaveBeenCalled();
+  });
+
+  it('authorizes a rejected rename in the original order and restores exact content', async () => {
+    const harness = createHarness();
+    const events: string[] = [];
+    harness.dependencies.scope.parseReviewRenameRecoveryExpectation.mockImplementation(() => {
+      events.push('parse-expectation');
+      return harness.expectation;
+    });
+    harness.dependencies.scope.resolveReviewPathAuthorization.mockImplementation(() => {
+      events.push('resolve');
+      return Promise.resolve({
+        scope: { teamName: 'safe-team', memberName: 'worker' },
+        authorization: harness.authorization,
+      });
+    });
+    harness.dependencies.scope.validateAuthorizedReviewFilePath.mockImplementation(() => {
+      events.push('validate-file');
+      return Promise.resolve(RENAMED_FILE_PATH);
+    });
+    harness.dependencies.scope.resolveAuthoritativeFileContent.mockImplementation(() => {
+      events.push('resolve-content');
+      return Promise.resolve(harness.content);
+    });
+    harness.dependencies.scope.validateSnippetPaths.mockImplementation(() => {
+      events.push('validate-snippets');
+      return Promise.resolve();
+    });
+    harness.dependencies.scope.assertExpectedAuthoritativeRename.mockImplementation(() => {
+      events.push('assert-expectation');
+    });
+    harness.dependencies.applier.restoreRejectedRename.mockImplementation(() => {
+      events.push('restore');
+      return Promise.resolve({ success: true });
+    });
+    harness.dependencies.scope.invalidateAuthoritativeReviewContent.mockImplementation(() => {
+      events.push('invalidate');
+    });
+    const feature = createReviewEditableMutationFeature(harness.dependencies);
+
+    await expect(
+      feature.restoreRejectedRename(
+        { teamName: 'renderer-team', memberName: 'worker' },
+        '/renderer/rename.ts',
+        { renderer: 'expectation' }
+      )
+    ).resolves.toEqual({ success: true });
+
+    expect(events).toEqual([
+      'parse-expectation',
+      'resolve',
+      'validate-file',
+      'resolve-content',
+      'validate-snippets',
+      'assert-expectation',
+      'restore',
+      'invalidate',
+    ]);
+    expect(harness.dependencies.scope.validateSnippetPaths).toHaveBeenCalledWith(
+      harness.authorization,
+      harness.content.snippets,
+      { requireReviewedFile: true, rejectHardlinks: true }
+    );
+    expect(harness.dependencies.applier.restoreRejectedRename).toHaveBeenCalledWith(
+      RENAMED_FILE_PATH,
+      'before\n',
+      'after\n',
+      harness.content.snippets
+    );
+  });
+
+  it('invalidates authoritative rename content when reapply fails', async () => {
+    const harness = createHarness();
+    harness.dependencies.applier.reapplyRejectedRename.mockRejectedValueOnce(
+      new Error('reapply incomplete')
+    );
+    const feature = createReviewEditableMutationFeature(harness.dependencies);
+
+    await expect(
+      feature.reapplyRejectedRename(
+        { teamName: 'safe-team', memberName: 'worker' },
+        RENAMED_FILE_PATH,
+        harness.expectation
+      )
+    ).rejects.toThrow('reapply incomplete');
+    expect(harness.dependencies.applier.reapplyRejectedRename).toHaveBeenCalledWith(
+      RENAMED_FILE_PATH,
+      'before\n',
+      harness.content.snippets
+    );
+    expect(harness.dependencies.scope.invalidateAuthoritativeReviewContent).toHaveBeenCalledWith(
+      harness.content
+    );
+  });
+
+  it('stops before scope resolution when rename expectation parsing fails', async () => {
+    const harness = createHarness();
+    harness.dependencies.scope.parseReviewRenameRecoveryExpectation.mockImplementationOnce(() => {
+      throw new Error('Invalid rename recovery expectation');
+    });
+    const feature = createReviewEditableMutationFeature(harness.dependencies);
+
+    await expect(
+      feature.restoreRejectedRename(
+        { teamName: 'safe-team', memberName: 'worker' },
+        RENAMED_FILE_PATH,
+        null
+      )
+    ).rejects.toThrow('Invalid rename recovery expectation');
+    expect(harness.dependencies.scope.resolveReviewPathAuthorization).not.toHaveBeenCalled();
+    expect(harness.dependencies.applier.restoreRejectedRename).not.toHaveBeenCalled();
+    expect(harness.dependencies.scope.invalidateAuthoritativeReviewContent).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Extracts editable save, delete, rejected-file rename, authorization, execution, and cache invalidation behind review-mutation application ports.
- Extracts watcher lifecycle, generation control, event presentation, and project-root validation behind the change-review feature boundary.
- Extracts decision persistence validation, scoped locking, and history authorization, while reusing one locked decision snapshot per command.
- Keeps `src/main/ipc/review.ts` as transport registration and composition instead of domain/application implementation.

## Size

- `src/main/ipc/review.ts`: 1,051 -> 783 physical lines in this PR.
- Full staged review series: 1,943 -> 783 lines.
- Removes the `review.ts` legacy size exception.
- Every new production source file remains below the 800-line limit.

## Verification

- 111 focused review IPC/domain/application tests pass.
- 38 crash/process/transaction tests pass, including SIGKILL recovery and lock ownership cases.
- Hosted-web architecture sweep passes after removing generated desktop artifacts and restoring the Node ABI: 38 suites pass, 2 platform suites skip as designed.
- `pnpm typecheck`, fast ESLint, type-aware ESLint, source-size guard, Prettier, and `git diff --check` pass.
- Fresh sandbox desktop E2E passes on exact HEAD: Accept All -> Reject file -> Restore back/forward -> Undo -> reload/hydrate -> stale branch -> reversible recovery -> Discard backup -> prior snapshot -> blocked response -> SIGKILL -> exact Undo.
- No real user project, team, terminal runtime, or agent action was used.

## Remaining

- None for `review.ts`; it is below 800 lines and its legacy exception is removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable review file watching with project-path validation, lifecycle management, and renderer notifications.
  * Added validated review decision persistence, history authorization, and per-scope operation locking.
  * Added support for saving, deleting, restoring, and reapplying edited review files and rejected renames.
* **Bug Fixes**
  * Reduced redundant persistence-state reads while preserving revision checks.
  * Prevented outdated watcher operations from overriding newer watch or unwatch requests.
* **Tests**
  * Added coverage for review persistence, file watching, editable mutations, and architectural boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->