### PR TITLE
refactor(change-review): extract dialog lifecycle

### DIFF
--- a/scripts/ci/source-file-size-legacy.json
+++ b/scripts/ci/source-file-size-legacy.json
@@ -150,7 +150,7 @@
   "src/renderer/components/team/members/MemberLogsTab.tsx": 985,
   "src/renderer/components/team/messages/MessageComposer.tsx": 1344,
   "src/renderer/components/team/messages/MessagesPanel.tsx": 1722,
-  "src/renderer/components/team/review/ChangeReviewDialog.tsx": 2684,
+  "src/renderer/components/team/review/ChangeReviewDialog.tsx": 2321,
   "src/renderer/components/team/review/CodeMirrorDiffView.tsx": 975,
   "src/renderer/components/team/useTeamChangesSummaries.ts": 826,
   "src/renderer/components/ui/MentionableTextarea.tsx": 1433,

--- a/src/features/change-review/README.md
+++ b/src/features/change-review/README.md
@@ -8,8 +8,9 @@ main-process review IPC shell.
 - `renderer/hooks` owns scope/lifecycle, draft history, conflict recovery, action-history,
   decision-persistence, keyboard orchestration, bulk Accept/Reject, manual file draft
   save/reload/discard flows, file-level Accept/Reject/Restore, and durable
-  Undo/Redo/checkpoint Restore through narrow command, state, editor, status, and
-  write-evidence ports.
+  Undo/Redo/checkpoint Restore. It also owns dialog open/fetch/hydration, close/app-close
+  flushing, saved-state recovery/discard, Apply cleanup, and Escape orchestration through
+  narrow command, state, editor, status, session, and write-evidence ports.
 - `renderer/ui` owns store-free presentation components.
 - `core/domain` owns pure review scope, rename expectation, snippet-shape, watcher-input, and
   decision-persistence policy.
@@ -18,8 +19,8 @@ main-process review IPC shell.
 - `main/infrastructure` owns Node path, filesystem, sensitive-path, hardlink, and watcher-root
   validation details.
 - The legacy dialog remains the temporary composition shell for Zustand, editor mutations,
-  hunk-level decision mutations, and outer close coordination while later slices move those
-  responsibilities behind focused hooks and use cases.
+  and hunk-level decision mutations while later slices move those responsibilities behind
+  focused hooks and use cases.
 
 Production callers import through `@features/change-review/renderer` or
 `@features/change-review/main`.

--- a/src/features/change-review/renderer/adapters/createChangeReviewDialogLifecyclePorts.ts
+++ b/src/features/change-review/renderer/adapters/createChangeReviewDialogLifecyclePorts.ts
@@ -1,0 +1,97 @@
+import type {
+  ChangeReviewDialogLifecycleCommandPort,
+  ChangeReviewDialogLifecycleStatePort,
+  ChangeReviewDialogLifecycleStateSnapshot,
+} from '../ports/changeReviewDialogLifecyclePorts';
+import type { TaskChangeRequestOptions } from '@renderer/utils/taskChangeRequest';
+import type { ApplyReviewResult } from '@shared/types';
+import type { ReviewAPI } from '@shared/types/api';
+
+interface ChangeReviewDialogLifecycleStore extends ChangeReviewDialogLifecycleStateSnapshot {
+  resetAllReviewState(): void;
+  clearChangeReviewCache(): void;
+  fetchAgentChanges(teamName: string, memberName: string): Promise<void>;
+  fetchTaskChanges(
+    teamName: string,
+    taskId: string,
+    options: TaskChangeRequestOptions
+  ): Promise<void>;
+  clearDecisionsFromDisk(
+    teamName: string,
+    scopeKey: string,
+    scopeToken?: string,
+    forceDiscard?: boolean
+  ): Promise<boolean>;
+  applyReview(
+    teamName: string,
+    taskId?: string,
+    memberName?: string
+  ): Promise<ApplyReviewResult | null>;
+}
+
+interface CreateChangeReviewDialogLifecycleStatePortInput {
+  getStore: () => ChangeReviewDialogLifecycleStore;
+  reportError: (message: string | null) => void;
+  completeSavedStateDiscard: (markDecisionHydrationLoaded: boolean) => void;
+}
+
+export function createChangeReviewDialogLifecycleStatePort({
+  getStore,
+  reportError,
+  completeSavedStateDiscard,
+}: CreateChangeReviewDialogLifecycleStatePortInput): ChangeReviewDialogLifecycleStatePort {
+  return {
+    getSnapshot: () => {
+      const state = getStore();
+      return {
+        editedContents: state.editedContents,
+        hunkDecisions: state.hunkDecisions,
+        fileDecisions: state.fileDecisions,
+        reviewActionHistory: state.reviewActionHistory,
+        reviewRedoHistory: state.reviewRedoHistory,
+        fileContents: state.fileContents,
+        fileChunkCounts: state.fileChunkCounts,
+        decisionHydrationScopeKey: state.decisionHydrationScopeKey,
+        decisionHydrationStatus: state.decisionHydrationStatus,
+        applying: state.applying,
+      };
+    },
+    reportError,
+    completeSavedStateDiscard,
+  };
+}
+
+type ChangeReviewDialogLifecycleReviewApi = Pick<ReviewAPI, 'retryMutationRecovery'>;
+
+interface CreateChangeReviewDialogLifecycleCommandPortInput {
+  getStore: () => ChangeReviewDialogLifecycleStore;
+  getReviewApi: () => ChangeReviewDialogLifecycleReviewApi;
+  hydrateDecisions: ChangeReviewDialogLifecycleCommandPort['hydrateDecisions'];
+}
+
+export function createChangeReviewDialogLifecycleCommandPort({
+  getStore,
+  getReviewApi,
+  hydrateDecisions,
+}: CreateChangeReviewDialogLifecycleCommandPortInput): ChangeReviewDialogLifecycleCommandPort {
+  return {
+    resetAllReviewState: () => getStore().resetAllReviewState(),
+    clearChangeReviewCache: () => getStore().clearChangeReviewCache(),
+    fetchAgentChanges: (teamName, memberName) => {
+      void getStore().fetchAgentChanges(teamName, memberName);
+    },
+    fetchTaskChanges: (teamName, taskId, options) => {
+      void getStore().fetchTaskChanges(teamName, taskId, options);
+    },
+    hydrateDecisions,
+    clearDecisions: ({ teamName, scopeKey, scopeToken }, forceDiscard) =>
+      getStore().clearDecisionsFromDisk(teamName, scopeKey, scopeToken, forceDiscard),
+    applyReview: async (teamName, taskId, memberName) => {
+      const result = await getStore().applyReview(teamName, taskId, memberName);
+      return result?.errors.length === 0
+        ? { status: 'applied', result }
+        : { status: 'failed', result };
+    },
+    retryMutationRecovery: (request) => getReviewApi().retryMutationRecovery(request),
+  };
+}

