### PR TITLE
refactor(change-review): extract file draft workflow

### DIFF
--- a/scripts/ci/source-file-size-legacy.json
+++ b/scripts/ci/source-file-size-legacy.json
@@ -150,7 +150,7 @@
   "src/renderer/components/team/members/MemberLogsTab.tsx": 985,
   "src/renderer/components/team/messages/MessageComposer.tsx": 1344,
   "src/renderer/components/team/messages/MessagesPanel.tsx": 1722,
-  "src/renderer/components/team/review/ChangeReviewDialog.tsx": 3430,
+  "src/renderer/components/team/review/ChangeReviewDialog.tsx": 3138,
   "src/renderer/components/team/review/CodeMirrorDiffView.tsx": 975,
   "src/renderer/components/team/useTeamChangesSummaries.ts": 826,
   "src/renderer/components/ui/MentionableTextarea.tsx": 1433,

--- a/scripts/ci/source-file-size-legacy.json
+++ b/scripts/ci/source-file-size-legacy.json
@@ -156,7 +156,7 @@
   "src/renderer/components/ui/MentionableTextarea.tsx": 1433,
   "src/renderer/index.css": 1950,
   "src/renderer/store/index.ts": 2626,
-  "src/renderer/store/slices/changeReviewSlice.ts": 2417,
+  "src/renderer/store/slices/changeReviewSlice.ts": 2416,
   "src/renderer/store/slices/cliInstallerSlice.ts": 1770,
   "src/renderer/store/slices/editorSlice.ts": 1483,
   "src/renderer/store/slices/extensionsSlice.ts": 1420,

--- a/src/features/change-review/README.md
+++ b/src/features/change-review/README.md
@@ -6,9 +6,9 @@ main-process review IPC shell.
 - `renderer/view-models` owns pure presentation projections.
 - `renderer/utils` owns pure scope and operation-generation policies.
 - `renderer/hooks` owns scope/lifecycle, draft history, conflict recovery, action-history,
-  decision-persistence, keyboard orchestration, bulk Accept/Reject, and durable
-  Undo/Redo/checkpoint Restore through narrow command, state, editor, status, and
-  write-evidence ports.
+  decision-persistence, keyboard orchestration, bulk Accept/Reject, manual file draft
+  save/reload/discard flows, and durable Undo/Redo/checkpoint Restore through narrow
+  command, state, editor, status, and write-evidence ports.
 - `renderer/ui` owns store-free presentation components.
 - `core/domain` owns pure review scope, rename expectation, snippet-shape, watcher-input, and
   decision-persistence policy.
@@ -17,8 +17,8 @@ main-process review IPC shell.
 - `main/infrastructure` owns Node path, filesystem, sensitive-path, hardlink, and watcher-root
   validation details.
 - The legacy dialog remains the temporary composition shell for Zustand, editor mutations,
-  per-file/hunk forward mutations and outer close coordination while later slices move those
-  responsibilities behind focused hooks and use cases.
+  per-file/hunk decision mutations, and outer close coordination while later slices move
+  those responsibilities behind focused hooks and use cases.
 
 Production callers import through `@features/change-review/renderer` or
 `@features/change-review/main`.

--- a/src/features/change-review/renderer/adapters/createChangeReviewFileDraftPorts.ts
+++ b/src/features/change-review/renderer/adapters/createChangeReviewFileDraftPorts.ts
@@ -1,0 +1,134 @@
+import type {
+  ChangeReviewFileDraftCommandPort,
+  ChangeReviewFileDraftStatePort,
+  ChangeReviewFileDraftStateSnapshot,
+  CommitChangeReviewExternalReloadInput,
+} from '../ports/changeReviewFileDraftPorts';
+import type {
+  ExecuteReviewMutationRequest,
+  ReviewFileScope,
+  ReviewPersistedStateSnapshot,
+} from '@shared/types';
+import type { ReviewAPI } from '@shared/types/api';
+
+interface ChangeReviewFileDraftStore {
+  activeChangeSet: {
+    files: readonly ChangeReviewFileDraftStateSnapshot['activeFiles'][number][];
+  } | null;
+  editedContents: ChangeReviewFileDraftStateSnapshot['editedContents'];
+  reviewExternalChangesByFile: ChangeReviewFileDraftStateSnapshot['reviewExternalChangesByFile'];
+  hunkDecisions: ChangeReviewFileDraftStateSnapshot['hunkDecisions'];
+  fileDecisions: ChangeReviewFileDraftStateSnapshot['fileDecisions'];
+  hunkContextHashesByFile: ChangeReviewFileDraftStateSnapshot['hunkContextHashesByFile'];
+  decisionRevision: number;
+  changeSetEpoch: number;
+  applyError: string | null;
+  updateEditedContent(filePath: string, content: string): void;
+  discardFileEdits(filePath: string): void;
+  clearReviewFileExternalChange(filePath: string): void;
+  reloadReviewFileFromDisk(filePath: string): void;
+  saveEditedFile(
+    filePath: string,
+    scope: ReviewFileScope,
+    expectedCurrentContent: string | null
+  ): Promise<void>;
+  quiesceDecisionPersistence(
+    teamName: string,
+    scopeKey: string,
+    scopeToken: string
+  ): Promise<boolean>;
+  recordDecisionRevision(
+    teamName: string,
+    scopeKey: string,
+    scopeToken: string,
+    revision: number
+  ): void;
+  fetchFileContent(
+    teamName: string,
+    memberName: string | undefined,
+    filePath: string
+  ): Promise<void>;
+}
+
+interface CreateChangeReviewFileDraftStatePortInput {
+  getStore: () => ChangeReviewFileDraftStore;
+  applyReloadedReviewState: (state: ReviewPersistedStateSnapshot) => void;
+  reportError: (message: string | null) => void;
+}
+
+export function createChangeReviewFileDraftStatePort({
+  getStore,
+  applyReloadedReviewState,
+  reportError,
+}: CreateChangeReviewFileDraftStatePortInput): ChangeReviewFileDraftStatePort {
+  return {
+    getSnapshot: () => {
+      const state = getStore();
+      return {
+        activeFiles: state.activeChangeSet?.files ?? [],
+        editedContents: state.editedContents,
+        reviewExternalChangesByFile: state.reviewExternalChangesByFile,
+        hunkDecisions: state.hunkDecisions,
+        fileDecisions: state.fileDecisions,
+        hunkContextHashesByFile: state.hunkContextHashesByFile,
+        decisionRevision: state.decisionRevision,
+        changeSetEpoch: state.changeSetEpoch,
+        applyError: state.applyError,
+      };
+    },
+    updateEditedContent: (filePath, content) => getStore().updateEditedContent(filePath, content),
+    discardFileEdits: (filePath) => getStore().discardFileEdits(filePath),
+    clearExternalChange: (filePath) => getStore().clearReviewFileExternalChange(filePath),
+    reloadFileFromDisk: (filePath) => getStore().reloadReviewFileFromDisk(filePath),
+    applyReloadedReviewState,
+    reportError,
+  };
+}
+
+type ChangeReviewFileDraftReviewApi = Pick<ReviewAPI, 'checkConflict' | 'executeMutation'>;
+
+interface CreateChangeReviewFileDraftCommandPortInput {
+  getStore: () => ChangeReviewFileDraftStore;
+  getReviewApi: () => ChangeReviewFileDraftReviewApi;
+}
+
+function toExternalReloadRequest({
+  reviewScope,
+  persistenceScope,
+  filePath,
+  persistedState,
+  expectedDecisionRevision,
+}: CommitChangeReviewExternalReloadInput): ExecuteReviewMutationRequest {
+  return {
+    scope: reviewScope,
+    decisionPersistenceScope: {
+      scopeKey: persistenceScope.scopeKey,
+      scopeToken: persistenceScope.scopeToken,
+    },
+    kind: 'reload-external' as const,
+    externalFilePath: filePath,
+    diskSteps: [],
+    persistedState,
+    expectedDecisionRevision,
+  };
+}
+
+export function createChangeReviewFileDraftCommandPort({
+  getStore,
+  getReviewApi,
+}: CreateChangeReviewFileDraftCommandPortInput): ChangeReviewFileDraftCommandPort {
+  return {
+    saveEditedFile: (filePath, reviewScope, expectedCurrentContent) =>
+      getStore().saveEditedFile(filePath, reviewScope, expectedCurrentContent),
+    checkConflict: (reviewScope, filePath, expectedContent) =>
+      getReviewApi().checkConflict(reviewScope, filePath, expectedContent),
+    commitExternalReload: (input) => getReviewApi().executeMutation(toExternalReloadRequest(input)),
+    quiescePersistence: ({ teamName, scopeKey, scopeToken }) =>
+      getStore().quiesceDecisionPersistence(teamName, scopeKey, scopeToken),
+    recordDecisionRevision: ({ teamName, scopeKey, scopeToken }, revision) =>
+      getStore().recordDecisionRevision(teamName, scopeKey, scopeToken, revision),
+    fetchFileContent: (teamName, memberName, filePath) => {
+      void getStore().fetchFileContent(teamName, memberName, filePath);
+    },
+  };
+}

--- a/src/features/change-review/renderer/adapters/createChangeReviewFileDraftPorts.ts
+++ b/src/features/change-review/renderer/adapters/createChangeReviewFileDraftPorts.ts
@@ -1,14 +1,12 @@
+import { normalizePathForComparison } from '@shared/utils/platformPath';
+
 import type {
   ChangeReviewFileDraftCommandPort,
   ChangeReviewFileDraftStatePort,
   ChangeReviewFileDraftStateSnapshot,
   CommitChangeReviewExternalReloadInput,
 } from '../ports/changeReviewFileDraftPorts';
