### PR TITLE
refactor(change-review): extract file decision workflow

### DIFF
--- a/scripts/ci/source-file-size-legacy.json
+++ b/scripts/ci/source-file-size-legacy.json
@@ -150,7 +150,7 @@
   "src/renderer/components/team/members/MemberLogsTab.tsx": 985,
   "src/renderer/components/team/messages/MessageComposer.tsx": 1344,
   "src/renderer/components/team/messages/MessagesPanel.tsx": 1722,
-  "src/renderer/components/team/review/ChangeReviewDialog.tsx": 3138,
+  "src/renderer/components/team/review/ChangeReviewDialog.tsx": 2684,
   "src/renderer/components/team/review/CodeMirrorDiffView.tsx": 975,
   "src/renderer/components/team/useTeamChangesSummaries.ts": 826,
   "src/renderer/components/ui/MentionableTextarea.tsx": 1433,

--- a/src/features/change-review/README.md
+++ b/src/features/change-review/README.md
@@ -7,8 +7,9 @@ main-process review IPC shell.
 - `renderer/utils` owns pure scope and operation-generation policies.
 - `renderer/hooks` owns scope/lifecycle, draft history, conflict recovery, action-history,
   decision-persistence, keyboard orchestration, bulk Accept/Reject, manual file draft
-  save/reload/discard flows, and durable Undo/Redo/checkpoint Restore through narrow
-  command, state, editor, status, and write-evidence ports.
+  save/reload/discard flows, file-level Accept/Reject/Restore, and durable
+  Undo/Redo/checkpoint Restore through narrow command, state, editor, status, and
+  write-evidence ports.
 - `renderer/ui` owns store-free presentation components.
 - `core/domain` owns pure review scope, rename expectation, snippet-shape, watcher-input, and
   decision-persistence policy.
@@ -17,8 +18,8 @@ main-process review IPC shell.
 - `main/infrastructure` owns Node path, filesystem, sensitive-path, hardlink, and watcher-root
   validation details.
 - The legacy dialog remains the temporary composition shell for Zustand, editor mutations,
-  per-file/hunk decision mutations, and outer close coordination while later slices move
-  those responsibilities behind focused hooks and use cases.
+  hunk-level decision mutations, and outer close coordination while later slices move those
+  responsibilities behind focused hooks and use cases.
 
 Production callers import through `@features/change-review/renderer` or
 `@features/change-review/main`.

--- a/src/features/change-review/renderer/adapters/createChangeReviewFileDecisionPorts.ts
+++ b/src/features/change-review/renderer/adapters/createChangeReviewFileDecisionPorts.ts
@@ -1,0 +1,103 @@
+import type {
+  ChangeReviewFileDecisionCommandPort,
+  ChangeReviewFileDecisionStatePort,
+  ChangeReviewFileDecisionStateSnapshot,
+} from '../ports/changeReviewFileDecisionPorts';
+import type { FileChangeSummary, ReviewDecisionSnapshot, ReviewFileScope } from '@shared/types';
+import type { ReviewAPI } from '@shared/types/api';
+
+interface ChangeReviewFileDecisionStore extends ChangeReviewFileDecisionStateSnapshot {
+  acceptAllFile(filePath: string): boolean;
+  rejectAllFile(filePath: string): void;
+  clearReviewFileExternalChange(filePath: string): void;
+  invalidateResolvedFileContent(filePath: string): void;
+  applySingleFileDecision(
+    teamName: string,
+    filePath: string,
+    taskId?: string,
+    memberName?: string
+  ): ReturnType<ChangeReviewFileDecisionCommandPort['applySingleFileDecision']>;
+  quiesceDecisionPersistence(
+    teamName: string,
+    scopeKey: string,
+    scopeToken: string
+  ): Promise<boolean>;
+  recordDecisionRevision(
+    teamName: string,
+    scopeKey: string,
+    scopeToken: string,
+    revision: number
+  ): void;
+  fetchFileContent(
+    teamName: string,
+    memberName: string | undefined,
+    filePath: string
+  ): Promise<void>;
+}
+
+interface CreateChangeReviewFileDecisionStatePortInput {
+  getStore: () => ChangeReviewFileDecisionStore;
+  applyRestoredDecisionState: (file: FileChangeSummary) => void;
+  restoreFileDecisions: (file: FileChangeSummary, snapshot: ReviewDecisionSnapshot) => void;
+  reportError: (message: string | null) => void;
+}
+
+export function createChangeReviewFileDecisionStatePort({
+  getStore,
+  applyRestoredDecisionState,
+  restoreFileDecisions,
+  reportError,
+}: CreateChangeReviewFileDecisionStatePortInput): ChangeReviewFileDecisionStatePort {
+  return {
+    getSnapshot: () => {
+      const state = getStore();
+      return {
+        fileContents: state.fileContents,
+        reviewExternalChangesByFile: state.reviewExternalChangesByFile,
+        hunkDecisions: state.hunkDecisions,
+        fileDecisions: state.fileDecisions,
+        hunkContextHashesByFile: state.hunkContextHashesByFile,
+        fileChunkCounts: state.fileChunkCounts,
+        decisionRevision: state.decisionRevision,
+        changeSetEpoch: state.changeSetEpoch,
+      };
+    },
+    acceptAllFile: (filePath) => getStore().acceptAllFile(filePath),
+    rejectAllFile: (filePath) => getStore().rejectAllFile(filePath),
+    applyRestoredDecisionState,
+    restoreFileDecisions,
+    clearExternalChange: (filePath) => getStore().clearReviewFileExternalChange(filePath),
+    invalidateResolvedFileContent: (filePath) => getStore().invalidateResolvedFileContent(filePath),
+    reportError,
+  };
+}
+
+type ChangeReviewFileDecisionReviewApi = Pick<ReviewAPI, 'checkConflict' | 'executeMutation'>;
+
+interface CreateChangeReviewFileDecisionCommandPortInput {
+  getStore: () => ChangeReviewFileDecisionStore;
+  getReviewApi: () => ChangeReviewFileDecisionReviewApi;
+  readCurrentDiskContent: (filePath: string, fallback: string) => Promise<string>;
+}
+
+export function createChangeReviewFileDecisionCommandPort({
+  getStore,
+  getReviewApi,
+  readCurrentDiskContent,
+}: CreateChangeReviewFileDecisionCommandPortInput): ChangeReviewFileDecisionCommandPort {
+  return {
+    checkConflict: (scope: ReviewFileScope, filePath, expectedContent) =>
+      getReviewApi().checkConflict(scope, filePath, expectedContent),
+    executeMutation: (request) => getReviewApi().executeMutation(request),
+    applySingleFileDecision: (teamName, filePath, taskId, memberName) =>
+      getStore().applySingleFileDecision(teamName, filePath, taskId, memberName),
+    quiescePersistence: ({ teamName, scopeKey, scopeToken }) =>
+      getStore().quiesceDecisionPersistence(teamName, scopeKey, scopeToken),
+    recordDecisionRevision: ({ teamName, scopeKey, scopeToken }, revision) =>
+      getStore().recordDecisionRevision(teamName, scopeKey, scopeToken, revision),
+    fetchFileContent: (teamName, memberName, filePath) => {
+      void getStore().fetchFileContent(teamName, memberName, filePath);
+    },
+    readCurrentDiskContent,
+  };
+}

