### PR TITLE
fix(change-review): stabilize extraction prerequisites

### DIFF
--- a/src/features/change-review/renderer/hooks/useChangeReviewScopeIdentity.ts
+++ b/src/features/change-review/renderer/hooks/useChangeReviewScopeIdentity.ts
@@ -17,9 +17,14 @@ export function useChangeReviewScopeIdentity({
   taskId,
   teamName,
 }: BuildChangeReviewScopeProjectionInput): ChangeReviewScopeProjection {
+  const reviewScope = useMemo(
+    () => ({ teamName, taskId, memberName }),
+    [memberName, taskId, teamName]
+  );
+
   return useMemo(
-    () =>
-      buildChangeReviewScopeProjection({
+    () => ({
+      ...buildChangeReviewScopeProjection({
         activeChangeSet,
         decisionHydrationScopeKey,
         decisionHydrationStatus,
@@ -30,6 +35,8 @@ export function useChangeReviewScopeIdentity({
         taskId,
         teamName,
       }),
+      reviewScope,
+    }),
     [
       activeChangeSet,
       decisionHydrationScopeKey,
@@ -37,6 +44,7 @@ export function useChangeReviewScopeIdentity({
       draftHistoryHydration,
       memberName,
       mode,
+      reviewScope,
       taskChangeRequestOptions,
       taskId,
       teamName,

--- a/src/features/review-mutations/core/domain/reviewDecisionCommandPolicy.ts
+++ b/src/features/review-mutations/core/domain/reviewDecisionCommandPolicy.ts
@@ -71,7 +71,7 @@ export function assertExactApplyReviewHistoryTransition(
   ) {
     throw new Error('Durable Reject history does not match the requested files');
   }
-  if ((decisions.length === 1) !== (action.kind === 'disk')) {
+  if (action.kind === 'disk' && decisions.length !== 1) {
     throw new Error('Durable Reject history action kind does not match the decision batch');
   }
   if (action.descriptor) {

--- a/test/features/change-review/renderer/useChangeReviewScopeIdentity.test.tsx
+++ b/test/features/change-review/renderer/useChangeReviewScopeIdentity.test.tsx
@@ -1,0 +1,59 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { useChangeReviewScopeIdentity } from '@features/change-review/renderer';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  ChangeReviewScopeProjection,
+  ReviewDraftHistoryHydrationState,
+} from '@features/change-review/renderer';
+
+interface ProbeProps {
+  draftHistoryHydration: ReviewDraftHistoryHydrationState;
+}
+
+let latestProjection: ChangeReviewScopeProjection | null = null;
+
+function Probe({ draftHistoryHydration }: Readonly<ProbeProps>): React.JSX.Element {
+  latestProjection = useChangeReviewScopeIdentity({
+    teamName: 'team-a',
+    mode: 'task',
+    taskId: 'task-a',
+    activeChangeSet: null,
+    decisionHydrationScopeKey: null,
+    decisionHydrationStatus: 'idle',
+    draftHistoryHydration,
+  });
+  return <div />;
+}
+
+describe('useChangeReviewScopeIdentity', () => {
+  afterEach(() => {
+    latestProjection = null;
+    document.body.innerHTML = '';
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps the review scope reference stable across hydration state changes', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    const root = createRoot(document.body.appendChild(document.createElement('div')));
+
+    await act(async () => {
+      root.render(<Probe draftHistoryHydration={{ key: null, status: 'idle' }} />);
+      await Promise.resolve();
+    });
+    const initialScope = latestProjection?.reviewScope;
+
+    await act(async () => {
+      root.render(<Probe draftHistoryHydration={{ key: 'hydration-a', status: 'loading' }} />);
+      await Promise.resolve();
+    });
+
+    expect(latestProjection?.reviewScope).toBe(initialScope);
+    await act(async () => {
+      root.unmount();
+      await Promise.resolve();
+    });
+  });
+});

--- a/test/features/change-review/renderer/useChangeReviewScopeIdentity.test.tsx
+++ b/test/features/change-review/renderer/useChangeReviewScopeIdentity.test.tsx
@@ -44,6 +44,7 @@ describe('useChangeReviewScopeIdentity', () => {
       await Promise.resolve();
     });
     const initialScope = latestProjection?.reviewScope;
+    expect(initialScope).toBeDefined();
 
     await act(async () => {
       root.render(<Probe draftHistoryHydration={{ key: 'hydration-a', status: 'loading' }} />);

--- a/test/features/review-mutations/core/reviewDecisionCommandPolicy.test.ts
+++ b/test/features/review-mutations/core/reviewDecisionCommandPolicy.test.ts
@@ -60,7 +60,7 @@ function createAction(id = 'action-1'): Extract<ReviewUndoAction, { kind: 'disk'
   };
 }
 
-function createState(action = createAction()): ReviewPersistedStateSnapshot {
+function createState(action: ReviewUndoAction = createAction()): ReviewPersistedStateSnapshot {
   return {
     hunkDecisions: {},
     fileDecisions: { [REVIEW_KEY]: 'rejected' },
@@ -80,6 +80,31 @@ describe('review decision command policy', () => {
     expect(() => assertCurrentReviewDecisionRevision(current, 4)).not.toThrow();
     expect(() =>
       assertExactApplyReviewHistoryTransition(createState(), current, [decision], context)
+    ).not.toThrow();
+  });
+
+  it('accepts a single-file Reject All transition represented by a bulk action', () => {
+    const action: Extract<ReviewUndoAction, { kind: 'bulk' }> = {
+      id: 'single-file-reject-all',
+      createdAt: '2026-07-24T00:00:00.000Z',
+      kind: 'bulk',
+      descriptor: { intent: 'reject-all', fileCount: 1 },
+      decisionSnapshot: {
+        hunkDecisions: current.hunkDecisions,
+        fileDecisions: current.fileDecisions,
+      },
+      diskSnapshots: [
+        {
+          filePath: FILE_PATH,
+          beforeContent: 'after\n',
+          afterContent: 'before\n',
+          file,
+        },
+      ],
+    };
+
+    expect(() =>
+      assertExactApplyReviewHistoryTransition(createState(action), current, [decision], context)
     ).not.toThrow();
   });
 

--- a/test/main/ipc/review.test.ts
+++ b/test/main/ipc/review.test.ts
@@ -4038,6 +4038,79 @@ describe('review IPC path confinement', () => {
     await expect(journal.list('safe-team', persistenceScope)).resolves.toEqual([]);
   });
 
+  it('accepts a durable Reject All bulk action for a single reviewed file', async () => {
+    const contentSnapshotToken = await getDisplayedSnapshotToken(projectFile);
+    const persistenceScope = {
+      scopeKey: 'agent-worker',
+      scopeToken: 'agent:worker:content:single-file-reject-all',
+    };
+    const file = {
+      filePath: projectFile,
+      relativePath: 'src/project.ts',
+      snippets: [],
+      linesAdded: 1,
+      linesRemoved: 1,
+      isNewFile: false,
+    };
+    const action = {
+      id: 'single-file-reject-all',
+      createdAt: '2026-07-23T12:00:00.000Z',
+      kind: 'bulk' as const,
+      descriptor: { intent: 'reject-all' as const, fileCount: 1 },
+      decisionSnapshot: { hunkDecisions: {}, fileDecisions: {} },
+      diskSnapshots: [
+        {
+          filePath: projectFile,
+          beforeContent: 'project\n',
+          afterContent: 'before\n',
+          file,
+        },
+      ],
+    };
+    applier.applyReviewDecisions.mockImplementationOnce(async (_request, _contents, hooks) => {
+      await hooks?.checkpointDiskTransitions([
+        { filePath: projectFile, beforeContent: 'project\n', afterContent: 'project\n' },
+      ]);
+      return { applied: 1, skipped: 0, conflicts: 0, errors: [] };
+    });
+
+    const result = await ipcMain.invoke(REVIEW_APPLY_DECISIONS, {
+      teamName: 'safe-team',
+      memberName: 'worker',
+      decisionPersistenceScope: persistenceScope,
+      expectedDecisionRevision: 0,
+      persistedState: {
+        hunkDecisions: {},
+        fileDecisions: { [projectFile]: 'rejected' },
+        hunkContextHashesByFile: {},
+        reviewActionHistory: [action],
+        reviewRedoHistory: [],
+      },
+      decisions: [
+        {
+          filePath: projectFile,
+          reviewKey: projectFile,
+          fileDecision: 'rejected',
+          hunkDecisions: {},
+          contentSnapshotToken,
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      data: {
+        applied: 1,
+        errors: [],
+        committedReviewAction: {
+          id: action.id,
+          kind: 'bulk',
+          descriptor: action.descriptor,
+        },
+      },
+    });
+  });
+
   it('removes a clean conflict journal so the next Changes load is not blocked', async () => {
     const contentSnapshotToken = await getDisplayedSnapshotToken(projectFile);
     const persistenceScope = {


### PR DESCRIPTION
## Summary

- Keeps the outer review-scope identity stable across hydration projection changes so the upcoming file, lifecycle, and hunk controllers do not restart on equivalent scopes.
- Preserves the existing inner draft-history scope stabilization from #347; the two guards cover different composition layers.
- Allows a one-file Reject All operation to use its correct durable bulk action while retaining exact disk-action and decision-count validation.
- Keeps the history invariant in `reviewDecisionCommandPolicy.ts`; no domain logic returns to `review.ts`.

## Size

- 5 files, +169/-4.
- `ChangeReviewDialog.tsx` remains 3,600 lines in this prerequisite.
- No new production file exceeds the 800-line limit.

## Verification

- 86 focused renderer/domain/IPC tests pass, including 74 review IPC tests.
- Regression tests cover stable outer and inner scope identities plus one-file Reject All at both policy and IPC levels.
- `pnpm typecheck`, fast ESLint, type-aware ESLint for changed feature files/tests, Prettier, source-size guard, and `git diff --check` pass.
- No desktop E2E in this prerequisite. The next bulk-decision PR changes disk behavior and will receive one fresh-sandbox desktop Changes E2E.
- No real user project, team, terminal runtime, or agent action was used.

## Remaining

- Adapt the bulk-decision boundary, then extract file drafts, file decisions, lifecycle, hunk decisions, interactions, mutation safety, actions, and the final dialog view until the facade is below 800 lines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected review decision validation so a single-file “Reject All” action can be represented as a bulk action.
  - Improved handling of review scope identity across hydration state changes.

- **Tests**
  - Added coverage for stable review scope identity.
  - Added validation for successful single-file bulk “Reject All” actions through the review workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->