### PR TITLE
chore: sync latest main into dev

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -30,9 +30,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@a0ee0af4232326288e81ba91c610047c5b2f7256
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@2dceefcd586a6d4f4f785b4bf288212f3f30b2d1
     with:
-      runtime_ref: "a0ee0af4232326288e81ba91c610047c5b2f7256"
+      runtime_ref: "2dceefcd586a6d4f4f785b4bf288212f3f30b2d1"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ inputs.pr_number }}
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@a0ee0af4232326288e81ba91c610047c5b2f7256
+        uses: 777genius/review-router@2dceefcd586a6d4f4f785b4bf288212f3f30b2d1
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"


### PR DESCRIPTION
## Summary
- bring the latest ReviewRouter action diagnostics pin from main into dev
- preserve the completed provider onboarding, dependency audit, and CI guard fixes already merged into dev
- restore main ancestry before syncing dev back into main

## Verification
- previous main-to-dev sync passed the full validate, lint, test, CodeQL, dependency review, and runtime install smoke matrix
- this PR contains only the newer ReviewRouter workflow pin from #349