--- a/src/features/change-review/renderer/hooks/useChangeReviewFileDecisionController.ts
+++ b/src/features/change-review/renderer/hooks/useChangeReviewFileDecisionController.ts
@@ -1,0 +1,571 @@
+import { useCallback } from 'react';
+
+import {
+  alignReviewDiskUndoSnapshotWithAppliedContent,
+  buildForwardDiskMutationSteps,
+  isLedgerRenameReviewFile,
+} from '@features/review-mutations';
+import { normalizePathForComparison } from '@shared/utils/platformPath';
+import { threeWayTextMerge } from '@shared/utils/threeWayTextMerge';
+
+import type {
+  ChangeReviewFileDecisionCommandPort,
+  ChangeReviewFileDecisionEditorPort,
+  ChangeReviewFileDecisionHistoryPort,
+  ChangeReviewFileDecisionPersistenceScope,
+  ChangeReviewFileDecisionPolicy,
+  ChangeReviewFileDecisionStatePort,
+  ChangeReviewFileDecisionStatusPort,
+  ChangeReviewFileDecisionWriteEvidencePort,
+} from '../ports/changeReviewFileDecisionPorts';
+import type { ReviewOperationScopeToken } from '../utils/reviewOperationGeneration';
+import type {
+  FileChangeSummary,
+  FileChangeWithContent,
+  ReviewDecisionSnapshot,
+  ReviewDiskUndoAction,
+  ReviewDiskUndoSnapshot,
+  ReviewFileScope,
+  ReviewUndoAction,
+} from '@shared/types';
+
+interface UseChangeReviewFileDecisionControllerInput {
+  files: readonly FileChangeSummary[];
+  fileContents: Record<string, FileChangeWithContent>;
+  changeSetEpoch: number;
+  instantApply: boolean;
+  teamName: string;
+  taskId: string | undefined;
+  memberName: string | undefined;
+  reviewScope: ReviewFileScope;
+  persistenceScope: ChangeReviewFileDecisionPersistenceScope | null;
+  history: ChangeReviewFileDecisionHistoryPort;
+  statePort: ChangeReviewFileDecisionStatePort;
+  commandPort: ChangeReviewFileDecisionCommandPort;
+  editorPort: ChangeReviewFileDecisionEditorPort;
+  statusPort: ChangeReviewFileDecisionStatusPort;
+  writeEvidencePort: ChangeReviewFileDecisionWriteEvidencePort;
+  policy: ChangeReviewFileDecisionPolicy;
+  persistLatestAcceptedAction: () => Promise<unknown>;
+  ensureDurableScope: () => boolean;
+  hasDraft: (filePath: string) => boolean;
+  hasActionInFlight: () => boolean;
+  blockForExternalChange: (filePath: string) => boolean;
+  captureOperationScope: () => ReviewOperationScopeToken | null;
+  isCurrentOperationScope: (scope: ReviewOperationScopeToken | null) => boolean;
+}
+
+export interface ChangeReviewFileDecisionController {
+  acceptFile: (filePath: string) => void;
+  rejectFile: (filePath: string) => Promise<void>;
+}
+
+function findLatestDiskSnapshots(
+  history: readonly ReviewUndoAction[],
+  filePath: string
+): {
+  latest: ReviewDiskUndoSnapshot | undefined;
+  session: ReviewDiskUndoSnapshot | undefined;
+} {
+  const normalizedFilePath = normalizePathForComparison(filePath);
+  const diskHistory = history.flatMap((action): ReviewDiskUndoAction[] =>
+    action.kind === 'disk'
+      ? [action.action]
+      : action.kind === 'bulk'
+        ? action.diskSnapshots.map((snapshot) => ({ snapshot }))
+        : []
+  );
+  const matchesFile = (action: ReviewDiskUndoAction): boolean =>
+    normalizePathForComparison(action.snapshot.filePath) === normalizedFilePath;
+  return {
+    latest: [...diskHistory].reverse().find(matchesFile)?.snapshot,
+    session: [...diskHistory]
+      .reverse()
+      .find((action) => action.originalIndex === undefined && matchesFile(action))?.snapshot,
+  };
+}
+
+function hasApplyErrorForFile(
+  filePath: string,
+  result: Awaited<ReturnType<ChangeReviewFileDecisionCommandPort['applySingleFileDecision']>>
+): boolean {
+  const normalizedFilePath = normalizePathForComparison(filePath);
+  return (
+    !result ||
+    result.errors.some((error) => normalizePathForComparison(error.filePath) === normalizedFilePath)
+  );
+}
+
+export function useChangeReviewFileDecisionController({
+  files,
+  fileContents,
+  changeSetEpoch,
+  instantApply,
+  teamName,
+  taskId,
+  memberName,
+  reviewScope,
+  persistenceScope,
+  history,
+  statePort,
+  commandPort,
+  editorPort,
+  statusPort,
+  writeEvidencePort,
+  policy,
+  persistLatestAcceptedAction,
+  ensureDurableScope,
+  hasDraft,
+  hasActionInFlight,
+  blockForExternalChange,
+  captureOperationScope,
+  isCurrentOperationScope,
+}: UseChangeReviewFileDecisionControllerInput): ChangeReviewFileDecisionController {
+  const restoreRejectedFileAsAccepted = useCallback(
+    async (filePath: string): Promise<void> => {
+      if (hasDraft(filePath) || hasActionInFlight() || blockForExternalChange(filePath)) {
+        return;
+      }
+      const operationEpoch = changeSetEpoch;
+      const operationScope = captureOperationScope();
+      if (!operationScope) return;
+      const file = files.find((candidate) => candidate.filePath === filePath);
+      if (!file) return;
+      const content = fileContents[filePath] ?? null;
+      const isExpectedDeletion = policy.isExpectedDeletion(file);
+      const { latest: latestDiskSnapshot, session: sessionSnapshot } = findLatestDiskSnapshots(
+        history.getUndoHistory(),
+        filePath
+      );
+      const hasAuthoritativeAgentContent =
+        content?.contentSource === 'ledger-exact' || content?.contentSource === 'ledger-snapshot';
+      const canReconstructCreatedFile = policy.resolveFileIsNew(file, content);
+      const desiredContent =
+        sessionSnapshot?.beforeContent ??
+        (hasAuthoritativeAgentContent || canReconstructCreatedFile
+          ? policy.resolveModifiedContent(file, content)
+          : null);
+      if (desiredContent === null) {
+        statePort.reportError(
+          'Agent content is unavailable after reopen; restore it from Git or rerun the change.'
+        );
+        return;
+      }
+
+      const initialState = statePort.getSnapshot();
+      const decisionSnapshot: ReviewDecisionSnapshot = {
+        hunkDecisions: { ...initialState.hunkDecisions },
+        fileDecisions: { ...initialState.fileDecisions },
+      };
+      const rejectedHunkCount = policy.getHunkCount(file, initialState);
+      const rejectedNewFileWasRemoved =
+        canReconstructCreatedFile &&
+        policy.isFileFullyRejected(file, rejectedHunkCount, decisionSnapshot);
+      statePort.reportError(null);
+      statusPort.beginFileMutation(filePath);
+      writeEvidencePort.markExpectedWrite(filePath, isExpectedDeletion ? null : desiredContent);
+      try {
+        if (!persistenceScope) {
+          throw new Error('Durable review scope is unavailable; refusing an unsafe restore.');
+        }
+        let rejectedDiskContent =
+          sessionSnapshot?.afterContent ?? content?.originalFullContent ?? '';
+        let restoredDiskContent: string | null = desiredContent;
+        let restoreMode: ReviewDiskUndoSnapshot['restoreMode'] = 'content';
+        let renameExpectation = null;
+
+        if (isLedgerRenameReviewFile(file)) {
+          renameExpectation =
+            sessionSnapshot?.renameExpectation ?? policy.getRenameRecoveryExpectation(file);
+          if (!renameExpectation) {
+            throw new Error('Rename recovery metadata is unavailable; refusing an unsafe restore.');
+          }
+          restoreMode = 'reapply-rejected-rename';
+        } else if (isExpectedDeletion) {
+          const expectedRejectedContent =
+            latestDiskSnapshot?.afterContent ??
+            sessionSnapshot?.afterContent ??
+            content?.originalFullContent;
+          if (expectedRejectedContent === null) {
+            throw new Error('Deleted file baseline is unavailable; refusing an unsafe restore.');
+          }
+          rejectedDiskContent = expectedRejectedContent;
+          restoredDiskContent = null;
+          restoreMode = 'create-file';
+        } else if (policy.resolveFileIsNew(file, content)) {
+          const current = await commandPort.checkConflict(reviewScope, filePath, '');
+          const isMissing = current.hasConflict && current.conflictContent === null;
+          if (isMissing) {
+            rejectedDiskContent = '';
+            restoreMode = 'delete-file';
+          } else {
+            if (rejectedNewFileWasRemoved) {
+              throw new Error('A file now exists at this path; refusing to overwrite it.');
+            }
+            if (
+              policy.hasUnresolvedExternalChange(filePath, initialState.reviewExternalChangesByFile)
+            ) {
+              throw new Error(
+                'Choose Reload from disk or Keep my draft before restoring this file.'
+              );
+            }
+            rejectedDiskContent = current.currentContent;
+            restoredDiskContent = desiredContent;
+          }
+        } else {
+          const baseline = sessionSnapshot?.afterContent ?? content?.originalFullContent;
+          if (baseline === null) {
+            throw new Error('Original file content is unavailable; unable to restore safely.');
+          }
+          const current = await commandPort.checkConflict(reviewScope, filePath, baseline);
+          if (current.hasConflict && current.conflictContent === null) {
+            throw new Error('File is missing on disk; unable to restore safely.');
+          }
+          rejectedDiskContent = current.currentContent;
+          const merged = threeWayTextMerge(baseline, current.currentContent, desiredContent);
+          if (merged.hasConflicts) {
+            throw new Error('Agent changes conflict with edits made after rejection.');
+          }
+          restoredDiskContent = merged.content;
+        }
+
+        if (
+          !isCurrentOperationScope(operationScope) ||
+          statePort.getSnapshot().changeSetEpoch !== operationEpoch
+        ) {
+          return;
+        }
+        const quiesced = await commandPort.quiescePersistence(persistenceScope);
+        if (
+          !isCurrentOperationScope(operationScope) ||
+          statePort.getSnapshot().changeSetEpoch !== operationEpoch
+        ) {
+          return;
+        }
+        if (!quiesced) {
+          throw new Error('Unable to finish saving the previous review state. Retry Restore.');
+        }
+        statePort.applyRestoredDecisionState(file);
+
+        const snapshot: ReviewDiskUndoSnapshot = {
+          filePath,
+          beforeContent: rejectedDiskContent,
+          afterContent: restoredDiskContent,
+          file,
+          restoreMode,
+          renameExpectation: renameExpectation ?? undefined,
+        };
+        const preparedAction = history.pushUndoAction({
+          kind: 'disk',
+          descriptor: {
+            intent: isLedgerRenameReviewFile(file) ? 'restore-rename' : 'restore-file',
+            filePath,
+          },
+          action: { snapshot, file, decisionSnapshot },
+        });
+        try {
+          const state = statePort.getSnapshot();
+          writeEvidencePort.markExpectedWrite(filePath, restoredDiskContent);
+          const committed = await commandPort.executeMutation({
+            scope: reviewScope,
+            decisionPersistenceScope: {
+              scopeKey: persistenceScope.scopeKey,
+              scopeToken: persistenceScope.scopeToken,
+            },
+            kind: isLedgerRenameReviewFile(file) ? 'rename' : 'restore',
+            diskSteps: buildForwardDiskMutationSteps(preparedAction.id, [snapshot]),
+            persistedState: {
+              hunkDecisions: state.hunkDecisions,
+              fileDecisions: state.fileDecisions,
+              hunkContextHashesByFile: state.hunkContextHashesByFile,
+              reviewActionHistory: history.getUndoHistory(),
+              reviewRedoHistory: history.getRedoHistory(),
+            },
+            expectedDecisionRevision: state.decisionRevision,
+          });
+          if (
+            !isCurrentOperationScope(operationScope) ||
+            statePort.getSnapshot().changeSetEpoch !== operationEpoch
+          ) {
+            return;
+          }
+          writeEvidencePort.markCommittedPostimages(committed.diskPostimages);
+          history.bindCommittedAction(preparedAction, committed.committedReviewAction);
+          commandPort.recordDecisionRevision(persistenceScope, committed.decisionRevision);
+        } catch (error) {
+          if (
+            !isCurrentOperationScope(operationScope) ||
+            statePort.getSnapshot().changeSetEpoch !== operationEpoch
+          ) {
+            return;
+          }
+          statePort.restoreFileDecisions(file, decisionSnapshot);
+          history.discardLatestAction(preparedAction);
+          throw error;
+        }
+        writeEvidencePort.markExpectedWrite(filePath, restoredDiskContent);
+        statePort.clearExternalChange(filePath);
+        statePort.invalidateResolvedFileContent(filePath);
+        statusPort.incrementDiscardCounter(filePath);
+        commandPort.fetchFileContent(teamName, memberName, filePath);
+      } catch (error) {
+        if (
+          isCurrentOperationScope(operationScope) &&
+          statePort.getSnapshot().changeSetEpoch === operationEpoch
+        ) {
+          statePort.reportError(
+            error instanceof Error ? error.message : 'Unable to restore the file.'
+          );
+          statePort.invalidateResolvedFileContent(filePath);
+          statusPort.incrementDiscardCounter(filePath);
+          commandPort.fetchFileContent(teamName, memberName, filePath);
+        }
+      } finally {
+        if (
+          isCurrentOperationScope(operationScope) &&
+          statePort.getSnapshot().changeSetEpoch === operationEpoch
+        ) {
+          statusPort.finishFileMutation(filePath);
+        }
+      }
+    },
+    [
+      blockForExternalChange,
+      captureOperationScope,
+      changeSetEpoch,
+      commandPort,
+      fileContents,
+      files,
+      hasActionInFlight,
+      hasDraft,
+      history,
+      isCurrentOperationScope,
+      memberName,
+      persistenceScope,
+      policy,
+      reviewScope,
+      statePort,
+      statusPort,
+      teamName,
+      writeEvidencePort,
+    ]
+  );
+
+  const acceptFile = useCallback(
+    (filePath: string): void => {
+      if (hasDraft(filePath) || hasActionInFlight() || blockForExternalChange(filePath)) {
+        return;
+      }
+      const file = files.find((candidate) => candidate.filePath === filePath);
+      if (!file) return;
+      const state = statePort.getSnapshot();
+      const content = state.fileContents[file.filePath];
+      const currentFileDecision = policy.getFileDecision(file, state);
+      if (!content || policy.isAcceptDisabled(file, content, currentFileDecision)) return;
+      const count = policy.getHunkCount(file, state);
+      const decisions = {
+        hunkDecisions: state.hunkDecisions,
+        fileDecisions: state.fileDecisions,
+      };
+      if (policy.hasFileRejections(file, count, decisions)) {
+        void restoreRejectedFileAsAccepted(filePath);
+        return;
+      }
+      const decisionSnapshot: ReviewDecisionSnapshot = {
+        hunkDecisions: { ...state.hunkDecisions },
+        fileDecisions: { ...state.fileDecisions },
+      };
+      if (!statePort.acceptAllFile(filePath)) return;
+      history.pushUndoAction({
+        kind: 'bulk',
+        descriptor: { intent: 'accept-file', filePath },
+        decisionSnapshot,
+        diskSnapshots: [],
+      });
+      void persistLatestAcceptedAction();
+      const operationScope = captureOperationScope();
+      editorPort.scheduleEditorSync(() => {
+        if (!operationScope || isCurrentOperationScope(operationScope)) {
+          editorPort.acceptAllEditorChunks(filePath);
+        }
+      });
+    },
+    [
+      blockForExternalChange,
+      captureOperationScope,
+      editorPort,
+      files,
+      hasActionInFlight,
+      hasDraft,
+      history,
+      isCurrentOperationScope,
+      persistLatestAcceptedAction,
+      policy,
+      restoreRejectedFileAsAccepted,
+      statePort,
+    ]
+  );
+
+  const rejectFile = useCallback(
+    async (filePath: string): Promise<void> => {
+      if (hasDraft(filePath) || hasActionInFlight() || blockForExternalChange(filePath)) {
+        return;
+      }
+      statusPort.beginFileMutation(filePath);
+      const operationEpoch = changeSetEpoch;
+      const operationScope = captureOperationScope();
+      if (!operationScope) {
+        statusPort.finishFileMutation(filePath);
+        return;
+      }
+      try {
+        const file = files.find((candidate) => candidate.filePath === filePath);
+        if (!file) return;
+        const state = statePort.getSnapshot();
+        if (!policy.isRejectable(file, state.fileContents[file.filePath] ?? null)) return;
+        const count = policy.getHunkCount(file, state);
+        const decisions = {
+          hunkDecisions: state.hunkDecisions,
+          fileDecisions: state.fileDecisions,
+        };
+        if (policy.isFileFullyRejected(file, count, decisions)) return;
+        const decisionSnapshot: ReviewDecisionSnapshot = {
+          hunkDecisions: { ...state.hunkDecisions },
+          fileDecisions: { ...state.fileDecisions },
+        };
+        const content = fileContents[filePath] ?? null;
+        const isNew = policy.resolveFileIsNew(file, content);
+        const shouldDeleteOnUndo = policy.shouldDeleteWhenUndoingReject(
+          file,
+          count,
+          decisionSnapshot
+        );
+        const beforeContent =
+          editorPort.getCurrentContent(filePath) ?? policy.resolveModifiedContent(file, content);
+        const afterContent = isNew ? null : (content?.originalFullContent ?? null);
+        const restoreContent = beforeContent ?? policy.resolveModifiedContent(file, content);
+        if (restoreContent === null || (!isNew && afterContent === null)) {
+          statePort.reportError(
+            'Exact disk contents are unavailable; refusing a reject without Undo.'
+          );
+          return;
+        }
+        const snapshot: ReviewDiskUndoSnapshot = {
+          filePath,
+          beforeContent: restoreContent,
+          afterContent,
+          file,
+          fileIndex: isNew
+            ? Math.max(
+                0,
+                files.findIndex((candidate) => candidate.filePath === filePath)
+              )
+            : undefined,
+          restoreMode: isNew ? 'create-file' : shouldDeleteOnUndo ? 'delete-file' : undefined,
+          renameExpectation: policy.getRenameRecoveryExpectation(file) ?? undefined,
+        };
+
+        statePort.rejectAllFile(filePath);
+        editorPort.rejectAllEditorChunks(filePath);
+        const preparedAction = history.pushUndoAction({
+          kind: 'disk',
+          descriptor: { intent: 'reject-file', filePath },
+          action: { snapshot, file, decisionSnapshot },
+        });
+        if (!instantApply) return;
+
+        writeEvidencePort.markExpectedWrite(
+          filePath,
+          isNew || isLedgerRenameReviewFile(file) ? null : afterContent
+        );
+        if (!ensureDurableScope()) {
+          statePort.restoreFileDecisions(file, decisionSnapshot);
+          editorPort.rollbackEditorContent(filePath, restoreContent);
+          history.discardLatestAction(preparedAction);
+          return;
+        }
+        const result = await commandPort.applySingleFileDecision(
+          teamName,
+          filePath,
+          taskId,
+          memberName
+        );
+        if (
+          !isCurrentOperationScope(operationScope) ||
+          statePort.getSnapshot().changeSetEpoch !== operationEpoch
+        ) {
+          return;
+        }
+        writeEvidencePort.markCommittedPostimages(result?.diskPostimages);
+        history.bindCommittedAction(preparedAction, result?.committedReviewAction);
+
+        if (hasApplyErrorForFile(filePath, result)) {
+          history.discardLatestAction(preparedAction);
+          statePort.restoreFileDecisions(file, decisionSnapshot);
+          editorPort.rollbackEditorContent(filePath, restoreContent);
+          statePort.invalidateResolvedFileContent(filePath);
+          statusPort.incrementDiscardCounter(filePath);
+          commandPort.fetchFileContent(teamName, memberName, filePath);
+          return;
+        }
+        if (isNew) {
+          writeEvidencePort.markExpectedWrite(filePath, null);
+          statePort.invalidateResolvedFileContent(filePath);
+          commandPort.fetchFileContent(teamName, memberName, filePath);
+          return;
+        }
+        if (beforeContent !== null && afterContent !== null) {
+          const actualAfterContent = await commandPort.readCurrentDiskContent(
+            filePath,
+            afterContent
+          );
+          if (
+            !isCurrentOperationScope(operationScope) ||
+            statePort.getSnapshot().changeSetEpoch !== operationEpoch
+          ) {
+            return;
+          }
+          if (snapshot.restoreMode !== 'delete-file' && !isLedgerRenameReviewFile(file)) {
+            alignReviewDiskUndoSnapshotWithAppliedContent(snapshot, actualAfterContent);
+          }
+          history.publishUndoHistory();
+        }
+        writeEvidencePort.markExpectedWrite(
+          filePath,
+          isLedgerRenameReviewFile(file) ? null : afterContent
+        );
+      } finally {
+        if (
+          isCurrentOperationScope(operationScope) &&
+          statePort.getSnapshot().changeSetEpoch === operationEpoch
+        ) {
+          statusPort.finishFileMutation(filePath);
+        }
+      }
+    },
+    [
+      blockForExternalChange,
+      captureOperationScope,
+      changeSetEpoch,
+      commandPort,
+      editorPort,
+      ensureDurableScope,
+      fileContents,
+      files,
+      hasActionInFlight,
+      hasDraft,
+      history,
+      instantApply,
+      isCurrentOperationScope,
+      memberName,
+      policy,
+      statePort,
+      statusPort,
+      taskId,
+      teamName,
+      writeEvidencePort,
+    ]
+  );
+
+  return { acceptFile, rejectFile };
+}