-import type {
-  ExecuteReviewMutationRequest,
-  ReviewFileScope,
-  ReviewPersistedStateSnapshot,
-} from '@shared/types';
+import type { ExecuteReviewMutationRequest, ReviewPersistedStateSnapshot } from '@shared/types';
 import type { ReviewAPI } from '@shared/types/api';
 
 interface ChangeReviewFileDraftStore {
@@ -22,16 +20,11 @@ interface ChangeReviewFileDraftStore {
   hunkContextHashesByFile: ChangeReviewFileDraftStateSnapshot['hunkContextHashesByFile'];
   decisionRevision: number;
   changeSetEpoch: number;
-  applyError: string | null;
   updateEditedContent(filePath: string, content: string): void;
   discardFileEdits(filePath: string): void;
   clearReviewFileExternalChange(filePath: string): void;
   reloadReviewFileFromDisk(filePath: string): void;
-  saveEditedFile(
-    filePath: string,
-    scope: ReviewFileScope,
-    expectedCurrentContent: string | null
-  ): Promise<void>;
+  saveEditedFile: ChangeReviewFileDraftCommandPort['saveEditedFile'];
   quiesceDecisionPersistence(
     teamName: string,
     scopeKey: string,
@@ -56,6 +49,17 @@ interface CreateChangeReviewFileDraftStatePortInput {
   reportError: (message: string | null) => void;
 }
 
+function findExternalChange(
+  changes: Record<string, object>,
+  filePath: string
+): { filePath: string; value: object } | undefined {
+  const normalizedPath = normalizePathForComparison(filePath);
+  const entry = Object.entries(changes).find(
+    ([candidate]) => normalizePathForComparison(candidate) === normalizedPath
+  );
+  return entry ? { filePath: entry[0], value: entry[1] } : undefined;
+}
+
 export function createChangeReviewFileDraftStatePort({
   getStore,
   applyReloadedReviewState,
@@ -73,12 +77,19 @@ export function createChangeReviewFileDraftStatePort({
         hunkContextHashesByFile: state.hunkContextHashesByFile,
         decisionRevision: state.decisionRevision,
         changeSetEpoch: state.changeSetEpoch,
-        applyError: state.applyError,
       };
     },
+    readExternalChange: (filePath) =>
+      findExternalChange(getStore().reviewExternalChangesByFile, filePath)?.value,
     updateEditedContent: (filePath, content) => getStore().updateEditedContent(filePath, content),
     discardFileEdits: (filePath) => getStore().discardFileEdits(filePath),
-    clearExternalChange: (filePath) => getStore().clearReviewFileExternalChange(filePath),
+    clearExternalChange: (filePath, observedChange) => {
+      const store = getStore();
+      const current = findExternalChange(store.reviewExternalChangesByFile, filePath);
+      if (current?.value !== observedChange) return false;
+      store.clearReviewFileExternalChange(current.filePath);
+      return true;
+    },
     reloadFileFromDisk: (filePath) => getStore().reloadReviewFileFromDisk(filePath),
     applyReloadedReviewState,
     reportError,

--- a/src/features/change-review/renderer/hooks/useChangeReviewFileDraftController.ts
+++ b/src/features/change-review/renderer/hooks/useChangeReviewFileDraftController.ts
@@ -1,0 +1,436 @@
+import { useCallback } from 'react';
+
+import { buildReviewExternalReloadState } from '@features/review-mutations';
+import { normalizePathForComparison } from '@shared/utils/platformPath';
+
+import type {
+  ChangeReviewFileDraftCommandPort,
+  ChangeReviewFileDraftPersistenceScope,
+  ChangeReviewFileDraftStatePort,
+  ChangeReviewFileDraftStatusPort,
+  ChangeReviewFileDraftWriteEvidencePort,
+} from '../ports/changeReviewFileDraftPorts';
+import type { ReviewOperationScopeToken } from '../utils/reviewOperationGeneration';
+import type { ChangeReviewActionHistoryController } from './useChangeReviewActionHistoryController';
+import type { ChangeReviewDraftHistoryController } from './useChangeReviewDraftHistoryController';
+import type { FileChangeSummary, FileChangeWithContent, ReviewFileScope } from '@shared/types';
+
+type ActionHistory = Pick<
+  ChangeReviewActionHistoryController,
+  'clearForFile' | 'getUndoHistory' | 'getRedoHistory' | 'replaceHistories'
+>;
+
+type DraftHistory = Pick<
+  ChangeReviewDraftHistoryController,
+  | 'getEntry'
+  | 'hasBaseline'
+  | 'getBaseline'
+  | 'setBaseline'
+  | 'deleteBaseline'
+  | 'unsuppressFile'
+  | 'publishCheckpoint'
+  | 'flushWrites'
+  | 'clearFile'
+>;
+
+interface UseChangeReviewFileDraftControllerInput {
+  files: readonly FileChangeSummary[];
+  fileContents: Record<string, FileChangeWithContent>;
+  teamName: string;
+  memberName: string | undefined;
+  reviewScope: ReviewFileScope;
+  persistenceScope: ChangeReviewFileDraftPersistenceScope | null;
+  actionHistory: ActionHistory;
+  draftHistory: DraftHistory;
+  statePort: ChangeReviewFileDraftStatePort;
+  commandPort: ChangeReviewFileDraftCommandPort;
+  statusPort: ChangeReviewFileDraftStatusPort;
+  writeEvidencePort: ChangeReviewFileDraftWriteEvidencePort;
+  hasActionInFlight: () => boolean;
+  captureOperationScope: () => ReviewOperationScopeToken | null;
+  isCurrentOperationScope: (scope: ReviewOperationScopeToken | null) => boolean;
+  resolveModifiedContent: (
+    file: FileChangeSummary,
+    content: FileChangeWithContent | null
+  ) => string | null;
+  isFileMissingOnDisk: (content: FileChangeWithContent | null) => boolean;
+  hasUnresolvedExternalChange: (filePath: string, changes: Record<string, unknown>) => boolean;
+}
+
+export interface ChangeReviewFileDraftController {
+  contentChanged: (filePath: string, content: string, previousContent?: string) => void;
+  saveFile: (filePath: string) => Promise<void>;
+  restoreMissingFile: (filePath: string, content: string) => void;
+  reloadFromDisk: (filePath: string) => void;
+  keepDraft: (filePath: string) => void;
+  discardFile: (filePath: string) => void;
+}
+
+export function useChangeReviewFileDraftController({
+  files,
+  fileContents,
+  teamName,
+  memberName,
+  reviewScope,
+  persistenceScope,
+  actionHistory,
+  draftHistory,
+  statePort,
+  commandPort,
+  statusPort,
+  writeEvidencePort,
+  hasActionInFlight,
+  captureOperationScope,
+  isCurrentOperationScope,
+  resolveModifiedContent,
+  isFileMissingOnDisk,
+  hasUnresolvedExternalChange,
+}: UseChangeReviewFileDraftControllerInput): ChangeReviewFileDraftController {
+  const contentChanged = useCallback(
+    (filePath: string, content: string, previousContent?: string): void => {
+      const baselineKey = normalizePathForComparison(filePath);
+      draftHistory.unsuppressFile(baselineKey);
+      if (!draftHistory.hasBaseline(baselineKey)) {
+        const fileContent = fileContents[filePath] ?? null;
+        if (isFileMissingOnDisk(fileContent)) {
+          draftHistory.setBaseline(baselineKey, null);
+        } else {
+          const baseline =
+            previousContent ??
+            resolveModifiedContent(
+              files.find((file) => file.filePath === filePath) ?? {
+                filePath,
+                relativePath: filePath,
+                snippets: [],
+                linesAdded: 0,
+                linesRemoved: 0,
+                isNewFile: false,
+              },
+              fileContent
+            );
+          if (baseline != null) draftHistory.setBaseline(baselineKey, baseline);
+        }
+      }
+      const diskBaseline = draftHistory.getBaseline(baselineKey);
+      if (diskBaseline !== null && diskBaseline !== undefined && content === diskBaseline) {
+        statePort.discardFileEdits(filePath);
+      } else {
+        statePort.updateEditedContent(filePath, content);
+      }
+    },
+    [draftHistory, fileContents, files, isFileMissingOnDisk, resolveModifiedContent, statePort]
+  );
+
+  const saveFile = useCallback(
+    async (filePath: string): Promise<void> => {
+      if (hasActionInFlight()) return;
+      const initialState = statePort.getSnapshot();
+      const contentToSave = initialState.editedContents[filePath];
+      if (contentToSave === undefined) return;
+      if (hasUnresolvedExternalChange(filePath, initialState.reviewExternalChangesByFile)) {
+        statePort.reportError('Choose Reload from disk or Keep my draft before saving this file.');
+        return;
+      }
+      const baselineKey = normalizePathForComparison(filePath);
+      if (!draftHistory.hasBaseline(baselineKey)) {
+        statePort.reportError(
+          'The draft disk baseline is unavailable. Reload the file before saving.'
+        );
+        return;
+      }
+      const expectedCurrentContent = draftHistory.getBaseline(baselineKey) ?? null;
+      const operationEpoch = initialState.changeSetEpoch;
+      const operationScope = captureOperationScope();
+      if (!operationScope) return;
+      writeEvidencePort.markExpectedWrite(filePath, contentToSave);
+      await commandPort.saveEditedFile(filePath, reviewScope, expectedCurrentContent);
+      if (!isCurrentOperationScope(operationScope)) return;
+      const state = statePort.getSnapshot();
+      if (state.changeSetEpoch === operationEpoch && !state.applyError) {
+        draftHistory.setBaseline(baselineKey, contentToSave);
+        const serializedState = draftHistory.getEntry(filePath)?.editorState;
+        if (serializedState) {
+          draftHistory.publishCheckpoint(filePath, serializedState, contentToSave);
+          const flushed = await draftHistory.flushWrites();
+          if (!isCurrentOperationScope(operationScope)) return;
+          if (!flushed) {
+            statePort.reportError(
+              'The file was saved, but its durable Undo history could not be updated.'
+            );
+          }
+        }
+        actionHistory.clearForFile(filePath);
+        writeEvidencePort.markExpectedWrite(filePath, contentToSave);
+      }
+    },
+    [
+      actionHistory,
+      captureOperationScope,
+      commandPort,
+      draftHistory,
+      hasActionInFlight,
+      hasUnresolvedExternalChange,
+      isCurrentOperationScope,
+      reviewScope,
+      statePort,
+      writeEvidencePort,
+    ]
+  );
+
+  const restoreMissingFile = useCallback(
+    (filePath: string, content: string): void => {
+      if (hasActionInFlight()) return;
+      const operationEpoch = statePort.getSnapshot().changeSetEpoch;
+      const operationScope = captureOperationScope();
+      if (!operationScope) return;
+      const baselineKey = normalizePathForComparison(filePath);
+      draftHistory.setBaseline(baselineKey, null);
+      writeEvidencePort.markExpectedWrite(filePath, content);
+      statePort.updateEditedContent(filePath, content);
+      void Promise.resolve().then(async () => {
+        if (!isCurrentOperationScope(operationScope)) return;
+        await commandPort.saveEditedFile(filePath, reviewScope, null);
+        if (!isCurrentOperationScope(operationScope)) return;
+        const state = statePort.getSnapshot();
+        if (state.changeSetEpoch === operationEpoch && !state.applyError) {
+          draftHistory.setBaseline(baselineKey, content);
+          const serializedState = draftHistory.getEntry(filePath)?.editorState;
+          if (serializedState) {
+            draftHistory.publishCheckpoint(filePath, serializedState, content);
+            const flushed = await draftHistory.flushWrites();
+            if (!isCurrentOperationScope(operationScope)) return;
+            if (!flushed) {
+              statePort.reportError(
+                'The file was restored, but its durable Undo history could not be updated.'
+              );
+            }
+          }
+          actionHistory.clearForFile(filePath);
+          writeEvidencePort.markExpectedWrite(filePath, content);
+        }
+      });
+    },
+    [
+      actionHistory,
+      captureOperationScope,
+      commandPort,
+      draftHistory,
+      hasActionInFlight,
+      isCurrentOperationScope,
+      reviewScope,
+      statePort,
+      writeEvidencePort,
+    ]
+  );
+
+  const reloadFromDisk = useCallback(
+    (filePath: string): void => {
+      if (hasActionInFlight()) return;
+      const operationEpoch = statePort.getSnapshot().changeSetEpoch;
+      const operationScope = captureOperationScope();
+      if (!operationScope) return;
+      statusPort.beginFileMutation(filePath);
+      void (async () => {
+        try {
+          if (!persistenceScope) {
+            throw new Error('Durable review scope is unavailable; refusing an unsafe reload.');
+          }
+          const quiesced = await commandPort.quiescePersistence(persistenceScope);
+          if (!isCurrentOperationScope(operationScope)) return;
+          if (!quiesced) {
+            throw new Error('Unable to finish saving the previous review state. Retry Reload.');
+          }
+          const state = statePort.getSnapshot();
+          const file = state.activeFiles.find(
+            (candidate) =>
+              normalizePathForComparison(candidate.filePath) ===
+              normalizePathForComparison(filePath)
+          );
+          if (!file) throw new Error('Reviewed file is unavailable for Reload.');
+          const next = buildReviewExternalReloadState(file, {
+            hunkDecisions: state.hunkDecisions,
+            fileDecisions: state.fileDecisions,
+            hunkContextHashesByFile: state.hunkContextHashesByFile,
+            reviewActionHistory: actionHistory.getUndoHistory(),
+            reviewRedoHistory: actionHistory.getRedoHistory(),
+          });
+          const committed = await commandPort.commitExternalReload({
+            reviewScope,
+            persistenceScope,
+            filePath,
+            persistedState: next,
+            expectedDecisionRevision: state.decisionRevision,
+          });
+          if (
+            !isCurrentOperationScope(operationScope) ||
+            statePort.getSnapshot().changeSetEpoch !== operationEpoch
+          ) {
+            return;
+          }
+          actionHistory.replaceHistories(next.reviewActionHistory, next.reviewRedoHistory);
+          commandPort.recordDecisionRevision(persistenceScope, committed.decisionRevision);
+          draftHistory.deleteBaseline(filePath);
+          statePort.applyReloadedReviewState(next);
+          await draftHistory.clearFile(filePath);
+          if (
+            !isCurrentOperationScope(operationScope) ||
+            statePort.getSnapshot().changeSetEpoch !== operationEpoch
+          ) {
+            return;
+          }
+          statePort.reloadFileFromDisk(filePath);
+          statusPort.incrementDiscardCounter(filePath);
+          commandPort.fetchFileContent(teamName, memberName, filePath);
+        } catch (error) {
+          if (
+            isCurrentOperationScope(operationScope) &&
+            statePort.getSnapshot().changeSetEpoch === operationEpoch
+          ) {
+            statePort.reportError(
+              error instanceof Error ? error.message : 'Unable to reload the external file.'
+            );
+          }
+        } finally {
+          if (
+            isCurrentOperationScope(operationScope) &&
+            statePort.getSnapshot().changeSetEpoch === operationEpoch
+          ) {
+            statusPort.finishFileMutation(filePath);
+          }
+        }
+      })();
+    },
+    [
+      actionHistory,
+      captureOperationScope,
+      commandPort,
+      draftHistory,
+      hasActionInFlight,
+      isCurrentOperationScope,
+      memberName,
+      persistenceScope,
+      reviewScope,
+      statePort,
+      statusPort,
+      teamName,
+    ]
+  );
+
+  const keepDraft = useCallback(
+    (filePath: string): void => {
+      if (hasActionInFlight()) return;
+      const baselineKey = normalizePathForComparison(filePath);
+      if (!draftHistory.hasBaseline(baselineKey)) {
+        statePort.reportError(
+          'The draft disk baseline is unavailable. Reload the file before continuing.'
+        );
+        return;
+      }
+      const expected = draftHistory.getBaseline(baselineKey) ?? '';
+      const operationEpoch = statePort.getSnapshot().changeSetEpoch;
+      const operationScope = captureOperationScope();
+      if (!operationScope) return;
+      statusPort.beginFileMutation(filePath);
+      void (async () => {
+        try {
+          const current = await commandPort.checkConflict(reviewScope, filePath, expected);
+          if (
+            !isCurrentOperationScope(operationScope) ||
+            statePort.getSnapshot().changeSetEpoch !== operationEpoch
+          ) {
+            return;
+          }
+          const nextBaseline =
+            current.hasConflict && current.conflictContent === null ? null : current.currentContent;
+          draftHistory.setBaseline(baselineKey, nextBaseline);
+          const serializedState = draftHistory.getEntry(filePath)?.editorState;
+          if (serializedState) {
+            draftHistory.publishCheckpoint(filePath, serializedState, nextBaseline);
+            const flushed = await draftHistory.flushWrites();
+            if (!isCurrentOperationScope(operationScope)) return;
+            if (!flushed) {
+              throw new Error('Unable to persist the rebased manual edit history');
+            }
+          }
+          statePort.clearExternalChange(filePath);
+          statePort.reportError(null);
+        } catch (error) {
+          if (
+            isCurrentOperationScope(operationScope) &&
+            statePort.getSnapshot().changeSetEpoch === operationEpoch
+          ) {
+            statePort.reportError(String(error));
+          }
+        } finally {
+          if (
+            isCurrentOperationScope(operationScope) &&
+            statePort.getSnapshot().changeSetEpoch === operationEpoch
+          ) {
+            statusPort.finishFileMutation(filePath);
+          }
+        }
+      })();
+    },
+    [
+      captureOperationScope,
+      commandPort,
+      draftHistory,
+      hasActionInFlight,
+      isCurrentOperationScope,
+      reviewScope,
+      statePort,
+      statusPort,
+    ]
+  );
+
+  const discardFile = useCallback(
+    (filePath: string): void => {
+      if (hasActionInFlight()) return;
+      const state = statePort.getSnapshot();
+      if (hasUnresolvedExternalChange(filePath, state.reviewExternalChangesByFile)) {
+        reloadFromDisk(filePath);
+        return;
+      }
+      const operationEpoch = state.changeSetEpoch;
+      const operationScope = captureOperationScope();
+      if (!operationScope) return;
+      statusPort.beginFileMutation(filePath);
+      void (async () => {
+        try {
+          await draftHistory.clearFile(filePath);
+          if (
+            !isCurrentOperationScope(operationScope) ||
+            statePort.getSnapshot().changeSetEpoch !== operationEpoch
+          ) {
+            return;
+          }
+          draftHistory.deleteBaseline(filePath);
+          statePort.discardFileEdits(filePath);
+          statusPort.incrementDiscardCounter(filePath);
+        } catch {
+          // The draft-history controller already reports durable cleanup failures.
+          // Keep the editor and native Undo history intact so Discard remains retryable.
+        } finally {
+          if (
+            isCurrentOperationScope(operationScope) &&
+            statePort.getSnapshot().changeSetEpoch === operationEpoch
+          ) {
+            statusPort.finishFileMutation(filePath);
+          }
+        }
+      })();
+    },
+    [
+      captureOperationScope,
+      draftHistory,
+      hasActionInFlight,
+      hasUnresolvedExternalChange,
+      isCurrentOperationScope,
+      reloadFromDisk,
+      statePort,
+      statusPort,
+    ]
+  );
+
+  return { contentChanged, saveFile, restoreMissingFile, reloadFromDisk, keepDraft, discardFile };
+}

--- a/src/features/change-review/renderer/hooks/useChangeReviewFileDraftController.ts
+++ b/src/features/change-review/renderer/hooks/useChangeReviewFileDraftController.ts
@@ -4,34 +4,18 @@ import { buildReviewExternalReloadState } from '@features/review-mutations';
 import { normalizePathForComparison } from '@shared/utils/platformPath';
 
 import type {
+  ChangeReviewFileDraftActionHistoryPort,
   ChangeReviewFileDraftCommandPort,
+  ChangeReviewFileDraftHistoryPort,
   ChangeReviewFileDraftPersistenceScope,
   ChangeReviewFileDraftStatePort,
   ChangeReviewFileDraftStatusPort,
   ChangeReviewFileDraftWriteEvidencePort,
 } from '../ports/changeReviewFileDraftPorts';
 import type { ReviewOperationScopeToken } from '../utils/reviewOperationGeneration';
-import type { ChangeReviewActionHistoryController } from './useChangeReviewActionHistoryController';
-import type { ChangeReviewDraftHistoryController } from './useChangeReviewDraftHistoryController';
 import type { FileChangeSummary, FileChangeWithContent, ReviewFileScope } from '@shared/types';
 
-type ActionHistory = Pick<
-  ChangeReviewActionHistoryController,
-  'clearForFile' | 'getUndoHistory' | 'getRedoHistory' | 'replaceHistories'
->;
-
-type DraftHistory = Pick<
-  ChangeReviewDraftHistoryController,
-  | 'getEntry'
-  | 'hasBaseline'
-  | 'getBaseline'
-  | 'setBaseline'
-  | 'deleteBaseline'
-  | 'unsuppressFile'
-  | 'publishCheckpoint'
-  | 'flushWrites'
-  | 'clearFile'
->;
+const KEEP_DRAFT_MAX_ATTEMPTS = 3;
 
 interface UseChangeReviewFileDraftControllerInput {
   files: readonly FileChangeSummary[];
@@ -40,8 +24,8 @@ interface UseChangeReviewFileDraftControllerInput {
   memberName: string | undefined;
   reviewScope: ReviewFileScope;
   persistenceScope: ChangeReviewFileDraftPersistenceScope | null;
-  actionHistory: ActionHistory;
-  draftHistory: DraftHistory;
+  actionHistory: ChangeReviewFileDraftActionHistoryPort;
+  draftHistory: ChangeReviewFileDraftHistoryPort;
   statePort: ChangeReviewFileDraftStatePort;
   commandPort: ChangeReviewFileDraftCommandPort;
   statusPort: ChangeReviewFileDraftStatusPort;
@@ -54,7 +38,11 @@ interface UseChangeReviewFileDraftControllerInput {
     content: FileChangeWithContent | null
   ) => string | null;
   isFileMissingOnDisk: (content: FileChangeWithContent | null) => boolean;
-  hasUnresolvedExternalChange: (filePath: string, changes: Record<string, unknown>) => boolean;
+  hasUnresolvedExternalChange: (filePath: string, changes: Record<string, object>) => boolean;
+}
+
+function toErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
 }
 
 export interface ChangeReviewFileDraftController {
@@ -143,10 +131,22 @@ export function useChangeReviewFileDraftController({
       const operationScope = captureOperationScope();
       if (!operationScope) return;
       writeEvidencePort.markExpectedWrite(filePath, contentToSave);
-      await commandPort.saveEditedFile(filePath, reviewScope, expectedCurrentContent);
-      if (!isCurrentOperationScope(operationScope)) return;
-      const state = statePort.getSnapshot();
-      if (state.changeSetEpoch === operationEpoch && !state.applyError) {
+      try {
+        const result = await commandPort.saveEditedFile(
+          filePath,
+          reviewScope,
+          expectedCurrentContent
+        );
+        if (
+          !isCurrentOperationScope(operationScope) ||
+          statePort.getSnapshot().changeSetEpoch !== operationEpoch
+        ) {
+          return;
+        }
+        if (!result.ok) {
+          statePort.reportError(result.error);
+          return;
+        }
         draftHistory.setBaseline(baselineKey, contentToSave);
         const serializedState = draftHistory.getEntry(filePath)?.editorState;
         if (serializedState) {
@@ -161,6 +161,13 @@ export function useChangeReviewFileDraftController({
         }
         actionHistory.clearForFile(filePath);
         writeEvidencePort.markExpectedWrite(filePath, contentToSave);
+      } catch (error) {
+        if (
+          isCurrentOperationScope(operationScope) &&
+          statePort.getSnapshot().changeSetEpoch === operationEpoch
+        ) {
+          statePort.reportError(toErrorMessage(error, 'Unable to save the edited file.'));
+        }
       }
     },
     [
@@ -189,10 +196,18 @@ export function useChangeReviewFileDraftController({
       statePort.updateEditedContent(filePath, content);
       void Promise.resolve().then(async () => {
         if (!isCurrentOperationScope(operationScope)) return;
-        await commandPort.saveEditedFile(filePath, reviewScope, null);
-        if (!isCurrentOperationScope(operationScope)) return;
-        const state = statePort.getSnapshot();
-        if (state.changeSetEpoch === operationEpoch && !state.applyError) {
+        try {
+          const result = await commandPort.saveEditedFile(filePath, reviewScope, null);
+          if (
+            !isCurrentOperationScope(operationScope) ||
+            statePort.getSnapshot().changeSetEpoch !== operationEpoch
+          ) {
+            return;
+          }
+          if (!result.ok) {
+            statePort.reportError(result.error);
+            return;
+          }
           draftHistory.setBaseline(baselineKey, content);
           const serializedState = draftHistory.getEntry(filePath)?.editorState;
           if (serializedState) {
@@ -207,6 +222,13 @@ export function useChangeReviewFileDraftController({
           }
           actionHistory.clearForFile(filePath);
           writeEvidencePort.markExpectedWrite(filePath, content);
+        } catch (error) {
+          if (
+            isCurrentOperationScope(operationScope) &&
+            statePort.getSnapshot().changeSetEpoch === operationEpoch
+          ) {
+            statePort.reportError(toErrorMessage(error, 'Unable to restore the missing file.'));
+          }
         }
       });
     },
@@ -326,40 +348,61 @@ export function useChangeReviewFileDraftController({
         );
         return;
       }
-      const expected = draftHistory.getBaseline(baselineKey) ?? '';
+      let expected = draftHistory.getBaseline(baselineKey) ?? '';
       const operationEpoch = statePort.getSnapshot().changeSetEpoch;
       const operationScope = captureOperationScope();
       if (!operationScope) return;
       statusPort.beginFileMutation(filePath);
       void (async () => {
         try {
-          const current = await commandPort.checkConflict(reviewScope, filePath, expected);
-          if (
-            !isCurrentOperationScope(operationScope) ||
-            statePort.getSnapshot().changeSetEpoch !== operationEpoch
-          ) {
+          for (let attempt = 0; attempt < KEEP_DRAFT_MAX_ATTEMPTS; attempt += 1) {
+            const observedChange = statePort.readExternalChange(filePath);
+            if (observedChange === undefined) return;
+            const current = await commandPort.checkConflict(reviewScope, filePath, expected);
+            if (
+              !isCurrentOperationScope(operationScope) ||
+              statePort.getSnapshot().changeSetEpoch !== operationEpoch
+            ) {
+              return;
+            }
+            const nextBaseline =
+              current.hasConflict && current.conflictContent === null
+                ? null
+                : current.currentContent;
+            if (statePort.readExternalChange(filePath) !== observedChange) {
+              expected = nextBaseline ?? '';
+              continue;
+            }
+            const serializedState = draftHistory.getEntry(filePath)?.editorState;
+            if (serializedState) {
+              draftHistory.publishCheckpoint(filePath, serializedState, nextBaseline);
+              const flushed = await draftHistory.flushWrites();
+              if (
+                !isCurrentOperationScope(operationScope) ||
+                statePort.getSnapshot().changeSetEpoch !== operationEpoch
+              ) {
+                return;
+              }
+              if (!flushed) {
+                throw new Error('Unable to persist the rebased manual edit history');
+              }
+            }
+            if (!statePort.clearExternalChange(filePath, observedChange)) {
+              expected = nextBaseline ?? '';
+              continue;
+            }
+            draftHistory.setBaseline(baselineKey, nextBaseline);
             return;
           }
-          const nextBaseline =
-            current.hasConflict && current.conflictContent === null ? null : current.currentContent;
-          draftHistory.setBaseline(baselineKey, nextBaseline);
-          const serializedState = draftHistory.getEntry(filePath)?.editorState;
-          if (serializedState) {
-            draftHistory.publishCheckpoint(filePath, serializedState, nextBaseline);
-            const flushed = await draftHistory.flushWrites();
-            if (!isCurrentOperationScope(operationScope)) return;
-            if (!flushed) {
-              throw new Error('Unable to persist the rebased manual edit history');
-            }
-          }
-          statePort.clearExternalChange(filePath);
-          statePort.reportError(null);
+          throw new Error(
+            'The file kept changing while the draft was rebased. Retry Keep my draft.'
+          );
         } catch (error) {
           if (
             isCurrentOperationScope(operationScope) &&
             statePort.getSnapshot().changeSetEpoch === operationEpoch
           ) {
-            statePort.reportError(String(error));
+            statePort.reportError(toErrorMessage(error, 'Unable to keep the manual file draft.'));
           }
         } finally {
           if (
@@ -407,9 +450,15 @@ export function useChangeReviewFileDraftController({
           draftHistory.deleteBaseline(filePath);
           statePort.discardFileEdits(filePath);
           statusPort.incrementDiscardCounter(filePath);
-        } catch {
-          // The draft-history controller already reports durable cleanup failures.
-          // Keep the editor and native Undo history intact so Discard remains retryable.
+        } catch (error) {
+          if (
+            isCurrentOperationScope(operationScope) &&
+            statePort.getSnapshot().changeSetEpoch === operationEpoch
+          ) {
+            statePort.reportError(
+              toErrorMessage(error, 'Unable to discard the saved manual edit history.')
+            );
+          }
         } finally {
           if (
             isCurrentOperationScope(operationScope) &&

--- a/src/features/change-review/renderer/index.ts
+++ b/src/features/change-review/renderer/index.ts
@@ -83,12 +83,15 @@ export type {
   ChangeReviewDraftHistoryVersion,
 } from './ports/changeReviewDraftHistoryPort';
 export type {
+  ChangeReviewFileDraftActionHistoryPort,
   ChangeReviewFileDraftCommandPort,
+  ChangeReviewFileDraftHistoryPort,
   ChangeReviewFileDraftPersistenceScope,
   ChangeReviewFileDraftStatePort,
   ChangeReviewFileDraftStateSnapshot,
   ChangeReviewFileDraftStatusPort,
   ChangeReviewFileDraftWriteEvidencePort,
+  ChangeReviewSaveEditedFileResult,
   CommitChangeReviewExternalReloadInput,
 } from './ports/changeReviewFileDraftPorts';
 export type {

--- a/src/features/change-review/renderer/index.ts
+++ b/src/features/change-review/renderer/index.ts
@@ -14,6 +14,10 @@ export type { ChangeReviewConflictStateBridge } from './adapters/createChangeRev
 export { createChangeReviewConflictStateBridge } from './adapters/createChangeReviewConflictStateBridge';
 export { createChangeReviewDraftHistoryPort } from './adapters/createChangeReviewDraftHistoryPort';
 export {
+  createChangeReviewFileDraftCommandPort,
+  createChangeReviewFileDraftStatePort,
+} from './adapters/createChangeReviewFileDraftPorts';
+export {
   createChangeReviewHistoryMutationCommandPort,
   createChangeReviewHistoryMutationStatePort,
 } from './adapters/createChangeReviewHistoryMutationPorts';
@@ -40,6 +44,8 @@ export type {
   ChangeReviewDraftHistoryDiagnostics,
 } from './hooks/useChangeReviewDraftHistoryController';
 export { useChangeReviewDraftHistoryController } from './hooks/useChangeReviewDraftHistoryController';
+export type { ChangeReviewFileDraftController } from './hooks/useChangeReviewFileDraftController';
+export { useChangeReviewFileDraftController } from './hooks/useChangeReviewFileDraftController';
 export type { ChangeReviewKeyboardEditorContext } from './hooks/useChangeReviewHistoryKeyboardShortcuts';
 export { useChangeReviewHistoryKeyboardShortcuts } from './hooks/useChangeReviewHistoryKeyboardShortcuts';
 export type {
@@ -76,6 +82,15 @@ export type {
   ChangeReviewDraftHistoryScope,
   ChangeReviewDraftHistoryVersion,
 } from './ports/changeReviewDraftHistoryPort';
+export type {
+  ChangeReviewFileDraftCommandPort,
+  ChangeReviewFileDraftPersistenceScope,
+  ChangeReviewFileDraftStatePort,
+  ChangeReviewFileDraftStateSnapshot,
+  ChangeReviewFileDraftStatusPort,
+  ChangeReviewFileDraftWriteEvidencePort,
+  CommitChangeReviewExternalReloadInput,
+} from './ports/changeReviewFileDraftPorts';
 export type {
   ChangeReviewHistoryMutationCommandPort,
   ChangeReviewHistoryMutationScope,

--- a/src/features/change-review/renderer/ports/changeReviewFileDraftPorts.ts
+++ b/src/features/change-review/renderer/ports/changeReviewFileDraftPorts.ts
@@ -1,9 +1,15 @@
 import type {
+  ReviewDraftHistoryEntry,
+  ReviewSerializedEditorState,
+} from '@features/change-review-history/contracts';
+import type {
   ExecuteReviewMutationResult,
   FileChangeSummary,
   HunkDecision,
   ReviewFileScope,
   ReviewPersistedStateSnapshot,
+  ReviewRedoAction,
+  ReviewUndoAction,
 } from '@shared/types';
 
 export interface ChangeReviewFileDraftPersistenceScope {
@@ -15,24 +21,51 @@ export interface ChangeReviewFileDraftPersistenceScope {
 export interface ChangeReviewFileDraftStateSnapshot {
   activeFiles: readonly FileChangeSummary[];
   editedContents: Partial<Record<string, string>>;
-  reviewExternalChangesByFile: Record<string, unknown>;
+  reviewExternalChangesByFile: Record<string, object>;
   hunkDecisions: Record<string, HunkDecision>;
   fileDecisions: Record<string, HunkDecision>;
   hunkContextHashesByFile: Record<string, Record<number, string>>;
   decisionRevision: number;
   changeSetEpoch: number;
-  applyError: string | null;
 }
 
 export interface ChangeReviewFileDraftStatePort {
   getSnapshot: () => ChangeReviewFileDraftStateSnapshot;
+  readExternalChange: (filePath: string) => object | undefined;
   updateEditedContent: (filePath: string, content: string) => void;
   discardFileEdits: (filePath: string) => void;
-  clearExternalChange: (filePath: string) => void;
+  clearExternalChange: (filePath: string, observedChange: object) => boolean;
   reloadFileFromDisk: (filePath: string) => void;
   applyReloadedReviewState: (state: ReviewPersistedStateSnapshot) => void;
   reportError: (message: string | null) => void;
 }
+
+export interface ChangeReviewFileDraftActionHistoryPort {
+  clearForFile: (filePath: string) => void;
+  getUndoHistory: () => ReviewUndoAction[];
+  getRedoHistory: () => ReviewRedoAction[];
+  replaceHistories: (undoHistory: ReviewUndoAction[], redoHistory: ReviewRedoAction[]) => void;
+}
+
+export interface ChangeReviewFileDraftHistoryPort {
+  getEntry: (filePath: string) => ReviewDraftHistoryEntry | undefined;
+  hasBaseline: (filePath: string) => boolean;
+  getBaseline: (filePath: string) => string | null | undefined;
+  setBaseline: (filePath: string, baseline: string | null) => void;
+  deleteBaseline: (filePath: string) => void;
+  unsuppressFile: (filePath: string) => void;
+  publishCheckpoint: (
+    filePath: string,
+    editorState: ReviewSerializedEditorState,
+    diskBaseline: string | null
+  ) => void;
+  flushWrites: () => Promise<boolean>;
+  clearFile: (filePath: string) => Promise<void>;
+}
+
+export type ChangeReviewSaveEditedFileResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly error: string };
 
 export interface CommitChangeReviewExternalReloadInput {
   reviewScope: ReviewFileScope;
@@ -47,7 +80,7 @@ export interface ChangeReviewFileDraftCommandPort {
     filePath: string,
     reviewScope: ReviewFileScope,
     expectedCurrentContent: string | null
-  ) => Promise<void>;
+  ) => Promise<ChangeReviewSaveEditedFileResult>;
   checkConflict: (
     reviewScope: ReviewFileScope,
     filePath: string,

--- a/src/features/change-review/renderer/ports/changeReviewFileDraftPorts.ts
+++ b/src/features/change-review/renderer/ports/changeReviewFileDraftPorts.ts
@@ -1,0 +1,76 @@
+import type {
+  ExecuteReviewMutationResult,
+  FileChangeSummary,
+  HunkDecision,
+  ReviewFileScope,
+  ReviewPersistedStateSnapshot,
+} from '@shared/types';
+
+export interface ChangeReviewFileDraftPersistenceScope {
+  teamName: string;
+  scopeKey: string;
+  scopeToken: string;
+}
+
+export interface ChangeReviewFileDraftStateSnapshot {
+  activeFiles: readonly FileChangeSummary[];
+  editedContents: Partial<Record<string, string>>;
+  reviewExternalChangesByFile: Record<string, unknown>;
+  hunkDecisions: Record<string, HunkDecision>;
+  fileDecisions: Record<string, HunkDecision>;
+  hunkContextHashesByFile: Record<string, Record<number, string>>;
+  decisionRevision: number;
+  changeSetEpoch: number;
+  applyError: string | null;
+}
+
+export interface ChangeReviewFileDraftStatePort {
+  getSnapshot: () => ChangeReviewFileDraftStateSnapshot;
+  updateEditedContent: (filePath: string, content: string) => void;
+  discardFileEdits: (filePath: string) => void;
+  clearExternalChange: (filePath: string) => void;
+  reloadFileFromDisk: (filePath: string) => void;
+  applyReloadedReviewState: (state: ReviewPersistedStateSnapshot) => void;
+  reportError: (message: string | null) => void;
+}
+
+export interface CommitChangeReviewExternalReloadInput {
+  reviewScope: ReviewFileScope;
+  persistenceScope: ChangeReviewFileDraftPersistenceScope;
+  filePath: string;
+  persistedState: ReviewPersistedStateSnapshot;
+  expectedDecisionRevision: number;
+}
+
+export interface ChangeReviewFileDraftCommandPort {
+  saveEditedFile: (
+    filePath: string,
+    reviewScope: ReviewFileScope,
+    expectedCurrentContent: string | null
+  ) => Promise<void>;
+  checkConflict: (
+    reviewScope: ReviewFileScope,
+    filePath: string,
+    expectedContent: string
+  ) => Promise<{
+    hasConflict: boolean;
+    conflictContent: string | null;
+    currentContent: string;
+  }>;
+  commitExternalReload: (
+    input: CommitChangeReviewExternalReloadInput
+  ) => Promise<ExecuteReviewMutationResult>;
+  quiescePersistence: (scope: ChangeReviewFileDraftPersistenceScope) => Promise<boolean>;
+  recordDecisionRevision: (scope: ChangeReviewFileDraftPersistenceScope, revision: number) => void;
+  fetchFileContent: (teamName: string, memberName: string | undefined, filePath: string) => void;
+}
+
+export interface ChangeReviewFileDraftStatusPort {
+  beginFileMutation: (filePath: string) => void;
+  finishFileMutation: (filePath: string) => void;
+  incrementDiscardCounter: (filePath: string) => void;
+}
+
+export interface ChangeReviewFileDraftWriteEvidencePort {
+  markExpectedWrite: (filePath: string, expectedContent: string | null) => void;
+}

--- a/src/renderer/components/team/review/ChangeReviewDialog.tsx
+++ b/src/renderer/components/team/review/ChangeReviewDialog.tsx
@@ -27,6 +27,8 @@ import {
   createChangeReviewConflictStateBridge,
   createChangeReviewDecisionPersistencePort,
   createChangeReviewDraftHistoryPort,
+  createChangeReviewFileDraftCommandPort,
+  createChangeReviewFileDraftStatePort,
   createChangeReviewHistoryMutationCommandPort,
   createChangeReviewHistoryMutationStatePort,
   findActiveReviewFile,
@@ -43,6 +45,7 @@ import {
   useChangeReviewDecisionAutoPersistence,
   useChangeReviewDecisionPersistenceController,
   useChangeReviewDraftHistoryController,
+  useChangeReviewFileDraftController,
   useChangeReviewHistoryKeyboardShortcuts,
   useChangeReviewHistoryMutationController,
   useChangeReviewLifecycleRegistration,
@@ -53,7 +56,6 @@ import { serializeReviewDraftEditorState } from '@features/change-review-history
 import { useAppTranslation } from '@features/localization/renderer';
 import {
   alignReviewDiskUndoSnapshotWithAppliedContent,
-  buildReviewExternalReloadState,
   buildReviewRestoreDecisionState,
   isLedgerRenameReviewFile,
 } from '@features/review-mutations';
@@ -130,6 +132,8 @@ import type {
   ChangeReviewBulkDecisionEditorPort,
   ChangeReviewBulkDecisionStatusPort,
   ChangeReviewBulkDecisionWriteEvidencePort,
+  ChangeReviewFileDraftStatusPort,
+  ChangeReviewFileDraftWriteEvidencePort,
   ChangeReviewHistoryMutationViewPort,
   ReviewDraftHistoryHydrationState,
 } from '@features/change-review/renderer';
@@ -178,6 +182,21 @@ const changeReviewBulkDecisionStatePort = createChangeReviewBulkDecisionStatePor
   getStore: useStore.getState,
   restoreDecisionSnapshot: ({ hunkDecisions, fileDecisions }) =>
     useStore.setState({ hunkDecisions, fileDecisions }),
+});
+const changeReviewFileDraftStatePort = createChangeReviewFileDraftStatePort({
+  getStore: useStore.getState,
+  applyReloadedReviewState: (state) =>
+    useStore.setState({
+      hunkDecisions: state.hunkDecisions,
+      fileDecisions: state.fileDecisions,
+      hunkContextHashesByFile: state.hunkContextHashesByFile ?? {},
+      applyError: null,
+    }),
+  reportError: (applyError) => useStore.setState({ applyError }),
+});
+const changeReviewFileDraftCommandPort = createChangeReviewFileDraftCommandPort({
+  getStore: useStore.getState,
+  getReviewApi: () => api.review,
 });
 const changeReviewHistoryMutationCommandPort = createChangeReviewHistoryMutationCommandPort(
   () => api.review
@@ -281,12 +300,8 @@ export const ChangeReviewDialog = ({
     applySingleFileDecision,
     addReviewFile,
     editedContents,
-    updateEditedContent,
-    discardFileEdits,
-    saveEditedFile,
     reviewExternalChangesByFile,
     clearReviewFileExternalChange,
-    reloadReviewFileFromDisk,
     quiesceDecisionPersistence,
     recordDecisionRevision,
     clearDecisionsFromDisk,
@@ -1886,49 +1901,109 @@ export const ChangeReviewDialog = ({
     ]
   );
 
-  const handleContentChanged = useCallback(
-    (filePath: string, content: string, previousContent?: string) => {
-      const baselineKey = normalizePathForComparison(filePath);
-      unsuppressDraftHistoryFile(baselineKey);
-      if (!hasDraftHistoryBaseline(baselineKey)) {
-        const fileContent = fileContents[filePath] ?? null;
-        if (isReviewFileMissingOnDisk(fileContent)) {
-          setDraftHistoryBaseline(baselineKey, null);
-        } else {
-          const baseline =
-            previousContent ??
-            getResolvedReviewModifiedContent(
-              activeChangeSet?.files.find((file) => file.filePath === filePath) ?? {
-                filePath,
-                relativePath: filePath,
-                snippets: [],
-                linesAdded: 0,
-                linesRemoved: 0,
-                isNewFile: false,
-              },
-              fileContent
-            );
-          if (baseline != null) setDraftHistoryBaseline(baselineKey, baseline);
-        }
-      }
-      const diskBaseline = getDraftHistoryBaseline(baselineKey);
-      if (diskBaseline !== null && diskBaseline !== undefined && content === diskBaseline) {
-        discardFileEdits(filePath);
-      } else {
-        updateEditedContent(filePath, content);
-      }
-    },
+  const fileDraftPersistenceScope = useMemo(
+    () =>
+      decisionScopeToken
+        ? {
+            teamName,
+            scopeKey: decisionScopeKey,
+            scopeToken: decisionScopeToken,
+          }
+        : null,
+    [decisionScopeKey, decisionScopeToken, teamName]
+  );
+  const fileDraftActionHistory = useMemo(
+    () => ({
+      clearForFile: clearReviewActionHistoryForFile,
+      getUndoHistory: getReviewUndoHistory,
+      getRedoHistory: getReviewRedoHistory,
+      replaceHistories: replaceReviewActionHistories,
+    }),
     [
-      activeChangeSet,
-      discardFileEdits,
-      fileContents,
-      getDraftHistoryBaseline,
-      hasDraftHistoryBaseline,
-      setDraftHistoryBaseline,
-      unsuppressDraftHistoryFile,
-      updateEditedContent,
+      clearReviewActionHistoryForFile,
+      getReviewRedoHistory,
+      getReviewUndoHistory,
+      replaceReviewActionHistories,
     ]
   );
+  const fileDraftHistory = useMemo(
+    () => ({
+      getEntry: getDraftHistoryEntry,
+      hasBaseline: hasDraftHistoryBaseline,
+      getBaseline: getDraftHistoryBaseline,
+      setBaseline: setDraftHistoryBaseline,
+      deleteBaseline: deleteDraftHistoryBaseline,
+      unsuppressFile: unsuppressDraftHistoryFile,
+      publishCheckpoint: publishDraftHistoryCheckpoint,
+      flushWrites: flushDraftHistoryWrites,
+      clearFile: clearDraftHistoryForFile,
+    }),
+    [
+      clearDraftHistoryForFile,
+      deleteDraftHistoryBaseline,
+      flushDraftHistoryWrites,
+      getDraftHistoryBaseline,
+      getDraftHistoryEntry,
+      hasDraftHistoryBaseline,
+      publishDraftHistoryCheckpoint,
+      setDraftHistoryBaseline,
+      unsuppressDraftHistoryFile,
+    ]
+  );
+  const fileDraftViewPorts = useMemo<{
+    status: ChangeReviewFileDraftStatusPort;
+    writeEvidence: ChangeReviewFileDraftWriteEvidencePort;
+  }>(
+    () => ({
+      status: {
+        beginFileMutation: (filePath) => {
+          fileApplyInFlightRef.current.add(filePath);
+          setFileApplying(filePath, true);
+        },
+        finishFileMutation: (filePath) => {
+          fileApplyInFlightRef.current.delete(filePath);
+          setFileApplying(filePath, false);
+        },
+        incrementDiscardCounter: (filePath) => {
+          setDiscardCounters((previous) => ({
+            ...previous,
+            [filePath]: (previous[filePath] ?? 0) + 1,
+          }));
+        },
+      },
+      writeEvidence: {
+        markExpectedWrite: markRecentReviewWrite,
+      },
+    }),
+    [markRecentReviewWrite, setFileApplying]
+  );
+  const {
+    contentChanged: handleContentChanged,
+    saveFile: handleSaveFile,
+    restoreMissingFile: handleRestoreMissingFile,
+    reloadFromDisk: handleReloadFromDisk,
+    keepDraft: handleKeepDraft,
+    discardFile: handleDiscardFile,
+  } = useChangeReviewFileDraftController({
+    files: activeChangeSet?.files ?? [],
+    fileContents,
+    teamName,
+    memberName,
+    reviewScope,
+    persistenceScope: fileDraftPersistenceScope,
+    actionHistory: fileDraftActionHistory,
+    draftHistory: fileDraftHistory,
+    statePort: changeReviewFileDraftStatePort,
+    commandPort: changeReviewFileDraftCommandPort,
+    statusPort: fileDraftViewPorts.status,
+    writeEvidencePort: fileDraftViewPorts.writeEvidence,
+    hasActionInFlight: hasReviewActionInFlight,
+    captureOperationScope: captureReviewOperationScope,
+    isCurrentOperationScope: isCurrentReviewOperationScope,
+    resolveModifiedContent: getResolvedReviewModifiedContent,
+    isFileMissingOnDisk: isReviewFileMissingOnDisk,
+    hasUnresolvedExternalChange: hasUnresolvedReviewExternalChange,
+  });
 
   const handleFullyViewed = useCallback(
     (filePath: string) => {
@@ -1937,373 +2012,6 @@ export const ChangeReviewDialog = ({
       }
     },
     [autoViewed, isViewed, markViewed]
-  );
-
-  const handleSaveFile = useCallback(
-    async (filePath: string) => {
-      if (hasReviewActionInFlight()) return;
-      const initialState = useStore.getState();
-      if (!(filePath in initialState.editedContents)) return;
-      const hasUnresolvedExternalChange = hasUnresolvedReviewExternalChange(
-        filePath,
-        initialState.reviewExternalChangesByFile
-      );
-      if (hasUnresolvedExternalChange) {
-        useStore.setState({
-          applyError: 'Choose Reload from disk or Keep my draft before saving this file.',
-        });
-        return;
-      }
-      const baselineKey = normalizePathForComparison(filePath);
-      if (!hasDraftHistoryBaseline(baselineKey)) {
-        useStore.setState({
-          applyError: 'The draft disk baseline is unavailable. Reload the file before saving.',
-        });
-        return;
-      }
-      const expectedCurrentContent = getDraftHistoryBaseline(baselineKey) ?? null;
-      const contentToSave = initialState.editedContents[filePath];
-      if (contentToSave === undefined) return;
-      const operationEpoch = initialState.changeSetEpoch;
-      const operationScope = captureReviewOperationScope();
-      if (!operationScope) return;
-      markRecentReviewWrite(filePath, contentToSave);
-      await saveEditedFile(filePath, reviewScope, expectedCurrentContent);
-      if (!isCurrentReviewOperationScope(operationScope)) return;
-      const state = useStore.getState();
-      if (state.changeSetEpoch === operationEpoch && !state.applyError) {
-        // Keep the exact saved baseline even when the buffer is clean. Native history is
-        // still valuable: Undo after Save (or restart) should produce a dirty draft.
-        setDraftHistoryBaseline(baselineKey, contentToSave);
-        const serializedState = getDraftHistoryEntry(filePath)?.editorState;
-        if (serializedState) {
-          publishDraftHistoryCheckpoint(filePath, serializedState, contentToSave);
-          const flushed = await flushDraftHistoryWrites();
-          if (!isCurrentReviewOperationScope(operationScope)) return;
-          if (!flushed) {
-            useStore.setState({
-              applyError: 'The file was saved, but its durable Undo history could not be updated.',
-            });
-          }
-        }
-        clearReviewActionHistoryForFile(filePath);
-        markRecentReviewWrite(filePath, contentToSave);
-      }
-    },
-    [
-      captureReviewOperationScope,
-      clearReviewActionHistoryForFile,
-      hasReviewActionInFlight,
-      isCurrentReviewOperationScope,
-      saveEditedFile,
-      reviewScope,
-      markRecentReviewWrite,
-      publishDraftHistoryCheckpoint,
-      flushDraftHistoryWrites,
-      getDraftHistoryBaseline,
-      getDraftHistoryEntry,
-      hasDraftHistoryBaseline,
-      setDraftHistoryBaseline,
-    ]
-  );
-
-  const handleRestoreMissingFile = useCallback(
-    (filePath: string, content: string) => {
-      if (hasReviewActionInFlight()) return;
-      const operationEpoch = useStore.getState().changeSetEpoch;
-      const operationScope = captureReviewOperationScope();
-      if (!operationScope) return;
-      const baselineKey = normalizePathForComparison(filePath);
-      setDraftHistoryBaseline(baselineKey, null);
-      markRecentReviewWrite(filePath, content);
-      updateEditedContent(filePath, content);
-      // Ensure editedContents is set before saveEditedFile reads it.
-      void Promise.resolve().then(async () => {
-        if (!isCurrentReviewOperationScope(operationScope)) return;
-        await saveEditedFile(filePath, reviewScope, null);
-        if (!isCurrentReviewOperationScope(operationScope)) return;
-        const state = useStore.getState();
-        if (state.changeSetEpoch === operationEpoch && !state.applyError) {
-          setDraftHistoryBaseline(baselineKey, content);
-          const serializedState = getDraftHistoryEntry(filePath)?.editorState;
-          if (serializedState) {
-            publishDraftHistoryCheckpoint(filePath, serializedState, content);
-            const flushed = await flushDraftHistoryWrites();
-            if (!isCurrentReviewOperationScope(operationScope)) return;
-            if (!flushed) {
-              useStore.setState({
-                applyError:
-                  'The file was restored, but its durable Undo history could not be updated.',
-              });
-            }
-          }
-          clearReviewActionHistoryForFile(filePath);
-          markRecentReviewWrite(filePath, content);
-        }
-      });
-    },
-    [
-      captureReviewOperationScope,
-      hasReviewActionInFlight,
-      isCurrentReviewOperationScope,
-      clearReviewActionHistoryForFile,
-      updateEditedContent,
-      saveEditedFile,
-      reviewScope,
-      markRecentReviewWrite,
-      publishDraftHistoryCheckpoint,
-      flushDraftHistoryWrites,
-      getDraftHistoryEntry,
-      setDraftHistoryBaseline,
-    ]
-  );
-
-  const handleReloadFromDisk = useCallback(
-    (filePath: string) => {
-      if (hasReviewActionInFlight()) return;
-      const operationEpoch = useStore.getState().changeSetEpoch;
-      const operationScope = captureReviewOperationScope();
-      if (!operationScope) return;
-      fileApplyInFlightRef.current.add(filePath);
-      setFileApplying(filePath, true);
-      void (async () => {
-        try {
-          if (!decisionScopeToken) {
-            throw new Error('Durable review scope is unavailable; refusing an unsafe reload.');
-          }
-          const quiesced = await quiesceDecisionPersistence(
-            teamName,
-            decisionScopeKey,
-            decisionScopeToken
-          );
-          if (!isCurrentReviewOperationScope(operationScope)) return;
-          if (!quiesced) {
-            throw new Error('Unable to finish saving the previous review state. Retry Reload.');
-          }
-          const state = useStore.getState();
-          const file = state.activeChangeSet?.files.find(
-            (candidate) =>
-              normalizePathForComparison(candidate.filePath) ===
-              normalizePathForComparison(filePath)
-          );
-          if (!file) throw new Error('Reviewed file is unavailable for Reload.');
-          const next = buildReviewExternalReloadState(file, {
-            hunkDecisions: state.hunkDecisions,
-            fileDecisions: state.fileDecisions,
-            hunkContextHashesByFile: state.hunkContextHashesByFile,
-            reviewActionHistory: getReviewUndoHistory(),
-            reviewRedoHistory: getReviewRedoHistory(),
-          });
-          const committed = await api.review.executeMutation({
-            scope: reviewScope,
-            decisionPersistenceScope: {
-              scopeKey: decisionScopeKey,
-              scopeToken: decisionScopeToken,
-            },
-            kind: 'reload-external',
-            externalFilePath: filePath,
-            diskSteps: [],
-            persistedState: next,
-            expectedDecisionRevision: state.decisionRevision,
-          });
-          if (
-            !isCurrentReviewOperationScope(operationScope) ||
-            useStore.getState().changeSetEpoch !== operationEpoch
-          ) {
-            return;
-          }
-          replaceReviewActionHistories(next.reviewActionHistory, next.reviewRedoHistory);
-          recordDecisionRevision(
-            teamName,
-            decisionScopeKey,
-            decisionScopeToken,
-            committed.decisionRevision
-          );
-          deleteDraftHistoryBaseline(filePath);
-          useStore.setState({
-            hunkDecisions: next.hunkDecisions,
-            fileDecisions: next.fileDecisions,
-            hunkContextHashesByFile: next.hunkContextHashesByFile ?? {},
-            applyError: null,
-          });
-          // Never destroy recoverable draft history before the durable review mutation
-          // commits. If cleanup fails, the external-change barrier stays visible and the
-          // user can retry without losing the draft across a restart.
-          await clearDraftHistoryForFile(filePath);
-          if (
-            !isCurrentReviewOperationScope(operationScope) ||
-            useStore.getState().changeSetEpoch !== operationEpoch
-          ) {
-            return;
-          }
-          reloadReviewFileFromDisk(filePath);
-          setDiscardCounters((prev) => ({ ...prev, [filePath]: (prev[filePath] ?? 0) + 1 }));
-          void fetchFileContent(teamName, memberName, filePath);
-        } catch (error) {
-          if (
-            isCurrentReviewOperationScope(operationScope) &&
-            useStore.getState().changeSetEpoch === operationEpoch
-          ) {
-            useStore.setState({
-              applyError:
-                error instanceof Error ? error.message : 'Unable to reload the external file.',
-            });
-          }
-        } finally {
-          if (
-            isCurrentReviewOperationScope(operationScope) &&
-            useStore.getState().changeSetEpoch === operationEpoch
-          ) {
-            fileApplyInFlightRef.current.delete(filePath);
-            setFileApplying(filePath, false);
-          }
-        }
-      })();
-    },
-    [
-      captureReviewOperationScope,
-      clearDraftHistoryForFile,
-      deleteDraftHistoryBaseline,
-      decisionScopeKey,
-      decisionScopeToken,
-      fetchFileContent,
-      hasReviewActionInFlight,
-      isCurrentReviewOperationScope,
-      memberName,
-      quiesceDecisionPersistence,
-      recordDecisionRevision,
-      reloadReviewFileFromDisk,
-      reviewScope,
-      getReviewRedoHistory,
-      getReviewUndoHistory,
-      replaceReviewActionHistories,
-      setFileApplying,
-      teamName,
-    ]
-  );
-
-  const handleKeepDraft = useCallback(
-    (filePath: string) => {
-      if (hasReviewActionInFlight()) return;
-      const baselineKey = normalizePathForComparison(filePath);
-      if (!hasDraftHistoryBaseline(baselineKey)) {
-        useStore.setState({
-          applyError: 'The draft disk baseline is unavailable. Reload the file before continuing.',
-        });
-        return;
-      }
-      const expected = getDraftHistoryBaseline(baselineKey) ?? '';
-      const operationEpoch = useStore.getState().changeSetEpoch;
-      const operationScope = captureReviewOperationScope();
-      if (!operationScope) return;
-      fileApplyInFlightRef.current.add(filePath);
-      setFileApplying(filePath, true);
-      void (async () => {
-        try {
-          const current = await api.review.checkConflict(reviewScope, filePath, expected);
-          if (
-            !isCurrentReviewOperationScope(operationScope) ||
-            useStore.getState().changeSetEpoch !== operationEpoch
-          ) {
-            return;
-          }
-          const nextBaseline =
-            current.hasConflict && current.conflictContent === null ? null : current.currentContent;
-          setDraftHistoryBaseline(baselineKey, nextBaseline);
-          const serializedState = getDraftHistoryEntry(filePath)?.editorState;
-          if (serializedState) {
-            publishDraftHistoryCheckpoint(filePath, serializedState, nextBaseline);
-            const flushed = await flushDraftHistoryWrites();
-            if (!isCurrentReviewOperationScope(operationScope)) return;
-            if (!flushed) {
-              throw new Error('Unable to persist the rebased manual edit history');
-            }
-          }
-          clearReviewFileExternalChange(filePath);
-          useStore.setState({ applyError: null });
-        } catch (error) {
-          if (
-            isCurrentReviewOperationScope(operationScope) &&
-            useStore.getState().changeSetEpoch === operationEpoch
-          ) {
-            useStore.setState({ applyError: String(error) });
-          }
-        } finally {
-          if (
-            isCurrentReviewOperationScope(operationScope) &&
-            useStore.getState().changeSetEpoch === operationEpoch
-          ) {
-            fileApplyInFlightRef.current.delete(filePath);
-            setFileApplying(filePath, false);
-          }
-        }
-      })();
-    },
-    [
-      captureReviewOperationScope,
-      clearReviewFileExternalChange,
-      flushDraftHistoryWrites,
-      getDraftHistoryBaseline,
-      getDraftHistoryEntry,
-      hasDraftHistoryBaseline,
-      hasReviewActionInFlight,
-      isCurrentReviewOperationScope,
-      publishDraftHistoryCheckpoint,
-      reviewScope,
-      setFileApplying,
-      setDraftHistoryBaseline,
-    ]
-  );
-
-  const handleDiscardFile = useCallback(
-    (filePath: string) => {
-      if (hasReviewActionInFlight()) return;
-      const state = useStore.getState();
-      if (hasUnresolvedReviewExternalChange(filePath, state.reviewExternalChangesByFile)) {
-        handleReloadFromDisk(filePath);
-        return;
-      }
-      const operationEpoch = state.changeSetEpoch;
-      const operationScope = captureReviewOperationScope();
-      if (!operationScope) return;
-      fileApplyInFlightRef.current.add(filePath);
-      setFileApplying(filePath, true);
-      void (async () => {
-        try {
-          await clearDraftHistoryForFile(filePath);
-          if (
-            !isCurrentReviewOperationScope(operationScope) ||
-            useStore.getState().changeSetEpoch !== operationEpoch
-          ) {
-            return;
-          }
-          deleteDraftHistoryBaseline(filePath);
-          discardFileEdits(filePath);
-          setDiscardCounters((prev) => ({ ...prev, [filePath]: (prev[filePath] ?? 0) + 1 }));
-        } catch {
-          // clearDraftHistoryForFile already reports the durable-history failure. Keep the
-          // editor and its local Undo state intact so Discard can be retried safely.
-        } finally {
-          if (
-            isCurrentReviewOperationScope(operationScope) &&
-            useStore.getState().changeSetEpoch === operationEpoch
-          ) {
-            fileApplyInFlightRef.current.delete(filePath);
-            setFileApplying(filePath, false);
-          }
-        }
-      })();
-    },
-    [
-      captureReviewOperationScope,
-      clearDraftHistoryForFile,
-      deleteDraftHistoryBaseline,
-      discardFileEdits,
-      handleReloadFromDisk,
-      hasReviewActionInFlight,
-      isCurrentReviewOperationScope,
-      setFileApplying,
-    ]
   );
 
   const reviewHistoryMutationScope = useMemo(

--- a/src/renderer/store/slices/changeReviewSlice.ts
+++ b/src/renderer/store/slices/changeReviewSlice.ts
@@ -177,6 +177,13 @@ export interface ReviewExternalChange {
   type: 'change' | 'add' | 'unlink';
 }
 
+export type SaveEditedReviewFileResult =
+  | { readonly ok: true }
+  | {
+      readonly ok: false;
+      readonly error: string;
+    };
+
 /**
  * When true, rejected hunks are immediately applied to disk (no need for "Apply All Changes").
  * When false, decisions are batched and applied manually via "Apply All Changes" button.
@@ -446,7 +453,7 @@ export interface ChangeReviewSlice {
     filePath: string,
     scope: ReviewFileScope,
     expectedCurrentContent: string | null
-  ) => Promise<void>;
+  ) => Promise<SaveEditedReviewFileResult>;
 
   // Task change availability
   checkTaskHasChanges: (
@@ -2133,8 +2140,8 @@ export const createChangeReviewSlice: StateCreator<AppState, [], [], ChangeRevie
       const content = hasRequestedDraft
         ? state.editedContents[filePath]
         : state.editedContents[canonicalFilePath];
-      if (!hasRequestedDraft && !hasCanonicalDraft) return;
-      if (content === undefined) return;
+      if (!hasRequestedDraft && !hasCanonicalDraft)
+        return { ok: false, error: 'The edited draft is no longer available.' };
       set((s) => ({
         fileContentsLoading: {
           ...s.fileContentsLoading,
@@ -2178,20 +2185,13 @@ export const createChangeReviewSlice: StateCreator<AppState, [], [], ChangeRevie
           const nextEdited = { ...s.editedContents };
           const currentDraft = s.editedContents[filePath] ?? s.editedContents[canonicalFilePath];
           const draftStillMatchesSavedContent = currentDraft === content;
-          if (draftStillMatchesSavedContent) {
-            for (const alias of aliases) delete nextEdited[alias];
-          }
-
+          if (draftStillMatchesSavedContent) for (const alias of aliases) delete nextEdited[alias];
           const nextFileChunkCounts = { ...s.fileChunkCounts };
           for (const alias of aliases) delete nextFileChunkCounts[alias];
-
           const nextHunkContextHashesByFile = { ...s.hunkContextHashesByFile };
           const reviewKey = getReviewKeyForFilePath(s.activeChangeSet?.files, canonicalFilePath);
           delete nextHunkContextHashesByFile[reviewKey];
           for (const alias of aliases) delete nextHunkContextHashesByFile[alias];
-
-          // A manual Save finalizes the user's current file version. Previously stored
-          // decisions refer to the pre-edit diff and cannot be replayed or undone safely.
           const decisionPrefixes = new Set([reviewKey, ...aliases].map((key) => `${key}:`));
           const nextHunkDecisions = { ...s.hunkDecisions };
           for (const key of Object.keys(nextHunkDecisions)) {
@@ -2202,13 +2202,9 @@ export const createChangeReviewSlice: StateCreator<AppState, [], [], ChangeRevie
           const nextFileDecisions = { ...s.fileDecisions };
           delete nextFileDecisions[reviewKey];
           for (const alias of aliases) delete nextFileDecisions[alias];
-
           const nextReviewExternalChangesByFile = { ...s.reviewExternalChangesByFile };
           for (const alias of aliases) delete nextReviewExternalChangesByFile[alias];
 
-          // Update cached content in-place to avoid skeleton flash.
-          // Replace modifiedFullContent with saved version so CodeMirror
-          // reflects the new baseline without a full re-fetch cycle.
           const nextContents = { ...s.fileContents };
           const existing = nextContents[canonicalFilePath] ?? nextContents[filePath];
           for (const alias of aliases) {
@@ -2233,14 +2229,17 @@ export const createChangeReviewSlice: StateCreator<AppState, [], [], ChangeRevie
             applying: false,
           };
         });
+        return { ok: true };
       } catch (error) {
+        const errorMessage = mapReviewError(error);
         const latest = get();
         if (
           latest.changeSetEpoch === changeSetEpoch &&
           getReviewChangeSetIdentityToken(latest.activeChangeSet) === scopeFingerprint
         ) {
-          set({ applying: false, applyError: mapReviewError(error) });
+          set({ applying: false, applyError: errorMessage });
         }
+        return { ok: false, error: errorMessage };
       }
     },
 

--- a/test/features/change-review/renderer/createChangeReviewFileDraftPorts.test.ts
+++ b/test/features/change-review/renderer/createChangeReviewFileDraftPorts.test.ts
@@ -1,0 +1,120 @@
+import {
+  createChangeReviewFileDraftCommandPort,
+  createChangeReviewFileDraftStatePort,
+} from '@features/change-review/renderer';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ExecuteReviewMutationRequest, ReviewPersistedStateSnapshot } from '@shared/types';
+
+function createStore() {
+  return {
+    activeChangeSet: { files: [] },
+    editedContents: { '/repo/a.ts': 'manual' },
+    reviewExternalChangesByFile: { '/repo/a.ts': { type: 'change' } },
+    hunkDecisions: { '/repo/a.ts:0': 'accepted' as const },
+    fileDecisions: {},
+    hunkContextHashesByFile: {},
+    decisionRevision: 4,
+    changeSetEpoch: 2,
+    applyError: null,
+    updateEditedContent: vi.fn(),
+    discardFileEdits: vi.fn(),
+    clearReviewFileExternalChange: vi.fn(),
+    reloadReviewFileFromDisk: vi.fn(),
+    saveEditedFile: vi.fn().mockResolvedValue(undefined),
+    quiesceDecisionPersistence: vi.fn().mockResolvedValue(true),
+    recordDecisionRevision: vi.fn(),
+    fetchFileContent: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+const persistedState: ReviewPersistedStateSnapshot = {
+  hunkDecisions: {},
+  fileDecisions: {},
+  hunkContextHashesByFile: {},
+  reviewActionHistory: [],
+  reviewRedoHistory: [],
+};
+
+describe('change-review file draft ports', () => {
+  it('maps only the state capabilities owned by file draft orchestration', () => {
+    const store = createStore();
+    const applyReloadedReviewState = vi.fn();
+    const reportError = vi.fn();
+    const port = createChangeReviewFileDraftStatePort({
+      getStore: () => store,
+      applyReloadedReviewState,
+      reportError,
+    });
+
+    expect(port.getSnapshot()).toMatchObject({
+      editedContents: { '/repo/a.ts': 'manual' },
+      decisionRevision: 4,
+      changeSetEpoch: 2,
+    });
+    port.updateEditedContent('/repo/a.ts', 'next');
+    port.discardFileEdits('/repo/a.ts');
+    port.clearExternalChange('/repo/a.ts');
+    port.reloadFileFromDisk('/repo/a.ts');
+    port.applyReloadedReviewState(persistedState);
+    port.reportError('failed');
+
+    expect(store.updateEditedContent).toHaveBeenCalledWith('/repo/a.ts', 'next');
+    expect(store.discardFileEdits).toHaveBeenCalledWith('/repo/a.ts');
+    expect(store.clearReviewFileExternalChange).toHaveBeenCalledWith('/repo/a.ts');
+    expect(store.reloadReviewFileFromDisk).toHaveBeenCalledWith('/repo/a.ts');
+    expect(applyReloadedReviewState).toHaveBeenCalledWith(persistedState);
+    expect(reportError).toHaveBeenCalledWith('failed');
+  });
+
+  it('maps Reload to the exact WAL mutation without leaking renderer-only scope fields', async () => {
+    const store = createStore();
+    const executeMutation = vi
+      .fn<
+        (request: ExecuteReviewMutationRequest) => Promise<{
+          decisionRevision: number;
+          diskPostimages: [];
+        }>
+      >()
+      .mockResolvedValue({ decisionRevision: 5, diskPostimages: [] });
+    const checkConflict = vi.fn().mockResolvedValue({
+      hasConflict: false,
+      conflictContent: null,
+      currentContent: 'disk',
+      originalContent: 'disk',
+    });
+    const port = createChangeReviewFileDraftCommandPort({
+      getStore: () => store,
+      getReviewApi: () => ({ executeMutation, checkConflict }),
+    });
+
+    await port.commitExternalReload({
+      reviewScope: { teamName: 'team', taskId: 'task' },
+      persistenceScope: { teamName: 'team', scopeKey: 'task-task', scopeToken: 'token' },
+      filePath: '/repo/a.ts',
+      persistedState,
+      expectedDecisionRevision: 4,
+    });
+    await port.quiescePersistence({
+      teamName: 'team',
+      scopeKey: 'task-task',
+      scopeToken: 'token',
+    });
+    port.recordDecisionRevision(
+      { teamName: 'team', scopeKey: 'task-task', scopeToken: 'token' },
+      5
+    );
+
+    expect(executeMutation).toHaveBeenCalledWith({
+      scope: { teamName: 'team', taskId: 'task' },
+      decisionPersistenceScope: { scopeKey: 'task-task', scopeToken: 'token' },
+      kind: 'reload-external',
+      externalFilePath: '/repo/a.ts',
+      diskSteps: [],
+      persistedState,
+      expectedDecisionRevision: 4,
+    });
+    expect(store.quiesceDecisionPersistence).toHaveBeenCalledWith('team', 'task-task', 'token');
+    expect(store.recordDecisionRevision).toHaveBeenCalledWith('team', 'task-task', 'token', 5);
+  });
+});

--- a/test/features/change-review/renderer/createChangeReviewFileDraftPorts.test.ts
+++ b/test/features/change-review/renderer/createChangeReviewFileDraftPorts.test.ts
@@ -4,6 +4,7 @@ import {
 } from '@features/change-review/renderer';
 import { describe, expect, it, vi } from 'vitest';
 
+import type { ChangeReviewFileDraftCommandPort } from '@features/change-review/renderer';
 import type { ExecuteReviewMutationRequest, ReviewPersistedStateSnapshot } from '@shared/types';
 
 function createStore() {
@@ -16,12 +17,14 @@ function createStore() {
     hunkContextHashesByFile: {},
     decisionRevision: 4,
     changeSetEpoch: 2,
-    applyError: null,
+    applyError: null as string | null,
     updateEditedContent: vi.fn(),
     discardFileEdits: vi.fn(),
     clearReviewFileExternalChange: vi.fn(),
     reloadReviewFileFromDisk: vi.fn(),
-    saveEditedFile: vi.fn().mockResolvedValue(undefined),
+    saveEditedFile: vi
+      .fn<ChangeReviewFileDraftCommandPort['saveEditedFile']>()
+      .mockResolvedValue({ ok: true }),
     quiesceDecisionPersistence: vi.fn().mockResolvedValue(true),
     recordDecisionRevision: vi.fn(),
     fetchFileContent: vi.fn().mockResolvedValue(undefined),
@@ -52,9 +55,12 @@ describe('change-review file draft ports', () => {
       decisionRevision: 4,
       changeSetEpoch: 2,
     });
+    const observedChange = port.readExternalChange('/repo/a.ts');
+    if (!observedChange) throw new Error('Expected the fixture external-change event.');
     port.updateEditedContent('/repo/a.ts', 'next');
     port.discardFileEdits('/repo/a.ts');
-    port.clearExternalChange('/repo/a.ts');
+    expect(port.clearExternalChange('/repo/a.ts', { type: 'change' })).toBe(false);
+    expect(port.clearExternalChange('/repo/a.ts', observedChange)).toBe(true);
     port.reloadFileFromDisk('/repo/a.ts');
     port.applyReloadedReviewState(persistedState);
     port.reportError('failed');
@@ -65,6 +71,21 @@ describe('change-review file draft ports', () => {
     expect(store.reloadReviewFileFromDisk).toHaveBeenCalledWith('/repo/a.ts');
     expect(applyReloadedReviewState).toHaveBeenCalledWith(persistedState);
     expect(reportError).toHaveBeenCalledWith('failed');
+  });
+
+  it('does not clear a watcher event that replaced the observed event', () => {
+    const store = createStore();
+    const port = createChangeReviewFileDraftStatePort({
+      getStore: () => store,
+      applyReloadedReviewState: vi.fn(),
+      reportError: vi.fn(),
+    });
+    const observedChange = port.readExternalChange('/repo/a.ts');
+    if (!observedChange) throw new Error('Expected the fixture external-change event.');
+    store.reviewExternalChangesByFile['/repo/a.ts'] = { type: 'change' };
+
+    expect(port.clearExternalChange('/repo/a.ts', observedChange)).toBe(false);
+    expect(store.clearReviewFileExternalChange).not.toHaveBeenCalled();
   });
 
   it('maps Reload to the exact WAL mutation without leaking renderer-only scope fields', async () => {
@@ -88,6 +109,9 @@ describe('change-review file draft ports', () => {
       getReviewApi: () => ({ executeMutation, checkConflict }),
     });
 
+    await expect(
+      port.saveEditedFile('/repo/a.ts', { teamName: 'team', taskId: 'task' }, 'disk-before')
+    ).resolves.toEqual({ ok: true });
     await port.commitExternalReload({
       reviewScope: { teamName: 'team', taskId: 'task' },
       persistenceScope: { teamName: 'team', scopeKey: 'task-task', scopeToken: 'token' },
@@ -116,5 +140,35 @@ describe('change-review file draft ports', () => {
     });
     expect(store.quiesceDecisionPersistence).toHaveBeenCalledWith('team', 'task-task', 'token');
     expect(store.recordDecisionRevision).toHaveBeenCalledWith('team', 'task-task', 'token', 5);
+    expect(store.saveEditedFile).toHaveBeenCalledWith(
+      '/repo/a.ts',
+      { teamName: 'team', taskId: 'task' },
+      'disk-before'
+    );
+  });
+
+  it('forwards the operation-owned Save result independently from the global UI error', async () => {
+    const store = createStore();
+    store.applyError = 'unrelated background error';
+    const port = createChangeReviewFileDraftCommandPort({
+      getStore: () => store,
+      getReviewApi: () => ({
+        executeMutation: vi.fn(),
+        checkConflict: vi.fn(),
+      }),
+    });
+
+    await expect(
+      port.saveEditedFile('/repo/a.ts', { teamName: 'team', taskId: 'task' }, 'disk')
+    ).resolves.toEqual({ ok: true });
+
+    store.applyError = null;
+    store.saveEditedFile.mockResolvedValueOnce({
+      ok: false,
+      error: 'disk changed again',
+    });
+    await expect(
+      port.saveEditedFile('/repo/a.ts', { teamName: 'team', taskId: 'task' }, 'disk')
+    ).resolves.toEqual({ ok: false, error: 'disk changed again' });
   });
 });

--- a/test/features/change-review/renderer/useChangeReviewFileDraftController.test.tsx
+++ b/test/features/change-review/renderer/useChangeReviewFileDraftController.test.tsx
@@ -9,10 +9,10 @@ import { normalizePathForComparison } from '@shared/utils/platformPath';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type {
-  ChangeReviewActionHistoryController,
-  ChangeReviewDraftHistoryController,
+  ChangeReviewFileDraftActionHistoryPort,
   ChangeReviewFileDraftCommandPort,
   ChangeReviewFileDraftController,
+  ChangeReviewFileDraftHistoryPort,
   ChangeReviewFileDraftStatePort,
   ChangeReviewFileDraftStateSnapshot,
   ChangeReviewFileDraftStatusPort,
@@ -26,26 +26,10 @@ import type {
   ReviewUndoAction,
 } from '@shared/types';
 
-type ActionHistory = Pick<
-  ChangeReviewActionHistoryController,
-  'clearForFile' | 'getUndoHistory' | 'getRedoHistory' | 'replaceHistories'
->;
-type DraftHistory = Pick<
-  ChangeReviewDraftHistoryController,
-  | 'getEntry'
-  | 'hasBaseline'
-  | 'getBaseline'
-  | 'setBaseline'
-  | 'deleteBaseline'
-  | 'unsuppressFile'
-  | 'publishCheckpoint'
-  | 'flushWrites'
-  | 'clearFile'
->;
-
 interface Deferred<T> {
   promise: Promise<T>;
   resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
 }
 
 interface Harness {
@@ -56,8 +40,8 @@ interface Harness {
   entries: Record<string, ReviewDraftHistoryEntry>;
   undoHistory: ReviewUndoAction[];
   redoHistory: ReviewRedoAction[];
-  actionHistory: ActionHistory;
-  draftHistory: DraftHistory;
+  actionHistory: ChangeReviewFileDraftActionHistoryPort;
+  draftHistory: ChangeReviewFileDraftHistoryPort;
   statePort: ChangeReviewFileDraftStatePort;
   commandPort: ChangeReviewFileDraftCommandPort;
   statusPort: ChangeReviewFileDraftStatusPort;
@@ -70,10 +54,12 @@ let latest: ChangeReviewFileDraftController | null = null;
 
 function deferred<T>(): Deferred<T> {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((resolvePromise) => {
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
     resolve = resolvePromise;
+    reject = rejectPromise;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 function makeFile(filePath = '/repo/a.ts'): FileChangeSummary {
@@ -129,13 +115,15 @@ function createHarness(): Harness {
     hunkContextHashesByFile: { '/repo/a.ts': { 0: 'hash' } },
     decisionRevision: 7,
     changeSetEpoch: 3,
-    applyError: null,
   };
   const harness = {} as Harness;
   const baselines = new Map<string, string | null>();
   const entries: Record<string, ReviewDraftHistoryEntry> = {};
   const statePort: ChangeReviewFileDraftStatePort = {
     getSnapshot: vi.fn<ChangeReviewFileDraftStatePort['getSnapshot']>(() => state),
+    readExternalChange: vi.fn<ChangeReviewFileDraftStatePort['readExternalChange']>(
+      (filePath) => state.reviewExternalChangesByFile[filePath]
+    ),
     updateEditedContent: vi.fn<ChangeReviewFileDraftStatePort['updateEditedContent']>(
       (filePath, content) => {
         state.editedContents[filePath] = content;
@@ -145,8 +133,10 @@ function createHarness(): Harness {
       delete state.editedContents[filePath];
     }),
     clearExternalChange: vi.fn<ChangeReviewFileDraftStatePort['clearExternalChange']>(
-      (filePath) => {
+      (filePath, observedChange) => {
+        if (state.reviewExternalChangesByFile[filePath] !== observedChange) return false;
         delete state.reviewExternalChangesByFile[filePath];
+        return true;
       }
     ),
     reloadFileFromDisk: vi.fn<ChangeReviewFileDraftStatePort['reloadFileFromDisk']>((filePath) => {
@@ -158,17 +148,14 @@ function createHarness(): Harness {
         state.hunkDecisions = { ...next.hunkDecisions };
         state.fileDecisions = { ...next.fileDecisions };
         state.hunkContextHashesByFile = { ...(next.hunkContextHashesByFile ?? {}) };
-        state.applyError = null;
       }
     ),
-    reportError: vi.fn<ChangeReviewFileDraftStatePort['reportError']>((message) => {
-      state.applyError = message;
-    }),
+    reportError: vi.fn<ChangeReviewFileDraftStatePort['reportError']>(),
   };
   const commandPort: ChangeReviewFileDraftCommandPort = {
     saveEditedFile: vi
       .fn<ChangeReviewFileDraftCommandPort['saveEditedFile']>()
-      .mockResolvedValue(undefined),
+      .mockResolvedValue({ ok: true }),
     checkConflict: vi.fn<ChangeReviewFileDraftCommandPort['checkConflict']>().mockResolvedValue({
       hasConflict: false,
       conflictContent: null,
@@ -194,8 +181,8 @@ function createHarness(): Harness {
   const writeEvidencePort: ChangeReviewFileDraftWriteEvidencePort = {
     markExpectedWrite: vi.fn<ChangeReviewFileDraftWriteEvidencePort['markExpectedWrite']>(),
   };
-  const actionHistory: ActionHistory = {
-    clearForFile: vi.fn<ActionHistory['clearForFile']>((filePath) => {
+  const actionHistory: ChangeReviewFileDraftActionHistoryPort = {
+    clearForFile: vi.fn<ChangeReviewFileDraftActionHistoryPort['clearForFile']>((filePath) => {
       harness.undoHistory = harness.undoHistory.filter((action) => {
         if (action.kind === 'bulk') return true;
         const actionPath =
@@ -204,33 +191,39 @@ function createHarness(): Harness {
       });
       harness.redoHistory = [];
     }),
-    getUndoHistory: vi.fn<ActionHistory['getUndoHistory']>(() => harness.undoHistory),
-    getRedoHistory: vi.fn<ActionHistory['getRedoHistory']>(() => harness.redoHistory),
-    replaceHistories: vi.fn<ActionHistory['replaceHistories']>((undoHistory, redoHistory) => {
-      harness.undoHistory = undoHistory;
-      harness.redoHistory = redoHistory;
-    }),
+    getUndoHistory: vi.fn<ChangeReviewFileDraftActionHistoryPort['getUndoHistory']>(
+      () => harness.undoHistory
+    ),
+    getRedoHistory: vi.fn<ChangeReviewFileDraftActionHistoryPort['getRedoHistory']>(
+      () => harness.redoHistory
+    ),
+    replaceHistories: vi.fn<ChangeReviewFileDraftActionHistoryPort['replaceHistories']>(
+      (undoHistory, redoHistory) => {
+        harness.undoHistory = undoHistory;
+        harness.redoHistory = redoHistory;
+      }
+    ),
   };
-  const draftHistory: DraftHistory = {
-    getEntry: vi.fn<DraftHistory['getEntry']>(
+  const draftHistory: ChangeReviewFileDraftHistoryPort = {
+    getEntry: vi.fn<ChangeReviewFileDraftHistoryPort['getEntry']>(
       (filePath) => entries[normalizePathForComparison(filePath)]
     ),
-    hasBaseline: vi.fn<DraftHistory['hasBaseline']>((filePath) =>
+    hasBaseline: vi.fn<ChangeReviewFileDraftHistoryPort['hasBaseline']>((filePath) =>
       baselines.has(normalizePathForComparison(filePath))
     ),
-    getBaseline: vi.fn<DraftHistory['getBaseline']>((filePath) =>
+    getBaseline: vi.fn<ChangeReviewFileDraftHistoryPort['getBaseline']>((filePath) =>
       baselines.get(normalizePathForComparison(filePath))
     ),
-    setBaseline: vi.fn<DraftHistory['setBaseline']>((filePath, baseline) => {
+    setBaseline: vi.fn<ChangeReviewFileDraftHistoryPort['setBaseline']>((filePath, baseline) => {
       baselines.set(normalizePathForComparison(filePath), baseline);
     }),
-    deleteBaseline: vi.fn<DraftHistory['deleteBaseline']>((filePath) => {
+    deleteBaseline: vi.fn<ChangeReviewFileDraftHistoryPort['deleteBaseline']>((filePath) => {
       baselines.delete(normalizePathForComparison(filePath));
     }),
-    unsuppressFile: vi.fn<DraftHistory['unsuppressFile']>(),
-    publishCheckpoint: vi.fn<DraftHistory['publishCheckpoint']>(),
-    flushWrites: vi.fn<DraftHistory['flushWrites']>().mockResolvedValue(true),
-    clearFile: vi.fn<DraftHistory['clearFile']>().mockResolvedValue(undefined),
+    unsuppressFile: vi.fn<ChangeReviewFileDraftHistoryPort['unsuppressFile']>(),
+    publishCheckpoint: vi.fn<ChangeReviewFileDraftHistoryPort['publishCheckpoint']>(),
+    flushWrites: vi.fn<ChangeReviewFileDraftHistoryPort['flushWrites']>().mockResolvedValue(true),
+    clearFile: vi.fn<ChangeReviewFileDraftHistoryPort['clearFile']>().mockResolvedValue(undefined),
   };
   Object.assign(harness, {
     files: [file],
@@ -333,7 +326,7 @@ describe('useChangeReviewFileDraftController', () => {
 
   it('ignores a late Save completion from a stale operation generation', async () => {
     const harness = createHarness();
-    const save = deferred<void>();
+    const save = deferred<{ ok: true }>();
     harness.state.editedContents['/repo/a.ts'] = 'manual';
     harness.baselines.set('/repo/a.ts', 'agent');
     vi.mocked(harness.commandPort.saveEditedFile).mockReturnValue(save.promise);
@@ -344,12 +337,62 @@ describe('useChangeReviewFileDraftController', () => {
       saving = latest!.saveFile('/repo/a.ts');
     });
     harness.current = false;
-    save.resolve(undefined);
+    save.resolve({ ok: true });
     await act(async () => saving);
 
     expect(harness.actionHistory.clearForFile).not.toHaveBeenCalled();
     expect(harness.draftHistory.publishCheckpoint).not.toHaveBeenCalled();
     expect(harness.writeEvidencePort.markExpectedWrite).toHaveBeenCalledOnce();
+  });
+
+  it('reports an explicit Save failure without committing draft history', async () => {
+    const harness = createHarness();
+    harness.state.editedContents['/repo/a.ts'] = 'manual';
+    harness.baselines.set('/repo/a.ts', 'agent');
+    vi.mocked(harness.commandPort.saveEditedFile).mockResolvedValue({
+      ok: false,
+      error: 'disk changed again',
+    });
+    renderHarness(harness);
+
+    await act(async () => latest!.saveFile('/repo/a.ts'));
+
+    expect(harness.statePort.reportError).toHaveBeenCalledWith('disk changed again');
+    expect(harness.actionHistory.clearForFile).not.toHaveBeenCalled();
+    expect(harness.draftHistory.publishCheckpoint).not.toHaveBeenCalled();
+  });
+
+  it('reports a rejected Save without committing draft history', async () => {
+    const harness = createHarness();
+    harness.state.editedContents['/repo/a.ts'] = 'manual';
+    harness.baselines.set('/repo/a.ts', 'agent');
+    vi.mocked(harness.commandPort.saveEditedFile).mockRejectedValue(
+      new Error('save transport failed')
+    );
+    renderHarness(harness);
+
+    await act(async () => latest!.saveFile('/repo/a.ts'));
+
+    expect(harness.statePort.reportError).toHaveBeenCalledWith('save transport failed');
+    expect(harness.actionHistory.clearForFile).not.toHaveBeenCalled();
+    expect(harness.draftHistory.publishCheckpoint).not.toHaveBeenCalled();
+  });
+
+  it('reports a rejected Restore and keeps the draft retryable', async () => {
+    const harness = createHarness();
+    vi.mocked(harness.commandPort.saveEditedFile).mockRejectedValue(
+      new Error('restore transport failed')
+    );
+    renderHarness(harness);
+
+    act(() => latest!.restoreMissingFile('/repo/a.ts', 'manual'));
+    await vi.waitFor(() =>
+      expect(harness.statePort.reportError).toHaveBeenCalledWith('restore transport failed')
+    );
+
+    expect(harness.state.editedContents['/repo/a.ts']).toBe('manual');
+    expect(harness.baselines.get('/repo/a.ts')).toBeNull();
+    expect(harness.actionHistory.clearForFile).not.toHaveBeenCalled();
   });
 
   it('commits Reload before clearing recoverable draft history and retains unrelated actions', async () => {
@@ -411,6 +454,27 @@ describe('useChangeReviewFileDraftController', () => {
     expect(harness.statusPort.finishFileMutation).not.toHaveBeenCalled();
   });
 
+  it('keeps the edited draft recoverable when Reload history cleanup rejects', async () => {
+    const harness = createHarness();
+    harness.state.editedContents['/repo/a.ts'] = 'manual';
+    harness.baselines.set('/repo/a.ts', 'agent');
+    harness.entries['/repo/a.ts'] = makeEntry('/repo/a.ts', 'manual');
+    harness.state.reviewExternalChangesByFile['/repo/a.ts'] = { type: 'change' };
+    vi.mocked(harness.draftHistory.clearFile).mockRejectedValue(new Error('reload cleanup failed'));
+    renderHarness(harness);
+
+    act(() => latest!.reloadFromDisk('/repo/a.ts'));
+    await vi.waitFor(() =>
+      expect(harness.statePort.reportError).toHaveBeenCalledWith('reload cleanup failed')
+    );
+
+    expect(harness.state.editedContents['/repo/a.ts']).toBe('manual');
+    expect(harness.entries['/repo/a.ts']).toBeDefined();
+    expect(harness.statePort.reloadFileFromDisk).not.toHaveBeenCalled();
+    expect(harness.commandPort.fetchFileContent).not.toHaveBeenCalled();
+    expect(harness.statusPort.finishFileMutation).toHaveBeenCalledWith('/repo/a.ts');
+  });
+
   it('rebases Keep draft onto a missing disk file and preserves its durable editor branch', async () => {
     const harness = createHarness();
     harness.baselines.set('/repo/a.ts', 'agent');
@@ -425,7 +489,10 @@ describe('useChangeReviewFileDraftController', () => {
 
     act(() => latest!.keepDraft('/repo/a.ts'));
     await vi.waitFor(() =>
-      expect(harness.statePort.clearExternalChange).toHaveBeenCalledWith('/repo/a.ts')
+      expect(harness.statePort.clearExternalChange).toHaveBeenCalledWith(
+        '/repo/a.ts',
+        expect.objectContaining({ type: 'unlink' })
+      )
     );
 
     expect(harness.baselines.get('/repo/a.ts')).toBeNull();
@@ -434,7 +501,110 @@ describe('useChangeReviewFileDraftController', () => {
       expect.objectContaining({ doc: 'manual' }),
       null
     );
-    expect(harness.statePort.reportError).toHaveBeenLastCalledWith(null);
+    expect(harness.statePort.reportError).not.toHaveBeenCalled();
+    expect(harness.statusPort.finishFileMutation).toHaveBeenCalledWith('/repo/a.ts');
+  });
+
+  it('rechecks Keep draft when a newer watcher event arrives during durable flush', async () => {
+    const harness = createHarness();
+    const firstFlush = deferred<boolean>();
+    const firstEvent = { type: 'change' };
+    const secondEvent = { type: 'change' };
+    harness.baselines.set('/repo/a.ts', 'agent');
+    harness.entries['/repo/a.ts'] = makeEntry('/repo/a.ts', 'manual');
+    harness.state.reviewExternalChangesByFile['/repo/a.ts'] = firstEvent;
+    vi.mocked(harness.commandPort.checkConflict)
+      .mockResolvedValueOnce({
+        hasConflict: true,
+        conflictContent: 'disk-first',
+        currentContent: 'disk-first',
+      })
+      .mockResolvedValueOnce({
+        hasConflict: true,
+        conflictContent: 'disk-second',
+        currentContent: 'disk-second',
+      });
+    vi.mocked(harness.draftHistory.flushWrites)
+      .mockReturnValueOnce(firstFlush.promise)
+      .mockResolvedValue(true);
+    renderHarness(harness);
+
+    act(() => latest!.keepDraft('/repo/a.ts'));
+    await vi.waitFor(() => expect(harness.draftHistory.flushWrites).toHaveBeenCalledOnce());
+    harness.state.reviewExternalChangesByFile['/repo/a.ts'] = secondEvent;
+    firstFlush.resolve(true);
+
+    await vi.waitFor(() =>
+      expect(harness.statePort.clearExternalChange).toHaveBeenLastCalledWith(
+        '/repo/a.ts',
+        secondEvent
+      )
+    );
+    expect(harness.commandPort.checkConflict).toHaveBeenCalledTimes(2);
+    expect(harness.draftHistory.flushWrites).toHaveBeenCalledTimes(2);
+    expect(harness.baselines.get('/repo/a.ts')).toBe('disk-second');
+    expect(harness.state.reviewExternalChangesByFile).toEqual({});
+  });
+
+  it('bounds Keep draft retries and leaves a noisy watcher event unresolved', async () => {
+    const harness = createHarness();
+    harness.baselines.set('/repo/a.ts', 'agent');
+    harness.entries['/repo/a.ts'] = makeEntry('/repo/a.ts', 'manual');
+    harness.state.reviewExternalChangesByFile['/repo/a.ts'] = { type: 'change' };
+    vi.mocked(harness.commandPort.checkConflict).mockImplementation(() => {
+      harness.state.reviewExternalChangesByFile['/repo/a.ts'] = { type: 'change' };
+      return Promise.resolve({
+        hasConflict: true,
+        conflictContent: 'newer-disk',
+        currentContent: 'newer-disk',
+      });
+    });
+    renderHarness(harness);
+
+    act(() => latest!.keepDraft('/repo/a.ts'));
+    await vi.waitFor(() =>
+      expect(harness.statePort.reportError).toHaveBeenCalledWith(
+        'The file kept changing while the draft was rebased. Retry Keep my draft.'
+      )
+    );
+
+    expect(harness.commandPort.checkConflict).toHaveBeenCalledTimes(3);
+    expect(harness.statePort.clearExternalChange).not.toHaveBeenCalled();
+    expect(harness.state.reviewExternalChangesByFile['/repo/a.ts']).toBeDefined();
+    expect(harness.statusPort.finishFileMutation).toHaveBeenCalledWith('/repo/a.ts');
+  });
+
+  it('does not clear an unrelated UI error after Keep draft succeeds', async () => {
+    const harness = createHarness();
+    harness.baselines.set('/repo/a.ts', 'agent');
+    harness.state.reviewExternalChangesByFile['/repo/a.ts'] = { type: 'change' };
+    harness.statePort.reportError('unrelated background error');
+    vi.mocked(harness.statePort.reportError).mockClear();
+    renderHarness(harness);
+
+    act(() => latest!.keepDraft('/repo/a.ts'));
+    await vi.waitFor(() => expect(harness.statePort.clearExternalChange).toHaveBeenCalledOnce());
+
+    expect(harness.statePort.reportError).not.toHaveBeenCalled();
+  });
+
+  it('retains edited content and reports a durable cleanup failure on Discard', async () => {
+    const harness = createHarness();
+    harness.state.editedContents['/repo/a.ts'] = 'manual';
+    harness.baselines.set('/repo/a.ts', 'agent');
+    harness.entries['/repo/a.ts'] = makeEntry('/repo/a.ts', 'manual');
+    vi.mocked(harness.draftHistory.clearFile).mockRejectedValue(new Error('draft cleanup failed'));
+    renderHarness(harness);
+
+    act(() => latest!.discardFile('/repo/a.ts'));
+    await vi.waitFor(() =>
+      expect(harness.statePort.reportError).toHaveBeenCalledWith('draft cleanup failed')
+    );
+
+    expect(harness.state.editedContents['/repo/a.ts']).toBe('manual');
+    expect(harness.entries['/repo/a.ts']).toBeDefined();
+    expect(harness.draftHistory.deleteBaseline).not.toHaveBeenCalled();
+    expect(harness.statePort.discardFileEdits).not.toHaveBeenCalled();
     expect(harness.statusPort.finishFileMutation).toHaveBeenCalledWith('/repo/a.ts');
   });
 });

--- a/test/features/change-review/renderer/useChangeReviewFileDraftController.test.tsx
+++ b/test/features/change-review/renderer/useChangeReviewFileDraftController.test.tsx
@@ -1,0 +1,440 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import {
+  createReviewOperationScopeToken,
+  useChangeReviewFileDraftController,
+} from '@features/change-review/renderer';
+import { normalizePathForComparison } from '@shared/utils/platformPath';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  ChangeReviewActionHistoryController,
+  ChangeReviewDraftHistoryController,
+  ChangeReviewFileDraftCommandPort,
+  ChangeReviewFileDraftController,
+  ChangeReviewFileDraftStatePort,
+  ChangeReviewFileDraftStateSnapshot,
+  ChangeReviewFileDraftStatusPort,
+  ChangeReviewFileDraftWriteEvidencePort,
+} from '@features/change-review/renderer';
+import type { ReviewDraftHistoryEntry } from '@features/change-review-history/contracts';
+import type {
+  FileChangeSummary,
+  FileChangeWithContent,
+  ReviewRedoAction,
+  ReviewUndoAction,
+} from '@shared/types';
+
+type ActionHistory = Pick<
+  ChangeReviewActionHistoryController,
+  'clearForFile' | 'getUndoHistory' | 'getRedoHistory' | 'replaceHistories'
+>;
+type DraftHistory = Pick<
+  ChangeReviewDraftHistoryController,
+  | 'getEntry'
+  | 'hasBaseline'
+  | 'getBaseline'
+  | 'setBaseline'
+  | 'deleteBaseline'
+  | 'unsuppressFile'
+  | 'publishCheckpoint'
+  | 'flushWrites'
+  | 'clearFile'
+>;
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+interface Harness {
+  files: FileChangeSummary[];
+  fileContents: Record<string, FileChangeWithContent>;
+  state: ChangeReviewFileDraftStateSnapshot;
+  baselines: Map<string, string | null>;
+  entries: Record<string, ReviewDraftHistoryEntry>;
+  undoHistory: ReviewUndoAction[];
+  redoHistory: ReviewRedoAction[];
+  actionHistory: ActionHistory;
+  draftHistory: DraftHistory;
+  statePort: ChangeReviewFileDraftStatePort;
+  commandPort: ChangeReviewFileDraftCommandPort;
+  statusPort: ChangeReviewFileDraftStatusPort;
+  writeEvidencePort: ChangeReviewFileDraftWriteEvidencePort;
+  current: boolean;
+  inFlight: boolean;
+}
+
+let latest: ChangeReviewFileDraftController | null = null;
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function makeFile(filePath = '/repo/a.ts'): FileChangeSummary {
+  return {
+    filePath,
+    relativePath: filePath.split('/').at(-1) ?? filePath,
+    snippets: [],
+    linesAdded: 1,
+    linesRemoved: 0,
+    isNewFile: false,
+  };
+}
+
+function makeFileContent(file: FileChangeSummary): FileChangeWithContent {
+  return {
+    ...file,
+    originalFullContent: 'original',
+    modifiedFullContent: 'agent',
+    contentSource: 'ledger-exact',
+  };
+}
+
+function makeEntry(filePath: string, doc = 'draft'): ReviewDraftHistoryEntry {
+  return {
+    filePath,
+    codec: 'codemirror-history-v1',
+    revision: 1,
+    generation: 'generation-1',
+    diskBaseline: 'disk',
+    editorState: { doc, history: { done: [], undone: [] } },
+    updatedAt: '2026-07-24T00:00:00.000Z',
+  };
+}
+
+function makeHunkAction(filePath: string, id: string): ReviewUndoAction {
+  return {
+    id,
+    createdAt: '2026-07-24T00:00:00.000Z',
+    kind: 'hunk',
+    descriptor: { intent: 'accept-hunk', filePath, hunkIndex: 0 },
+    action: { filePath, originalIndex: 0 },
+  };
+}
+
+function createHarness(): Harness {
+  const file = makeFile();
+  const state: ChangeReviewFileDraftStateSnapshot = {
+    activeFiles: [file],
+    editedContents: {},
+    reviewExternalChangesByFile: {},
+    hunkDecisions: { '/repo/a.ts:0': 'accepted' },
+    fileDecisions: { '/repo/a.ts': 'accepted' },
+    hunkContextHashesByFile: { '/repo/a.ts': { 0: 'hash' } },
+    decisionRevision: 7,
+    changeSetEpoch: 3,
+    applyError: null,
+  };
+  const harness = {} as Harness;
+  const baselines = new Map<string, string | null>();
+  const entries: Record<string, ReviewDraftHistoryEntry> = {};
+  const statePort: ChangeReviewFileDraftStatePort = {
+    getSnapshot: vi.fn<ChangeReviewFileDraftStatePort['getSnapshot']>(() => state),
+    updateEditedContent: vi.fn<ChangeReviewFileDraftStatePort['updateEditedContent']>(
+      (filePath, content) => {
+        state.editedContents[filePath] = content;
+      }
+    ),
+    discardFileEdits: vi.fn<ChangeReviewFileDraftStatePort['discardFileEdits']>((filePath) => {
+      delete state.editedContents[filePath];
+    }),
+    clearExternalChange: vi.fn<ChangeReviewFileDraftStatePort['clearExternalChange']>(
+      (filePath) => {
+        delete state.reviewExternalChangesByFile[filePath];
+      }
+    ),
+    reloadFileFromDisk: vi.fn<ChangeReviewFileDraftStatePort['reloadFileFromDisk']>((filePath) => {
+      delete state.editedContents[filePath];
+      delete state.reviewExternalChangesByFile[filePath];
+    }),
+    applyReloadedReviewState: vi.fn<ChangeReviewFileDraftStatePort['applyReloadedReviewState']>(
+      (next) => {
+        state.hunkDecisions = { ...next.hunkDecisions };
+        state.fileDecisions = { ...next.fileDecisions };
+        state.hunkContextHashesByFile = { ...(next.hunkContextHashesByFile ?? {}) };
+        state.applyError = null;
+      }
+    ),
+    reportError: vi.fn<ChangeReviewFileDraftStatePort['reportError']>((message) => {
+      state.applyError = message;
+    }),
+  };
+  const commandPort: ChangeReviewFileDraftCommandPort = {
+    saveEditedFile: vi
+      .fn<ChangeReviewFileDraftCommandPort['saveEditedFile']>()
+      .mockResolvedValue(undefined),
+    checkConflict: vi.fn<ChangeReviewFileDraftCommandPort['checkConflict']>().mockResolvedValue({
+      hasConflict: false,
+      conflictContent: null,
+      currentContent: 'disk-current',
+    }),
+    commitExternalReload: vi
+      .fn<ChangeReviewFileDraftCommandPort['commitExternalReload']>()
+      .mockResolvedValue({
+        decisionRevision: 8,
+        diskPostimages: [],
+      }),
+    quiescePersistence: vi
+      .fn<ChangeReviewFileDraftCommandPort['quiescePersistence']>()
+      .mockResolvedValue(true),
+    recordDecisionRevision: vi.fn<ChangeReviewFileDraftCommandPort['recordDecisionRevision']>(),
+    fetchFileContent: vi.fn<ChangeReviewFileDraftCommandPort['fetchFileContent']>(),
+  };
+  const statusPort: ChangeReviewFileDraftStatusPort = {
+    beginFileMutation: vi.fn<ChangeReviewFileDraftStatusPort['beginFileMutation']>(),
+    finishFileMutation: vi.fn<ChangeReviewFileDraftStatusPort['finishFileMutation']>(),
+    incrementDiscardCounter: vi.fn<ChangeReviewFileDraftStatusPort['incrementDiscardCounter']>(),
+  };
+  const writeEvidencePort: ChangeReviewFileDraftWriteEvidencePort = {
+    markExpectedWrite: vi.fn<ChangeReviewFileDraftWriteEvidencePort['markExpectedWrite']>(),
+  };
+  const actionHistory: ActionHistory = {
+    clearForFile: vi.fn<ActionHistory['clearForFile']>((filePath) => {
+      harness.undoHistory = harness.undoHistory.filter((action) => {
+        if (action.kind === 'bulk') return true;
+        const actionPath =
+          action.kind === 'disk' ? action.action.snapshot.filePath : action.action.filePath;
+        return normalizePathForComparison(actionPath) !== normalizePathForComparison(filePath);
+      });
+      harness.redoHistory = [];
+    }),
+    getUndoHistory: vi.fn<ActionHistory['getUndoHistory']>(() => harness.undoHistory),
+    getRedoHistory: vi.fn<ActionHistory['getRedoHistory']>(() => harness.redoHistory),
+    replaceHistories: vi.fn<ActionHistory['replaceHistories']>((undoHistory, redoHistory) => {
+      harness.undoHistory = undoHistory;
+      harness.redoHistory = redoHistory;
+    }),
+  };
+  const draftHistory: DraftHistory = {
+    getEntry: vi.fn<DraftHistory['getEntry']>(
+      (filePath) => entries[normalizePathForComparison(filePath)]
+    ),
+    hasBaseline: vi.fn<DraftHistory['hasBaseline']>((filePath) =>
+      baselines.has(normalizePathForComparison(filePath))
+    ),
+    getBaseline: vi.fn<DraftHistory['getBaseline']>((filePath) =>
+      baselines.get(normalizePathForComparison(filePath))
+    ),
+    setBaseline: vi.fn<DraftHistory['setBaseline']>((filePath, baseline) => {
+      baselines.set(normalizePathForComparison(filePath), baseline);
+    }),
+    deleteBaseline: vi.fn<DraftHistory['deleteBaseline']>((filePath) => {
+      baselines.delete(normalizePathForComparison(filePath));
+    }),
+    unsuppressFile: vi.fn<DraftHistory['unsuppressFile']>(),
+    publishCheckpoint: vi.fn<DraftHistory['publishCheckpoint']>(),
+    flushWrites: vi.fn<DraftHistory['flushWrites']>().mockResolvedValue(true),
+    clearFile: vi.fn<DraftHistory['clearFile']>().mockResolvedValue(undefined),
+  };
+  Object.assign(harness, {
+    files: [file],
+    fileContents: { [file.filePath]: makeFileContent(file) },
+    state,
+    baselines,
+    entries,
+    undoHistory: [],
+    redoHistory: [],
+    actionHistory,
+    draftHistory,
+    statePort,
+    commandPort,
+    statusPort,
+    writeEvidencePort,
+    current: true,
+    inFlight: false,
+  });
+  return harness;
+}
+
+function Probe({ harness }: { readonly harness: Harness }): React.JSX.Element {
+  latest = useChangeReviewFileDraftController({
+    files: harness.files,
+    fileContents: harness.fileContents,
+    teamName: 'team',
+    memberName: undefined,
+    reviewScope: { teamName: 'team', taskId: 'task' },
+    persistenceScope: { teamName: 'team', scopeKey: 'task-task', scopeToken: 'token' },
+    actionHistory: harness.actionHistory,
+    draftHistory: harness.draftHistory,
+    statePort: harness.statePort,
+    commandPort: harness.commandPort,
+    statusPort: harness.statusPort,
+    writeEvidencePort: harness.writeEvidencePort,
+    hasActionInFlight: () => harness.inFlight,
+    captureOperationScope: () => createReviewOperationScopeToken('scope'),
+    isCurrentOperationScope: () => harness.current,
+    resolveModifiedContent: (_file, content) => content?.modifiedFullContent ?? null,
+    isFileMissingOnDisk: (content) => Boolean(content && content.modifiedFullContent == null),
+    hasUnresolvedExternalChange: (filePath, changes) => {
+      const normalized = normalizePathForComparison(filePath);
+      return Object.keys(changes).some(
+        (candidate) => normalizePathForComparison(candidate) === normalized
+      );
+    },
+  });
+  return <div />;
+}
+
+function renderHarness(harness: Harness): ReturnType<typeof createRoot> {
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  const root = createRoot(document.body.appendChild(document.createElement('div')));
+  act(() => root.render(<Probe harness={harness} />));
+  return root;
+}
+
+describe('useChangeReviewFileDraftController', () => {
+  afterEach(() => {
+    latest = null;
+    document.body.innerHTML = '';
+    vi.unstubAllGlobals();
+  });
+
+  it('captures the exact disk baseline and removes a draft that returns to it', () => {
+    const harness = createHarness();
+    renderHarness(harness);
+
+    act(() => latest!.contentChanged('/repo/a.ts', 'manual', 'agent'));
+    expect(harness.draftHistory.setBaseline).toHaveBeenCalledWith('/repo/a.ts', 'agent');
+    expect(harness.state.editedContents).toEqual({ '/repo/a.ts': 'manual' });
+
+    act(() => latest!.contentChanged('/repo/a.ts', 'agent'));
+    expect(harness.statePort.discardFileEdits).toHaveBeenCalledWith('/repo/a.ts');
+    expect(harness.state.editedContents).toEqual({});
+  });
+
+  it('saves against the captured baseline and durably checkpoints native Undo history', async () => {
+    const harness = createHarness();
+    harness.state.editedContents['/repo/a.ts'] = 'manual';
+    harness.baselines.set('/repo/a.ts', 'agent');
+    harness.entries['/repo/a.ts'] = makeEntry('/repo/a.ts', 'manual');
+    renderHarness(harness);
+
+    await act(async () => latest!.saveFile('/repo/a.ts'));
+
+    expect(harness.commandPort.saveEditedFile).toHaveBeenCalledWith(
+      '/repo/a.ts',
+      { teamName: 'team', taskId: 'task' },
+      'agent'
+    );
+    expect(harness.draftHistory.publishCheckpoint).toHaveBeenCalledWith(
+      '/repo/a.ts',
+      expect.objectContaining({ doc: 'manual' }),
+      'manual'
+    );
+    expect(harness.actionHistory.clearForFile).toHaveBeenCalledWith('/repo/a.ts');
+    expect(harness.writeEvidencePort.markExpectedWrite).toHaveBeenCalledTimes(2);
+  });
+
+  it('ignores a late Save completion from a stale operation generation', async () => {
+    const harness = createHarness();
+    const save = deferred<void>();
+    harness.state.editedContents['/repo/a.ts'] = 'manual';
+    harness.baselines.set('/repo/a.ts', 'agent');
+    vi.mocked(harness.commandPort.saveEditedFile).mockReturnValue(save.promise);
+    renderHarness(harness);
+
+    let saving!: Promise<void>;
+    act(() => {
+      saving = latest!.saveFile('/repo/a.ts');
+    });
+    harness.current = false;
+    save.resolve(undefined);
+    await act(async () => saving);
+
+    expect(harness.actionHistory.clearForFile).not.toHaveBeenCalled();
+    expect(harness.draftHistory.publishCheckpoint).not.toHaveBeenCalled();
+    expect(harness.writeEvidencePort.markExpectedWrite).toHaveBeenCalledOnce();
+  });
+
+  it('commits Reload before clearing recoverable draft history and retains unrelated actions', async () => {
+    const harness = createHarness();
+    harness.state.reviewExternalChangesByFile['/repo/a.ts'] = { type: 'change' };
+    harness.undoHistory = [
+      makeHunkAction('/repo/a.ts', 'a-action'),
+      makeHunkAction('/repo/b.ts', 'b-action'),
+    ];
+    harness.baselines.set('/repo/a.ts', 'agent');
+    renderHarness(harness);
+
+    act(() => latest!.reloadFromDisk('/repo/a.ts'));
+    await vi.waitFor(() =>
+      expect(harness.commandPort.fetchFileContent).toHaveBeenCalledWith(
+        'team',
+        undefined,
+        '/repo/a.ts'
+      )
+    );
+
+    const reloadInput = vi.mocked(harness.commandPort.commitExternalReload).mock.calls[0]?.[0];
+    expect(reloadInput?.filePath).toBe('/repo/a.ts');
+    expect(reloadInput?.expectedDecisionRevision).toBe(7);
+    expect(reloadInput?.persistedState.reviewActionHistory.map((action) => action.id)).toEqual([
+      'b-action',
+    ]);
+    expect(reloadInput?.persistedState.reviewRedoHistory).toEqual([]);
+    expect(harness.actionHistory.replaceHistories).toHaveBeenCalledWith(
+      [expect.objectContaining({ id: 'b-action' })],
+      []
+    );
+    expect(harness.commandPort.recordDecisionRevision).toHaveBeenCalledWith(
+      { teamName: 'team', scopeKey: 'task-task', scopeToken: 'token' },
+      8
+    );
+    expect(
+      vi.mocked(harness.commandPort.commitExternalReload).mock.invocationCallOrder[0]
+    ).toBeLessThan(vi.mocked(harness.draftHistory.clearFile).mock.invocationCallOrder[0]);
+    expect(harness.statePort.reloadFileFromDisk).toHaveBeenCalledWith('/repo/a.ts');
+    expect(harness.statusPort.finishFileMutation).toHaveBeenCalledWith('/repo/a.ts');
+  });
+
+  it('does not let a stale Reload completion mutate the newly opened scope', async () => {
+    const harness = createHarness();
+    const commit = deferred<{ decisionRevision: number; diskPostimages: [] }>();
+    vi.mocked(harness.commandPort.commitExternalReload).mockReturnValue(commit.promise);
+    renderHarness(harness);
+
+    act(() => latest!.reloadFromDisk('/repo/a.ts'));
+    await vi.waitFor(() => expect(harness.commandPort.commitExternalReload).toHaveBeenCalledOnce());
+    harness.current = false;
+    commit.resolve({ decisionRevision: 8, diskPostimages: [] });
+    await act(async () => commit.promise);
+
+    expect(harness.actionHistory.replaceHistories).not.toHaveBeenCalled();
+    expect(harness.draftHistory.clearFile).not.toHaveBeenCalled();
+    expect(harness.statePort.reloadFileFromDisk).not.toHaveBeenCalled();
+    expect(harness.statusPort.finishFileMutation).not.toHaveBeenCalled();
+  });
+
+  it('rebases Keep draft onto a missing disk file and preserves its durable editor branch', async () => {
+    const harness = createHarness();
+    harness.baselines.set('/repo/a.ts', 'agent');
+    harness.entries['/repo/a.ts'] = makeEntry('/repo/a.ts', 'manual');
+    harness.state.reviewExternalChangesByFile['/repo/a.ts'] = { type: 'unlink' };
+    vi.mocked(harness.commandPort.checkConflict).mockResolvedValue({
+      hasConflict: true,
+      conflictContent: null,
+      currentContent: '',
+    });
+    renderHarness(harness);
+
+    act(() => latest!.keepDraft('/repo/a.ts'));
+    await vi.waitFor(() =>
+      expect(harness.statePort.clearExternalChange).toHaveBeenCalledWith('/repo/a.ts')
+    );
+
+    expect(harness.baselines.get('/repo/a.ts')).toBeNull();
+    expect(harness.draftHistory.publishCheckpoint).toHaveBeenCalledWith(
+      '/repo/a.ts',
+      expect.objectContaining({ doc: 'manual' }),
+      null
+    );
+    expect(harness.statePort.reportError).toHaveBeenLastCalledWith(null);
+    expect(harness.statusPort.finishFileMutation).toHaveBeenCalledWith('/repo/a.ts');
+  });
+});

--- a/test/renderer/store/changeReviewSlice.test.ts
+++ b/test/renderer/store/changeReviewSlice.test.ts
@@ -1620,8 +1620,11 @@ describe('changeReviewSlice task changes', () => {
       fileContentVersionByPath: {},
     });
 
-    await store.getState().saveEditedFile('/repo/new.ts', AGENT_REVIEW_SCOPE, 'draft-before-save');
+    const result = await store
+      .getState()
+      .saveEditedFile('/repo/new.ts', AGENT_REVIEW_SCOPE, 'draft-before-save');
 
+    expect(result).toEqual({ ok: true });
     expect(hoisted.saveEditedFile).toHaveBeenCalledWith(
       AGENT_REVIEW_SCOPE,
       '/repo/new.ts',
@@ -1635,6 +1638,28 @@ describe('changeReviewSlice task changes', () => {
     expect(store.getState().fileContents['/repo/new.ts']?.modifiedFullContent).toBe(
       'saved-content'
     );
+  });
+
+  it('returns a Save-owned failure result without consuming the edited draft', async () => {
+    const store = createSliceStore();
+    hoisted.saveEditedFile.mockRejectedValueOnce(new Error('conflict on disk'));
+    store.setState({
+      activeChangeSet: makeAgentChangeSet('/repo/file.ts'),
+      editedContents: { '/repo/file.ts': 'manual' },
+      changeSetEpoch: 1,
+      fileContentVersionByPath: {},
+    });
+
+    const result = await store
+      .getState()
+      .saveEditedFile('/repo/file.ts', AGENT_REVIEW_SCOPE, 'agent-change');
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'File has been modified since agent changes.',
+    });
+    expect(store.getState().applyError).toBe('File has been modified since agent changes.');
+    expect(store.getState().editedContents).toEqual({ '/repo/file.ts': 'manual' });
   });
 
   it('saves edited content through canonical Windows ledger paths and clears aliases', async () => {


### PR DESCRIPTION
## Summary

- reduce `ChangeReviewDialog.tsx` from 3430 to 3138 physical lines
- extract file draft Save, Restore, Reload, Keep, Discard, baseline, and durable editor-history orchestration into a focused controller
- bind Zustand, review IPC, action history, and draft history through narrow explicit ports
- lower the ChangeReviewDialog legacy cap from 3430 to 3138
- lower the touched `changeReviewSlice.ts` cap from 2417 to 2416; no cap or exception was raised

## Architecture and safety

- controller depends on capability ports rather than concrete sibling controllers
- Zustand Save returns an operation-owned typed result; the adapter no longer infers success from global `applyError`
- watcher resolution uses observed-event identity CAS and rechecks a replacement event
- Keep draft is bounded to three attempts under watcher churn, leaves the newest marker visible, reports a retryable error, and always releases mutation status
- Save, Restore, Reload, and Discard failures preserve retryable draft state and report errors explicitly
- successful Keep draft does not clear unrelated global UI errors
- no service locator, inheritance, hidden dependency, duplicate draft state, or new legacy exception

## Verification

- 120/120 focused controller, port, guard, and Zustand store tests passed
- pinned native TypeScript 7 typecheck passed
- fast ESLint passed for all touched TypeScript files
- full type-aware ESLint passed with 0 errors for production and new boundary tests; remaining security warnings are fixture indexing only
- source-size guard passed with the global 800-line limit and both ratchets preserved/lowered
- Prettier and `git diff --check` passed
- three independent read-only audit rounds ended at blockers 0 / P3 0 on exact head `4f438b8b9`

## Desktop E2E evidence

The parent bulk-decision slice passed the full fresh-sandbox Changes desktop flow. This intermediate responsibility extraction does not rerun Electron E2E by design; it uses focused deterministic tests and quality gates. Full desktop Changes E2E will run again on the final `<800` dialog slice.

No real user project, agent team, terminal runtime, or provisioning flow was opened.

## Remaining ChangeReviewDialog work

3138 lines remain. Follow-up PRs will extract file decisions, lifecycle, hunk decisions, interactions/presentation, composition safety, decision actions, and the final view until the facade is below 800 lines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved change-review file editing with more reliable saving, reloading, restoring, and draft retention.
  * Added clearer save results and error reporting when edits cannot be saved.
  * Preserved undo/redo history and checkpoints across draft operations.

* **Bug Fixes**
  * Prevented stale asynchronous operations from overwriting newer draft changes.
  * Improved handling of external file changes, conflicts, and missing files.

* **Documentation**
  * Clarified ownership and responsibilities for change-review editing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->