--- a/src/features/change-review/renderer/adapters/createChangeReviewDialogLifecyclePorts.ts
+++ b/src/features/change-review/renderer/adapters/createChangeReviewDialogLifecyclePorts.ts
@@ -8,6 +8,7 @@ import type { ApplyReviewResult } from '@shared/types';
 import type { ReviewAPI } from '@shared/types/api';
 
 interface ChangeReviewDialogLifecycleStore extends ChangeReviewDialogLifecycleStateSnapshot {
+  applyError: string | null;
   resetAllReviewState(): void;
   clearChangeReviewCache(): void;
   fetchAgentChanges(teamName: string, memberName: string): Promise<void>;
@@ -88,9 +89,17 @@ export function createChangeReviewDialogLifecycleCommandPort({
       getStore().clearDecisionsFromDisk(teamName, scopeKey, scopeToken, forceDiscard),
     applyReview: async (teamName, taskId, memberName) => {
       const result = await getStore().applyReview(teamName, taskId, memberName);
-      return result?.errors.length === 0
-        ? { status: 'applied', result }
-        : { status: 'failed', result };
+      if (result?.errors.length === 0) {
+        return { status: 'applied', result };
+      }
+      return {
+        status: 'failed',
+        result,
+        errorMessage:
+          result?.errors.map((entry) => entry.error).join('\n') ||
+          getStore().applyError ||
+          'Unable to apply this review. Changes remains open; retry Apply.',
+      };
     },
     retryMutationRecovery: (request) => getReviewApi().retryMutationRecovery(request),
   };

--- a/src/features/change-review/renderer/hooks/useChangeReviewDialogLifecycleController.ts
+++ b/src/features/change-review/renderer/hooks/useChangeReviewDialogLifecycleController.ts
@@ -1,0 +1,517 @@
+import { useCallback, useEffect, useMemo } from 'react';
+
+import {
+  evaluateChangeReviewCloseReadiness,
+  shouldRequestReviewCloseForEscape,
+} from '../utils/changeReviewDialogLifecycle';
+
+import { useChangeReviewDecisionAutoPersistence } from './useChangeReviewDecisionAutoPersistence';
+import { useChangeReviewLifecycleRegistration } from './useChangeReviewLifecycleRegistration';
+
+import type {
+  ChangeReviewDialogLifecycleCommandPort,
+  ChangeReviewDialogLifecycleDecisionPersistencePort,
+  ChangeReviewDialogLifecycleDraftHistoryPort,
+  ChangeReviewDialogLifecycleEditorPort,
+  ChangeReviewDialogLifecyclePersistenceScope,
+  ChangeReviewDialogLifecycleSessionPort,
+  ChangeReviewDialogLifecycleStatePort,
+  ChangeReviewDialogLifecycleStatusPort,
+  ChangeReviewDialogLifecycleWriteEvidencePort,
+} from '../ports/changeReviewDialogLifecyclePorts';
+import type {
+  RegisterChangeReviewAppCloseParticipant,
+  RegisterChangeReviewLifecycleOwner,
+} from '../ports/changeReviewLifecyclePorts';
+import type { ReviewDraftHistoryHydrationState } from '../utils/changeReviewScope';
+import type { ReviewOperationScopeToken } from '../utils/reviewOperationGeneration';
+import type { TaskChangeRequestOptions } from '@renderer/utils/taskChangeRequest';
+import type { ReviewFileScope } from '@shared/types';
+
+interface UseChangeReviewDialogLifecycleControllerInput {
+  open: boolean;
+  authorized: boolean;
+  setAuthorized: (authorized: boolean) => void;
+  hostId: string;
+  sessionId: string;
+  tabId: string | undefined;
+  focus: (() => void) | undefined;
+  teamName: string;
+  mode: 'agent' | 'task';
+  memberName: string | undefined;
+  taskId: string | undefined;
+  taskChangeRequestOptions: TaskChangeRequestOptions | undefined;
+  scopeKey: string;
+  decisionScopeKey: string;
+  decisionScopeToken: string | null;
+  decisionHydrationKey: string | null;
+  decisionHydrationReady: boolean;
+  decisionHydrationFailed: boolean;
+  draftHistoryHydration: ReviewDraftHistoryHydrationState;
+  draftHistoryHydrationFailed: boolean;
+  reviewScope: ReviewFileScope;
+  reviewMutationBusy: boolean;
+  reviewActionsBusy: boolean;
+  onOpenChange: (open: boolean) => void;
+  statePort: ChangeReviewDialogLifecycleStatePort;
+  commandPort: ChangeReviewDialogLifecycleCommandPort;
+  editorPort: ChangeReviewDialogLifecycleEditorPort;
+  statusPort: ChangeReviewDialogLifecycleStatusPort;
+  sessionPort: ChangeReviewDialogLifecycleSessionPort;
+  writeEvidencePort: ChangeReviewDialogLifecycleWriteEvidencePort;
+  decisionPersistence: ChangeReviewDialogLifecycleDecisionPersistencePort;
+  draftHistory: ChangeReviewDialogLifecycleDraftHistoryPort;
+  hasActionInFlight: () => boolean;
+  blockForExternalChange: () => boolean;
+  captureOperationScope: () => ReviewOperationScopeToken | null;
+  isCurrentOperationScope: (scope: ReviewOperationScopeToken | null) => boolean;
+  registerOwner: RegisterChangeReviewLifecycleOwner;
+  registerAppCloseParticipant: RegisterChangeReviewAppCloseParticipant;
+}
+
+export interface ChangeReviewDialogLifecycleController {
+  requestClose: () => Promise<void>;
+  retrySavedReviewState: () => Promise<void>;
+  discardSavedDecisionState: () => Promise<void>;
+  apply: () => Promise<void>;
+}
+
+interface ReviewCloseFlushResult {
+  ok: boolean;
+  blocker?: string;
+}
+
+export function useChangeReviewDialogLifecycleController({
+  open,
+  authorized,
+  setAuthorized,
+  hostId,
+  sessionId,
+  tabId,
+  focus,
+  teamName,
+  mode,
+  memberName,
+  taskId,
+  taskChangeRequestOptions,
+  scopeKey,
+  decisionScopeKey,
+  decisionScopeToken,
+  decisionHydrationKey,
+  decisionHydrationReady,
+  decisionHydrationFailed,
+  draftHistoryHydration,
+  draftHistoryHydrationFailed,
+  reviewScope,
+  reviewMutationBusy,
+  reviewActionsBusy,
+  onOpenChange,
+  statePort,
+  commandPort,
+  editorPort,
+  statusPort,
+  sessionPort,
+  writeEvidencePort,
+  decisionPersistence,
+  draftHistory,
+  hasActionInFlight,
+  blockForExternalChange,
+  captureOperationScope,
+  isCurrentOperationScope,
+  registerOwner,
+  registerAppCloseParticipant,
+}: UseChangeReviewDialogLifecycleControllerInput): ChangeReviewDialogLifecycleController {
+  const {
+    flushForClose: flushReviewDecisionsForClose,
+    getDiagnostics: getDecisionPersistenceDiagnostics,
+    scheduleAutoPersistence,
+    clearAfterDurableStateEmptied,
+  } = decisionPersistence;
+  const {
+    getEntry: getDraftHistoryEntry,
+    flushWrites: flushDraftHistoryWrites,
+    retryHydration: retryDraftHistoryHydration,
+    discardUnreadableScope: discardUnreadableDraftHistoryScope,
+    getDiagnostics: getDraftHistoryDiagnostics,
+  } = draftHistory;
+  const persistenceScope = useMemo<ChangeReviewDialogLifecyclePersistenceScope | null>(
+    () =>
+      decisionScopeToken
+        ? {
+            teamName,
+            scopeKey: decisionScopeKey,
+            scopeToken: decisionScopeToken,
+          }
+        : null,
+    [decisionScopeKey, decisionScopeToken, teamName]
+  );
+
+  useEffect(() => {
+    if (!open || !authorized) return;
+    commandPort.resetAllReviewState();
+    if (mode === 'agent' && memberName) {
+      commandPort.fetchAgentChanges(teamName, memberName);
+    } else if (mode === 'task' && taskId) {
+      commandPort.fetchTaskChanges(teamName, taskId, taskChangeRequestOptions ?? {});
+    }
+    return () => commandPort.clearChangeReviewCache();
+  }, [
+    authorized,
+    commandPort,
+    decisionScopeKey,
+    memberName,
+    mode,
+    open,
+    taskChangeRequestOptions,
+    taskId,
+    teamName,
+  ]);
+
+  useEffect(() => {
+    if (!open || !authorized || !persistenceScope || !decisionHydrationKey) return;
+    void commandPort.hydrateDecisions(persistenceScope, decisionHydrationKey);
+  }, [authorized, commandPort, decisionHydrationKey, open, persistenceScope]);
+
+  const renderedState = statePort.getSnapshot();
+  const hasDurableReviewState =
+    Object.keys(renderedState.hunkDecisions).length > 0 ||
+    Object.keys(renderedState.fileDecisions).length > 0 ||
+    renderedState.reviewActionHistory.length > 0 ||
+    renderedState.reviewRedoHistory.length > 0;
+  useChangeReviewDecisionAutoPersistence({
+    active: open && authorized,
+    hydrationKey: decisionHydrationKey,
+    scope: persistenceScope,
+    hydrationReady: decisionHydrationReady,
+    blocked: reviewActionsBusy,
+    hasDurableReviewState,
+    hunkDecisions: renderedState.hunkDecisions,
+    fileDecisions: renderedState.fileDecisions,
+    undoHistory: renderedState.reviewActionHistory,
+    redoHistory: renderedState.reviewRedoHistory,
+    fileContents: renderedState.fileContents,
+    fileChunkCounts: renderedState.fileChunkCounts,
+    scheduleAutoPersistence,
+    clearAfterDurableStateEmptied,
+  });
+
+  const flushReviewStateForClose = useCallback(async (): Promise<ReviewCloseFlushResult> => {
+    const operationScope = captureOperationScope();
+    if (!operationScope) {
+      return {
+        ok: false,
+        blocker: 'Review scope changed before Changes could close.',
+      };
+    }
+    const scopeChangedResult: ReviewCloseFlushResult = {
+      ok: false,
+      blocker: 'Review scope changed while Changes was closing.',
+    };
+    const state = statePort.getSnapshot();
+    const draftDiagnostics = getDraftHistoryDiagnostics();
+    const decisionDiagnostics = getDecisionPersistenceDiagnostics();
+    const hydrationHasError =
+      decisionHydrationKey !== null &&
+      ((state.decisionHydrationScopeKey === decisionHydrationKey &&
+        state.decisionHydrationStatus === 'error') ||
+        (draftHistoryHydration.key === decisionHydrationKey &&
+          draftHistoryHydration.status === 'error'));
+    const scopedDraftDiagnostics = hydrationHasError
+      ? getDraftHistoryDiagnostics(decisionHydrationKey)
+      : draftDiagnostics;
+    const readiness = evaluateChangeReviewCloseReadiness({
+      hydrationKey: decisionHydrationKey,
+      decisionHydrationScopeKey: state.decisionHydrationScopeKey,
+      decisionHydrationStatus: state.decisionHydrationStatus,
+      draftHydrationKey: draftHistoryHydration.key,
+      draftHydrationStatus: draftHistoryHydration.status,
+      editedContentCount: Object.keys(state.editedContents).length,
+      hunkDecisionCount: Object.keys(state.hunkDecisions).length,
+      fileDecisionCount: Object.keys(state.fileDecisions).length,
+      undoHistoryCount: state.reviewActionHistory.length,
+      redoHistoryCount: state.reviewRedoHistory.length,
+      draftDiagnostics,
+      scopedDraftDiagnostics,
+      decisionDiagnostics,
+      pendingApplyCleanupKey: sessionPort.getPendingApplyCleanupKey(),
+      actionLockState: statusPort.getActionLockState(state.applying),
+    });
+    if (readiness.disposition === 'block') {
+      statePort.reportError(readiness.blocker);
+      return { ok: false, blocker: readiness.blocker };
+    }
+    if (readiness.disposition === 'close-without-flush') {
+      return { ok: true };
+    }
+
+    statusPort.beginClosing();
+    try {
+      editorPort.captureDraftSnapshots(
+        (filePath) => filePath in state.editedContents || Boolean(getDraftHistoryEntry(filePath))
+      );
+      const currentState = statePort.getSnapshot();
+      for (const filePath of Object.keys(currentState.editedContents)) {
+        if (!getDraftHistoryEntry(filePath)) {
+          const blocker = `Manual edits for ${filePath} are not durable yet. Keep Changes open and retry.`;
+          statePort.reportError(blocker);
+          return { ok: false, blocker };
+        }
+      }
+      const draftsFlushed = await flushDraftHistoryWrites();
+      if (!isCurrentOperationScope(operationScope)) return scopeChangedResult;
+      if (!draftsFlushed) {
+        const blocker = 'Unable to save manual edit history. Changes remains open.';
+        statePort.reportError(blocker);
+        return { ok: false, blocker };
+      }
+      if (persistenceScope && sessionPort.getPendingApplyCleanupKey() === decisionHydrationKey) {
+        const cleared = await commandPort.clearDecisions(persistenceScope);
+        if (!isCurrentOperationScope(operationScope)) return scopeChangedResult;
+        if (!cleared) {
+          const blocker =
+            'Review was applied, but its saved state could not be cleared. Changes remains open.';
+          statePort.reportError(blocker);
+          return { ok: false, blocker };
+        }
+        sessionPort.setPendingApplyCleanupKey(null);
+        return { ok: true };
+      }
+      if (persistenceScope) {
+        const flushed = await flushReviewDecisionsForClose();
+        if (!isCurrentOperationScope(operationScope)) return scopeChangedResult;
+        if (!flushed) {
+          const blocker = 'Unable to save review decisions. Changes remains open.';
+          statePort.reportError(blocker);
+          return { ok: false, blocker };
+        }
+      }
+      return { ok: true };
+    } finally {
+      if (isCurrentOperationScope(operationScope)) statusPort.finishClosing();
+    }
+  }, [
+    captureOperationScope,
+    commandPort,
+    decisionHydrationKey,
+    draftHistoryHydration.key,
+    draftHistoryHydration.status,
+    editorPort,
+    flushDraftHistoryWrites,
+    flushReviewDecisionsForClose,
+    getDecisionPersistenceDiagnostics,
+    getDraftHistoryDiagnostics,
+    getDraftHistoryEntry,
+    isCurrentOperationScope,
+    persistenceScope,
+    sessionPort,
+    statePort,
+    statusPort,
+  ]);
+
+  const requestLifecycleClose = useCallback(async (): Promise<boolean> => {
+    const operationScope = captureOperationScope();
+    if (!operationScope) return false;
+    const result = await flushReviewStateForClose();
+    if (!isCurrentOperationScope(operationScope)) return false;
+    if (result.ok) onOpenChange(false);
+    return result.ok;
+  }, [captureOperationScope, flushReviewStateForClose, isCurrentOperationScope, onOpenChange]);
+
+  const requestClose = useCallback(async (): Promise<void> => {
+    await requestLifecycleClose();
+  }, [requestLifecycleClose]);
+
+  const closeRejectedDialog = useCallback((): void => onOpenChange(false), [onOpenChange]);
+  useChangeReviewLifecycleRegistration({
+    open,
+    authorized,
+    hostId,
+    sessionId,
+    tabId,
+    focus,
+    requestClose: requestLifecycleClose,
+    closeRejectedDialog,
+    setAuthorized,
+    appCloseParticipantId: `changes:${teamName}:${decisionHydrationKey ?? scopeKey}`,
+    flushForAppClose: flushReviewStateForClose,
+    registerOwner,
+    registerAppCloseParticipant,
+  });
+
+  const retrySavedReviewState = useCallback(async (): Promise<void> => {
+    if (!persistenceScope || !decisionHydrationKey || reviewMutationBusy) {
+      return;
+    }
+    const operationScope = captureOperationScope();
+    if (!operationScope) return;
+    statusPort.setRecoveryInFlight(true);
+    try {
+      if (decisionHydrationFailed) {
+        const recovered = await commandPort.retryMutationRecovery({
+          scope: reviewScope,
+          decisionPersistenceScope: {
+            scopeKey: persistenceScope.scopeKey,
+            scopeToken: persistenceScope.scopeToken,
+          },
+        });
+        if (!isCurrentOperationScope(operationScope)) return;
+        writeEvidencePort.markCommittedPostimages(recovered.diskPostimages);
+        await commandPort.hydrateDecisions(persistenceScope, decisionHydrationKey);
+        if (!isCurrentOperationScope(operationScope)) return;
+      }
+      if (draftHistoryHydrationFailed) retryDraftHistoryHydration();
+    } catch (error) {
+      if (!isCurrentOperationScope(operationScope)) return;
+      statePort.reportError(`Unable to resume the saved review update: ${String(error)}`);
+    } finally {
+      if (isCurrentOperationScope(operationScope)) {
+        statusPort.setRecoveryInFlight(false);
+      }
+    }
+  }, [
+    captureOperationScope,
+    commandPort,
+    decisionHydrationFailed,
+    decisionHydrationKey,
+    draftHistoryHydrationFailed,
+    isCurrentOperationScope,
+    persistenceScope,
+    reviewMutationBusy,
+    reviewScope,
+    retryDraftHistoryHydration,
+    statePort,
+    statusPort,
+    writeEvidencePort,
+  ]);
+
+  const discardSavedDecisionState = useCallback(async (): Promise<void> => {
+    if (!persistenceScope || !decisionHydrationKey || reviewMutationBusy) {
+      throw new Error('Saved review state is not ready to be discarded.');
+    }
+    const operationScope = captureOperationScope();
+    if (!operationScope) {
+      throw new Error('Saved review scope is no longer active.');
+    }
+    statusPort.beginClosing();
+    try {
+      if (decisionHydrationFailed) {
+        const cleared = await commandPort.clearDecisions(persistenceScope, true);
+        if (!isCurrentOperationScope(operationScope)) return;
+        if (!cleared) {
+          const message = 'Unable to discard the unreadable saved review decisions.';
+          statePort.reportError(message);
+          throw new Error(message);
+        }
+      }
+      if (draftHistoryHydrationFailed) {
+        try {
+          const discarded = await discardUnreadableDraftHistoryScope(operationScope);
+          if (!discarded) return;
+        } catch (error) {
+          if (!isCurrentOperationScope(operationScope)) return;
+          const message = `Unable to discard the unreadable manual edit history: ${String(error)}`;
+          statePort.reportError(message);
+          throw new Error(message, { cause: error });
+        }
+      }
+      const state = statePort.getSnapshot();
+      if (decisionHydrationFailed && state.decisionHydrationScopeKey !== decisionHydrationKey) {
+        throw new Error('Saved review scope changed before it could be discarded.');
+      }
+      statePort.completeSavedStateDiscard(decisionHydrationFailed);
+    } finally {
+      if (isCurrentOperationScope(operationScope)) statusPort.finishClosing();
+    }
+  }, [
+    captureOperationScope,
+    commandPort,
+    decisionHydrationFailed,
+    decisionHydrationKey,
+    discardUnreadableDraftHistoryScope,
+    draftHistoryHydrationFailed,
+    isCurrentOperationScope,
+    persistenceScope,
+    reviewMutationBusy,
+    statePort,
+    statusPort,
+  ]);
+
+  const apply = useCallback(async (): Promise<void> => {
+    if (hasActionInFlight() || blockForExternalChange()) return;
+    if (!persistenceScope || !decisionHydrationKey) {
+      statePort.reportError('Durable review scope is unavailable. Reload Changes before applying.');
+      return;
+    }
+    const operationScope = captureOperationScope();
+    if (!operationScope) return;
+
+    if (sessionPort.getPendingApplyCleanupKey() !== decisionHydrationKey) {
+      const outcome = await commandPort.applyReview(teamName, taskId, memberName);
+      if (!isCurrentOperationScope(operationScope)) return;
+      writeEvidencePort.markCommittedPostimages(outcome.result?.diskPostimages);
+      if (outcome.status === 'failed') return;
+      if (!sessionPort.isExpectedHydrationKey(decisionHydrationKey)) return;
+      sessionPort.setPendingApplyCleanupKey(decisionHydrationKey);
+    }
+
+    statusPort.beginClosing();
+    try {
+      const cleared = await commandPort.clearDecisions(persistenceScope);
+      if (!isCurrentOperationScope(operationScope)) return;
+      if (!cleared) {
+        statePort.reportError(
+          'Review was applied, but its saved state could not be cleared. Changes remains open; retry Apply to finish cleanup.'
+        );
+        return;
+      }
+      sessionPort.setPendingApplyCleanupKey(null);
+      if (sessionPort.isExpectedHydrationKey(decisionHydrationKey)) {
+        commandPort.resetAllReviewState();
+      }
+    } finally {
+      if (isCurrentOperationScope(operationScope)) statusPort.finishClosing();
+    }
+  }, [
+    blockForExternalChange,
+    captureOperationScope,
+    commandPort,
+    decisionHydrationKey,
+    hasActionInFlight,
+    isCurrentOperationScope,
+    memberName,
+    persistenceScope,
+    sessionPort,
+    statePort,
+    statusPort,
+    taskId,
+    teamName,
+    writeEvidencePort,
+  ]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (event: KeyboardEvent): void => {
+      if (
+        shouldRequestReviewCloseForEscape({
+          key: event.key,
+          defaultPrevented: event.defaultPrevented,
+          hasOpenModalLayer: Boolean(
+            document.querySelector('[role="alertdialog"][data-state="open"]')
+          ),
+        })
+      ) {
+        event.preventDefault();
+        void requestClose();
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [open, requestClose]);
+
+  return {
+    requestClose,
+    retrySavedReviewState,
+    discardSavedDecisionState,
+    apply,
+  };
+}

--- a/src/features/change-review/renderer/hooks/useChangeReviewDialogLifecycleController.ts
+++ b/src/features/change-review/renderer/hooks/useChangeReviewDialogLifecycleController.ts
@@ -450,10 +450,7 @@ export function useChangeReviewDialogLifecycleController({
       if (!isCurrentOperationScope(operationScope)) return;
       writeEvidencePort.markCommittedPostimages(outcome.result?.diskPostimages);
       if (outcome.status === 'failed') {
-        statePort.reportError(
-          outcome.result?.errors[0]?.error ??
-            'Unable to apply this review. Changes remains open; retry Apply.'
-        );
+        statePort.reportError(outcome.errorMessage);
         return;
       }
       if (!sessionPort.isExpectedHydrationKey(decisionHydrationKey)) return;

--- a/src/features/change-review/renderer/hooks/useChangeReviewDialogLifecycleController.ts
+++ b/src/features/change-review/renderer/hooks/useChangeReviewDialogLifecycleController.ts
@@ -449,7 +449,13 @@ export function useChangeReviewDialogLifecycleController({
       const outcome = await commandPort.applyReview(teamName, taskId, memberName);
       if (!isCurrentOperationScope(operationScope)) return;
       writeEvidencePort.markCommittedPostimages(outcome.result?.diskPostimages);
-      if (outcome.status === 'failed') return;
+      if (outcome.status === 'failed') {
+        statePort.reportError(
+          outcome.result?.errors[0]?.error ??
+            'Unable to apply this review. Changes remains open; retry Apply.'
+        );
+        return;
+      }
       if (!sessionPort.isExpectedHydrationKey(decisionHydrationKey)) return;
       sessionPort.setPendingApplyCleanupKey(decisionHydrationKey);
     }

--- a/src/features/change-review/renderer/index.ts
+++ b/src/features/change-review/renderer/index.ts
@@ -12,6 +12,10 @@ export {
 } from './adapters/createChangeReviewConflictPorts';
 export type { ChangeReviewConflictStateBridge } from './adapters/createChangeReviewConflictStateBridge';
 export { createChangeReviewConflictStateBridge } from './adapters/createChangeReviewConflictStateBridge';
+export {
+  createChangeReviewDialogLifecycleCommandPort,
+  createChangeReviewDialogLifecycleStatePort,
+} from './adapters/createChangeReviewDialogLifecyclePorts';
 export { createChangeReviewDraftHistoryPort } from './adapters/createChangeReviewDraftHistoryPort';
 export {
   createChangeReviewFileDecisionCommandPort,
@@ -43,6 +47,8 @@ export {
   CHANGE_REVIEW_PERSISTENCE_ERROR,
   useChangeReviewDecisionPersistenceController,
 } from './hooks/useChangeReviewDecisionPersistenceController';
+export type { ChangeReviewDialogLifecycleController } from './hooks/useChangeReviewDialogLifecycleController';
+export { useChangeReviewDialogLifecycleController } from './hooks/useChangeReviewDialogLifecycleController';
 export type {
   ChangeReviewDraftHistoryController,
   ChangeReviewDraftHistoryDiagnostics,
@@ -82,6 +88,20 @@ export type {
   ChangeReviewConflictQueryPort,
   ChangeReviewConflictScope,
 } from './ports/changeReviewConflictPorts';
+export type {
+  ChangeReviewDialogLifecycleApplyOutcome,
+  ChangeReviewDialogLifecycleAutoClearResult,
+  ChangeReviewDialogLifecycleCommandPort,
+  ChangeReviewDialogLifecycleDecisionPersistencePort,
+  ChangeReviewDialogLifecycleDraftHistoryPort,
+  ChangeReviewDialogLifecycleEditorPort,
+  ChangeReviewDialogLifecyclePersistenceScope,
+  ChangeReviewDialogLifecycleSessionPort,
+  ChangeReviewDialogLifecycleStatePort,
+  ChangeReviewDialogLifecycleStateSnapshot,
+  ChangeReviewDialogLifecycleStatusPort,
+  ChangeReviewDialogLifecycleWriteEvidencePort,
+} from './ports/changeReviewDialogLifecyclePorts';
 export type {
   ChangeReviewDraftHistoryEntryInput,
   ChangeReviewDraftHistoryPort,
@@ -148,6 +168,20 @@ export {
   describeReviewConflictDiscard,
   selectLatestReviewConflictCandidate,
 } from './utils/changeReviewConflicts';
+export type {
+  ChangeReviewActionLockState,
+  ChangeReviewCloseReadiness,
+  ChangeReviewCloseReadinessInput,
+  ChangeReviewDecisionWriteDiagnostics,
+  ChangeReviewDraftWriteDiagnostics,
+} from './utils/changeReviewDialogLifecycle';
+export {
+  evaluateChangeReviewCloseReadiness,
+  getReviewCloseBlockReason,
+  hasUnscopedLocalReviewState,
+  isReviewActionLocked,
+  shouldRequestReviewCloseForEscape,
+} from './utils/changeReviewDialogLifecycle';
 export type { ReviewHistoryRecoveryDisposition } from './utils/changeReviewHistoryMutation';
 export {
   areReviewPersistedStatesEqual,

--- a/src/features/change-review/renderer/ports/changeReviewDialogLifecyclePorts.ts
+++ b/src/features/change-review/renderer/ports/changeReviewDialogLifecyclePorts.ts
@@ -1,0 +1,111 @@
+import type {
+  ChangeReviewActionLockState,
+  ChangeReviewDecisionWriteDiagnostics,
+  ChangeReviewDraftWriteDiagnostics,
+} from '../utils/changeReviewDialogLifecycle';
+import type { ReviewOperationScopeToken } from '../utils/reviewOperationGeneration';
+import type { ReviewDraftHistoryEntry } from '@features/change-review-history/contracts';
+import type { TaskChangeRequestOptions } from '@renderer/utils/taskChangeRequest';
+import type {
+  ApplyReviewResult,
+  FileChangeWithContent,
+  HunkDecision,
+  RetryReviewMutationRecoveryRequest,
+  RetryReviewMutationRecoveryResult,
+  ReviewMutationDiskPostimage,
+  ReviewRedoAction,
+  ReviewUndoAction,
+} from '@shared/types';
+
+export interface ChangeReviewDialogLifecyclePersistenceScope {
+  teamName: string;
+  scopeKey: string;
+  scopeToken: string;
+}
+
+export type ChangeReviewDialogLifecycleAutoClearResult = 'cleared' | 'failed' | 'stale' | 'pending';
+
+export type ChangeReviewDialogLifecycleApplyOutcome =
+  | { status: 'applied'; result: ApplyReviewResult }
+  | { status: 'failed'; result: ApplyReviewResult | null };
+
+export interface ChangeReviewDialogLifecycleDecisionPersistencePort {
+  scheduleAutoPersistence: (scope: ChangeReviewDialogLifecyclePersistenceScope) => void;
+  clearAfterDurableStateEmptied: (
+    scope: ChangeReviewDialogLifecyclePersistenceScope,
+    hydrationKey: string
+  ) => Promise<ChangeReviewDialogLifecycleAutoClearResult>;
+  flushForClose: () => Promise<boolean>;
+  getDiagnostics: () => ChangeReviewDecisionWriteDiagnostics;
+}
+
+export interface ChangeReviewDialogLifecycleDraftHistoryPort {
+  getEntry: (filePath: string) => ReviewDraftHistoryEntry | undefined;
+  flushWrites: () => Promise<boolean>;
+  retryHydration: () => void;
+  discardUnreadableScope: (operationScope: ReviewOperationScopeToken) => Promise<boolean>;
+  getDiagnostics: (hydrationKey?: string | null) => ChangeReviewDraftWriteDiagnostics;
+}
+
+export interface ChangeReviewDialogLifecycleStateSnapshot {
+  editedContents: Record<string, string>;
+  hunkDecisions: Record<string, HunkDecision>;
+  fileDecisions: Record<string, HunkDecision>;
+  reviewActionHistory: ReviewUndoAction[];
+  reviewRedoHistory: ReviewRedoAction[];
+  fileContents: Record<string, FileChangeWithContent>;
+  fileChunkCounts: Record<string, number>;
+  decisionHydrationScopeKey: string | null;
+  decisionHydrationStatus: 'idle' | 'loading' | 'loaded' | 'error';
+  applying: boolean;
+}
+
+export interface ChangeReviewDialogLifecycleStatePort {
+  getSnapshot: () => ChangeReviewDialogLifecycleStateSnapshot;
+  reportError: (message: string | null) => void;
+  completeSavedStateDiscard: (markDecisionHydrationLoaded: boolean) => void;
+}
+
+export interface ChangeReviewDialogLifecycleCommandPort {
+  resetAllReviewState: () => void;
+  clearChangeReviewCache: () => void;
+  fetchAgentChanges: (teamName: string, memberName: string) => void;
+  fetchTaskChanges: (teamName: string, taskId: string, options: TaskChangeRequestOptions) => void;
+  hydrateDecisions: (
+    scope: ChangeReviewDialogLifecyclePersistenceScope,
+    hydrationKey: string
+  ) => Promise<void>;
+  clearDecisions: (
+    scope: ChangeReviewDialogLifecyclePersistenceScope,
+    forceDiscard?: boolean
+  ) => Promise<boolean>;
+  applyReview: (
+    teamName: string,
+    taskId: string | undefined,
+    memberName: string | undefined
+  ) => Promise<ChangeReviewDialogLifecycleApplyOutcome>;
+  retryMutationRecovery: (
+    request: RetryReviewMutationRecoveryRequest
+  ) => Promise<RetryReviewMutationRecoveryResult>;
+}
+
+export interface ChangeReviewDialogLifecycleEditorPort {
+  captureDraftSnapshots: (shouldCapture: (filePath: string) => boolean) => void;
+}
+
+export interface ChangeReviewDialogLifecycleStatusPort {
+  getActionLockState: (applying: boolean) => ChangeReviewActionLockState;
+  beginClosing: () => void;
+  finishClosing: () => void;
+  setRecoveryInFlight: (value: boolean) => void;
+}
+
+export interface ChangeReviewDialogLifecycleSessionPort {
+  getPendingApplyCleanupKey: () => string | null;
+  setPendingApplyCleanupKey: (key: string | null) => void;
+  isExpectedHydrationKey: (hydrationKey: string) => boolean;
+}
+
+export interface ChangeReviewDialogLifecycleWriteEvidencePort {
+  markCommittedPostimages: (postimages: readonly ReviewMutationDiskPostimage[] | undefined) => void;
+}

--- a/src/features/change-review/renderer/ports/changeReviewDialogLifecyclePorts.ts
+++ b/src/features/change-review/renderer/ports/changeReviewDialogLifecyclePorts.ts
@@ -27,7 +27,7 @@ export type ChangeReviewDialogLifecycleAutoClearResult = 'cleared' | 'failed' | 
 
 export type ChangeReviewDialogLifecycleApplyOutcome =
   | { status: 'applied'; result: ApplyReviewResult }
-  | { status: 'failed'; result: ApplyReviewResult | null };
+  | { status: 'failed'; result: ApplyReviewResult | null; errorMessage: string };
 
 export interface ChangeReviewDialogLifecycleDecisionPersistencePort {
   scheduleAutoPersistence: (scope: ChangeReviewDialogLifecyclePersistenceScope) => void;

--- a/src/features/change-review/renderer/utils/changeReviewDialogLifecycle.ts
+++ b/src/features/change-review/renderer/utils/changeReviewDialogLifecycle.ts
@@ -1,0 +1,167 @@
+import type { ReviewActionPersistenceStatus } from './changeReviewActionHistory';
+
+export interface ChangeReviewActionLockState {
+  applying: boolean;
+  fileApplyCount: number;
+  undoing: boolean;
+  closing: boolean;
+}
+
+export interface ChangeReviewDraftWriteDiagnostics {
+  pendingWriteCount: number;
+  writeChainCount: number;
+  writeErrorCount: number;
+}
+
+export interface ChangeReviewDecisionWriteDiagnostics {
+  pendingDecisionClear: boolean;
+  persistenceStatus: ReviewActionPersistenceStatus;
+}
+
+export interface ChangeReviewCloseReadinessInput {
+  hydrationKey: string | null;
+  decisionHydrationScopeKey: string | null;
+  decisionHydrationStatus: 'idle' | 'loading' | 'loaded' | 'error';
+  draftHydrationKey: string | null;
+  draftHydrationStatus: 'idle' | 'loading' | 'loaded' | 'error';
+  editedContentCount: number;
+  hunkDecisionCount: number;
+  fileDecisionCount: number;
+  undoHistoryCount: number;
+  redoHistoryCount: number;
+  draftDiagnostics: ChangeReviewDraftWriteDiagnostics;
+  scopedDraftDiagnostics: ChangeReviewDraftWriteDiagnostics;
+  decisionDiagnostics: ChangeReviewDecisionWriteDiagnostics;
+  pendingApplyCleanupKey: string | null;
+  actionLockState: ChangeReviewActionLockState;
+}
+
+export type ChangeReviewCloseReadiness =
+  | { disposition: 'flush' }
+  | { disposition: 'close-without-flush' }
+  | { disposition: 'block'; blocker: string };
+
+export function shouldRequestReviewCloseForEscape(input: {
+  key: string;
+  defaultPrevented: boolean;
+  hasOpenModalLayer: boolean;
+}): boolean {
+  return input.key === 'Escape' && !input.defaultPrevented && !input.hasOpenModalLayer;
+}
+
+export function isReviewActionLocked(state: ChangeReviewActionLockState): boolean {
+  return state.applying || state.fileApplyCount > 0 || state.undoing || state.closing;
+}
+
+export function getReviewCloseBlockReason(input: {
+  busy: boolean;
+  draftCount: number;
+}): string | null {
+  if (input.busy) return 'Wait for the current review action to finish.';
+  if (input.draftCount > 0) return 'Save or discard manual edits before closing Changes.';
+  return null;
+}
+
+export function hasUnscopedLocalReviewState(input: {
+  editedContentCount: number;
+  hunkDecisionCount: number;
+  fileDecisionCount: number;
+  undoHistoryCount: number;
+  redoHistoryCount: number;
+  pendingDraftWriteCount: number;
+  draftWriteChainCount: number;
+  draftWriteErrorCount: number;
+  pendingApplyCleanup: boolean;
+  pendingDecisionClear: boolean;
+  persistenceStatus: ReviewActionPersistenceStatus;
+}): boolean {
+  return (
+    input.editedContentCount > 0 ||
+    input.hunkDecisionCount > 0 ||
+    input.fileDecisionCount > 0 ||
+    input.undoHistoryCount > 0 ||
+    input.redoHistoryCount > 0 ||
+    input.pendingDraftWriteCount > 0 ||
+    input.draftWriteChainCount > 0 ||
+    input.draftWriteErrorCount > 0 ||
+    input.pendingApplyCleanup ||
+    input.pendingDecisionClear ||
+    input.persistenceStatus !== 'saved'
+  );
+}
+
+function hasLocalReviewBranch(input: ChangeReviewCloseReadinessInput): boolean {
+  return (
+    input.editedContentCount > 0 ||
+    input.hunkDecisionCount > 0 ||
+    input.fileDecisionCount > 0 ||
+    input.undoHistoryCount > 0 ||
+    input.redoHistoryCount > 0 ||
+    input.scopedDraftDiagnostics.pendingWriteCount > 0 ||
+    input.scopedDraftDiagnostics.writeChainCount > 0 ||
+    input.scopedDraftDiagnostics.writeErrorCount > 0 ||
+    input.pendingApplyCleanupKey === input.hydrationKey ||
+    input.decisionDiagnostics.pendingDecisionClear ||
+    input.decisionDiagnostics.persistenceStatus !== 'saved'
+  );
+}
+
+export function evaluateChangeReviewCloseReadiness(
+  input: ChangeReviewCloseReadinessInput
+): ChangeReviewCloseReadiness {
+  const localStateRequiresScope = hasUnscopedLocalReviewState({
+    editedContentCount: input.editedContentCount,
+    hunkDecisionCount: input.hunkDecisionCount,
+    fileDecisionCount: input.fileDecisionCount,
+    undoHistoryCount: input.undoHistoryCount,
+    redoHistoryCount: input.redoHistoryCount,
+    pendingDraftWriteCount: input.draftDiagnostics.pendingWriteCount,
+    draftWriteChainCount: input.draftDiagnostics.writeChainCount,
+    draftWriteErrorCount: input.draftDiagnostics.writeErrorCount,
+    pendingApplyCleanup: input.pendingApplyCleanupKey !== null,
+    pendingDecisionClear: input.decisionDiagnostics.pendingDecisionClear,
+    persistenceStatus: input.decisionDiagnostics.persistenceStatus,
+  });
+  if (!input.hydrationKey && localStateRequiresScope) {
+    return {
+      disposition: 'block',
+      blocker:
+        'Manual edit history lost its saved review scope. Keep Changes open and retry recovery.',
+    };
+  }
+
+  if (input.hydrationKey) {
+    const matchesCurrentHydration = input.decisionHydrationScopeKey === input.hydrationKey;
+    const matchesDraftHydration = input.draftHydrationKey === input.hydrationKey;
+    if (
+      (matchesCurrentHydration && input.decisionHydrationStatus === 'error') ||
+      (matchesDraftHydration && input.draftHydrationStatus === 'error')
+    ) {
+      if (hasLocalReviewBranch(input)) {
+        return {
+          disposition: 'block',
+          blocker:
+            'Saved review state could not be reconciled with local changes. Retry recovery before closing Changes.',
+        };
+      }
+      return { disposition: 'close-without-flush' };
+    }
+    if (
+      !matchesCurrentHydration ||
+      input.decisionHydrationStatus !== 'loaded' ||
+      !matchesDraftHydration ||
+      input.draftHydrationStatus !== 'loaded'
+    ) {
+      return {
+        disposition: 'block',
+        blocker: 'Wait for saved review state to finish loading before closing Changes.',
+      };
+    }
+  }
+
+  const blockReason = getReviewCloseBlockReason({
+    busy: isReviewActionLocked(input.actionLockState),
+    draftCount: 0,
+  });
+  return blockReason ? { disposition: 'block', blocker: blockReason } : { disposition: 'flush' };
+}

--- a/src/features/change-review/renderer/utils/changeReviewDialogLifecycle.ts
+++ b/src/features/change-review/renderer/utils/changeReviewDialogLifecycle.ts
@@ -62,6 +62,33 @@ export function getReviewCloseBlockReason(input: {
   return null;
 }
 
+interface LocalReviewStateInput {
+  editedContentCount: number;
+  hunkDecisionCount: number;
+  fileDecisionCount: number;
+  undoHistoryCount: number;
+  redoHistoryCount: number;
+  draftDiagnostics: ChangeReviewDraftWriteDiagnostics;
+  pendingApplyCleanup: boolean;
+  decisionDiagnostics: ChangeReviewDecisionWriteDiagnostics;
+}
+
+function hasLocalReviewState(input: LocalReviewStateInput): boolean {
+  return (
+    input.editedContentCount > 0 ||
+    input.hunkDecisionCount > 0 ||
+    input.fileDecisionCount > 0 ||
+    input.undoHistoryCount > 0 ||
+    input.redoHistoryCount > 0 ||
+    input.draftDiagnostics.pendingWriteCount > 0 ||
+    input.draftDiagnostics.writeChainCount > 0 ||
+    input.draftDiagnostics.writeErrorCount > 0 ||
+    input.pendingApplyCleanup ||
+    input.decisionDiagnostics.pendingDecisionClear ||
+    input.decisionDiagnostics.persistenceStatus !== 'saved'
+  );
+}
+
 export function hasUnscopedLocalReviewState(input: {
   editedContentCount: number;
   hunkDecisionCount: number;
@@ -75,35 +102,36 @@ export function hasUnscopedLocalReviewState(input: {
   pendingDecisionClear: boolean;
   persistenceStatus: ReviewActionPersistenceStatus;
 }): boolean {
-  return (
-    input.editedContentCount > 0 ||
-    input.hunkDecisionCount > 0 ||
-    input.fileDecisionCount > 0 ||
-    input.undoHistoryCount > 0 ||
-    input.redoHistoryCount > 0 ||
-    input.pendingDraftWriteCount > 0 ||
-    input.draftWriteChainCount > 0 ||
-    input.draftWriteErrorCount > 0 ||
-    input.pendingApplyCleanup ||
-    input.pendingDecisionClear ||
-    input.persistenceStatus !== 'saved'
-  );
+  return hasLocalReviewState({
+    editedContentCount: input.editedContentCount,
+    hunkDecisionCount: input.hunkDecisionCount,
+    fileDecisionCount: input.fileDecisionCount,
+    undoHistoryCount: input.undoHistoryCount,
+    redoHistoryCount: input.redoHistoryCount,
+    draftDiagnostics: {
+      pendingWriteCount: input.pendingDraftWriteCount,
+      writeChainCount: input.draftWriteChainCount,
+      writeErrorCount: input.draftWriteErrorCount,
+    },
+    pendingApplyCleanup: input.pendingApplyCleanup,
+    decisionDiagnostics: {
+      pendingDecisionClear: input.pendingDecisionClear,
+      persistenceStatus: input.persistenceStatus,
+    },
+  });
 }
 
 function hasLocalReviewBranch(input: ChangeReviewCloseReadinessInput): boolean {
-  return (
-    input.editedContentCount > 0 ||
-    input.hunkDecisionCount > 0 ||
-    input.fileDecisionCount > 0 ||
-    input.undoHistoryCount > 0 ||
-    input.redoHistoryCount > 0 ||
-    input.scopedDraftDiagnostics.pendingWriteCount > 0 ||
-    input.scopedDraftDiagnostics.writeChainCount > 0 ||
-    input.scopedDraftDiagnostics.writeErrorCount > 0 ||
-    input.pendingApplyCleanupKey === input.hydrationKey ||
-    input.decisionDiagnostics.pendingDecisionClear ||
-    input.decisionDiagnostics.persistenceStatus !== 'saved'
-  );
+  return hasLocalReviewState({
+    editedContentCount: input.editedContentCount,
+    hunkDecisionCount: input.hunkDecisionCount,
+    fileDecisionCount: input.fileDecisionCount,
+    undoHistoryCount: input.undoHistoryCount,
+    redoHistoryCount: input.redoHistoryCount,
+    draftDiagnostics: input.scopedDraftDiagnostics,
+    pendingApplyCleanup: input.pendingApplyCleanupKey === input.hydrationKey,
+    decisionDiagnostics: input.decisionDiagnostics,
+  });
 }
 
 export function evaluateChangeReviewCloseReadiness(

--- a/src/renderer/components/team/review/ChangeReviewDialog.tsx
+++ b/src/renderer/components/team/review/ChangeReviewDialog.tsx
@@ -26,6 +26,8 @@ import {
   createChangeReviewConflictQueryPort,
   createChangeReviewConflictStateBridge,
   createChangeReviewDecisionPersistencePort,
+  createChangeReviewDialogLifecycleCommandPort,
+  createChangeReviewDialogLifecycleStatePort,
   createChangeReviewDraftHistoryPort,
   createChangeReviewFileDecisionCommandPort,
   createChangeReviewFileDecisionStatePort,
@@ -44,14 +46,13 @@ import {
   useChangeReviewBulkDecisionController,
   useChangeReviewConflictDiscoveryController,
   useChangeReviewConflictInteractionController,
-  useChangeReviewDecisionAutoPersistence,
   useChangeReviewDecisionPersistenceController,
+  useChangeReviewDialogLifecycleController,
   useChangeReviewDraftHistoryController,
   useChangeReviewFileDecisionController,
   useChangeReviewFileDraftController,
   useChangeReviewHistoryKeyboardShortcuts,
   useChangeReviewHistoryMutationController,
-  useChangeReviewLifecycleRegistration,
   useChangeReviewOperationGeneration,
   useChangeReviewScopeIdentity,
 } from '@features/change-review/renderer';
@@ -95,11 +96,9 @@ import { KeyboardShortcutsHelp } from './KeyboardShortcutsHelp';
 import { buildPathChangeLabels } from './pathChangeLabels';
 import { getReviewActionFilePath } from './reviewActionPresentation';
 import {
-  getReviewCloseBlockReason,
   getReviewRenameRecoveryExpectation,
   hasReviewFileRejections,
   hasUnresolvedReviewExternalChange,
-  hasUnscopedLocalReviewState,
   isReviewActionLocked,
   isReviewFileFullyRejected,
   replaceReviewScopedRecord,
@@ -107,7 +106,6 @@ import {
   restoreReviewDecisionRecordsForFile,
   shouldCreateFileWhenUndoingReject,
   shouldDeleteFileWhenUndoingReject,
-  shouldRequestReviewCloseForEscape,
 } from './reviewActionState';
 import {
   getResolvedReviewModifiedContent,
@@ -130,6 +128,10 @@ import type {
   ChangeReviewBulkDecisionEditorPort,
   ChangeReviewBulkDecisionStatusPort,
   ChangeReviewBulkDecisionWriteEvidencePort,
+  ChangeReviewDialogLifecycleEditorPort,
+  ChangeReviewDialogLifecycleSessionPort,
+  ChangeReviewDialogLifecycleStatusPort,
+  ChangeReviewDialogLifecycleWriteEvidencePort,
   ChangeReviewFileDecisionEditorPort,
   ChangeReviewFileDecisionPolicy,
   ChangeReviewFileDecisionStatusPort,
@@ -154,11 +156,6 @@ type RecentHunkUndoAction = Extract<ReviewUndoAction, { kind: 'hunk' }>['action'
 interface RecentReviewWrite {
   at: number;
   expectedContent: string | null;
-}
-
-interface ReviewCloseFlushResult {
-  ok: boolean;
-  blocker?: string;
 }
 
 const changeReviewConflictQueryPort = createChangeReviewConflictQueryPort(() => api.review);
@@ -226,6 +223,15 @@ const changeReviewFileDecisionPolicy: ChangeReviewFileDecisionPolicy = {
   hasUnresolvedExternalChange: hasUnresolvedReviewExternalChange,
   getRenameRecoveryExpectation: getReviewRenameRecoveryExpectation,
 };
+const changeReviewDialogLifecycleStatePort = createChangeReviewDialogLifecycleStatePort({
+  getStore: useStore.getState,
+  reportError: (applyError) => useStore.setState({ applyError }),
+  completeSavedStateDiscard: (markDecisionHydrationLoaded) =>
+    useStore.setState({
+      ...(markDecisionHydrationLoaded ? { decisionHydrationStatus: 'loaded' as const } : {}),
+      applyError: null,
+    }),
+});
 const changeReviewHistoryMutationCommandPort = createChangeReviewHistoryMutationCommandPort(
   () => api.review
 );
@@ -306,9 +312,6 @@ export const ChangeReviewDialog = ({
     activeChangeSet,
     changeSetLoading,
     changeSetError,
-    fetchAgentChanges,
-    fetchTaskChanges,
-    clearChangeReviewCache,
     hunkDecisions,
     fileDecisions,
     reviewActionHistory,
@@ -322,13 +325,10 @@ export const ChangeReviewDialog = ({
     clearHunkDecisionByOriginalIndex,
     setCollapseUnchanged,
     fetchFileContent,
-    applyReview,
     applySingleFileDecision,
     addReviewFile,
     editedContents,
     reviewExternalChangesByFile,
-    clearDecisionsFromDisk,
-    resetAllReviewState,
     fileChunkCounts,
     hunkContextHashesByFile,
     changeSetEpoch,
@@ -511,10 +511,6 @@ export const ChangeReviewDialog = ({
     publishSaved: publishReviewActionPersistenceSaved,
     hydrate: hydrateReviewDecisions,
     persistLatest: persistLatestAcceptedReviewAction,
-    scheduleAutoPersistence: scheduleReviewDecisionAutoPersistence,
-    clearAfterDurableStateEmptied: clearReviewDecisionsAfterStateEmptied,
-    flushForClose: flushReviewDecisionsForClose,
-    getDiagnostics: getReviewDecisionPersistenceDiagnostics,
   } = decisionPersistence;
   const hydrateConflictDecisions = useCallback(
     async (scope: NonNullable<typeof conflictScope>, hydrationKey: string): Promise<void> => {
@@ -609,9 +605,6 @@ export const ChangeReviewDialog = ({
     flushWrites: flushDraftHistoryWrites,
     clearFile: clearDraftHistoryForFile,
     resolveConflictCandidate: resolveDraftHistoryConflictCandidate,
-    retryHydration: retryDraftHistoryHydration,
-    discardUnreadableScope: discardUnreadableDraftHistoryScope,
-    getDiagnostics: getDraftHistoryDiagnostics,
   } = draftHistory;
 
   const {
@@ -1667,6 +1660,108 @@ export const ChangeReviewDialog = ({
     getPersistenceStatus: getReviewActionPersistenceStatus,
   });
 
+  const dialogLifecycleCommandPort = useMemo(
+    () =>
+      createChangeReviewDialogLifecycleCommandPort({
+        getStore: useStore.getState,
+        getReviewApi: () => api.review,
+        hydrateDecisions: hydrateReviewDecisions,
+      }),
+    [hydrateReviewDecisions]
+  );
+  const dialogLifecycleViewPorts = useMemo<{
+    editor: ChangeReviewDialogLifecycleEditorPort;
+    session: ChangeReviewDialogLifecycleSessionPort;
+    status: ChangeReviewDialogLifecycleStatusPort;
+    writeEvidence: ChangeReviewDialogLifecycleWriteEvidencePort;
+  }>(
+    () => ({
+      editor: {
+        captureDraftSnapshots: (shouldCapture) => {
+          for (const [filePath, view] of editorViewMapRef.current.entries()) {
+            if (shouldCapture(filePath)) {
+              handleSerializedStateChanged(filePath, serializeReviewDraftEditorState(view.state));
+            }
+          }
+        },
+      },
+      session: {
+        getPendingApplyCleanupKey: () => pendingApplyCleanupKeyRef.current,
+        setPendingApplyCleanupKey: (key) => {
+          pendingApplyCleanupKeyRef.current = key;
+        },
+        isExpectedHydrationKey: (hydrationKey) =>
+          expectedDraftHistoryKeyRef.current === hydrationKey,
+      },
+      status: {
+        getActionLockState: (applyingState) => ({
+          applying: applyingState,
+          fileApplyCount: fileApplyInFlightRef.current.size,
+          undoing: undoInFlightRef.current,
+          closing: closingRef.current,
+        }),
+        beginClosing: () => {
+          closingRef.current = true;
+          setClosing(true);
+        },
+        finishClosing: () => {
+          closingRef.current = false;
+          setClosing(false);
+        },
+        setRecoveryInFlight: setUndoInFlight,
+      },
+      writeEvidence: {
+        markCommittedPostimages: markCommittedReviewPostimages,
+      },
+    }),
+    [handleSerializedStateChanged, markCommittedReviewPostimages, setUndoInFlight]
+  );
+  const {
+    requestClose,
+    retrySavedReviewState: handleRetrySavedReviewState,
+    discardSavedDecisionState: handleDiscardSavedDecisionState,
+    apply: handleApply,
+  } = useChangeReviewDialogLifecycleController({
+    open,
+    authorized: lifecycleAuthorized,
+    setAuthorized: setLifecycleAuthorized,
+    hostId: resolvedLifecycleHostId,
+    sessionId: reviewLifecycleSessionId,
+    tabId: lifecycleTabId,
+    focus: onLifecycleFocus,
+    teamName,
+    mode,
+    memberName,
+    taskId,
+    taskChangeRequestOptions,
+    scopeKey,
+    decisionScopeKey,
+    decisionScopeToken,
+    decisionHydrationKey,
+    decisionHydrationReady,
+    decisionHydrationFailed,
+    draftHistoryHydration,
+    draftHistoryHydrationFailed,
+    reviewScope,
+    reviewMutationBusy,
+    reviewActionsBusy,
+    onOpenChange,
+    statePort: changeReviewDialogLifecycleStatePort,
+    commandPort: dialogLifecycleCommandPort,
+    editorPort: dialogLifecycleViewPorts.editor,
+    statusPort: dialogLifecycleViewPorts.status,
+    sessionPort: dialogLifecycleViewPorts.session,
+    writeEvidencePort: dialogLifecycleViewPorts.writeEvidence,
+    decisionPersistence,
+    draftHistory,
+    hasActionInFlight: hasReviewActionInFlight,
+    blockForExternalChange: blockReviewMutationForExternalChange,
+    captureOperationScope: captureReviewOperationScope,
+    isCurrentOperationScope: isCurrentReviewOperationScope,
+    registerOwner: registerChangeReviewLifecycleOwner,
+    registerAppCloseParticipant,
+  });
+
   // Selection change handler (debounced for non-empty, immediate for clear)
   const handleSelectionChange = useCallback((info: EditorSelectionInfo | null) => {
     if (!info) {
@@ -1733,313 +1828,6 @@ export const ChangeReviewDialog = ({
     setContainerRect(el.getBoundingClientRect());
     return () => observer.disconnect();
   }, [hasData]);
-
-  const flushReviewStateForClose = useCallback(async (): Promise<ReviewCloseFlushResult> => {
-    const operationScope = captureReviewOperationScope();
-    if (!operationScope) {
-      return { ok: false, blocker: 'Review scope changed before Changes could close.' };
-    }
-    const scopeChangedResult: ReviewCloseFlushResult = {
-      ok: false,
-      blocker: 'Review scope changed while Changes was closing.',
-    };
-    const state = useStore.getState();
-    const draftHistoryDiagnostics = getDraftHistoryDiagnostics();
-    const decisionPersistenceDiagnostics = getReviewDecisionPersistenceDiagnostics();
-    const localStateRequiresScope = hasUnscopedLocalReviewState({
-      editedContentCount: Object.keys(state.editedContents).length,
-      hunkDecisionCount: Object.keys(state.hunkDecisions).length,
-      fileDecisionCount: Object.keys(state.fileDecisions).length,
-      undoHistoryCount: state.reviewActionHistory.length,
-      redoHistoryCount: state.reviewRedoHistory.length,
-      pendingDraftWriteCount: draftHistoryDiagnostics.pendingWriteCount,
-      draftWriteChainCount: draftHistoryDiagnostics.writeChainCount,
-      draftWriteErrorCount: draftHistoryDiagnostics.writeErrorCount,
-      pendingApplyCleanup: pendingApplyCleanupKeyRef.current !== null,
-      pendingDecisionClear: decisionPersistenceDiagnostics.pendingDecisionClear,
-      persistenceStatus: decisionPersistenceDiagnostics.persistenceStatus,
-    });
-    if (!decisionHydrationKey && localStateRequiresScope) {
-      const blocker =
-        'Manual edit history lost its saved review scope. Keep Changes open and retry recovery.';
-      useStore.setState({ applyError: blocker });
-      return { ok: false, blocker };
-    }
-    if (decisionHydrationKey) {
-      const matchesCurrentHydration = state.decisionHydrationScopeKey === decisionHydrationKey;
-      const matchesDraftHydration = draftHistoryHydration.key === decisionHydrationKey;
-      if (
-        (matchesCurrentHydration && state.decisionHydrationStatus === 'error') ||
-        (matchesDraftHydration && draftHistoryHydration.status === 'error')
-      ) {
-        const scopedDraftHistoryDiagnostics = getDraftHistoryDiagnostics(decisionHydrationKey);
-        const hasLocalState =
-          Object.keys(state.editedContents).length > 0 ||
-          Object.keys(state.hunkDecisions).length > 0 ||
-          Object.keys(state.fileDecisions).length > 0 ||
-          state.reviewActionHistory.length > 0 ||
-          state.reviewRedoHistory.length > 0 ||
-          scopedDraftHistoryDiagnostics.pendingWriteCount > 0 ||
-          scopedDraftHistoryDiagnostics.writeChainCount > 0 ||
-          scopedDraftHistoryDiagnostics.writeErrorCount > 0 ||
-          pendingApplyCleanupKeyRef.current === decisionHydrationKey ||
-          decisionPersistenceDiagnostics.pendingDecisionClear ||
-          decisionPersistenceDiagnostics.persistenceStatus !== 'saved';
-        if (hasLocalState) {
-          const blocker =
-            'Saved review state could not be reconciled with local changes. Retry recovery before closing Changes.';
-          useStore.setState({ applyError: blocker });
-          return { ok: false, blocker };
-        }
-        // With no local branch to lose, preserve the last readable disk copy and close.
-        return { ok: true };
-      }
-      if (
-        !matchesCurrentHydration ||
-        state.decisionHydrationStatus !== 'loaded' ||
-        !matchesDraftHydration ||
-        draftHistoryHydration.status !== 'loaded'
-      ) {
-        const blocker = 'Wait for saved review state to finish loading before closing Changes.';
-        useStore.setState({ applyError: blocker });
-        return { ok: false, blocker };
-      }
-    }
-    const blockReason = getReviewCloseBlockReason({
-      busy: isReviewActionLocked({
-        applying: state.applying,
-        fileApplyCount: fileApplyInFlightRef.current.size,
-        undoing: undoInFlightRef.current,
-        closing: closingRef.current,
-      }),
-      draftCount: 0,
-    });
-    if (blockReason) {
-      useStore.setState({ applyError: blockReason });
-      return { ok: false, blocker: blockReason };
-    }
-
-    closingRef.current = true;
-    setClosing(true);
-    try {
-      for (const [filePath, view] of editorViewMapRef.current.entries()) {
-        if (filePath in state.editedContents || getDraftHistoryEntry(filePath)) {
-          handleSerializedStateChanged(filePath, serializeReviewDraftEditorState(view.state));
-        }
-      }
-      const currentState = useStore.getState();
-      for (const filePath of Object.keys(currentState.editedContents)) {
-        if (!getDraftHistoryEntry(filePath)) {
-          const blocker = `Manual edits for ${filePath} are not durable yet. Keep Changes open and retry.`;
-          useStore.setState({ applyError: blocker });
-          return { ok: false, blocker };
-        }
-      }
-      const draftsFlushed = await flushDraftHistoryWrites();
-      if (!isCurrentReviewOperationScope(operationScope)) return scopeChangedResult;
-      if (!draftsFlushed) {
-        const blocker = 'Unable to save manual edit history. Changes remains open.';
-        useStore.setState({ applyError: blocker });
-        return { ok: false, blocker };
-      }
-      if (decisionScopeToken && pendingApplyCleanupKeyRef.current === decisionHydrationKey) {
-        const cleared = await clearDecisionsFromDisk(
-          teamName,
-          decisionScopeKey,
-          decisionScopeToken
-        );
-        if (!isCurrentReviewOperationScope(operationScope)) return scopeChangedResult;
-        if (!cleared) {
-          const blocker =
-            'Review was applied, but its saved state could not be cleared. Changes remains open.';
-          useStore.setState({ applyError: blocker });
-          return { ok: false, blocker };
-        }
-        pendingApplyCleanupKeyRef.current = null;
-        return { ok: true };
-      }
-      if (decisionScopeToken) {
-        const flushed = await flushReviewDecisionsForClose();
-        if (!isCurrentReviewOperationScope(operationScope)) return scopeChangedResult;
-        if (!flushed) {
-          const blocker = 'Unable to save review decisions. Changes remains open.';
-          useStore.setState({ applyError: blocker });
-          return { ok: false, blocker };
-        }
-      }
-      return { ok: true };
-    } finally {
-      if (isCurrentReviewOperationScope(operationScope)) {
-        closingRef.current = false;
-        setClosing(false);
-      }
-    }
-  }, [
-    captureReviewOperationScope,
-    clearDecisionsFromDisk,
-    decisionScopeKey,
-    decisionHydrationKey,
-    decisionScopeToken,
-    draftHistoryHydration.key,
-    draftHistoryHydration.status,
-    flushDraftHistoryWrites,
-    flushReviewDecisionsForClose,
-    getDraftHistoryDiagnostics,
-    getDraftHistoryEntry,
-    getReviewDecisionPersistenceDiagnostics,
-    handleSerializedStateChanged,
-    isCurrentReviewOperationScope,
-    teamName,
-  ]);
-
-  const requestLifecycleClose = useCallback(async (): Promise<boolean> => {
-    const operationScope = captureReviewOperationScope();
-    if (!operationScope) return false;
-    const result = await flushReviewStateForClose();
-    if (!isCurrentReviewOperationScope(operationScope)) return false;
-    if (result.ok) onOpenChange(false);
-    return result.ok;
-  }, [
-    captureReviewOperationScope,
-    flushReviewStateForClose,
-    isCurrentReviewOperationScope,
-    onOpenChange,
-  ]);
-
-  const requestClose = useCallback(async (): Promise<void> => {
-    await requestLifecycleClose();
-  }, [requestLifecycleClose]);
-
-  const closeRejectedDialog = useCallback((): void => onOpenChange(false), [onOpenChange]);
-  useChangeReviewLifecycleRegistration({
-    open,
-    authorized: lifecycleAuthorized,
-    hostId: resolvedLifecycleHostId,
-    sessionId: reviewLifecycleSessionId,
-    tabId: lifecycleTabId,
-    focus: onLifecycleFocus,
-    requestClose: requestLifecycleClose,
-    closeRejectedDialog,
-    setAuthorized: setLifecycleAuthorized,
-    appCloseParticipantId: `changes:${teamName}:${decisionHydrationKey ?? scopeKey}`,
-    flushForAppClose: flushReviewStateForClose,
-    registerOwner: registerChangeReviewLifecycleOwner,
-    registerAppCloseParticipant,
-  });
-
-  const handleRetrySavedReviewState = useCallback(async (): Promise<void> => {
-    if (!decisionScopeToken || !decisionHydrationKey || reviewMutationBusy) return;
-    const operationScope = captureReviewOperationScope();
-    if (!operationScope) return;
-    setUndoInFlight(true);
-    try {
-      if (decisionHydrationFailed) {
-        const recovered = await api.review.retryMutationRecovery({
-          scope: reviewScope,
-          decisionPersistenceScope: {
-            scopeKey: decisionScopeKey,
-            scopeToken: decisionScopeToken,
-          },
-        });
-        if (!isCurrentReviewOperationScope(operationScope)) return;
-        markCommittedReviewPostimages(recovered.diskPostimages);
-        await hydrateReviewDecisions(
-          { teamName, scopeKey: decisionScopeKey, scopeToken: decisionScopeToken },
-          decisionHydrationKey
-        );
-        if (!isCurrentReviewOperationScope(operationScope)) return;
-      }
-      if (draftHistoryHydrationFailed) {
-        retryDraftHistoryHydration();
-      }
-    } catch (error) {
-      if (!isCurrentReviewOperationScope(operationScope)) return;
-      useStore.setState({
-        applyError: `Unable to resume the saved review update: ${String(error)}`,
-      });
-    } finally {
-      if (isCurrentReviewOperationScope(operationScope)) setUndoInFlight(false);
-    }
-  }, [
-    captureReviewOperationScope,
-    decisionHydrationFailed,
-    decisionScopeKey,
-    decisionScopeToken,
-    draftHistoryHydrationFailed,
-    retryDraftHistoryHydration,
-    decisionHydrationKey,
-    hydrateReviewDecisions,
-    isCurrentReviewOperationScope,
-    markCommittedReviewPostimages,
-    reviewMutationBusy,
-    reviewScope,
-    setUndoInFlight,
-    teamName,
-  ]);
-
-  const handleDiscardSavedDecisionState = useCallback(async (): Promise<void> => {
-    if (!decisionScopeToken || !decisionHydrationKey || reviewMutationBusy) {
-      throw new Error('Saved review state is not ready to be discarded.');
-    }
-    const operationScope = captureReviewOperationScope();
-    if (!operationScope) throw new Error('Saved review scope is no longer active.');
-    closingRef.current = true;
-    setClosing(true);
-    try {
-      if (decisionHydrationFailed) {
-        const cleared = await clearDecisionsFromDisk(
-          teamName,
-          decisionScopeKey,
-          decisionScopeToken,
-          true
-        );
-        if (!isCurrentReviewOperationScope(operationScope)) return;
-        if (!cleared) {
-          const message = 'Unable to discard the unreadable saved review decisions.';
-          useStore.setState({ applyError: message });
-          throw new Error(message);
-        }
-      }
-      if (draftHistoryHydrationFailed) {
-        try {
-          const discarded = await discardUnreadableDraftHistoryScope(operationScope);
-          if (!discarded) return;
-        } catch (error) {
-          if (!isCurrentReviewOperationScope(operationScope)) return;
-          const message = `Unable to discard the unreadable manual edit history: ${String(error)}`;
-          useStore.setState({ applyError: message });
-          throw new Error(message, { cause: error });
-        }
-      }
-      const state = useStore.getState();
-      if (decisionHydrationFailed && state.decisionHydrationScopeKey !== decisionHydrationKey) {
-        throw new Error('Saved review scope changed before it could be discarded.');
-      }
-      // Keep any in-memory choice that raced an earlier load. Only the explicitly
-      // discarded disk copy is reset; the current review can now become authoritative.
-      useStore.setState({
-        ...(decisionHydrationFailed ? { decisionHydrationStatus: 'loaded' as const } : {}),
-        applyError: null,
-      });
-    } finally {
-      if (isCurrentReviewOperationScope(operationScope)) {
-        closingRef.current = false;
-        setClosing(false);
-      }
-    }
-  }, [
-    captureReviewOperationScope,
-    clearDecisionsFromDisk,
-    decisionHydrationFailed,
-    decisionHydrationKey,
-    decisionScopeKey,
-    decisionScopeToken,
-    discardUnreadableDraftHistoryScope,
-    draftHistoryHydrationFailed,
-    isCurrentReviewOperationScope,
-    reviewMutationBusy,
-    teamName,
-  ]);
 
   // Save active file (for Cmd+S keyboard shortcut)
   const handleSaveActiveFile = useCallback(() => {
@@ -2119,77 +1907,6 @@ export const ChangeReviewDialog = ({
     });
   }, [activeChangeSet]);
 
-  // Load data on open
-  useEffect(() => {
-    if (!open || !lifecycleAuthorized) return;
-
-    resetAllReviewState();
-
-    // Fetch changeSet
-    if (mode === 'agent' && memberName) {
-      void fetchAgentChanges(teamName, memberName);
-    } else if (mode === 'task' && taskId) {
-      void fetchTaskChanges(teamName, taskId, taskChangeRequestOptions ?? {});
-    }
-
-    // On close - clear only volatile cache, keep decisions in store
-    return () => clearChangeReviewCache();
-  }, [
-    open,
-    lifecycleAuthorized,
-    mode,
-    teamName,
-    memberName,
-    taskId,
-    taskChangeRequestOptions,
-    decisionScopeKey,
-    fetchAgentChanges,
-    fetchTaskChanges,
-    clearChangeReviewCache,
-    resetAllReviewState,
-  ]);
-
-  useEffect(() => {
-    if (!open || !lifecycleAuthorized || !decisionScopeToken || !decisionHydrationKey) return;
-    void hydrateReviewDecisions(
-      { teamName, scopeKey: decisionScopeKey, scopeToken: decisionScopeToken },
-      decisionHydrationKey
-    );
-  }, [
-    decisionHydrationKey,
-    decisionScopeKey,
-    decisionScopeToken,
-    lifecycleAuthorized,
-    hydrateReviewDecisions,
-    open,
-    teamName,
-  ]);
-
-  // Persist decisions to disk on change (debounced via store action).
-  // When decisions go from non-empty to empty (e.g. undo to clean state),
-  // clear the persisted file so stale decisions don't reload on reopen.
-  const hasDurableReviewState =
-    Object.keys(hunkDecisions).length > 0 ||
-    Object.keys(fileDecisions).length > 0 ||
-    reviewActionHistory.length > 0 ||
-    reviewRedoHistory.length > 0;
-  useChangeReviewDecisionAutoPersistence({
-    active: open && lifecycleAuthorized,
-    hydrationKey: decisionHydrationKey,
-    scope: conflictScope,
-    hydrationReady: decisionHydrationReady,
-    blocked: reviewActionsBusy,
-    hasDurableReviewState,
-    hunkDecisions,
-    fileDecisions,
-    undoHistory: reviewActionHistory,
-    redoHistory: reviewRedoHistory,
-    fileContents,
-    fileChunkCounts,
-    scheduleAutoPersistence: scheduleReviewDecisionAutoPersistence,
-    clearAfterDurableStateEmptied: clearReviewDecisionsAfterStateEmptied,
-  });
-
   // Scroll to initialFilePath once data is loaded
   useEffect(() => {
     const scrollKey = buildInitialReviewFileScrollKey(activeChangeSet, initialFilePath);
@@ -2217,27 +1934,6 @@ export const ChangeReviewDialog = ({
       if (selectionTimerRef.current) clearTimeout(selectionTimerRef.current);
     }
   }, [open]);
-
-  // Escape to close
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: KeyboardEvent): void => {
-      if (
-        shouldRequestReviewCloseForEscape({
-          key: e.key,
-          defaultPrevented: e.defaultPrevented,
-          hasOpenModalLayer: Boolean(
-            document.querySelector('[role="alertdialog"][data-state="open"]')
-          ),
-        })
-      ) {
-        e.preventDefault();
-        void requestClose();
-      }
-    };
-    document.addEventListener('keydown', handler);
-    return () => document.removeEventListener('keydown', handler);
-  }, [open, requestClose]);
 
   // Review actions use one ordered stack. Manual draft edits keep CodeMirror's native history.
   const resolveReviewKeyboardEditorContext = useCallback(
@@ -2315,65 +2011,6 @@ export const ChangeReviewDialog = ({
   );
 
   const changeStats = useMemo(() => buildReviewChangeStats(activeChangeSet), [activeChangeSet]);
-
-  const handleApply = useCallback(async () => {
-    if (hasReviewActionInFlight() || blockReviewMutationForExternalChange()) return;
-    if (!decisionScopeToken || !decisionHydrationKey) {
-      useStore.setState({
-        applyError: 'Durable review scope is unavailable. Reload Changes before applying.',
-      });
-      return;
-    }
-    const operationScope = captureReviewOperationScope();
-    if (!operationScope) return;
-
-    if (pendingApplyCleanupKeyRef.current !== decisionHydrationKey) {
-      const result = await applyReview(teamName, taskId, memberName);
-      if (!isCurrentReviewOperationScope(operationScope)) return;
-      markCommittedReviewPostimages(result?.diskPostimages);
-      if (useStore.getState().applyError) return;
-      if (expectedDraftHistoryKeyRef.current !== decisionHydrationKey) return;
-      pendingApplyCleanupKeyRef.current = decisionHydrationKey;
-    }
-
-    closingRef.current = true;
-    setClosing(true);
-    try {
-      const cleared = await clearDecisionsFromDisk(teamName, decisionScopeKey, decisionScopeToken);
-      if (!isCurrentReviewOperationScope(operationScope)) return;
-      if (!cleared) {
-        useStore.setState({
-          applyError:
-            'Review was applied, but its saved state could not be cleared. Changes remains open; retry Apply to finish cleanup.',
-        });
-        return;
-      }
-      pendingApplyCleanupKeyRef.current = null;
-      if (expectedDraftHistoryKeyRef.current === decisionHydrationKey) {
-        resetAllReviewState();
-      }
-    } finally {
-      if (isCurrentReviewOperationScope(operationScope)) {
-        closingRef.current = false;
-        setClosing(false);
-      }
-    }
-  }, [
-    applyReview,
-    blockReviewMutationForExternalChange,
-    captureReviewOperationScope,
-    teamName,
-    taskId,
-    memberName,
-    markCommittedReviewPostimages,
-    clearDecisionsFromDisk,
-    decisionHydrationKey,
-    decisionScopeKey,
-    decisionScopeToken,
-    resetAllReviewState,
-    hasReviewActionInFlight,
-    isCurrentReviewOperationScope,
-  ]);
 
   const taskChangeSet = toTaskChangeSetV2(activeChangeSet);
   const hasReviewFiles = (activeChangeSet?.files.length ?? 0) > 0;

--- a/src/renderer/components/team/review/reviewActionState.ts
+++ b/src/renderer/components/team/review/reviewActionState.ts
@@ -12,7 +12,6 @@ import {
   isReviewFileExpectedDeleted,
 } from './reviewContentPreview';
 
-import type { ReviewActionPersistenceStatus } from '@features/change-review/renderer';
 import type {
   ConflictCheckResult,
   FileChangeSummary,
@@ -26,22 +25,18 @@ export type { ReviewConflictCandidateSelection } from '@features/change-review/r
 export type { ReviewActionPersistenceStatus } from '@features/change-review/renderer';
 export {
   createReviewOperationScopeToken,
+  getReviewCloseBlockReason,
   getReviewDecisionHydrationGuard,
+  hasUnscopedLocalReviewState,
+  isReviewActionLocked,
   isReviewOperationScopeCurrent,
   selectLatestReviewConflictCandidate,
+  shouldRequestReviewCloseForEscape,
 } from '@features/change-review/renderer';
 
 export interface ReviewDecisionRecords {
   hunkDecisions: Record<string, HunkDecision>;
   fileDecisions: Record<string, HunkDecision>;
-}
-
-export function shouldRequestReviewCloseForEscape(input: {
-  key: string;
-  defaultPrevented: boolean;
-  hasOpenModalLayer: boolean;
-}): boolean {
-  return input.key === 'Escape' && !input.defaultPrevented && !input.hasOpenModalLayer;
 }
 
 export function replaceReviewScopedRecord<T>(
@@ -68,15 +63,6 @@ export {
   restoreReviewDecisionRecordsForFiles,
 };
 
-export function isReviewActionLocked(state: {
-  applying: boolean;
-  fileApplyCount: number;
-  undoing: boolean;
-  closing: boolean;
-}): boolean {
-  return state.applying || state.fileApplyCount > 0 || state.undoing || state.closing;
-}
-
 /** True when a retried Undo finds that its guarded disk preimage was already restored. */
 export function isReviewDiskPreimageRestored(
   conflict: ConflictCheckResult,
@@ -85,43 +71,6 @@ export function isReviewDiskPreimageRestored(
   return expectedContent === null
     ? conflict.hasConflict && conflict.conflictContent === null
     : !conflict.hasConflict;
-}
-
-export function getReviewCloseBlockReason(input: {
-  busy: boolean;
-  draftCount: number;
-}): string | null {
-  if (input.busy) return 'Wait for the current review action to finish.';
-  if (input.draftCount > 0) return 'Save or discard manual edits before closing Changes.';
-  return null;
-}
-
-export function hasUnscopedLocalReviewState(input: {
-  editedContentCount: number;
-  hunkDecisionCount: number;
-  fileDecisionCount: number;
-  undoHistoryCount: number;
-  redoHistoryCount: number;
-  pendingDraftWriteCount: number;
-  draftWriteChainCount: number;
-  draftWriteErrorCount: number;
-  pendingApplyCleanup: boolean;
-  pendingDecisionClear: boolean;
-  persistenceStatus: ReviewActionPersistenceStatus;
-}): boolean {
-  return (
-    input.editedContentCount > 0 ||
-    input.hunkDecisionCount > 0 ||
-    input.fileDecisionCount > 0 ||
-    input.undoHistoryCount > 0 ||
-    input.redoHistoryCount > 0 ||
-    input.pendingDraftWriteCount > 0 ||
-    input.draftWriteChainCount > 0 ||
-    input.draftWriteErrorCount > 0 ||
-    input.pendingApplyCleanup ||
-    input.pendingDecisionClear ||
-    input.persistenceStatus !== 'saved'
-  );
 }
 
 /** A draft that survives an async Save must rebase onto the bytes that Save published. */

--- a/src/renderer/store/slices/changeReviewSlice.ts
+++ b/src/renderer/store/slices/changeReviewSlice.ts
@@ -1641,7 +1641,7 @@ export const createChangeReviewSlice: StateCreator<AppState, [], [], ChangeRevie
             });
           }
           set({ applying: false });
-          return null;
+          return { applied: 0, skipped: 0, conflicts: 0, errors: [] };
         }
 
         const decisionPersistenceScope = buildApplyDecisionPersistenceScope(

--- a/test/features/change-review/renderer/changeReviewDialogLifecycle.test.ts
+++ b/test/features/change-review/renderer/changeReviewDialogLifecycle.test.ts
@@ -1,0 +1,127 @@
+import { evaluateChangeReviewCloseReadiness } from '@features/change-review/renderer';
+import { describe, expect, it } from 'vitest';
+
+import type { ChangeReviewCloseReadinessInput } from '@features/change-review/renderer';
+
+function readyInput(
+  overrides: Partial<ChangeReviewCloseReadinessInput> = {}
+): ChangeReviewCloseReadinessInput {
+  return {
+    hydrationKey: 'hydration-a',
+    decisionHydrationScopeKey: 'hydration-a',
+    decisionHydrationStatus: 'loaded',
+    draftHydrationKey: 'hydration-a',
+    draftHydrationStatus: 'loaded',
+    editedContentCount: 0,
+    hunkDecisionCount: 0,
+    fileDecisionCount: 0,
+    undoHistoryCount: 0,
+    redoHistoryCount: 0,
+    draftDiagnostics: {
+      pendingWriteCount: 0,
+      writeChainCount: 0,
+      writeErrorCount: 0,
+    },
+    scopedDraftDiagnostics: {
+      pendingWriteCount: 0,
+      writeChainCount: 0,
+      writeErrorCount: 0,
+    },
+    decisionDiagnostics: {
+      pendingDecisionClear: false,
+      persistenceStatus: 'saved',
+    },
+    pendingApplyCleanupKey: null,
+    actionLockState: {
+      applying: false,
+      fileApplyCount: 0,
+      undoing: false,
+      closing: false,
+    },
+    ...overrides,
+  };
+}
+
+describe('changeReviewDialogLifecycle', () => {
+  it('flushes a fully hydrated idle scope', () => {
+    expect(evaluateChangeReviewCloseReadiness(readyInput())).toEqual({
+      disposition: 'flush',
+    });
+  });
+
+  it('blocks dirty local state that has lost its durable scope', () => {
+    expect(
+      evaluateChangeReviewCloseReadiness(
+        readyInput({
+          hydrationKey: null,
+          decisionHydrationScopeKey: null,
+          decisionHydrationStatus: 'idle',
+          draftHydrationKey: null,
+          draftHydrationStatus: 'idle',
+          editedContentCount: 1,
+        })
+      )
+    ).toEqual({
+      disposition: 'block',
+      blocker:
+        'Manual edit history lost its saved review scope. Keep Changes open and retry recovery.',
+    });
+  });
+
+  it('allows an unreadable remote scope to close only when no local branch exists', () => {
+    const unreadable = readyInput({
+      decisionHydrationStatus: 'error',
+    });
+
+    expect(evaluateChangeReviewCloseReadiness(unreadable)).toEqual({
+      disposition: 'close-without-flush',
+    });
+    expect(
+      evaluateChangeReviewCloseReadiness({
+        ...unreadable,
+        hunkDecisionCount: 1,
+      })
+    ).toEqual({
+      disposition: 'block',
+      blocker:
+        'Saved review state could not be reconciled with local changes. Retry recovery before closing Changes.',
+    });
+  });
+
+  it('blocks pending hydration before evaluating action locks', () => {
+    expect(
+      evaluateChangeReviewCloseReadiness(
+        readyInput({
+          draftHydrationStatus: 'loading',
+          actionLockState: {
+            applying: true,
+            fileApplyCount: 0,
+            undoing: false,
+            closing: false,
+          },
+        })
+      )
+    ).toEqual({
+      disposition: 'block',
+      blocker: 'Wait for saved review state to finish loading before closing Changes.',
+    });
+  });
+
+  it('blocks a hydrated scope while another review action is active', () => {
+    expect(
+      evaluateChangeReviewCloseReadiness(
+        readyInput({
+          actionLockState: {
+            applying: false,
+            fileApplyCount: 1,
+            undoing: false,
+            closing: false,
+          },
+        })
+      )
+    ).toEqual({
+      disposition: 'block',
+      blocker: 'Wait for the current review action to finish.',
+    });
+  });
+});

--- a/test/features/change-review/renderer/createChangeReviewDialogLifecyclePorts.test.ts
+++ b/test/features/change-review/renderer/createChangeReviewDialogLifecyclePorts.test.ts
@@ -1,0 +1,134 @@
+import {
+  createChangeReviewDialogLifecycleCommandPort,
+  createChangeReviewDialogLifecycleStatePort,
+} from '@features/change-review/renderer';
+import { describe, expect, it, vi } from 'vitest';
+
+function createStore() {
+  return {
+    editedContents: { '/repo/a.ts': 'manual' },
+    hunkDecisions: { '/repo/a.ts:0': 'accepted' as const },
+    fileDecisions: {},
+    reviewActionHistory: [],
+    reviewRedoHistory: [],
+    fileContents: {},
+    fileChunkCounts: { '/repo/a.ts': 1 },
+    decisionHydrationScopeKey: 'hydration-a',
+    decisionHydrationStatus: 'loaded' as const,
+    applying: false,
+    resetAllReviewState: vi.fn(),
+    clearChangeReviewCache: vi.fn(),
+    fetchAgentChanges: vi.fn().mockResolvedValue(undefined),
+    fetchTaskChanges: vi.fn().mockResolvedValue(undefined),
+    clearDecisionsFromDisk: vi.fn().mockResolvedValue(true),
+    applyReview: vi.fn().mockResolvedValue({
+      applied: 1,
+      skipped: 0,
+      conflicts: 0,
+      errors: [],
+    }),
+  };
+}
+
+describe('change-review dialog lifecycle ports', () => {
+  it('exposes only lifecycle state and delegates local state transitions', () => {
+    const store = createStore();
+    const reportError = vi.fn();
+    const completeSavedStateDiscard = vi.fn();
+    const port = createChangeReviewDialogLifecycleStatePort({
+      getStore: () => store,
+      reportError,
+      completeSavedStateDiscard,
+    });
+
+    expect(port.getSnapshot()).toEqual({
+      editedContents: { '/repo/a.ts': 'manual' },
+      hunkDecisions: { '/repo/a.ts:0': 'accepted' },
+      fileDecisions: {},
+      reviewActionHistory: [],
+      reviewRedoHistory: [],
+      fileContents: {},
+      fileChunkCounts: { '/repo/a.ts': 1 },
+      decisionHydrationScopeKey: 'hydration-a',
+      decisionHydrationStatus: 'loaded',
+      applying: false,
+    });
+
+    port.reportError('failed');
+    port.completeSavedStateDiscard(true);
+    expect(reportError).toHaveBeenCalledWith('failed');
+    expect(completeSavedStateDiscard).toHaveBeenCalledWith(true);
+  });
+
+  it('maps fetch, hydration, recovery, apply, and durable cleanup commands exactly', async () => {
+    const store = createStore();
+    const hydrateDecisions = vi.fn().mockResolvedValue(undefined);
+    const retryMutationRecovery = vi.fn().mockResolvedValue({
+      decisionRevision: 5,
+      diskPostimages: [],
+    });
+    const port = createChangeReviewDialogLifecycleCommandPort({
+      getStore: () => store,
+      getReviewApi: () => ({ retryMutationRecovery }),
+      hydrateDecisions,
+    });
+    const scope = {
+      teamName: 'team',
+      scopeKey: 'task-task',
+      scopeToken: 'token',
+    };
+    const recoveryRequest = {
+      scope: { teamName: 'team', taskId: 'task' },
+      decisionPersistenceScope: {
+        scopeKey: 'task-task',
+        scopeToken: 'token',
+      },
+    };
+
+    port.resetAllReviewState();
+    port.clearChangeReviewCache();
+    port.fetchAgentChanges('team', 'alice');
+    port.fetchTaskChanges('team', 'task', { owner: 'alice' });
+    await port.hydrateDecisions(scope, 'hydration-a');
+    await port.clearDecisions(scope, true);
+    await expect(port.applyReview('team', 'task', undefined)).resolves.toMatchObject({
+      status: 'applied',
+      result: { applied: 1 },
+    });
+    await port.retryMutationRecovery(recoveryRequest);
+
+    expect(store.resetAllReviewState).toHaveBeenCalledOnce();
+    expect(store.clearChangeReviewCache).toHaveBeenCalledOnce();
+    expect(store.fetchAgentChanges).toHaveBeenCalledWith('team', 'alice');
+    expect(store.fetchTaskChanges).toHaveBeenCalledWith('team', 'task', { owner: 'alice' });
+    expect(hydrateDecisions).toHaveBeenCalledWith(scope, 'hydration-a');
+    expect(store.clearDecisionsFromDisk).toHaveBeenCalledWith('team', 'task-task', 'token', true);
+    expect(store.applyReview).toHaveBeenCalledWith('team', 'task', undefined);
+    expect(retryMutationRecovery).toHaveBeenCalledWith(recoveryRequest);
+  });
+
+  it('returns an operation-owned failed Apply outcome for null and partial results', async () => {
+    const store = createStore();
+    const port = createChangeReviewDialogLifecycleCommandPort({
+      getStore: () => store,
+      getReviewApi: () => ({ retryMutationRecovery: vi.fn() }),
+      hydrateDecisions: vi.fn(),
+    });
+
+    store.applyReview.mockResolvedValueOnce(null).mockResolvedValueOnce({
+      applied: 0,
+      skipped: 1,
+      conflicts: 1,
+      errors: [{ filePath: '/repo/a.ts', error: 'changed' }],
+    });
+
+    await expect(port.applyReview('team', 'task', undefined)).resolves.toEqual({
+      status: 'failed',
+      result: null,
+    });
+    await expect(port.applyReview('team', 'task', undefined)).resolves.toMatchObject({
+      status: 'failed',
+      result: { conflicts: 1 },
+    });
+  });
+});

--- a/test/features/change-review/renderer/createChangeReviewDialogLifecyclePorts.test.ts
+++ b/test/features/change-review/renderer/createChangeReviewDialogLifecyclePorts.test.ts
@@ -16,6 +16,7 @@ function createStore() {
     decisionHydrationScopeKey: 'hydration-a',
     decisionHydrationStatus: 'loaded' as const,
     applying: false,
+    applyError: null as string | null,
     resetAllReviewState: vi.fn(),
     clearChangeReviewCache: vi.fn(),
     fetchAgentChanges: vi.fn().mockResolvedValue(undefined),
@@ -115,20 +116,43 @@ describe('change-review dialog lifecycle ports', () => {
       hydrateDecisions: vi.fn(),
     });
 
-    store.applyReview.mockResolvedValueOnce(null).mockResolvedValueOnce({
-      applied: 0,
-      skipped: 1,
-      conflicts: 1,
-      errors: [{ filePath: '/repo/a.ts', error: 'changed' }],
-    });
+    store.applyError = 'Review scope changed. Reload Changes before applying.';
+    store.applyReview
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        applied: 0,
+        skipped: 1,
+        conflicts: 1,
+        errors: [
+          { filePath: '/repo/a.ts', error: 'changed' },
+          { filePath: '/repo/b.ts', error: 'also changed' },
+        ],
+      })
+      .mockResolvedValueOnce(null);
 
     await expect(port.applyReview('team', 'task', undefined)).resolves.toEqual({
       status: 'failed',
       result: null,
+      errorMessage: 'Review scope changed. Reload Changes before applying.',
     });
-    await expect(port.applyReview('team', 'task', undefined)).resolves.toMatchObject({
+    await expect(port.applyReview('team', 'task', undefined)).resolves.toEqual({
       status: 'failed',
-      result: { conflicts: 1 },
+      result: {
+        applied: 0,
+        skipped: 1,
+        conflicts: 1,
+        errors: [
+          { filePath: '/repo/a.ts', error: 'changed' },
+          { filePath: '/repo/b.ts', error: 'also changed' },
+        ],
+      },
+      errorMessage: 'changed\nalso changed',
+    });
+    store.applyError = null;
+    await expect(port.applyReview('team', 'task', undefined)).resolves.toEqual({
+      status: 'failed',
+      result: null,
+      errorMessage: 'Unable to apply this review. Changes remains open; retry Apply.',
     });
   });
 });

--- a/test/features/change-review/renderer/useChangeReviewDialogLifecycleController.test.tsx
+++ b/test/features/change-review/renderer/useChangeReviewDialogLifecycleController.test.tsx
@@ -1,0 +1,602 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import {
+  createReviewOperationScopeToken,
+  useChangeReviewDialogLifecycleController,
+} from '@features/change-review/renderer';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  ChangeReviewDialogLifecycleCommandPort,
+  ChangeReviewDialogLifecycleController,
+  ChangeReviewDialogLifecycleDecisionPersistencePort,
+  ChangeReviewDialogLifecycleDraftHistoryPort,
+  ChangeReviewDialogLifecycleEditorPort,
+  ChangeReviewDialogLifecycleSessionPort,
+  ChangeReviewDialogLifecycleStatePort,
+  ChangeReviewDialogLifecycleStateSnapshot,
+  ChangeReviewDialogLifecycleStatusPort,
+  ChangeReviewDialogLifecycleWriteEvidencePort,
+  RegisterChangeReviewAppCloseParticipant,
+  RegisterChangeReviewLifecycleOwner,
+} from '@features/change-review/renderer';
+import type { ApplyReviewResult, RetryReviewMutationRecoveryResult } from '@shared/types';
+
+type ControllerInput = Parameters<typeof useChangeReviewDialogLifecycleController>[0];
+type RegisteredAppCloseParticipant = Parameters<RegisterChangeReviewAppCloseParticipant>[1];
+
+function successfulApply(input: Partial<ApplyReviewResult> = {}): ApplyReviewResult {
+  return { applied: 1, skipped: 0, conflicts: 0, errors: [], ...input };
+}
+
+function successfulRecovery(): RetryReviewMutationRecoveryResult {
+  return {
+    decisionRevision: 5,
+    recoveredMutation: true,
+    recoveredRestoreHistory: false,
+    differentMutationPending: false,
+    persistedState: null,
+    expectedRestoreCompleted: false,
+    diskPostimages: [{ filePath: '/repo/a.ts', content: 'after' }],
+    retried: true,
+  };
+}
+
+function createHarness() {
+  const events: string[] = [];
+  const mutable = {
+    current: true,
+    pendingApplyCleanupKey: null as string | null,
+    expectedHydrationKey: 'hydration-a',
+    appCloseParticipant: null as RegisteredAppCloseParticipant | null,
+  };
+  const operationScope = createReviewOperationScopeToken('hydration-a');
+  const snapshot: ChangeReviewDialogLifecycleStateSnapshot = {
+    editedContents: {},
+    hunkDecisions: {},
+    fileDecisions: {},
+    reviewActionHistory: [],
+    reviewRedoHistory: [],
+    fileContents: {},
+    fileChunkCounts: {},
+    decisionHydrationScopeKey: 'hydration-a',
+    decisionHydrationStatus: 'loaded',
+    applying: false,
+  };
+  const statePort: ChangeReviewDialogLifecycleStatePort = {
+    getSnapshot: vi.fn<ChangeReviewDialogLifecycleStatePort['getSnapshot']>(() => snapshot),
+    reportError: vi.fn<ChangeReviewDialogLifecycleStatePort['reportError']>((message) => {
+      events.push(`error:${message}`);
+    }),
+    completeSavedStateDiscard:
+      vi.fn<ChangeReviewDialogLifecycleStatePort['completeSavedStateDiscard']>(),
+  };
+  const commandPort: ChangeReviewDialogLifecycleCommandPort = {
+    resetAllReviewState: vi.fn<ChangeReviewDialogLifecycleCommandPort['resetAllReviewState']>(
+      () => {
+        events.push('reset');
+      }
+    ),
+    clearChangeReviewCache:
+      vi.fn<ChangeReviewDialogLifecycleCommandPort['clearChangeReviewCache']>(),
+    fetchAgentChanges: vi.fn<ChangeReviewDialogLifecycleCommandPort['fetchAgentChanges']>(),
+    fetchTaskChanges: vi.fn<ChangeReviewDialogLifecycleCommandPort['fetchTaskChanges']>(),
+    hydrateDecisions: vi.fn<ChangeReviewDialogLifecycleCommandPort['hydrateDecisions']>(() => {
+      events.push('hydrate');
+      return Promise.resolve();
+    }),
+    clearDecisions: vi.fn<ChangeReviewDialogLifecycleCommandPort['clearDecisions']>(() => {
+      events.push('clear-decisions');
+      return Promise.resolve(true);
+    }),
+    applyReview: vi.fn<ChangeReviewDialogLifecycleCommandPort['applyReview']>(() => {
+      events.push('apply-review');
+      return Promise.resolve({
+        status: 'applied',
+        result: successfulApply({
+          diskPostimages: [{ filePath: '/repo/a.ts', content: 'after' }],
+        }),
+      });
+    }),
+    retryMutationRecovery: vi.fn<ChangeReviewDialogLifecycleCommandPort['retryMutationRecovery']>(
+      () => {
+        events.push('retry-recovery');
+        return Promise.resolve(successfulRecovery());
+      }
+    ),
+  };
+  const editorPort: ChangeReviewDialogLifecycleEditorPort = {
+    captureDraftSnapshots: vi.fn<ChangeReviewDialogLifecycleEditorPort['captureDraftSnapshots']>(
+      () => {
+        events.push('capture-drafts');
+      }
+    ),
+  };
+  const statusPort: ChangeReviewDialogLifecycleStatusPort = {
+    getActionLockState: vi.fn<ChangeReviewDialogLifecycleStatusPort['getActionLockState']>(
+      (applying) => ({
+        applying,
+        fileApplyCount: 0,
+        undoing: false,
+        closing: false,
+      })
+    ),
+    beginClosing: vi.fn<ChangeReviewDialogLifecycleStatusPort['beginClosing']>(() => {
+      events.push('begin-closing');
+    }),
+    finishClosing: vi.fn<ChangeReviewDialogLifecycleStatusPort['finishClosing']>(() => {
+      events.push('finish-closing');
+    }),
+    setRecoveryInFlight: vi.fn<ChangeReviewDialogLifecycleStatusPort['setRecoveryInFlight']>(
+      (value) => {
+        events.push(`recovery:${String(value)}`);
+      }
+    ),
+  };
+  const sessionPort: ChangeReviewDialogLifecycleSessionPort = {
+    getPendingApplyCleanupKey: vi.fn<
+      ChangeReviewDialogLifecycleSessionPort['getPendingApplyCleanupKey']
+    >(() => mutable.pendingApplyCleanupKey),
+    setPendingApplyCleanupKey: vi.fn<
+      ChangeReviewDialogLifecycleSessionPort['setPendingApplyCleanupKey']
+    >((key) => {
+      mutable.pendingApplyCleanupKey = key;
+      events.push(`pending:${key ?? 'null'}`);
+    }),
+    isExpectedHydrationKey: vi.fn<ChangeReviewDialogLifecycleSessionPort['isExpectedHydrationKey']>(
+      (hydrationKey) => hydrationKey === mutable.expectedHydrationKey
+    ),
+  };
+  const writeEvidencePort: ChangeReviewDialogLifecycleWriteEvidencePort = {
+    markCommittedPostimages: vi.fn<
+      ChangeReviewDialogLifecycleWriteEvidencePort['markCommittedPostimages']
+    >(() => {
+      events.push('mark-postimages');
+    }),
+  };
+  const decisionPersistence: ChangeReviewDialogLifecycleDecisionPersistencePort = {
+    flushForClose: vi.fn<ChangeReviewDialogLifecycleDecisionPersistencePort['flushForClose']>(
+      () => {
+        events.push('flush-decisions');
+        return Promise.resolve(true);
+      }
+    ),
+    getDiagnostics: vi.fn<ChangeReviewDialogLifecycleDecisionPersistencePort['getDiagnostics']>(
+      () => ({
+        pendingDecisionClear: false,
+        persistenceStatus: 'saved',
+      })
+    ),
+    scheduleAutoPersistence:
+      vi.fn<ChangeReviewDialogLifecycleDecisionPersistencePort['scheduleAutoPersistence']>(),
+    clearAfterDurableStateEmptied: vi.fn<
+      ChangeReviewDialogLifecycleDecisionPersistencePort['clearAfterDurableStateEmptied']
+    >(() => Promise.resolve('cleared')),
+  };
+  const draftHistory: ChangeReviewDialogLifecycleDraftHistoryPort = {
+    getEntry: vi.fn<ChangeReviewDialogLifecycleDraftHistoryPort['getEntry']>(() => undefined),
+    flushWrites: vi.fn<ChangeReviewDialogLifecycleDraftHistoryPort['flushWrites']>(() => {
+      events.push('flush-drafts');
+      return Promise.resolve(true);
+    }),
+    retryHydration: vi.fn<ChangeReviewDialogLifecycleDraftHistoryPort['retryHydration']>(() => {
+      events.push('retry-drafts');
+    }),
+    discardUnreadableScope: vi.fn<
+      ChangeReviewDialogLifecycleDraftHistoryPort['discardUnreadableScope']
+    >(() => Promise.resolve(true)),
+    getDiagnostics: vi.fn<ChangeReviewDialogLifecycleDraftHistoryPort['getDiagnostics']>(() => ({
+      pendingWriteCount: 0,
+      writeChainCount: 0,
+      writeErrorCount: 0,
+    })),
+  };
+  const unregisterOwner = vi.fn();
+  const unregisterAppCloseParticipant = vi.fn();
+  const registerOwner = vi.fn<RegisterChangeReviewLifecycleOwner>(() => ({
+    accepted: true,
+    unregister: unregisterOwner,
+  }));
+  const registerAppCloseParticipant = vi.fn<RegisterChangeReviewAppCloseParticipant>(
+    (_participantId, participant) => {
+      mutable.appCloseParticipant = participant;
+      return unregisterAppCloseParticipant;
+    }
+  );
+  const setAuthorized = vi.fn();
+  const onOpenChange = vi.fn((open: boolean) => events.push(`open:${String(open)}`));
+
+  return {
+    events,
+    mutable,
+    operationScope,
+    snapshot,
+    statePort,
+    commandPort,
+    editorPort,
+    statusPort,
+    sessionPort,
+    writeEvidencePort,
+    decisionPersistence,
+    draftHistory,
+    registerOwner,
+    registerAppCloseParticipant,
+    unregisterOwner,
+    unregisterAppCloseParticipant,
+    setAuthorized,
+    onOpenChange,
+  };
+}
+
+type Harness = ReturnType<typeof createHarness>;
+
+function createInput(harness: Harness, overrides: Partial<ControllerInput> = {}): ControllerInput {
+  return {
+    open: true,
+    authorized: true,
+    setAuthorized: harness.setAuthorized,
+    hostId: 'host-a',
+    sessionId: 'session-a',
+    tabId: 'tab-a',
+    focus: undefined,
+    teamName: 'team',
+    mode: 'task',
+    memberName: undefined,
+    taskId: 'task',
+    taskChangeRequestOptions: {},
+    scopeKey: 'task:task',
+    decisionScopeKey: 'task-task',
+    decisionScopeToken: 'token-a',
+    decisionHydrationKey: 'hydration-a',
+    decisionHydrationReady: true,
+    decisionHydrationFailed: false,
+    draftHistoryHydration: { key: 'hydration-a', status: 'loaded' },
+    draftHistoryHydrationFailed: false,
+    reviewScope: { teamName: 'team', taskId: 'task' },
+    reviewMutationBusy: false,
+    reviewActionsBusy: false,
+    onOpenChange: harness.onOpenChange,
+    statePort: harness.statePort,
+    commandPort: harness.commandPort,
+    editorPort: harness.editorPort,
+    statusPort: harness.statusPort,
+    sessionPort: harness.sessionPort,
+    writeEvidencePort: harness.writeEvidencePort,
+    decisionPersistence: harness.decisionPersistence,
+    draftHistory: harness.draftHistory,
+    hasActionInFlight: () => false,
+    blockForExternalChange: () => false,
+    captureOperationScope: () => harness.operationScope,
+    isCurrentOperationScope: (scope) => harness.mutable.current && scope === harness.operationScope,
+    registerOwner: harness.registerOwner,
+    registerAppCloseParticipant: harness.registerAppCloseParticipant,
+    ...overrides,
+  };
+}
+
+let latest: ChangeReviewDialogLifecycleController | null = null;
+
+function Probe({ input }: Readonly<{ input: ControllerInput }>): React.JSX.Element {
+  latest = useChangeReviewDialogLifecycleController(input);
+  return <div />;
+}
+
+async function renderHarness(
+  harness: Harness,
+  overrides: Partial<ControllerInput> = {}
+): Promise<ReturnType<typeof createRoot>> {
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  const root = createRoot(document.body.appendChild(document.createElement('div')));
+  const input = createInput(harness, overrides);
+  await act(async () => {
+    root.render(<Probe input={input} />);
+    await Promise.resolve();
+  });
+  harness.events.length = 0;
+  return root;
+}
+
+describe('useChangeReviewDialogLifecycleController', () => {
+  afterEach(() => {
+    latest = null;
+    document.body.innerHTML = '';
+    vi.unstubAllGlobals();
+  });
+
+  it('captures editor drafts and flushes draft history before decision history and close', async () => {
+    const harness = createHarness();
+    const root = await renderHarness(harness);
+
+    await act(async () => latest!.requestClose());
+
+    expect(harness.events).toEqual([
+      'begin-closing',
+      'capture-drafts',
+      'flush-drafts',
+      'flush-decisions',
+      'finish-closing',
+      'open:false',
+    ]);
+    act(() => root.unmount());
+  });
+
+  it('loads, cleans up, and loads again across close and reopen', async () => {
+    const harness = createHarness();
+    const root = await renderHarness(harness);
+
+    expect(harness.commandPort.resetAllReviewState).toHaveBeenCalledOnce();
+    expect(harness.commandPort.fetchTaskChanges).toHaveBeenCalledOnce();
+    expect(harness.commandPort.hydrateDecisions).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      root.render(<Probe input={createInput(harness, { open: false, authorized: false })} />);
+      await Promise.resolve();
+    });
+    expect(harness.commandPort.clearChangeReviewCache).toHaveBeenCalledOnce();
+    expect(harness.unregisterOwner).toHaveBeenCalledOnce();
+    expect(harness.unregisterAppCloseParticipant).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      root.render(<Probe input={createInput(harness)} />);
+      await Promise.resolve();
+    });
+    expect(harness.commandPort.resetAllReviewState).toHaveBeenCalledTimes(2);
+    expect(harness.commandPort.fetchTaskChanges).toHaveBeenCalledTimes(2);
+    expect(harness.commandPort.hydrateDecisions).toHaveBeenCalledTimes(2);
+    act(() => root.unmount());
+  });
+
+  it('blocks close when a captured manual draft is not durable', async () => {
+    const harness = createHarness();
+    harness.snapshot.editedContents['/repo/a.ts'] = 'manual';
+    const root = await renderHarness(harness);
+
+    await act(async () => latest!.requestClose());
+
+    expect(harness.draftHistory.flushWrites).not.toHaveBeenCalled();
+    expect(harness.decisionPersistence.flushForClose).not.toHaveBeenCalled();
+    expect(harness.onOpenChange).not.toHaveBeenCalled();
+    expect(harness.events).toEqual([
+      'begin-closing',
+      'capture-drafts',
+      'error:Manual edits for /repo/a.ts are not durable yet. Keep Changes open and retry.',
+      'finish-closing',
+    ]);
+    act(() => root.unmount());
+  });
+
+  it('keeps Changes open when draft-history flush fails', async () => {
+    const harness = createHarness();
+    harness.snapshot.hunkDecisions['/repo/a.ts:0'] = 'accepted';
+    vi.mocked(harness.draftHistory.flushWrites).mockImplementation(() => {
+      harness.events.push('flush-drafts');
+      return Promise.resolve(false);
+    });
+    const root = await renderHarness(harness);
+
+    await act(async () => latest!.requestClose());
+
+    expect(harness.decisionPersistence.flushForClose).not.toHaveBeenCalled();
+    expect(harness.onOpenChange).not.toHaveBeenCalled();
+    expect(harness.events).toEqual([
+      'begin-closing',
+      'capture-drafts',
+      'flush-drafts',
+      'error:Unable to save manual edit history. Changes remains open.',
+      'finish-closing',
+    ]);
+    act(() => root.unmount());
+  });
+
+  it('keeps Changes open when decision-history flush fails', async () => {
+    const harness = createHarness();
+    harness.snapshot.hunkDecisions['/repo/a.ts:0'] = 'accepted';
+    vi.mocked(harness.decisionPersistence.flushForClose).mockImplementation(() => {
+      harness.events.push('flush-decisions');
+      return Promise.resolve(false);
+    });
+    const root = await renderHarness(harness);
+
+    await act(async () => latest!.requestClose());
+
+    expect(harness.onOpenChange).not.toHaveBeenCalled();
+    expect(harness.events).toEqual([
+      'begin-closing',
+      'capture-drafts',
+      'flush-drafts',
+      'flush-decisions',
+      'error:Unable to save review decisions. Changes remains open.',
+      'finish-closing',
+    ]);
+    act(() => root.unmount());
+  });
+
+  it('uses the same ordered fail-closed flush for app close without closing the dialog itself', async () => {
+    const harness = createHarness();
+    harness.snapshot.hunkDecisions['/repo/a.ts:0'] = 'accepted';
+    const root = await renderHarness(harness);
+    const participant = harness.mutable.appCloseParticipant;
+    expect(participant).not.toBeNull();
+
+    let result: Awaited<ReturnType<RegisteredAppCloseParticipant>> | undefined;
+    await act(async () => {
+      result = await participant!({
+        requestId: 'close-a',
+        reason: 'window-close',
+        deadlineAt: Date.now() + 1_000,
+      });
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(harness.events).toEqual([
+      'begin-closing',
+      'capture-drafts',
+      'flush-drafts',
+      'flush-decisions',
+      'finish-closing',
+    ]);
+    expect(harness.onOpenChange).not.toHaveBeenCalled();
+    act(() => root.unmount());
+    expect(harness.unregisterOwner).toHaveBeenCalledOnce();
+    expect(harness.unregisterAppCloseParticipant).toHaveBeenCalledOnce();
+  });
+
+  it('finishes pending Apply cleanup without rewriting decision history', async () => {
+    const harness = createHarness();
+    harness.mutable.pendingApplyCleanupKey = 'hydration-a';
+    const root = await renderHarness(harness);
+
+    await act(async () => latest!.requestClose());
+
+    expect(harness.events).toEqual([
+      'begin-closing',
+      'capture-drafts',
+      'flush-drafts',
+      'clear-decisions',
+      'pending:null',
+      'finish-closing',
+      'open:false',
+    ]);
+    expect(harness.decisionPersistence.flushForClose).not.toHaveBeenCalled();
+    act(() => root.unmount());
+  });
+
+  it('fences close completion when the operation scope changes after draft flush', async () => {
+    const harness = createHarness();
+    vi.mocked(harness.draftHistory.flushWrites).mockImplementation(() => {
+      harness.events.push('flush-drafts');
+      harness.mutable.current = false;
+      return Promise.resolve(true);
+    });
+    const root = await renderHarness(harness);
+
+    await act(async () => latest!.requestClose());
+
+    expect(harness.events).toEqual(['begin-closing', 'capture-drafts', 'flush-drafts']);
+    expect(harness.decisionPersistence.flushForClose).not.toHaveBeenCalled();
+    expect(harness.statusPort.finishClosing).not.toHaveBeenCalled();
+    expect(harness.onOpenChange).not.toHaveBeenCalled();
+    act(() => root.unmount());
+  });
+
+  it('orders Apply, WAL postimage evidence, durable cleanup, and local reset', async () => {
+    const harness = createHarness();
+    const root = await renderHarness(harness);
+
+    await act(async () => latest!.apply());
+
+    expect(harness.events).toEqual([
+      'apply-review',
+      'mark-postimages',
+      'pending:hydration-a',
+      'begin-closing',
+      'clear-decisions',
+      'pending:null',
+      'reset',
+      'finish-closing',
+    ]);
+    act(() => root.unmount());
+  });
+
+  it('does not clear durable decisions after an operation-owned failed Apply result', async () => {
+    const harness = createHarness();
+    vi.mocked(harness.commandPort.applyReview).mockImplementation(() => {
+      harness.events.push('apply-review');
+      return Promise.resolve({
+        status: 'failed',
+        result: successfulApply({
+          applied: 0,
+          conflicts: 1,
+          errors: [{ filePath: '/repo/a.ts', error: 'changed' }],
+          diskPostimages: [{ filePath: '/repo/a.ts', content: 'partial' }],
+        }),
+      });
+    });
+    const root = await renderHarness(harness);
+
+    await act(async () => latest!.apply());
+
+    expect(harness.events).toEqual(['apply-review', 'mark-postimages']);
+    expect(harness.sessionPort.setPendingApplyCleanupKey).not.toHaveBeenCalled();
+    expect(harness.commandPort.clearDecisions).not.toHaveBeenCalled();
+    act(() => root.unmount());
+  });
+
+  it('discards unreadable decision and draft state only after both durable clears succeed', async () => {
+    const harness = createHarness();
+    const root = await renderHarness(harness, {
+      decisionHydrationFailed: true,
+      draftHistoryHydrationFailed: true,
+    });
+
+    await act(async () => latest!.discardSavedDecisionState());
+
+    expect(harness.commandPort.clearDecisions).toHaveBeenCalledWith(
+      {
+        teamName: 'team',
+        scopeKey: 'task-task',
+        scopeToken: 'token-a',
+      },
+      true
+    );
+    expect(harness.draftHistory.discardUnreadableScope).toHaveBeenCalledWith(
+      harness.operationScope
+    );
+    expect(harness.statePort.completeSavedStateDiscard).toHaveBeenCalledWith(true);
+    expect(harness.events).toEqual(['begin-closing', 'clear-decisions', 'finish-closing']);
+    act(() => root.unmount());
+  });
+
+  it('fails closed when unreadable decision state cannot be discarded', async () => {
+    const harness = createHarness();
+    vi.mocked(harness.commandPort.clearDecisions).mockImplementation(() => {
+      harness.events.push('clear-decisions');
+      return Promise.resolve(false);
+    });
+    const root = await renderHarness(harness, {
+      decisionHydrationFailed: true,
+      draftHistoryHydrationFailed: true,
+    });
+    let failure: unknown;
+
+    await act(async () => {
+      try {
+        await latest!.discardSavedDecisionState();
+      } catch (error) {
+        failure = error;
+      }
+    });
+
+    expect(failure).toEqual(new Error('Unable to discard the unreadable saved review decisions.'));
+    expect(harness.draftHistory.discardUnreadableScope).not.toHaveBeenCalled();
+    expect(harness.statePort.completeSavedStateDiscard).not.toHaveBeenCalled();
+    expect(harness.events).toEqual([
+      'begin-closing',
+      'clear-decisions',
+      'error:Unable to discard the unreadable saved review decisions.',
+      'finish-closing',
+    ]);
+    act(() => root.unmount());
+  });
+
+  it('retries WAL recovery before decision hydration and draft-history retry', async () => {
+    const harness = createHarness();
+    const root = await renderHarness(harness, {
+      decisionHydrationFailed: true,
+      draftHistoryHydrationFailed: true,
+    });
+
+    await act(async () => latest!.retrySavedReviewState());
+
+    expect(harness.events).toEqual([
+      'recovery:true',
+      'retry-recovery',
+      'mark-postimages',
+      'hydrate',
+      'retry-drafts',
+      'recovery:false',
+    ]);
+    act(() => root.unmount());
+  });
+});

--- a/test/features/change-review/renderer/useChangeReviewDialogLifecycleController.test.tsx
+++ b/test/features/change-review/renderer/useChangeReviewDialogLifecycleController.test.tsx
@@ -517,7 +517,30 @@ describe('useChangeReviewDialogLifecycleController', () => {
 
     await act(async () => latest!.apply());
 
-    expect(harness.events).toEqual(['apply-review', 'mark-postimages']);
+    expect(harness.events).toEqual(['apply-review', 'mark-postimages', 'error:changed']);
+    expect(harness.sessionPort.setPendingApplyCleanupKey).not.toHaveBeenCalled();
+    expect(harness.commandPort.clearDecisions).not.toHaveBeenCalled();
+    act(() => root.unmount());
+  });
+
+  it('reports a deterministic fallback when Apply fails without a result', async () => {
+    const harness = createHarness();
+    vi.mocked(harness.commandPort.applyReview).mockImplementation(() => {
+      harness.events.push('apply-review');
+      return Promise.resolve({
+        status: 'failed',
+        result: null,
+      });
+    });
+    const root = await renderHarness(harness);
+
+    await act(async () => latest!.apply());
+
+    expect(harness.events).toEqual([
+      'apply-review',
+      'mark-postimages',
+      'error:Unable to apply this review. Changes remains open; retry Apply.',
+    ]);
     expect(harness.sessionPort.setPendingApplyCleanupKey).not.toHaveBeenCalled();
     expect(harness.commandPort.clearDecisions).not.toHaveBeenCalled();
     act(() => root.unmount());

--- a/test/features/change-review/renderer/useChangeReviewDialogLifecycleController.test.tsx
+++ b/test/features/change-review/renderer/useChangeReviewDialogLifecycleController.test.tsx
@@ -511,6 +511,7 @@ describe('useChangeReviewDialogLifecycleController', () => {
           errors: [{ filePath: '/repo/a.ts', error: 'changed' }],
           diskPostimages: [{ filePath: '/repo/a.ts', content: 'partial' }],
         }),
+        errorMessage: 'changed',
       });
     });
     const root = await renderHarness(harness);
@@ -523,13 +524,14 @@ describe('useChangeReviewDialogLifecycleController', () => {
     act(() => root.unmount());
   });
 
-  it('reports a deterministic fallback when Apply fails without a result', async () => {
+  it('reports the operation-owned error when Apply fails without a result', async () => {
     const harness = createHarness();
     vi.mocked(harness.commandPort.applyReview).mockImplementation(() => {
       harness.events.push('apply-review');
       return Promise.resolve({
         status: 'failed',
         result: null,
+        errorMessage: 'Review scope changed. Reload Changes before applying.',
       });
     });
     const root = await renderHarness(harness);
@@ -539,7 +541,7 @@ describe('useChangeReviewDialogLifecycleController', () => {
     expect(harness.events).toEqual([
       'apply-review',
       'mark-postimages',
-      'error:Unable to apply this review. Changes remains open; retry Apply.',
+      'error:Review scope changed. Reload Changes before applying.',
     ]);
     expect(harness.sessionPort.setPendingApplyCleanupKey).not.toHaveBeenCalled();
     expect(harness.commandPort.clearDecisions).not.toHaveBeenCalled();

--- a/test/renderer/store/changeReviewSlice.test.ts
+++ b/test/renderer/store/changeReviewSlice.test.ts
@@ -2440,6 +2440,25 @@ describe('changeReviewSlice task changes', () => {
     expect(store.getState().applying).toBe(false);
   });
 
+  it('returns an operation-owned success result when Apply only approves pending changes', async () => {
+    const store = createSliceStore();
+    store.setState({
+      activeChangeSet: makeAgentChangeSet(),
+      hunkDecisions: { '/repo/file.ts:0': 'accepted' },
+      fileChunkCounts: { '/repo/file.ts': 1 },
+      changeSetEpoch: 1,
+    });
+
+    await expect(store.getState().applyReview('team-a')).resolves.toEqual({
+      applied: 0,
+      skipped: 0,
+      conflicts: 0,
+      errors: [],
+    });
+    expect(hoisted.applyDecisions).not.toHaveBeenCalled();
+    expect(store.getState().applyError).toBeNull();
+  });
+
   it('refuses to apply a stale change set owned by another team', async () => {
     const store = createSliceStore();
     store.setState({


### PR DESCRIPTION
## Summary

- Extract dialog open, close, Apply, recovery, and discard orchestration behind lifecycle-owned ports.
- Replace concrete sibling-controller Picks with narrow DecisionPersistence and DraftHistory contracts.
- Make Apply cleanup depend on a discriminated operation-owned outcome instead of shared applyError state.
- Reduce ChangeReviewDialog.tsx from 2684 to 2321 lines and ratchet its legacy cap.

## Verification

- Focused tests: 94/94 passed.
- Source-size guard: 8/8 passed.
- TypeScript 7 typecheck passed.
- Fast lint passed.
- Full type-aware lint: 0 errors.
- Prettier and git diff checks passed.
- Independent exact-commit audit: blockers 0, P3 0.

Full desktop Changes E2E is intentionally reserved for the final ChangeReviewDialog below-800 gate. This intermediate extraction changes orchestration boundaries, and its close/app-close/reopen/fail-closed/discard sequences are covered by focused integration tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Change Review dialog lifecycle with a dedicated controller for safer open/close/apply flows, improved recovery and retry, and consistent close handling (including Escape).
  * Added centralized lifecycle “ports” to coordinate state, commands, status, and persistence behavior.
* **Bug Fixes**
  * Applying already-accepted changes now returns a consistent success result instead of `null`.
* **Tests**
  * Added coverage for close-readiness evaluation, lifecycle ports, and full controller sequencing (including failure and recovery paths).
* **Documentation**
  * Updated Change Review lifecycle ownership guidance and responsibilities.
* **Chores**
  * Refreshed CI source-size legacy snapshot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->