--- a/src/features/change-review/renderer/index.ts
+++ b/src/features/change-review/renderer/index.ts
@@ -14,6 +14,10 @@ export type { ChangeReviewConflictStateBridge } from './adapters/createChangeRev
 export { createChangeReviewConflictStateBridge } from './adapters/createChangeReviewConflictStateBridge';
 export { createChangeReviewDraftHistoryPort } from './adapters/createChangeReviewDraftHistoryPort';
 export {
+  createChangeReviewFileDecisionCommandPort,
+  createChangeReviewFileDecisionStatePort,
+} from './adapters/createChangeReviewFileDecisionPorts';
+export {
   createChangeReviewFileDraftCommandPort,
   createChangeReviewFileDraftStatePort,
 } from './adapters/createChangeReviewFileDraftPorts';
@@ -44,6 +48,8 @@ export type {
   ChangeReviewDraftHistoryDiagnostics,
 } from './hooks/useChangeReviewDraftHistoryController';
 export { useChangeReviewDraftHistoryController } from './hooks/useChangeReviewDraftHistoryController';
+export type { ChangeReviewFileDecisionController } from './hooks/useChangeReviewFileDecisionController';
+export { useChangeReviewFileDecisionController } from './hooks/useChangeReviewFileDecisionController';
 export type { ChangeReviewFileDraftController } from './hooks/useChangeReviewFileDraftController';
 export { useChangeReviewFileDraftController } from './hooks/useChangeReviewFileDraftController';
 export type { ChangeReviewKeyboardEditorContext } from './hooks/useChangeReviewHistoryKeyboardShortcuts';
@@ -82,6 +88,17 @@ export type {
   ChangeReviewDraftHistoryScope,
   ChangeReviewDraftHistoryVersion,
 } from './ports/changeReviewDraftHistoryPort';
