### PR TITLE
chore(review): pin action v2 diagnostics release

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -30,9 +30,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@a0ee0af4232326288e81ba91c610047c5b2f7256
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@2dceefcd586a6d4f4f785b4bf288212f3f30b2d1
     with:
-      runtime_ref: "a0ee0af4232326288e81ba91c610047c5b2f7256"
+      runtime_ref: "2dceefcd586a6d4f4f785b4bf288212f3f30b2d1"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ inputs.pr_number }}
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@a0ee0af4232326288e81ba91c610047c5b2f7256
+        uses: 777genius/review-router@2dceefcd586a6d4f4f785b4bf288212f3f30b2d1
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"


### PR DESCRIPTION
Pin the ReviewRouter reusable workflow, runtime, and refresh action to immutable release `2dceefc`.

This release preserves validated Review Action v2 server issues in workflow diagnostics so control-plane failures are actionable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated code review workflow to use the latest verified workflow version.
  * Improved reliability and consistency of automated review and refresh processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->