+export type {
+  ChangeReviewFileDecisionCommandPort,
+  ChangeReviewFileDecisionEditorPort,
+  ChangeReviewFileDecisionHistoryPort,
+  ChangeReviewFileDecisionPersistenceScope,
+  ChangeReviewFileDecisionPolicy,
+  ChangeReviewFileDecisionStatePort,
+  ChangeReviewFileDecisionStateSnapshot,
+  ChangeReviewFileDecisionStatusPort,
+  ChangeReviewFileDecisionWriteEvidencePort,
+} from './ports/changeReviewFileDecisionPorts';
 export type {
   ChangeReviewFileDraftActionHistoryPort,
   ChangeReviewFileDraftCommandPort,

--- a/src/features/change-review/renderer/ports/changeReviewFileDecisionPorts.ts
+++ b/src/features/change-review/renderer/ports/changeReviewFileDecisionPorts.ts
@@ -1,0 +1,133 @@
+import type { ReviewUndoActionInput } from '../utils/changeReviewActionHistory';
+import type {
+  ApplyReviewResult,
+  ConflictCheckResult,
+  ExecuteReviewMutationRequest,
+  ExecuteReviewMutationResult,
+  FileChangeSummary,
+  FileChangeWithContent,
+  HunkDecision,
+  ReviewDecisionSnapshot,
+  ReviewMutationDiskPostimage,
+  ReviewRedoAction,
+  ReviewRenameRecoveryExpectation,
+  ReviewUndoAction,
+} from '@shared/types';
+
+export interface ChangeReviewFileDecisionPersistenceScope {
+  teamName: string;
+  scopeKey: string;
+  scopeToken: string;
+}
+
+export interface ChangeReviewFileDecisionStateSnapshot {
+  fileContents: Record<string, FileChangeWithContent>;
+  reviewExternalChangesByFile: Record<string, unknown>;
+  hunkDecisions: Record<string, HunkDecision>;
+  fileDecisions: Record<string, HunkDecision>;
+  hunkContextHashesByFile: Record<string, Record<number, string>>;
+  fileChunkCounts: Record<string, number>;
+  decisionRevision: number;
+  changeSetEpoch: number;
+}
+
+export interface ChangeReviewFileDecisionStatePort {
+  getSnapshot: () => ChangeReviewFileDecisionStateSnapshot;
+  acceptAllFile: (filePath: string) => boolean;
+  rejectAllFile: (filePath: string) => void;
+  applyRestoredDecisionState: (file: FileChangeSummary) => void;
+  restoreFileDecisions: (file: FileChangeSummary, snapshot: ReviewDecisionSnapshot) => void;
+  clearExternalChange: (filePath: string) => void;
+  invalidateResolvedFileContent: (filePath: string) => void;
+  reportError: (message: string | null) => void;
+}
+
+export interface ChangeReviewFileDecisionHistoryPort {
+  pushUndoAction: (input: ReviewUndoActionInput) => ReviewUndoAction;
+  bindCommittedAction: (
+    optimistic: ReviewUndoAction,
+    committed: ReviewUndoAction | undefined
+  ) => boolean;
+  discardLatestAction: (action: ReviewUndoAction) => boolean;
+  getUndoHistory: () => ReviewUndoAction[];
+  getRedoHistory: () => ReviewRedoAction[];
+  publishUndoHistory: () => void;
+}
+
+export interface ChangeReviewFileDecisionCommandPort {
+  checkConflict: (
+    scope: ExecuteReviewMutationRequest['scope'],
+    filePath: string,
+    expectedContent: string
+  ) => Promise<ConflictCheckResult>;
+  executeMutation: (request: ExecuteReviewMutationRequest) => Promise<ExecuteReviewMutationResult>;
+  applySingleFileDecision: (
+    teamName: string,
+    filePath: string,
+    taskId?: string,
+    memberName?: string
+  ) => Promise<ApplyReviewResult | null>;
+  quiescePersistence: (scope: ChangeReviewFileDecisionPersistenceScope) => Promise<boolean>;
+  recordDecisionRevision: (
+    scope: ChangeReviewFileDecisionPersistenceScope,
+    revision: number
+  ) => void;
+  fetchFileContent: (teamName: string, memberName: string | undefined, filePath: string) => void;
+  readCurrentDiskContent: (filePath: string, fallback: string) => Promise<string>;
+}
+
+export interface ChangeReviewFileDecisionEditorPort {
+  getCurrentContent: (filePath: string) => string | null;
+  scheduleEditorSync: (callback: () => void) => void;
+  acceptAllEditorChunks: (filePath: string) => void;
+  rejectAllEditorChunks: (filePath: string) => void;
+  rollbackEditorContent: (filePath: string, content: string) => void;
+}
+
+export interface ChangeReviewFileDecisionStatusPort {
+  beginFileMutation: (filePath: string) => void;
+  finishFileMutation: (filePath: string) => void;
+  incrementDiscardCounter: (filePath: string) => void;
+}
+
+export interface ChangeReviewFileDecisionWriteEvidencePort {
+  markExpectedWrite: (filePath: string, expectedContent: string | null) => void;
+  markCommittedPostimages: (postimages: readonly ReviewMutationDiskPostimage[] | undefined) => void;
+}
+
+export interface ChangeReviewFileDecisionPolicy {
+  getHunkCount: (file: FileChangeSummary, state: ChangeReviewFileDecisionStateSnapshot) => number;
+  getFileDecision: (
+    file: FileChangeSummary,
+    state: ChangeReviewFileDecisionStateSnapshot
+  ) => HunkDecision | undefined;
+  resolveModifiedContent: (
+    file: FileChangeSummary,
+    content: FileChangeWithContent | null
+  ) => string | null;
+  resolveFileIsNew: (file: FileChangeSummary, content: FileChangeWithContent | null) => boolean;
+  isExpectedDeletion: (file: FileChangeSummary) => boolean;
+  isAcceptDisabled: (
+    file: FileChangeSummary,
+    content: FileChangeWithContent,
+    fileDecision: HunkDecision | undefined
+  ) => boolean;
+  isRejectable: (file: FileChangeSummary, content: FileChangeWithContent | null) => boolean;
+  hasFileRejections: (
+    file: FileChangeSummary,
+    hunkCount: number,
+    decisions: ReviewDecisionSnapshot
+  ) => boolean;
+  isFileFullyRejected: (
+    file: FileChangeSummary,
+    hunkCount: number,
+    decisions: ReviewDecisionSnapshot
+  ) => boolean;
+  shouldDeleteWhenUndoingReject: (
+    file: FileChangeSummary,
+    hunkCount: number,
+    decisions: ReviewDecisionSnapshot
+  ) => boolean;
+  hasUnresolvedExternalChange: (filePath: string, changes: Record<string, unknown>) => boolean;
+  getRenameRecoveryExpectation: (file: FileChangeSummary) => ReviewRenameRecoveryExpectation | null;
+}

--- a/src/renderer/components/team/review/ChangeReviewDialog.tsx
+++ b/src/renderer/components/team/review/ChangeReviewDialog.tsx
@@ -27,6 +27,8 @@ import {
   createChangeReviewConflictStateBridge,
   createChangeReviewDecisionPersistencePort,
   createChangeReviewDraftHistoryPort,
+  createChangeReviewFileDecisionCommandPort,
+  createChangeReviewFileDecisionStatePort,
   createChangeReviewFileDraftCommandPort,
   createChangeReviewFileDraftStatePort,
   createChangeReviewHistoryMutationCommandPort,
@@ -45,6 +47,7 @@ import {
   useChangeReviewDecisionAutoPersistence,
   useChangeReviewDecisionPersistenceController,
   useChangeReviewDraftHistoryController,
+  useChangeReviewFileDecisionController,
   useChangeReviewFileDraftController,
   useChangeReviewHistoryKeyboardShortcuts,
   useChangeReviewHistoryMutationController,
@@ -75,7 +78,6 @@ import {
 import { buildSelectionInfo, SELECTION_DEBOUNCE_MS } from '@renderer/utils/codemirrorSelectionInfo';
 import { getFileReviewKey } from '@renderer/utils/reviewKey';
 import { normalizePathForComparison } from '@shared/utils/platformPath';
-import { threeWayTextMerge } from '@shared/utils/threeWayTextMerge';
 import { ChevronDown, Clock, X } from 'lucide-react';
 
 import { ChangesLoadingAnimation } from './ChangesLoadingAnimation';
@@ -117,21 +119,21 @@ import {
 } from './reviewContentPreview';
 import { resolveReviewFilePath } from './reviewFilePathResolution';
 import { ReviewFileTree } from './ReviewFileTree';
-import {
-  buildForwardDiskMutationSteps,
-  markReviewMutationDiskPostimages,
-} from './reviewHistoryTimeline';
+import { markReviewMutationDiskPostimages } from './reviewHistoryTimeline';
 import { ReviewToolbar } from './ReviewToolbar';
 import { SavedReviewStateRecoveryGate } from './SavedReviewStateRecoveryGate';
 import { ScopeWarningBanner } from './ScopeWarningBanner';
 import { ViewedProgressBar } from './ViewedProgressBar';
 
-import type { ReviewDecisionRecords } from './reviewActionState';
 import type { EditorView } from '@codemirror/view';
 import type {
   ChangeReviewBulkDecisionEditorPort,
   ChangeReviewBulkDecisionStatusPort,
   ChangeReviewBulkDecisionWriteEvidencePort,
+  ChangeReviewFileDecisionEditorPort,
+  ChangeReviewFileDecisionPolicy,
+  ChangeReviewFileDecisionStatusPort,
+  ChangeReviewFileDecisionWriteEvidencePort,
   ChangeReviewFileDraftStatusPort,
   ChangeReviewFileDraftWriteEvidencePort,
   ChangeReviewHistoryMutationViewPort,
@@ -140,19 +142,15 @@ import type {
 import type { TaskChangeRequestOptions } from '@renderer/utils/taskChangeRequest';
 import type {
   FileChangeSummary,
-  HunkDecision,
   ReviewDecisionSnapshot,
-  ReviewDiskUndoAction,
   ReviewDiskUndoSnapshot,
   ReviewMutationDiskPostimage,
   ReviewRedoAction,
-  ReviewRenameRecoveryExpectation,
   ReviewUndoAction,
 } from '@shared/types';
 import type { EditorSelectionAction, EditorSelectionInfo } from '@shared/types/editor';
 
 type RecentHunkUndoAction = Extract<ReviewUndoAction, { kind: 'hunk' }>['action'];
-type RecentDiskUndoAction = ReviewDiskUndoAction;
 interface RecentReviewWrite {
   at: number;
   expectedContent: string | null;
@@ -198,6 +196,36 @@ const changeReviewFileDraftCommandPort = createChangeReviewFileDraftCommandPort(
   getStore: useStore.getState,
   getReviewApi: () => api.review,
 });
+const changeReviewFileDecisionStatePort = createChangeReviewFileDecisionStatePort({
+  getStore: useStore.getState,
+  applyRestoredDecisionState: (file) =>
+    useStore.setState((state) => buildReviewRestoreDecisionState(file, state)),
+  restoreFileDecisions: (file, snapshot) =>
+    useStore.setState((state) => restoreReviewDecisionRecordsForFile(file, state, snapshot)),
+  reportError: (applyError) => useStore.setState({ applyError }),
+});
+const changeReviewFileDecisionPolicy: ChangeReviewFileDecisionPolicy = {
+  getHunkCount: (file, state) =>
+    getFileHunkCount(file.filePath, file.snippets.length, state.fileChunkCounts),
+  getFileDecision: (file, state) =>
+    state.fileDecisions[getFileReviewKey(file)] ?? state.fileDecisions[file.filePath],
+  resolveModifiedContent: getResolvedReviewModifiedContent,
+  resolveFileIsNew: resolveReviewFileIsNew,
+  isExpectedDeletion: isReviewFileExpectedDeleted,
+  isAcceptDisabled: (_file, content, fileDecision) =>
+    isReviewAcceptDisabled({
+      hasEdits: false,
+      isMissingOnDisk: isReviewFileMissingOnDisk(content),
+      isContentUnavailable: isReviewTextContentUnavailable(_file, content),
+      fileDecision,
+    }),
+  isRejectable: isReviewRejectable,
+  hasFileRejections: hasReviewFileRejections,
+  isFileFullyRejected: isReviewFileFullyRejected,
+  shouldDeleteWhenUndoingReject: shouldDeleteFileWhenUndoingReject,
+  hasUnresolvedExternalChange: hasUnresolvedReviewExternalChange,
+  getRenameRecoveryExpectation: getReviewRenameRecoveryExpectation,
+};
 const changeReviewHistoryMutationCommandPort = createChangeReviewHistoryMutationCommandPort(
   () => api.review
 );
@@ -294,16 +322,11 @@ export const ChangeReviewDialog = ({
     clearHunkDecisionByOriginalIndex,
     setCollapseUnchanged,
     fetchFileContent,
-    acceptAllFile,
-    rejectAllFile,
     applyReview,
     applySingleFileDecision,
     addReviewFile,
     editedContents,
     reviewExternalChangesByFile,
-    clearReviewFileExternalChange,
-    quiesceDecisionPersistence,
-    recordDecisionRevision,
     clearDecisionsFromDisk,
     resetAllReviewState,
     fileChunkCounts,
@@ -764,21 +787,6 @@ export const ChangeReviewDialog = ({
     []
   );
 
-  const restoreFileDecisions = useCallback(
-    (
-      file: FileChangeSummary,
-      snapshot: {
-        hunkDecisions: Record<string, HunkDecision>;
-        fileDecisions: Record<string, HunkDecision>;
-      }
-    ): void => {
-      useStore.setState((state) => {
-        return restoreReviewDecisionRecordsForFile(file, state, snapshot);
-      });
-    },
-    []
-  );
-
   const rollbackEditorContent = useCallback((filePath: string, content: string): void => {
     const view = editorViewMapRef.current.get(filePath);
     if (!view?.dom.isConnected) return;
@@ -1143,555 +1151,93 @@ export const ChangeReviewDialog = ({
       captureOperationScope: captureReviewOperationScope,
       isCurrentOperationScope: isCurrentReviewOperationScope,
     });
-  // File-level accept/reject (Cursor-style)
-  const handleRestoreRejectedFileAsAccepted = useCallback(
-    async (filePath: string): Promise<void> => {
-      if (
-        hasReviewDraft(filePath) ||
-        hasReviewActionInFlight() ||
-        blockReviewMutationForExternalChange(filePath)
-      ) {
-        return;
-      }
-      const operationEpoch = changeSetEpoch;
-      const operationScope = captureReviewOperationScope();
-      if (!operationScope) return;
-      const file = activeChangeSet?.files.find((candidate) => candidate.filePath === filePath);
-      if (!file) return;
-      const content = fileContents[filePath] ?? null;
-      const isExpectedDeletion = isReviewFileExpectedDeleted(file);
-      const normalizedFilePath = normalizePathForComparison(filePath);
-      const diskHistory = getReviewUndoHistory().flatMap((action): ReviewDiskUndoAction[] =>
-        action.kind === 'disk'
-          ? [action.action]
-          : action.kind === 'bulk'
-            ? action.diskSnapshots.map((snapshot) => ({ snapshot }))
-            : []
-      );
-      const latestDiskSnapshot = [...diskHistory]
-        .reverse()
-        .find(
-          (action) => normalizePathForComparison(action.snapshot.filePath) === normalizedFilePath
-        )?.snapshot;
-      const sessionSnapshot = [...diskHistory]
-        .reverse()
-        .find(
-          (action) =>
-            action.originalIndex === undefined &&
-            normalizePathForComparison(action.snapshot.filePath) === normalizedFilePath
-        )?.snapshot;
-      const hasAuthoritativeAgentContent =
-        content?.contentSource === 'ledger-exact' || content?.contentSource === 'ledger-snapshot';
-      const canReconstructCreatedFile = resolveReviewFileIsNew(file, content);
-      const desiredContent =
-        sessionSnapshot?.beforeContent ??
-        (hasAuthoritativeAgentContent || canReconstructCreatedFile
-          ? getResolvedReviewModifiedContent(file, content)
-          : null);
-      if (desiredContent === null) {
-        useStore.setState({
-          applyError:
-            'Agent content is unavailable after reopen; restore it from Git or rerun the change.',
-        });
-        return;
-      }
-
-      const decisionSnapshot: ReviewDecisionRecords = {
-        hunkDecisions: { ...useStore.getState().hunkDecisions },
-        fileDecisions: { ...useStore.getState().fileDecisions },
-      };
-      const rejectedHunkCount = getFileHunkCount(
-        file.filePath,
-        file.snippets.length,
-        useStore.getState().fileChunkCounts
-      );
-      const rejectedNewFileWasRemoved =
-        canReconstructCreatedFile &&
-        isReviewFileFullyRejected(file, rejectedHunkCount, decisionSnapshot);
-      useStore.setState({ applyError: null });
-      fileApplyInFlightRef.current.add(filePath);
-      setFileApplying(filePath, true);
-      markRecentReviewWrite(filePath, isExpectedDeletion ? null : desiredContent);
-      try {
-        if (!decisionScopeToken) {
-          throw new Error('Durable review scope is unavailable; refusing an unsafe restore.');
-        }
-        let rejectedDiskContent =
-          sessionSnapshot?.afterContent ?? content?.originalFullContent ?? '';
-        let restoredDiskContent: string | null = desiredContent;
-        let restoreMode: ReviewDiskUndoSnapshot['restoreMode'] = 'content';
-        let renameExpectation: ReviewRenameRecoveryExpectation | null = null;
-
-        if (isLedgerRenameReviewFile(file)) {
-          renameExpectation =
-            sessionSnapshot?.renameExpectation ?? getReviewRenameRecoveryExpectation(file);
-          if (!renameExpectation) {
-            throw new Error('Rename recovery metadata is unavailable; refusing an unsafe restore.');
-          }
-          restoreMode = 'reapply-rejected-rename';
-        } else if (isExpectedDeletion) {
-          const expectedRejectedContent =
-            latestDiskSnapshot?.afterContent ??
-            sessionSnapshot?.afterContent ??
-            content?.originalFullContent;
-          if (expectedRejectedContent === null || expectedRejectedContent === undefined) {
-            throw new Error('Deleted file baseline is unavailable; refusing an unsafe restore.');
-          }
-          rejectedDiskContent = expectedRejectedContent;
-          restoredDiskContent = null;
-          restoreMode = 'create-file';
-        } else if (resolveReviewFileIsNew(file, content)) {
-          const current = await api.review.checkConflict(reviewScope, filePath, '');
-          const isMissing = current.hasConflict && current.conflictContent === null;
-          if (isMissing) {
-            rejectedDiskContent = '';
-            restoreMode = 'delete-file';
-          } else {
-            if (rejectedNewFileWasRemoved) {
-              throw new Error('A file now exists at this path; refusing to overwrite it.');
-            }
-            if (hasUnresolvedReviewExternalChange(filePath, reviewExternalChangesByFile)) {
-              throw new Error(
-                'Choose Reload from disk or Keep my draft before restoring this file.'
-              );
-            }
-            rejectedDiskContent = current.currentContent;
-            restoredDiskContent = desiredContent;
-          }
-        } else {
-          const baseline = sessionSnapshot?.afterContent ?? content?.originalFullContent;
-          if (baseline === null || baseline === undefined) {
-            throw new Error('Original file content is unavailable; unable to restore safely.');
-          }
-          const current = await api.review.checkConflict(reviewScope, filePath, baseline);
-          if (current.hasConflict && current.conflictContent === null) {
-            throw new Error('File is missing on disk; unable to restore safely.');
-          }
-          rejectedDiskContent = current.currentContent;
-          const merged = threeWayTextMerge(baseline, current.currentContent, desiredContent);
-          if (merged.hasConflicts) {
-            throw new Error('Agent changes conflict with edits made after rejection.');
-          }
-          restoredDiskContent = merged.content;
-        }
-
-        if (
-          !isCurrentReviewOperationScope(operationScope) ||
-          useStore.getState().changeSetEpoch !== operationEpoch
-        ) {
-          return;
-        }
-        const quiesced = await quiesceDecisionPersistence(
-          teamName,
-          decisionScopeKey,
-          decisionScopeToken
-        );
-        if (
-          !isCurrentReviewOperationScope(operationScope) ||
-          useStore.getState().changeSetEpoch !== operationEpoch
-        ) {
-          return;
-        }
-        if (!quiesced) {
-          throw new Error('Unable to finish saving the previous review state. Retry Restore.');
-        }
-        useStore.setState((state) => buildReviewRestoreDecisionState(file, state));
-
-        const snapshot: ReviewDiskUndoSnapshot = {
-          filePath,
-          beforeContent: rejectedDiskContent,
-          afterContent: restoredDiskContent,
-          file,
-          restoreMode,
-          renameExpectation: renameExpectation ?? undefined,
-        };
-        const undoAction: RecentDiskUndoAction = {
-          snapshot,
-          file,
-          decisionSnapshot,
-        };
-        const preparedAction = pushReviewUndoAction({
-          kind: 'disk',
-          descriptor: {
-            intent: isLedgerRenameReviewFile(file) ? 'restore-rename' : 'restore-file',
-            filePath,
-          },
-          action: undoAction,
-        });
-        try {
-          const state = useStore.getState();
-          markRecentReviewWrite(filePath, restoredDiskContent);
-          const committed = await api.review.executeMutation({
-            scope: reviewScope,
-            decisionPersistenceScope: {
-              scopeKey: decisionScopeKey,
-              scopeToken: decisionScopeToken,
-            },
-            kind: isLedgerRenameReviewFile(file) ? 'rename' : 'restore',
-            diskSteps: buildForwardDiskMutationSteps(preparedAction.id, [snapshot]),
-            persistedState: {
-              hunkDecisions: state.hunkDecisions,
-              fileDecisions: state.fileDecisions,
-              hunkContextHashesByFile: state.hunkContextHashesByFile,
-              reviewActionHistory: getReviewUndoHistory(),
-              reviewRedoHistory: getReviewRedoHistory(),
-            },
-            expectedDecisionRevision: state.decisionRevision,
-          });
-          if (
-            !isCurrentReviewOperationScope(operationScope) ||
-            useStore.getState().changeSetEpoch !== operationEpoch
-          ) {
-            return;
-          }
-          markCommittedReviewPostimages(committed.diskPostimages);
-          bindCommittedReviewAction(preparedAction, committed.committedReviewAction);
-          recordDecisionRevision(
-            teamName,
-            decisionScopeKey,
-            decisionScopeToken,
-            committed.decisionRevision
-          );
-        } catch (error) {
-          if (
-            !isCurrentReviewOperationScope(operationScope) ||
-            useStore.getState().changeSetEpoch !== operationEpoch
-          ) {
-            return;
-          }
-          restoreFileDecisions(file, decisionSnapshot);
-          discardLatestReviewAction(preparedAction);
-          throw error;
-        }
-        markRecentReviewWrite(filePath, restoredDiskContent);
-        clearReviewFileExternalChange(filePath);
-        useStore.getState().invalidateResolvedFileContent(filePath);
-        setDiscardCounters((previous) => ({
-          ...previous,
-          [filePath]: (previous[filePath] ?? 0) + 1,
-        }));
-        void fetchFileContent(teamName, memberName, filePath);
-      } catch (error) {
-        if (
-          isCurrentReviewOperationScope(operationScope) &&
-          useStore.getState().changeSetEpoch === operationEpoch
-        ) {
-          useStore.setState({
-            applyError: error instanceof Error ? error.message : 'Unable to restore the file.',
-          });
-          useStore.getState().invalidateResolvedFileContent(filePath);
+  const fileDecisionCommandPort = useMemo(
+    () =>
+      createChangeReviewFileDecisionCommandPort({
+        getStore: useStore.getState,
+        getReviewApi: () => api.review,
+        readCurrentDiskContent: readCurrentReviewDiskContent,
+      }),
+    [readCurrentReviewDiskContent]
+  );
+  const fileDecisionViewPorts = useMemo<{
+    editor: ChangeReviewFileDecisionEditorPort;
+    status: ChangeReviewFileDecisionStatusPort;
+    writeEvidence: ChangeReviewFileDecisionWriteEvidencePort;
+  }>(
+    () => ({
+      editor: {
+        getCurrentContent: (filePath) =>
+          editorViewMapRef.current.get(filePath)?.state.doc.toString() ?? null,
+        scheduleEditorSync: (callback) => requestAnimationFrame(callback),
+        acceptAllEditorChunks: (filePath) => {
+          const view = editorViewMapRef.current.get(filePath);
+          if (view) acceptAllChunks(view);
+        },
+        rejectAllEditorChunks: (filePath) => {
+          const view = editorViewMapRef.current.get(filePath);
+          if (view) rejectAllChunks(view);
+        },
+        rollbackEditorContent,
+      },
+      status: {
+        beginFileMutation: (filePath) => {
+          fileApplyInFlightRef.current.add(filePath);
+          setFileApplying(filePath, true);
+        },
+        finishFileMutation: (filePath) => {
+          fileApplyInFlightRef.current.delete(filePath);
+          setFileApplying(filePath, false);
+        },
+        incrementDiscardCounter: (filePath) => {
           setDiscardCounters((previous) => ({
             ...previous,
             [filePath]: (previous[filePath] ?? 0) + 1,
           }));
-          void fetchFileContent(teamName, memberName, filePath);
-        }
-      } finally {
-        if (
-          isCurrentReviewOperationScope(operationScope) &&
-          useStore.getState().changeSetEpoch === operationEpoch
-        ) {
-          fileApplyInFlightRef.current.delete(filePath);
-          setFileApplying(filePath, false);
-        }
-      }
-    },
-    [
-      activeChangeSet,
-      bindCommittedReviewAction,
-      blockReviewMutationForExternalChange,
-      captureReviewOperationScope,
-      changeSetEpoch,
-      clearReviewFileExternalChange,
-      fetchFileContent,
+        },
+      },
+      writeEvidence: {
+        markExpectedWrite: markRecentReviewWrite,
+        markCommittedPostimages: markCommittedReviewPostimages,
+      },
+    }),
+    [markCommittedReviewPostimages, markRecentReviewWrite, rollbackEditorContent, setFileApplying]
+  );
+  const { acceptFile: handleAcceptFile, rejectFile: handleRejectFile } =
+    useChangeReviewFileDecisionController({
+      files: activeChangeSet?.files ?? [],
       fileContents,
-      getReviewRedoHistory,
-      getReviewUndoHistory,
-      hasReviewActionInFlight,
-      hasReviewDraft,
-      isCurrentReviewOperationScope,
-      markCommittedReviewPostimages,
-      markRecentReviewWrite,
-      memberName,
-      decisionScopeKey,
-      decisionScopeToken,
-      discardLatestReviewAction,
-      pushReviewUndoAction,
-      quiesceDecisionPersistence,
-      recordDecisionRevision,
-      restoreFileDecisions,
-      reviewExternalChangesByFile,
-      reviewScope,
-      setFileApplying,
-      teamName,
-    ]
-  );
-
-  const handleAcceptFile = useCallback(
-    (filePath: string) => {
-      if (
-        hasReviewDraft(filePath) ||
-        hasReviewActionInFlight() ||
-        blockReviewMutationForExternalChange(filePath)
-      ) {
-        return;
-      }
-      const file = activeChangeSet?.files.find((candidate) => candidate.filePath === filePath);
-      if (!file) return;
-      const state = useStore.getState();
-      const content = state.fileContents[file.filePath];
-      const currentFileDecision =
-        state.fileDecisions[getFileReviewKey(file)] ?? state.fileDecisions[file.filePath];
-      if (
-        !content ||
-        isReviewAcceptDisabled({
-          hasEdits: false,
-          isMissingOnDisk: isReviewFileMissingOnDisk(content),
-          isContentUnavailable: isReviewTextContentUnavailable(file, content),
-          fileDecision: currentFileDecision,
-        })
-      ) {
-        return;
-      }
-      const count = getFileHunkCount(file.filePath, file.snippets.length, state.fileChunkCounts);
-      if (
-        hasReviewFileRejections(file, count, {
-          hunkDecisions: state.hunkDecisions,
-          fileDecisions: state.fileDecisions,
-        })
-      ) {
-        void handleRestoreRejectedFileAsAccepted(filePath);
-        return;
-      }
-      const decisionSnapshot: ReviewDecisionSnapshot = {
-        hunkDecisions: { ...state.hunkDecisions },
-        fileDecisions: { ...state.fileDecisions },
-      };
-      if (!acceptAllFile(filePath)) return;
-      pushReviewUndoAction({
-        kind: 'bulk',
-        descriptor: { intent: 'accept-file', filePath },
-        decisionSnapshot,
-        diskSnapshots: [],
-      });
-      void persistLatestAcceptedReviewAction();
-      const view = editorViewMapRef.current.get(filePath);
-      if (view) {
-        requestAnimationFrame(() => acceptAllChunks(view));
-      }
-    },
-    [
-      acceptAllFile,
-      activeChangeSet,
-      blockReviewMutationForExternalChange,
-      hasReviewActionInFlight,
-      hasReviewDraft,
-      handleRestoreRejectedFileAsAccepted,
-      persistLatestAcceptedReviewAction,
-      pushReviewUndoAction,
-    ]
-  );
-
-  const handleRejectFile = useCallback(
-    async (filePath: string) => {
-      if (
-        hasReviewDraft(filePath) ||
-        hasReviewActionInFlight() ||
-        blockReviewMutationForExternalChange(filePath)
-      ) {
-        return;
-      }
-      fileApplyInFlightRef.current.add(filePath);
-      setFileApplying(filePath, true);
-      const operationEpoch = changeSetEpoch;
-      const operationScope = captureReviewOperationScope();
-      if (!operationScope) {
-        fileApplyInFlightRef.current.delete(filePath);
-        setFileApplying(filePath, false);
-        return;
-      }
-      try {
-        const file = activeChangeSet?.files.find((f) => f.filePath === filePath);
-        if (!file) return;
-        const state = useStore.getState();
-        if (!isReviewRejectable(file, state.fileContents[file.filePath] ?? null)) return;
-        const count = getFileHunkCount(file.filePath, file.snippets.length, state.fileChunkCounts);
-        if (
-          isReviewFileFullyRejected(file, count, {
-            hunkDecisions: state.hunkDecisions,
-            fileDecisions: state.fileDecisions,
-          })
-        ) {
-          return;
-        }
-        const decisionSnapshot = {
-          hunkDecisions: { ...state.hunkDecisions },
-          fileDecisions: { ...state.fileDecisions },
-        };
-        const isNew = resolveReviewFileIsNew(file, fileContents[filePath]);
-        const shouldDeleteOnUndo = shouldDeleteFileWhenUndoingReject(file, count, decisionSnapshot);
-        const view = editorViewMapRef.current.get(filePath);
-        const beforeContent =
-          view?.state.doc.toString() ??
-          (file ? getResolvedReviewModifiedContent(file, fileContents[filePath] ?? null) : null);
-        const afterContent = isNew ? null : (fileContents[filePath]?.originalFullContent ?? null);
-        const restoreContent =
-          beforeContent ?? getResolvedReviewModifiedContent(file, fileContents[filePath] ?? null);
-        if (restoreContent === null || (!isNew && afterContent === null)) {
-          useStore.setState({
-            applyError: 'Exact disk contents are unavailable; refusing a reject without Undo.',
-          });
-          return;
-        }
-        const snapshot: ReviewDiskUndoSnapshot = {
-          filePath,
-          beforeContent: restoreContent,
-          afterContent,
-          file,
-          fileIndex: isNew
-            ? Math.max(
-                0,
-                activeChangeSet?.files.findIndex((entry) => entry.filePath === filePath) ?? 0
-              )
-            : undefined,
-          restoreMode: isNew ? 'create-file' : shouldDeleteOnUndo ? 'delete-file' : undefined,
-          renameExpectation: getReviewRenameRecoveryExpectation(file) ?? undefined,
-        };
-
-        // Mark rejected in store + update CM view immediately for feedback
-        rejectAllFile(filePath);
-        if (view) {
-          rejectAllChunks(view);
-        }
-        const preparedAction = pushReviewUndoAction({
-          kind: 'disk',
-          descriptor: { intent: 'reject-file', filePath },
-          action: { snapshot, file, decisionSnapshot },
-        });
-
-        if (REVIEW_INSTANT_APPLY) {
-          // Reject a whole file should apply immediately (restore original on disk),
-          // and NEW-file reject should delete it.
-          markRecentReviewWrite(
-            filePath,
-            isNew || isLedgerRenameReviewFile(file) ? null : afterContent
-          );
-          if (!ensureDurableReviewScope()) {
-            restoreFileDecisions(file, decisionSnapshot);
-            rollbackEditorContent(filePath, restoreContent);
-            discardLatestReviewAction(preparedAction);
-            return;
-          }
-          const result = await applySingleFileDecision(teamName, filePath, taskId, memberName);
-          if (
-            !isCurrentReviewOperationScope(operationScope) ||
-            useStore.getState().changeSetEpoch !== operationEpoch
-          ) {
-            return;
-          }
-          markCommittedReviewPostimages(result?.diskPostimages);
-          bindCommittedReviewAction(preparedAction, result?.committedReviewAction);
-
-          if (isNew) {
-            const hasErrorForFile =
-              !result ||
-              result.errors.some(
-                (error) =>
-                  normalizePathForComparison(error.filePath) ===
-                  normalizePathForComparison(filePath)
-              );
-            if (!hasErrorForFile) {
-              markRecentReviewWrite(filePath, null);
-              useStore.getState().invalidateResolvedFileContent(filePath);
-              void fetchFileContent(teamName, memberName, filePath);
-            } else {
-              discardLatestReviewAction(preparedAction);
-              restoreFileDecisions(file, decisionSnapshot);
-              if (beforeContent != null) rollbackEditorContent(filePath, beforeContent);
-              useStore.getState().invalidateResolvedFileContent(filePath);
-              setDiscardCounters((previous) => ({
-                ...previous,
-                [filePath]: (previous[filePath] ?? 0) + 1,
-              }));
-              void fetchFileContent(teamName, memberName, filePath);
-            }
-          } else {
-            const hasErrorForFile =
-              !result ||
-              result.errors.some(
-                (error) =>
-                  normalizePathForComparison(error.filePath) ===
-                  normalizePathForComparison(filePath)
-              );
-            if (result && !hasErrorForFile) {
-              if (beforeContent != null && afterContent != null) {
-                const actualAfterContent = await readCurrentReviewDiskContent(
-                  filePath,
-                  afterContent
-                );
-                if (
-                  !isCurrentReviewOperationScope(operationScope) ||
-                  useStore.getState().changeSetEpoch !== operationEpoch
-                ) {
-                  return;
-                }
-                if (snapshot.restoreMode !== 'delete-file' && !isLedgerRenameReviewFile(file)) {
-                  alignReviewDiskUndoSnapshotWithAppliedContent(snapshot, actualAfterContent);
-                }
-                publishReviewUndoHistory();
-              }
-              markRecentReviewWrite(filePath, isLedgerRenameReviewFile(file) ? null : afterContent);
-            } else {
-              discardLatestReviewAction(preparedAction);
-              restoreFileDecisions(file, decisionSnapshot);
-              if (beforeContent != null) rollbackEditorContent(filePath, beforeContent);
-              useStore.getState().invalidateResolvedFileContent(filePath);
-              setDiscardCounters((previous) => ({
-                ...previous,
-                [filePath]: (previous[filePath] ?? 0) + 1,
-              }));
-              void fetchFileContent(teamName, memberName, filePath);
-            }
-          }
-        }
-      } finally {
-        if (
-          isCurrentReviewOperationScope(operationScope) &&
-          useStore.getState().changeSetEpoch === operationEpoch
-        ) {
-          fileApplyInFlightRef.current.delete(filePath);
-          setFileApplying(filePath, false);
-        }
-      }
-    },
-    [
-      rejectAllFile,
-      activeChangeSet,
-      applySingleFileDecision,
-      bindCommittedReviewAction,
+      changeSetEpoch,
+      instantApply: REVIEW_INSTANT_APPLY,
       teamName,
       taskId,
-      blockReviewMutationForExternalChange,
-      captureReviewOperationScope,
       memberName,
-      markCommittedReviewPostimages,
-      markRecentReviewWrite,
-      fileContents,
-      fetchFileContent,
-      changeSetEpoch,
-      setFileApplying,
-      readCurrentReviewDiskContent,
-      hasReviewActionInFlight,
-      restoreFileDecisions,
-      rollbackEditorContent,
-      hasReviewDraft,
-      isCurrentReviewOperationScope,
-      pushReviewUndoAction,
-      discardLatestReviewAction,
-      ensureDurableReviewScope,
-      publishReviewUndoHistory,
-    ]
-  );
+      reviewScope,
+      persistenceScope: decisionScopeToken
+        ? { teamName, scopeKey: decisionScopeKey, scopeToken: decisionScopeToken }
+        : null,
+      history: {
+        pushUndoAction: pushReviewUndoAction,
+        bindCommittedAction: bindCommittedReviewAction,
+        discardLatestAction: discardLatestReviewAction,
+        getUndoHistory: getReviewUndoHistory,
+        getRedoHistory: getReviewRedoHistory,
+        publishUndoHistory: publishReviewUndoHistory,
+      },
+      statePort: changeReviewFileDecisionStatePort,
+      commandPort: fileDecisionCommandPort,
+      editorPort: fileDecisionViewPorts.editor,
+      statusPort: fileDecisionViewPorts.status,
+      writeEvidencePort: fileDecisionViewPorts.writeEvidence,
+      policy: changeReviewFileDecisionPolicy,
+      persistLatestAcceptedAction: persistLatestAcceptedReviewAction,
+      ensureDurableScope: ensureDurableReviewScope,
+      hasDraft: hasReviewDraft,
+      hasActionInFlight: hasReviewActionInFlight,
+      blockForExternalChange: blockReviewMutationForExternalChange,
+      captureOperationScope: captureReviewOperationScope,
+      isCurrentOperationScope: isCurrentReviewOperationScope,
+    });
 
   // Per-file callbacks for ContinuousScrollView
   const handleHunkAccepted = useCallback(

--- a/test/features/change-review/renderer/createChangeReviewFileDecisionPorts.test.ts
+++ b/test/features/change-review/renderer/createChangeReviewFileDecisionPorts.test.ts
@@ -1,0 +1,131 @@
+import {
+  createChangeReviewFileDecisionCommandPort,
+  createChangeReviewFileDecisionStatePort,
+} from '@features/change-review/renderer';
+import { describe, expect, it, vi } from 'vitest';
+
+import type {
+  ExecuteReviewMutationRequest,
+  FileChangeSummary,
+  ReviewDecisionSnapshot,
+} from '@shared/types';
+
+function createStore() {
+  return {
+    fileContents: {},
+    reviewExternalChangesByFile: {},
+    hunkDecisions: {},
+    fileDecisions: {},
+    hunkContextHashesByFile: {},
+    fileChunkCounts: {},
+    decisionRevision: 1,
+    changeSetEpoch: 2,
+    acceptAllFile: vi.fn(() => true),
+    rejectAllFile: vi.fn(),
+    clearReviewFileExternalChange: vi.fn(),
+    invalidateResolvedFileContent: vi.fn(),
+    applySingleFileDecision: vi.fn().mockResolvedValue(null),
+    quiesceDecisionPersistence: vi.fn().mockResolvedValue(true),
+    recordDecisionRevision: vi.fn(),
+    fetchFileContent: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+const file: FileChangeSummary = {
+  filePath: '/repo/file.ts',
+  relativePath: 'file.ts',
+  snippets: [],
+  linesAdded: 1,
+  linesRemoved: 0,
+  isNewFile: false,
+};
+
+describe('change-review file decision ports', () => {
+  it('maps only the state capabilities required by the controller', () => {
+    const store = createStore();
+    const applyRestoredDecisionState = vi.fn<(candidate: FileChangeSummary) => void>();
+    const restoreFileDecisions =
+      vi.fn<(candidate: FileChangeSummary, snapshot: ReviewDecisionSnapshot) => void>();
+    const reportError = vi.fn<(message: string | null) => void>();
+    const port = createChangeReviewFileDecisionStatePort({
+      getStore: () => store,
+      applyRestoredDecisionState,
+      restoreFileDecisions,
+      reportError,
+    });
+    const snapshot = { hunkDecisions: {}, fileDecisions: {} };
+
+    expect(port.acceptAllFile(file.filePath)).toBe(true);
+    expect(port.getSnapshot()).not.toHaveProperty('acceptAllFile');
+    port.rejectAllFile(file.filePath);
+    port.applyRestoredDecisionState(file);
+    port.restoreFileDecisions(file, snapshot);
+    port.clearExternalChange(file.filePath);
+    port.invalidateResolvedFileContent(file.filePath);
+    port.reportError('failed');
+
+    expect(store.acceptAllFile).toHaveBeenCalledWith(file.filePath);
+    expect(store.rejectAllFile).toHaveBeenCalledWith(file.filePath);
+    expect(applyRestoredDecisionState).toHaveBeenCalledWith(file);
+    expect(restoreFileDecisions).toHaveBeenCalledWith(file, snapshot);
+    expect(store.clearReviewFileExternalChange).toHaveBeenCalledWith(file.filePath);
+    expect(store.invalidateResolvedFileContent).toHaveBeenCalledWith(file.filePath);
+    expect(reportError).toHaveBeenCalledWith('failed');
+  });
+
+  it('maps durable commands without exposing the store or Review API', async () => {
+    const store = createStore();
+    const checkConflict = vi.fn().mockResolvedValue({
+      hasConflict: false,
+      conflictContent: null,
+      originalContent: 'expected',
+      currentContent: 'disk',
+    });
+    const executeMutation = vi.fn().mockResolvedValue({
+      decisionRevision: 3,
+      diskPostimages: [],
+    });
+    const readCurrentDiskContent = vi.fn().mockResolvedValue('disk');
+    const port = createChangeReviewFileDecisionCommandPort({
+      getStore: () => store,
+      getReviewApi: () => ({ checkConflict, executeMutation }),
+      readCurrentDiskContent,
+    });
+    const scope = { teamName: 'team', taskId: 'task' };
+    const persistenceScope = { teamName: 'team', scopeKey: 'task', scopeToken: 'token' };
+    const request = {
+      scope,
+      decisionPersistenceScope: persistenceScope,
+      kind: 'restore',
+      diskSteps: [],
+      persistedState: {
+        hunkDecisions: {},
+        fileDecisions: {},
+        hunkContextHashesByFile: {},
+        reviewActionHistory: [],
+        reviewRedoHistory: [],
+      },
+      expectedDecisionRevision: 1,
+    } satisfies ExecuteReviewMutationRequest;
+
+    await port.checkConflict(scope, file.filePath, 'expected');
+    await port.executeMutation(request);
+    await port.applySingleFileDecision('team', file.filePath, 'task', undefined);
+    await expect(port.quiescePersistence(persistenceScope)).resolves.toBe(true);
+    port.recordDecisionRevision(persistenceScope, 3);
+    port.fetchFileContent('team', undefined, file.filePath);
+    await expect(port.readCurrentDiskContent(file.filePath, 'fallback')).resolves.toBe('disk');
+
+    expect(checkConflict).toHaveBeenCalledWith(scope, file.filePath, 'expected');
+    expect(executeMutation).toHaveBeenCalledWith(request);
+    expect(store.applySingleFileDecision).toHaveBeenCalledWith(
+      'team',
+      file.filePath,
+      'task',
+      undefined
+    );
+    expect(store.quiesceDecisionPersistence).toHaveBeenCalledWith('team', 'task', 'token');
+    expect(store.recordDecisionRevision).toHaveBeenCalledWith('team', 'task', 'token', 3);
+    expect(store.fetchFileContent).toHaveBeenCalledWith('team', undefined, file.filePath);
+  });
+});

--- a/test/features/change-review/renderer/useChangeReviewFileDecisionController.test.tsx
+++ b/test/features/change-review/renderer/useChangeReviewFileDecisionController.test.tsx
@@ -1,0 +1,456 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import {
+  createReviewOperationScopeToken,
+  useChangeReviewFileDecisionController,
+} from '@features/change-review/renderer';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  ChangeReviewFileDecisionCommandPort,
+  ChangeReviewFileDecisionController,
+  ChangeReviewFileDecisionEditorPort,
+  ChangeReviewFileDecisionHistoryPort,
+  ChangeReviewFileDecisionPolicy,
+  ChangeReviewFileDecisionStatePort,
+  ChangeReviewFileDecisionStateSnapshot,
+  ChangeReviewFileDecisionStatusPort,
+  ChangeReviewFileDecisionWriteEvidencePort,
+} from '@features/change-review/renderer';
+import type {
+  ApplyReviewResult,
+  ExecuteReviewMutationResult,
+  FileChangeSummary,
+  FileChangeWithContent,
+  ReviewUndoAction,
+} from '@shared/types';
+
+interface Harness {
+  file: FileChangeSummary;
+  content: FileChangeWithContent;
+  state: ChangeReviewFileDecisionStateSnapshot;
+  history: ChangeReviewFileDecisionHistoryPort;
+  statePort: ChangeReviewFileDecisionStatePort;
+  commandPort: ChangeReviewFileDecisionCommandPort;
+  editorPort: ChangeReviewFileDecisionEditorPort;
+  statusPort: ChangeReviewFileDecisionStatusPort;
+  writeEvidencePort: ChangeReviewFileDecisionWriteEvidencePort;
+  policy: ChangeReviewFileDecisionPolicy;
+  persistLatest: ReturnType<typeof vi.fn<() => Promise<boolean>>>;
+  undoHistory: ReviewUndoAction[];
+  events: string[];
+  current: boolean;
+  durable: boolean;
+}
+
+let latest: ChangeReviewFileDecisionController | null = null;
+
+function makeFile(filePath = '/repo/file.ts'): FileChangeSummary {
+  return {
+    filePath,
+    relativePath: 'file.ts',
+    snippets: [],
+    linesAdded: 1,
+    linesRemoved: 1,
+    isNewFile: false,
+  };
+}
+
+function makeContent(file: FileChangeSummary): FileChangeWithContent {
+  return {
+    ...file,
+    originalFullContent: 'before',
+    modifiedFullContent: 'after',
+    contentSource: 'ledger-exact',
+  };
+}
+
+function successfulApply(): ApplyReviewResult {
+  return { applied: 1, skipped: 0, conflicts: 0, errors: [] };
+}
+
+function successfulMutation(): ExecuteReviewMutationResult {
+  return {
+    decisionRevision: 9,
+    diskPostimages: [{ filePath: '/repo/file.ts', content: 'after' }],
+  };
+}
+
+function createHarness(): Harness {
+  const file = makeFile();
+  const content = makeContent(file);
+  const state: ChangeReviewFileDecisionStateSnapshot = {
+    fileContents: { [file.filePath]: content },
+    reviewExternalChangesByFile: {},
+    hunkDecisions: {},
+    fileDecisions: {},
+    hunkContextHashesByFile: {},
+    fileChunkCounts: { [file.filePath]: 1 },
+    decisionRevision: 4,
+    changeSetEpoch: 7,
+  };
+  const harness = {} as Harness;
+  const undoHistory: ReviewUndoAction[] = [];
+  const events: string[] = [];
+  const history: ChangeReviewFileDecisionHistoryPort = {
+    pushUndoAction: vi.fn<ChangeReviewFileDecisionHistoryPort['pushUndoAction']>((input) => {
+      events.push('history:push');
+      const action = {
+        ...input,
+        id: `action-${undoHistory.length + 1}`,
+        createdAt: '2026-07-24T00:00:00.000Z',
+      } as ReviewUndoAction;
+      undoHistory.push(action);
+      return action;
+    }),
+    bindCommittedAction: vi.fn<ChangeReviewFileDecisionHistoryPort['bindCommittedAction']>(() => {
+      events.push('history:bind');
+      return true;
+    }),
+    discardLatestAction: vi.fn<ChangeReviewFileDecisionHistoryPort['discardLatestAction']>(
+      (action) => {
+        events.push('history:discard');
+        if (undoHistory.at(-1)?.id !== action.id) return false;
+        undoHistory.pop();
+        return true;
+      }
+    ),
+    getUndoHistory: vi.fn<ChangeReviewFileDecisionHistoryPort['getUndoHistory']>(() => undoHistory),
+    getRedoHistory: vi.fn<ChangeReviewFileDecisionHistoryPort['getRedoHistory']>(() => []),
+    publishUndoHistory: vi.fn<ChangeReviewFileDecisionHistoryPort['publishUndoHistory']>(() => {
+      events.push('history:publish');
+    }),
+  };
+  const statePort: ChangeReviewFileDecisionStatePort = {
+    getSnapshot: vi.fn<ChangeReviewFileDecisionStatePort['getSnapshot']>(() => state),
+    acceptAllFile: vi.fn<ChangeReviewFileDecisionStatePort['acceptAllFile']>(() => {
+      events.push('state:accept');
+      state.fileDecisions[file.filePath] = 'accepted';
+      return true;
+    }),
+    rejectAllFile: vi.fn<ChangeReviewFileDecisionStatePort['rejectAllFile']>(() => {
+      events.push('state:reject');
+      state.fileDecisions[file.filePath] = 'rejected';
+    }),
+    applyRestoredDecisionState: vi.fn<
+      ChangeReviewFileDecisionStatePort['applyRestoredDecisionState']
+    >(() => {
+      events.push('state:restore');
+      state.fileDecisions[file.filePath] = 'accepted';
+    }),
+    restoreFileDecisions: vi.fn<ChangeReviewFileDecisionStatePort['restoreFileDecisions']>(
+      (_file, snapshot) => {
+        events.push('state:rollback');
+        state.hunkDecisions = { ...snapshot.hunkDecisions };
+        state.fileDecisions = { ...snapshot.fileDecisions };
+      }
+    ),
+    clearExternalChange: vi.fn<ChangeReviewFileDecisionStatePort['clearExternalChange']>(() =>
+      events.push('state:clear-external')
+    ),
+    invalidateResolvedFileContent: vi.fn<
+      ChangeReviewFileDecisionStatePort['invalidateResolvedFileContent']
+    >(() => events.push('state:invalidate')),
+    reportError: vi.fn<ChangeReviewFileDecisionStatePort['reportError']>((message) =>
+      events.push(`state:error:${message ?? 'clear'}`)
+    ),
+  };
+  const commandPort: ChangeReviewFileDecisionCommandPort = {
+    checkConflict: vi.fn<ChangeReviewFileDecisionCommandPort['checkConflict']>(
+      (_scope, _filePath, expectedContent) => {
+        events.push('command:conflict');
+        return Promise.resolve({
+          hasConflict: false,
+          conflictContent: null,
+          originalContent: expectedContent,
+          currentContent: expectedContent,
+        });
+      }
+    ),
+    executeMutation: vi.fn<ChangeReviewFileDecisionCommandPort['executeMutation']>(() => {
+      events.push('command:execute');
+      return Promise.resolve(successfulMutation());
+    }),
+    applySingleFileDecision: vi.fn<ChangeReviewFileDecisionCommandPort['applySingleFileDecision']>(
+      () => {
+        events.push('command:apply');
+        return Promise.resolve(successfulApply());
+      }
+    ),
+    quiescePersistence: vi.fn<ChangeReviewFileDecisionCommandPort['quiescePersistence']>(() => {
+      events.push('command:quiesce');
+      return Promise.resolve(true);
+    }),
+    recordDecisionRevision: vi.fn<ChangeReviewFileDecisionCommandPort['recordDecisionRevision']>(
+      () => events.push('command:revision')
+    ),
+    fetchFileContent: vi.fn<ChangeReviewFileDecisionCommandPort['fetchFileContent']>(() =>
+      events.push('command:fetch')
+    ),
+    readCurrentDiskContent: vi.fn<ChangeReviewFileDecisionCommandPort['readCurrentDiskContent']>(
+      (_filePath, fallback) => {
+        events.push('command:read');
+        return Promise.resolve(fallback);
+      }
+    ),
+  };
+  const editorPort: ChangeReviewFileDecisionEditorPort = {
+    getCurrentContent: vi.fn<ChangeReviewFileDecisionEditorPort['getCurrentContent']>(
+      () => content.modifiedFullContent
+    ),
+    scheduleEditorSync: vi.fn<ChangeReviewFileDecisionEditorPort['scheduleEditorSync']>(
+      (callback) => callback()
+    ),
+    acceptAllEditorChunks: vi.fn<ChangeReviewFileDecisionEditorPort['acceptAllEditorChunks']>(() =>
+      events.push('editor:accept')
+    ),
+    rejectAllEditorChunks: vi.fn<ChangeReviewFileDecisionEditorPort['rejectAllEditorChunks']>(() =>
+      events.push('editor:reject')
+    ),
+    rollbackEditorContent: vi.fn<ChangeReviewFileDecisionEditorPort['rollbackEditorContent']>(() =>
+      events.push('editor:rollback')
+    ),
+  };
+  const statusPort: ChangeReviewFileDecisionStatusPort = {
+    beginFileMutation: vi.fn(() => events.push('status:begin')),
+    finishFileMutation: vi.fn(() => events.push('status:finish')),
+    incrementDiscardCounter: vi.fn(() => events.push('status:discard-counter')),
+  };
+  const writeEvidencePort: ChangeReviewFileDecisionWriteEvidencePort = {
+    markExpectedWrite: vi.fn(() => events.push('write:expected')),
+    markCommittedPostimages: vi.fn(() => events.push('write:committed')),
+  };
+  const policy: ChangeReviewFileDecisionPolicy = {
+    getHunkCount: () => 1,
+    getFileDecision: (candidate, snapshot) => snapshot.fileDecisions[candidate.filePath],
+    resolveModifiedContent: (_candidate, candidateContent) =>
+      candidateContent?.modifiedFullContent ?? null,
+    resolveFileIsNew: (candidate, candidateContent) =>
+      candidateContent?.isNewFile ?? candidate.isNewFile,
+    isExpectedDeletion: () => false,
+    isAcceptDisabled: () => false,
+    isRejectable: () => true,
+    hasFileRejections: (candidate, _count, decisions) =>
+      decisions.fileDecisions[candidate.filePath] === 'rejected',
+    isFileFullyRejected: (candidate, _count, decisions) =>
+      decisions.fileDecisions[candidate.filePath] === 'rejected',
+    shouldDeleteWhenUndoingReject: () => false,
+    hasUnresolvedExternalChange: () => false,
+    getRenameRecoveryExpectation: () => null,
+  };
+  Object.assign(harness, {
+    file,
+    content,
+    state,
+    history,
+    statePort,
+    commandPort,
+    editorPort,
+    statusPort,
+    writeEvidencePort,
+    policy,
+    persistLatest: vi.fn<() => Promise<boolean>>().mockResolvedValue(true),
+    undoHistory,
+    events,
+    current: true,
+    durable: true,
+  });
+  return harness;
+}
+
+function Probe({ harness }: { readonly harness: Harness }): React.JSX.Element {
+  latest = useChangeReviewFileDecisionController({
+    files: [harness.file],
+    fileContents: { [harness.file.filePath]: harness.content },
+    changeSetEpoch: 7,
+    instantApply: true,
+    teamName: 'team',
+    taskId: 'task',
+    memberName: undefined,
+    reviewScope: { teamName: 'team', taskId: 'task' },
+    persistenceScope: { teamName: 'team', scopeKey: 'task', scopeToken: 'token' },
+    history: harness.history,
+    statePort: harness.statePort,
+    commandPort: harness.commandPort,
+    editorPort: harness.editorPort,
+    statusPort: harness.statusPort,
+    writeEvidencePort: harness.writeEvidencePort,
+    policy: harness.policy,
+    persistLatestAcceptedAction: harness.persistLatest,
+    ensureDurableScope: () => harness.durable,
+    hasDraft: () => false,
+    hasActionInFlight: () => false,
+    blockForExternalChange: () => false,
+    captureOperationScope: () => createReviewOperationScopeToken('scope'),
+    isCurrentOperationScope: () => harness.current,
+  });
+  return <div />;
+}
+
+function renderHarness(harness: Harness): ReturnType<typeof createRoot> {
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  const root = createRoot(document.body.appendChild(document.createElement('div')));
+  act(() => root.render(<Probe harness={harness} />));
+  return root;
+}
+
+afterEach(() => {
+  latest = null;
+  vi.unstubAllGlobals();
+  document.body.replaceChildren();
+});
+
+describe('useChangeReviewFileDecisionController', () => {
+  it('accepts a pending file and records history before durable persistence', () => {
+    const harness = createHarness();
+    const root = renderHarness(harness);
+
+    act(() => latest?.acceptFile(harness.file.filePath));
+
+    expect(harness.events).toEqual(['state:accept', 'history:push', 'editor:accept']);
+    expect(harness.persistLatest).toHaveBeenCalledTimes(1);
+    expect(harness.undoHistory[0]).toMatchObject({
+      kind: 'bulk',
+      descriptor: { intent: 'accept-file', filePath: harness.file.filePath },
+    });
+    act(() => root.unmount());
+  });
+
+  it('restores a rejected file with quiesce, history, WAL commit, then revision binding', async () => {
+    const harness = createHarness();
+    harness.state.fileDecisions[harness.file.filePath] = 'rejected';
+    const root = renderHarness(harness);
+
+    act(() => latest?.acceptFile(harness.file.filePath));
+    await vi.waitFor(() => {
+      expect(harness.commandPort.executeMutation).toHaveBeenCalledTimes(1);
+      expect(harness.statusPort.finishFileMutation).toHaveBeenCalledTimes(1);
+    });
+
+    const quiesceIndex = harness.events.indexOf('command:quiesce');
+    const restoreIndex = harness.events.indexOf('state:restore');
+    const pushIndex = harness.events.indexOf('history:push');
+    const executeIndex = harness.events.indexOf('command:execute');
+    const bindIndex = harness.events.indexOf('history:bind');
+    const revisionIndex = harness.events.indexOf('command:revision');
+    expect(quiesceIndex).toBeLessThan(restoreIndex);
+    expect(restoreIndex).toBeLessThan(pushIndex);
+    expect(pushIndex).toBeLessThan(executeIndex);
+    expect(executeIndex).toBeLessThan(bindIndex);
+    expect(bindIndex).toBeLessThan(revisionIndex);
+
+    const request = vi.mocked(harness.commandPort.executeMutation).mock.calls[0][0];
+    expect(request).toMatchObject({
+      kind: 'restore',
+      expectedDecisionRevision: 4,
+      persistedState: {
+        fileDecisions: { [harness.file.filePath]: 'accepted' },
+      },
+    });
+    expect(request.persistedState.reviewActionHistory).toHaveLength(1);
+    act(() => root.unmount());
+  });
+
+  it('rolls back decision, editor, and optimistic history when instant reject fails', async () => {
+    const harness = createHarness();
+    vi.mocked(harness.commandPort.applySingleFileDecision).mockResolvedValueOnce(null);
+    const root = renderHarness(harness);
+
+    await act(async () => {
+      await latest?.rejectFile(harness.file.filePath);
+    });
+
+    expect(harness.events).toContain('state:reject');
+    expect(harness.events).toContain('history:discard');
+    expect(harness.events).toContain('state:rollback');
+    expect(harness.events).toContain('editor:rollback');
+    expect(harness.events).toContain('state:invalidate');
+    expect(harness.events).toContain('status:discard-counter');
+    expect(harness.events.at(-1)).toBe('status:finish');
+    expect(harness.undoHistory).toHaveLength(0);
+    act(() => root.unmount());
+  });
+
+  it('records exact create-file Undo state when rejecting a new file', async () => {
+    const harness = createHarness();
+    harness.file.isNewFile = true;
+    harness.content.isNewFile = true;
+    harness.content.originalFullContent = '';
+    const root = renderHarness(harness);
+
+    await act(async () => {
+      await latest?.rejectFile(harness.file.filePath);
+    });
+
+    expect(harness.undoHistory[0]).toMatchObject({
+      kind: 'disk',
+      action: {
+        snapshot: {
+          afterContent: null,
+          beforeContent: 'after',
+          fileIndex: 0,
+          restoreMode: 'create-file',
+        },
+      },
+    });
+    expect(harness.commandPort.readCurrentDiskContent).not.toHaveBeenCalled();
+    expect(harness.statePort.invalidateResolvedFileContent).toHaveBeenCalledWith(
+      harness.file.filePath
+    );
+    act(() => root.unmount());
+  });
+
+  it('restores an expected deletion as an absent postimage without a conflict read', async () => {
+    const harness = createHarness();
+    harness.state.fileDecisions[harness.file.filePath] = 'rejected';
+    harness.policy.isExpectedDeletion = () => true;
+    const root = renderHarness(harness);
+
+    act(() => latest?.acceptFile(harness.file.filePath));
+    await vi.waitFor(() => expect(harness.commandPort.executeMutation).toHaveBeenCalledTimes(1));
+
+    expect(harness.commandPort.checkConflict).not.toHaveBeenCalled();
+    expect(harness.undoHistory[0]).toMatchObject({
+      kind: 'disk',
+      action: {
+        snapshot: {
+          beforeContent: 'before',
+          afterContent: null,
+          restoreMode: 'create-file',
+        },
+      },
+    });
+    expect(harness.writeEvidencePort.markExpectedWrite).toHaveBeenCalledWith(
+      harness.file.filePath,
+      null
+    );
+    act(() => root.unmount());
+  });
+
+  it('ignores a late reject result from an obsolete operation generation', async () => {
+    const harness = createHarness();
+    let resolveApply: ((result: ApplyReviewResult) => void) | undefined;
+    vi.mocked(harness.commandPort.applySingleFileDecision).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveApply = resolve;
+        })
+    );
+    const root = renderHarness(harness);
+
+    const pending = latest?.rejectFile(harness.file.filePath);
+    await vi.waitFor(() =>
+      expect(harness.commandPort.applySingleFileDecision).toHaveBeenCalledTimes(1)
+    );
+    harness.current = false;
+    resolveApply?.(successfulApply());
+    await pending;
+
+    expect(harness.writeEvidencePort.markCommittedPostimages).not.toHaveBeenCalled();
+    expect(harness.history.bindCommittedAction).not.toHaveBeenCalled();
+    expect(harness.history.discardLatestAction).not.toHaveBeenCalled();
+    expect(harness.statusPort.finishFileMutation).not.toHaveBeenCalled();
+    act(() => root.unmount());
+  });
+});


### PR DESCRIPTION
## Summary

- reduce `ChangeReviewDialog.tsx` from 3138 to 2684 physical lines
- extract single-file Accept and Reject orchestration into a focused controller
- isolate decision state, review commands, editor synchronization, mutation status, write evidence, policy, and history behind narrow ports
- preserve new-file, deleted-file, rename-recovery, instant-apply, rollback, Undo, revision, and stale-operation behavior
- lower the ChangeReviewDialog legacy cap from 3138 to 2684

## Architecture and safety

- controller depends on a feature-owned `ChangeReviewFileDecisionHistoryPort`, not a sibling hook implementation type
- adapters bind Zustand and review IPC only at the renderer composition boundary
- mutation ordering remains quiesce -> optimistic state/history -> WAL commit -> committed history binding -> decision revision
- failed instant Reject restores decisions, editor content, optimistic history, cache state, and retry status
- operation scope and epoch guards fence late results from a replaced review
- no service locator, inheritance, hidden dependency, duplicate decision state, or new legacy exception

## Verification

- 38/38 focused port, controller, and dialog guard tests passed on exact rebased head
- pinned native TypeScript 7 typecheck passed
- fast ESLint passed for all touched TypeScript files
- full type-aware ESLint passed with 0 errors for all new architecture boundaries and tests
- source-size guard passed with the global 800-line limit and ratchet reduced to 2684
- Prettier and `git diff --check` passed
- independent read-only audit ended at blockers 0 / P3 0; rebased head preserves the audited tree `8815c84a`

## Desktop E2E evidence

The parent bulk-decision slice passed the full fresh-sandbox Changes desktop flow. This intermediate responsibility extraction uses focused deterministic tests and does not rerun Electron E2E. Full desktop Changes E2E will run again on the final `<800` dialog slice.

No real user project, agent team, terminal runtime, or provisioning flow was opened.

## Remaining ChangeReviewDialog work

2684 lines remain. Follow-up PRs will extract lifecycle, hunk decisions, interactions/presentation, composition safety, decision actions, and the final view until the facade is below 800 lines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved file-level change review actions, including accepting, rejecting, restoring, and handling new, deleted, or renamed files.
  * Added safer conflict handling, undo history, rollback behavior, and persistence of review decisions.
  * Improved synchronization between editor content and file decisions.

* **Documentation**
  * Clarified the ongoing transition of change-review responsibilities and supported file decision workflows.

* **Tests**
  * Added coverage for decision actions, restoration, failure recovery, conflict handling, undo behavior, and stale operation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->