### PR TITLE
refactor(change-review): extract composition and mutation safety

### DIFF
--- a/scripts/ci/source-file-size-legacy.json
+++ b/scripts/ci/source-file-size-legacy.json
@@ -150,7 +150,7 @@
   "src/renderer/components/team/members/MemberLogsTab.tsx": 985,
   "src/renderer/components/team/messages/MessageComposer.tsx": 1344,
   "src/renderer/components/team/messages/MessagesPanel.tsx": 1722,
-  "src/renderer/components/team/review/ChangeReviewDialog.tsx": 1540,
+  "src/renderer/components/team/review/ChangeReviewDialog.tsx": 1413,
   "src/renderer/components/team/review/CodeMirrorDiffView.tsx": 975,
   "src/renderer/components/team/useTeamChangesSummaries.ts": 826,
   "src/renderer/components/ui/MentionableTextarea.tsx": 1433,

--- a/scripts/ci/source-file-size-legacy.json
+++ b/scripts/ci/source-file-size-legacy.json
@@ -150,7 +150,7 @@
   "src/renderer/components/team/members/MemberLogsTab.tsx": 985,
   "src/renderer/components/team/messages/MessageComposer.tsx": 1344,
   "src/renderer/components/team/messages/MessagesPanel.tsx": 1722,
-  "src/renderer/components/team/review/ChangeReviewDialog.tsx": 1413,
+  "src/renderer/components/team/review/ChangeReviewDialog.tsx": 1291,
   "src/renderer/components/team/review/CodeMirrorDiffView.tsx": 975,
   "src/renderer/components/team/useTeamChangesSummaries.ts": 826,
   "src/renderer/components/ui/MentionableTextarea.tsx": 1433,

--- a/src/features/change-review/README.md
+++ b/src/features/change-review/README.md
@@ -23,9 +23,10 @@ main-process review IPC shell.
   decision-persistence coordination behind narrow ports.
 - `main/infrastructure` owns Node path, filesystem, sensitive-path, hardlink, and watcher-root
   validation details.
-- The legacy dialog remains the temporary composition shell for Zustand subscription,
-  controller/adapter composition, CodeMirror action injection, and the main diff/content
-  rendering while later slices move those responsibilities behind focused hooks and use cases.
+- The legacy app-shell composition module binds feature ports and policies to Zustand, the
+  renderer API, and remaining review utilities. The dialog keeps per-instance controller
+  composition, CodeMirror action injection, and the main diff/content rendering while later
+  slices move those responsibilities behind focused hooks and use cases.
 
 Production callers import through `@features/change-review/renderer` or
 `@features/change-review/main`.

--- a/src/features/change-review/README.md
+++ b/src/features/change-review/README.md
@@ -11,9 +11,10 @@ main-process review IPC shell.
   decision-persistence, keyboard orchestration, bulk Accept/Reject, manual file draft
   save/reload/discard flows, file-level and hunk-level Accept/Reject/Restore, and durable
   Undo/Redo/checkpoint Restore. It also owns dialog view state, selection/collapse/viewed
-  presentation interactions, diff/history keyboard navigation, external-file watcher
-  suppression, dialog open/fetch/hydration, close/app-close flushing, saved-state
-  recovery/discard, Apply cleanup, and Escape orchestration through narrow ports.
+  presentation interactions, diff/history keyboard navigation, operation-state latches,
+  mutation guards, external-change processing and watcher suppression, dialog
+  open/fetch/hydration, close/app-close flushing, saved-state recovery/discard, Apply cleanup,
+  and Escape orchestration through narrow ports.
 - `renderer/ui` owns store-free presentation components, including the review navigation
   sidebar, file tree, and active-file edit timeline. Decision state reaches that subtree
   through explicit props rather than direct Zustand access.

--- a/src/features/change-review/renderer/hooks/useChangeReviewExternalChangeController.ts
+++ b/src/features/change-review/renderer/hooks/useChangeReviewExternalChangeController.ts
@@ -1,0 +1,107 @@
+import { useCallback } from 'react';
+
+import { normalizePathForComparison } from '@shared/utils/platformPath';
+
+import { useChangeReviewExternalFileWatcher } from './useChangeReviewExternalFileWatcher';
+
+import type {
+  ChangeReviewExternalFileWatcherPort,
+  ChangeReviewRecentWrite,
+} from '../ports/changeReviewDialogInteractionPorts';
+import type {
+  ChangeReviewExternalChangePolicy,
+  ChangeReviewExternalChangeStatePort,
+} from '../ports/changeReviewMutationSafetyPorts';
+import type { ReviewDraftHistoryEntry } from '@features/change-review-history/contracts';
+import type { EditorFileChangeEvent, ReviewFileScope } from '@shared/types';
+import type { RefObject } from 'react';
+
+interface UseChangeReviewExternalChangeControllerInput {
+  open: boolean;
+  enabled: boolean;
+  projectPath: string | undefined;
+  watchedFilePathsKey: string;
+  reviewScope: ReviewFileScope;
+  externalChangesByFile: Readonly<Record<string, unknown>>;
+  recentWritesRef: RefObject<Map<string, ChangeReviewRecentWrite>>;
+  isMutationInFlight: (normalizedPath: string) => boolean;
+  getDraftHistoryEntry: (filePath: string) => ReviewDraftHistoryEntry | undefined;
+  statePort: ChangeReviewExternalChangeStatePort;
+  policy: ChangeReviewExternalChangePolicy;
+  watcherPort: ChangeReviewExternalFileWatcherPort;
+}
+
+export interface ChangeReviewExternalChangeController {
+  reviewMutationBlockedByExternalChange: boolean;
+  blockReviewMutationForExternalChange: (filePath?: string) => boolean;
+}
+
+export function useChangeReviewExternalChangeController({
+  open,
+  enabled,
+  projectPath,
+  watchedFilePathsKey,
+  reviewScope,
+  externalChangesByFile,
+  recentWritesRef,
+  isMutationInFlight,
+  getDraftHistoryEntry,
+  statePort,
+  policy,
+  watcherPort,
+}: UseChangeReviewExternalChangeControllerInput): ChangeReviewExternalChangeController {
+  const reviewMutationBlockedByExternalChange = Object.keys(externalChangesByFile).length > 0;
+  const blockReviewMutationForExternalChange = useCallback(
+    (filePath?: string): boolean => {
+      const externalChanges = statePort.getSnapshot().reviewExternalChangesByFile;
+      const blocked = filePath
+        ? policy.hasUnresolvedExternalChange(filePath, externalChanges)
+        : Object.keys(externalChanges).length > 0;
+      if (blocked) {
+        statePort.reportError(
+          'Reload files changed outside Changes before continuing review actions.'
+        );
+      }
+      return blocked;
+    },
+    [policy, statePort]
+  );
+  const processExternalChange = useCallback(
+    (event: EditorFileChangeEvent): void => {
+      const normalizedPath = normalizePathForComparison(event.path);
+      const state = statePort.getSnapshot();
+      const file = state.activeChangeSet?.files.find(
+        (entry) => normalizePathForComparison(entry.filePath) === normalizedPath
+      );
+      if (!file) return;
+      const durableDraftHistory = getDraftHistoryEntry(file.filePath);
+      if (!(file.filePath in state.editedContents) && durableDraftHistory) {
+        statePort.restoreDraft(file.filePath, durableDraftHistory.editorState.doc);
+      }
+      const changeType =
+        event.type === 'create' ? 'add' : event.type === 'delete' ? 'unlink' : 'change';
+      statePort.markExternalChange(file.filePath, changeType);
+      statePort.reportError(
+        'A reviewed file changed outside Changes. Reload it from disk before continuing review actions.'
+      );
+    },
+    [getDraftHistoryEntry, statePort]
+  );
+
+  useChangeReviewExternalFileWatcher({
+    open,
+    enabled,
+    projectPath,
+    watchedFilePathsKey,
+    reviewScope,
+    recentWritesRef,
+    isMutationInFlight,
+    processExternalChange,
+    port: watcherPort,
+  });
+
+  return {
+    reviewMutationBlockedByExternalChange,
+    blockReviewMutationForExternalChange,
+  };
+}

--- a/src/features/change-review/renderer/hooks/useChangeReviewMutationGuards.ts
+++ b/src/features/change-review/renderer/hooks/useChangeReviewMutationGuards.ts
@@ -1,0 +1,124 @@
+import { useCallback } from 'react';
+
+import { isReviewActionPersistenceBlocking } from '../utils/changeReviewActionHistory';
+import { isReviewActionLocked } from '../utils/changeReviewDialogLifecycle';
+
+import type { ChangeReviewOperationStatePort } from '../ports/changeReviewMutationSafetyPorts';
+import type { ReviewActionPersistenceStatus } from '../utils/changeReviewActionHistory';
+import type { ReviewDraftHistoryHydrationState } from '../utils/changeReviewScope';
+import type { ChangeReviewOperationState } from './useChangeReviewOperationState';
+
+interface ChangeReviewConflictGuardState {
+  refreshPending: boolean;
+  loadError: string | null;
+  candidateCount: number;
+  resolvingCandidateId: string | null;
+}
+
+interface UseChangeReviewMutationGuardsInput {
+  applying: boolean;
+  operation: ChangeReviewOperationState;
+  decisionScopeToken: string | null;
+  decisionHydrationKey: string | null;
+  decisionHydrationReady: boolean;
+  draftHistoryHydration: ReviewDraftHistoryHydrationState;
+  draftHistoryHydrationReady: boolean;
+  conflict: ChangeReviewConflictGuardState;
+  persistenceStatus: ReviewActionPersistenceStatus;
+  getPersistenceStatus: () => ReviewActionPersistenceStatus;
+  port: ChangeReviewOperationStatePort;
+}
+
+export interface ChangeReviewMutationGuards {
+  reviewMutationBusy: boolean;
+  reviewActionsBusy: boolean;
+  reviewCloseBusy: boolean;
+  hasReviewActionInFlight: () => boolean;
+  ensureDurableReviewScope: () => boolean;
+}
+
+const DURABLE_SCOPE_ERROR =
+  'Durable review scope is unavailable; refusing an unsafe disk mutation.';
+
+export function useChangeReviewMutationGuards({
+  applying,
+  operation,
+  decisionScopeToken,
+  decisionHydrationKey,
+  decisionHydrationReady,
+  draftHistoryHydration,
+  draftHistoryHydrationReady,
+  conflict,
+  persistenceStatus,
+  getPersistenceStatus,
+  port,
+}: UseChangeReviewMutationGuardsInput): ChangeReviewMutationGuards {
+  const reviewMutationBusy = isReviewActionLocked({
+    applying,
+    fileApplyCount: operation.filesApplying.size,
+    undoing: operation.undoing,
+    closing: operation.closing,
+  });
+  const reviewActionsBusy =
+    reviewMutationBusy ||
+    conflict.refreshPending ||
+    conflict.loadError !== null ||
+    conflict.candidateCount > 0 ||
+    conflict.resolvingCandidateId !== null ||
+    isReviewActionPersistenceBlocking(persistenceStatus) ||
+    (decisionHydrationKey !== null && (!decisionHydrationReady || !draftHistoryHydrationReady));
+  // Discovery and persistence drains may finish during close flushing. Only
+  // active mutation or conflict resolution keeps the close control locked.
+  const reviewCloseBusy = reviewMutationBusy || conflict.resolvingCandidateId !== null;
+
+  const hasReviewActionInFlight = useCallback((): boolean => {
+    const state = port.getSnapshot();
+    const hydrationReady =
+      decisionHydrationKey === null ||
+      (state.decisionHydrationScopeKey === decisionHydrationKey &&
+        state.decisionHydrationStatus === 'loaded' &&
+        draftHistoryHydration.key === decisionHydrationKey &&
+        draftHistoryHydration.status === 'loaded');
+    return (
+      !hydrationReady ||
+      conflict.refreshPending ||
+      conflict.loadError !== null ||
+      conflict.candidateCount > 0 ||
+      conflict.resolvingCandidateId !== null ||
+      isReviewActionPersistenceBlocking(getPersistenceStatus()) ||
+      isReviewActionLocked({
+        applying: state.applying,
+        fileApplyCount: operation.viewPortBindings.fileApplyInFlightRef.current.size,
+        undoing: operation.viewPortBindings.undoInFlightRef.current,
+        closing: operation.viewPortBindings.closingRef.current,
+      })
+    );
+  }, [
+    conflict.candidateCount,
+    conflict.loadError,
+    conflict.refreshPending,
+    conflict.resolvingCandidateId,
+    decisionHydrationKey,
+    draftHistoryHydration.key,
+    draftHistoryHydration.status,
+    getPersistenceStatus,
+    operation.viewPortBindings.closingRef,
+    operation.viewPortBindings.fileApplyInFlightRef,
+    operation.viewPortBindings.undoInFlightRef,
+    port,
+  ]);
+
+  const ensureDurableReviewScope = useCallback((): boolean => {
+    if (decisionScopeToken) return true;
+    port.reportError(DURABLE_SCOPE_ERROR);
+    return false;
+  }, [decisionScopeToken, port]);
+
+  return {
+    reviewMutationBusy,
+    reviewActionsBusy,
+    reviewCloseBusy,
+    hasReviewActionInFlight,
+    ensureDurableReviewScope,
+  };
+}

--- a/src/features/change-review/renderer/hooks/useChangeReviewOperationState.ts
+++ b/src/features/change-review/renderer/hooks/useChangeReviewOperationState.ts
@@ -1,0 +1,135 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { normalizePathForComparison } from '@shared/utils/platformPath';
+
+import { useChangeReviewOperationGeneration } from './useChangeReviewOperationGeneration';
+
+import type { ChangeReviewRecentWrite } from '../ports/changeReviewDialogInteractionPorts';
+import type { ChangeReviewOperationStatePort } from '../ports/changeReviewMutationSafetyPorts';
+import type { ReviewOperationScopeToken } from '../utils/reviewOperationGeneration';
+import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
+
+export interface ChangeReviewOperationViewPortBindings {
+  fileApplyInFlightRef: MutableRefObject<Set<string>>;
+  undoInFlightRef: MutableRefObject<boolean>;
+  closingRef: MutableRefObject<boolean>;
+  pendingApplyCleanupKeyRef: MutableRefObject<string | null>;
+  recentReviewWritesRef: MutableRefObject<Map<string, ChangeReviewRecentWrite>>;
+  setFilesApplying: Dispatch<SetStateAction<Set<string>>>;
+  setUndoing: Dispatch<SetStateAction<boolean>>;
+  setClosing: Dispatch<SetStateAction<boolean>>;
+}
+
+interface UseChangeReviewOperationStateInput {
+  active: boolean;
+  decisionHydrationKey: string | null;
+  fallbackScopeKey: string;
+  changeSetEpoch: number;
+  resetKey: string;
+  port: ChangeReviewOperationStatePort;
+}
+
+export interface ChangeReviewOperationState {
+  filesApplying: Set<string>;
+  undoing: boolean;
+  closing: boolean;
+  viewPortBindings: ChangeReviewOperationViewPortBindings;
+  captureReviewOperationScope: () => ReviewOperationScopeToken | null;
+  isCurrentReviewOperationScope: (
+    operationScope: ReviewOperationScopeToken | null
+  ) => operationScope is ReviewOperationScopeToken;
+  isFileMutationInFlight: (filePath: string) => boolean;
+  isPathMutationInFlight: (normalizedPath: string) => boolean;
+}
+
+export function useChangeReviewOperationState({
+  active,
+  decisionHydrationKey,
+  fallbackScopeKey,
+  changeSetEpoch,
+  resetKey,
+  port,
+}: UseChangeReviewOperationStateInput): ChangeReviewOperationState {
+  const [filesApplying, setFilesApplying] = useState<Set<string>>(() => new Set());
+  const [undoing, setUndoing] = useState(false);
+  const [closing, setClosing] = useState(false);
+  const fileApplyInFlightRef = useRef(new Set<string>());
+  const undoInFlightRef = useRef(false);
+  const closingRef = useRef(false);
+  const pendingApplyCleanupKeyRef = useRef<string | null>(null);
+  const recentReviewWritesRef = useRef(new Map<string, ChangeReviewRecentWrite>());
+
+  const resetGenerationState = useCallback((): void => {
+    // Busy state belongs to one operation generation. Keep recent-write evidence
+    // so late filesystem events from committed mutations remain suppressible.
+    fileApplyInFlightRef.current.clear();
+    undoInFlightRef.current = false;
+    closingRef.current = false;
+    setFilesApplying(new Set());
+    setUndoing(false);
+    setClosing(false);
+  }, []);
+
+  const { captureReviewOperationScope, isCurrentReviewOperationScope } =
+    useChangeReviewOperationGeneration({
+      active,
+      decisionHydrationKey,
+      fallbackScopeKey,
+      changeSetEpoch,
+      resetGenerationState,
+    });
+
+  useEffect(() => {
+    if (pendingApplyCleanupKeyRef.current !== decisionHydrationKey) {
+      pendingApplyCleanupKeyRef.current = null;
+    }
+  }, [decisionHydrationKey]);
+
+  useEffect(() => {
+    fileApplyInFlightRef.current.clear();
+    recentReviewWritesRef.current.clear();
+    undoInFlightRef.current = false;
+    closingRef.current = false;
+    setUndoing(false);
+    setClosing(false);
+    setFilesApplying(new Set());
+  }, [resetKey]);
+
+  const isFileMutationInFlight = useCallback(
+    (filePath: string): boolean => fileApplyInFlightRef.current.has(filePath),
+    []
+  );
+  const isPathMutationInFlight = useCallback(
+    (normalizedPath: string): boolean => {
+      const pathBusy = [...fileApplyInFlightRef.current].some(
+        (filePath) => normalizePathForComparison(filePath) === normalizedPath
+      );
+      return pathBusy || undoInFlightRef.current || port.getSnapshot().applying;
+    },
+    [port]
+  );
+  const viewPortBindings = useMemo<ChangeReviewOperationViewPortBindings>(
+    () => ({
+      fileApplyInFlightRef,
+      undoInFlightRef,
+      closingRef,
+      pendingApplyCleanupKeyRef,
+      recentReviewWritesRef,
+      setFilesApplying,
+      setUndoing,
+      setClosing,
+    }),
+    []
+  );
+
+  return {
+    filesApplying,
+    undoing,
+    closing,
+    viewPortBindings,
+    captureReviewOperationScope,
+    isCurrentReviewOperationScope,
+    isFileMutationInFlight,
+    isPathMutationInFlight,
+  };
+}

--- a/src/features/change-review/renderer/index.ts
+++ b/src/features/change-review/renderer/index.ts
@@ -71,6 +71,8 @@ export type {
   ChangeReviewDraftHistoryDiagnostics,
 } from './hooks/useChangeReviewDraftHistoryController';
 export { useChangeReviewDraftHistoryController } from './hooks/useChangeReviewDraftHistoryController';
+export type { ChangeReviewExternalChangeController } from './hooks/useChangeReviewExternalChangeController';
+export { useChangeReviewExternalChangeController } from './hooks/useChangeReviewExternalChangeController';
 export { useChangeReviewExternalFileWatcher } from './hooks/useChangeReviewExternalFileWatcher';
 export type { ChangeReviewFileDecisionController } from './hooks/useChangeReviewFileDecisionController';
 export { useChangeReviewFileDecisionController } from './hooks/useChangeReviewFileDecisionController';
@@ -86,7 +88,14 @@ export { useChangeReviewHistoryMutationController } from './hooks/useChangeRevie
 export type { ChangeReviewHunkDecisionController } from './hooks/useChangeReviewHunkDecisionController';
 export { useChangeReviewHunkDecisionController } from './hooks/useChangeReviewHunkDecisionController';
 export { useChangeReviewLifecycleRegistration } from './hooks/useChangeReviewLifecycleRegistration';
+export type { ChangeReviewMutationGuards } from './hooks/useChangeReviewMutationGuards';
+export { useChangeReviewMutationGuards } from './hooks/useChangeReviewMutationGuards';
 export { useChangeReviewOperationGeneration } from './hooks/useChangeReviewOperationGeneration';
+export type {
+  ChangeReviewOperationState,
+  ChangeReviewOperationViewPortBindings,
+} from './hooks/useChangeReviewOperationState';
+export { useChangeReviewOperationState } from './hooks/useChangeReviewOperationState';
 export { useChangeReviewScopeIdentity } from './hooks/useChangeReviewScopeIdentity';
 export type {
   ChangeReviewActionHistoryStorePort,
@@ -182,6 +191,14 @@ export type {
   RegisterChangeReviewAppCloseParticipant,
   RegisterChangeReviewLifecycleOwner,
 } from './ports/changeReviewLifecyclePorts';
+export type {
+  ChangeReviewExternalChangePolicy,
+  ChangeReviewExternalChangeStatePort,
+  ChangeReviewExternalChangeStateSnapshot,
+  ChangeReviewExternalChangeType,
+  ChangeReviewOperationStatePort,
+  ChangeReviewOperationStateSnapshot,
+} from './ports/changeReviewMutationSafetyPorts';
 export {
   ChangeReviewConflictDiscardDialog,
   ChangeReviewConflictNotices,

--- a/src/features/change-review/renderer/ports/changeReviewMutationSafetyPorts.ts
+++ b/src/features/change-review/renderer/ports/changeReviewMutationSafetyPorts.ts
@@ -1,0 +1,34 @@
+import type { ReviewDecisionHydrationStatus } from '../utils/changeReviewScope';
+
+export interface ChangeReviewOperationStateSnapshot {
+  applying: boolean;
+  decisionHydrationScopeKey: string | null;
+  decisionHydrationStatus: ReviewDecisionHydrationStatus;
+}
+
+export interface ChangeReviewOperationStatePort {
+  getSnapshot: () => ChangeReviewOperationStateSnapshot;
+  reportError: (message: string) => void;
+}
+
+export type ChangeReviewExternalChangeType = 'change' | 'add' | 'unlink';
+
+export interface ChangeReviewExternalChangeStateSnapshot {
+  activeChangeSet: { files: readonly { filePath: string }[] } | null;
+  editedContents: Readonly<Record<string, string>>;
+  reviewExternalChangesByFile: Readonly<Record<string, unknown>>;
+}
+
+export interface ChangeReviewExternalChangeStatePort {
+  getSnapshot: () => ChangeReviewExternalChangeStateSnapshot;
+  restoreDraft: (filePath: string, content: string) => void;
+  markExternalChange: (filePath: string, changeType: ChangeReviewExternalChangeType) => void;
+  reportError: (message: string) => void;
+}
+
+export interface ChangeReviewExternalChangePolicy {
+  hasUnresolvedExternalChange: (
+    filePath: string,
+    changes: Readonly<Record<string, unknown>>
+  ) => boolean;
+}

--- a/src/renderer/components/team/review/ChangeReviewDialog.tsx
+++ b/src/renderer/components/team/review/ChangeReviewDialog.tsx
@@ -17,26 +17,11 @@ import {
   ChangeReviewConflictDiscardDialog,
   ChangeReviewConflictNotices,
   ChangeReviewSidebar,
-  createChangeReviewActionHistoryStorePort,
   createChangeReviewBulkDecisionCommandPort,
-  createChangeReviewBulkDecisionStatePort,
-  createChangeReviewConflictCommandPort,
-  createChangeReviewConflictQueryPort,
-  createChangeReviewConflictStateBridge,
-  createChangeReviewDecisionPersistencePort,
   createChangeReviewDialogLifecycleCommandPort,
-  createChangeReviewDialogLifecycleStatePort,
   createChangeReviewDialogViewPorts,
-  createChangeReviewDraftHistoryPort,
-  createChangeReviewExternalFileWatcherPort,
   createChangeReviewFileDecisionCommandPort,
-  createChangeReviewFileDecisionStatePort,
-  createChangeReviewFileDraftCommandPort,
-  createChangeReviewFileDraftStatePort,
-  createChangeReviewHistoryMutationCommandPort,
-  createChangeReviewHistoryMutationStatePort,
   createChangeReviewHunkDecisionCommandPort,
-  createChangeReviewHunkDecisionStatePort,
   isReviewActionPersistenceBlocking,
   shouldShowTaskScopeBanner,
   TaskChangesEmptyState,
@@ -58,7 +43,6 @@ import {
   useChangeReviewOperationGeneration,
   useChangeReviewScopeIdentity,
 } from '@features/change-review/renderer';
-import { buildReviewRestoreDecisionState } from '@features/review-mutations';
 import { api, isElectronMode } from '@renderer/api';
 import { EditorSelectionMenu } from '@renderer/components/team/editor/EditorSelectionMenu';
 import { useStore } from '@renderer/store';
@@ -72,6 +56,26 @@ import { getFileReviewKey } from '@renderer/utils/reviewKey';
 import { normalizePathForComparison } from '@shared/utils/platformPath';
 import { X } from 'lucide-react';
 
+import {
+  changeReviewActionHistoryStorePort,
+  changeReviewBulkDecisionStatePort,
+  changeReviewConflictCommandPort,
+  changeReviewConflictQueryPort,
+  changeReviewConflictStateBridge,
+  changeReviewDecisionPersistencePort,
+  changeReviewDialogLifecycleStatePort,
+  changeReviewDialogViewStatePolicy,
+  changeReviewDraftHistoryPort,
+  changeReviewExternalFileWatcherPort,
+  changeReviewFileDecisionPolicy,
+  changeReviewFileDecisionStatePort,
+  changeReviewFileDraftCommandPort,
+  changeReviewFileDraftStatePort,
+  changeReviewHistoryMutationCommandPort,
+  changeReviewHistoryMutationStatePort,
+  changeReviewHunkDecisionPolicy,
+  changeReviewHunkDecisionStatePort,
+} from './changeReviewDialogComposition';
 import { ChangesLoadingAnimation } from './ChangesLoadingAnimation';
 import {
   acceptAllChunks,
@@ -81,40 +85,30 @@ import {
   rejectChunk,
 } from './CodeMirrorDiffUtils';
 import { ContinuousScrollView } from './ContinuousScrollView';
-import { buildInitialReviewFileScrollKey } from './initialReviewFileScroll';
 import { KeyboardShortcutsHelp } from './KeyboardShortcutsHelp';
 import { buildPathChangeLabels } from './pathChangeLabels';
-import { getReviewActionFilePath } from './reviewActionPresentation';
 import {
   getReviewRenameRecoveryExpectation,
-  hasReviewFileRejections,
   hasUnresolvedReviewExternalChange,
   isReviewActionLocked,
   isReviewFileFullyRejected,
   replaceReviewScopedRecord,
   resolveReviewFileIsNew,
-  restoreReviewDecisionRecordsForFile,
-  shouldCreateFileWhenUndoingReject,
   shouldDeleteFileWhenUndoingReject,
 } from './reviewActionState';
 import {
   getResolvedReviewModifiedContent,
   isReviewAcceptDisabled,
-  isReviewFileExpectedDeleted,
   isReviewFileMissingOnDisk,
   isReviewRejectable,
   isReviewTextContentUnavailable,
 } from './reviewContentPreview';
-import { resolveReviewFilePath } from './reviewFilePathResolution';
 import { ReviewToolbar } from './ReviewToolbar';
 import { SavedReviewStateRecoveryGate } from './SavedReviewStateRecoveryGate';
 import { ScopeWarningBanner } from './ScopeWarningBanner';
 import { ViewedProgressBar } from './ViewedProgressBar';
 
 import type {
-  ChangeReviewDialogViewStatePolicy,
-  ChangeReviewFileDecisionPolicy,
-  ChangeReviewHunkDecisionPolicy,
   ChangeReviewRecentWrite,
   ReviewDraftHistoryHydrationState,
 } from '@features/change-review/renderer';
@@ -128,127 +122,6 @@ import type {
   ReviewUndoAction,
 } from '@shared/types';
 import type { EditorSelectionAction } from '@shared/types/editor';
-
-const changeReviewConflictQueryPort = createChangeReviewConflictQueryPort(() => api.review);
-const changeReviewConflictCommandPort = createChangeReviewConflictCommandPort(() => api.review);
-const changeReviewConflictStateBridge = createChangeReviewConflictStateBridge({
-  getSnapshot: useStore.getState,
-  setApplyError: (applyError) => useStore.setState({ applyError }),
-});
-const changeReviewDraftHistoryPort = createChangeReviewDraftHistoryPort(() => api.review);
-const changeReviewExternalFileWatcherPort = createChangeReviewExternalFileWatcherPort(
-  () => api.review
-);
-const changeReviewActionHistoryStorePort = createChangeReviewActionHistoryStorePort({
-  getStore: useStore.getState,
-  clearLegacyUndoStack: () => useStore.setState({ reviewUndoStack: [] }),
-});
-const changeReviewDecisionPersistencePort = createChangeReviewDecisionPersistencePort({
-  getStore: useStore.getState,
-  setApplyError: (applyError) => useStore.setState({ applyError }),
-});
-const changeReviewBulkDecisionStatePort = createChangeReviewBulkDecisionStatePort({
-  getStore: useStore.getState,
-  restoreDecisionSnapshot: ({ hunkDecisions, fileDecisions }) =>
-    useStore.setState({ hunkDecisions, fileDecisions }),
-});
-const changeReviewFileDraftStatePort = createChangeReviewFileDraftStatePort({
-  getStore: useStore.getState,
-  applyReloadedReviewState: (state) =>
-    useStore.setState({
-      hunkDecisions: state.hunkDecisions,
-      fileDecisions: state.fileDecisions,
-      hunkContextHashesByFile: state.hunkContextHashesByFile ?? {},
-      applyError: null,
-    }),
-  reportError: (applyError) => useStore.setState({ applyError }),
-});
-const changeReviewFileDraftCommandPort = createChangeReviewFileDraftCommandPort({
-  getStore: useStore.getState,
-  getReviewApi: () => api.review,
-});
-const changeReviewFileDecisionStatePort = createChangeReviewFileDecisionStatePort({
-  getStore: useStore.getState,
-  applyRestoredDecisionState: (file) =>
-    useStore.setState((state) => buildReviewRestoreDecisionState(file, state)),
-  restoreFileDecisions: (file, snapshot) =>
-    useStore.setState((state) => restoreReviewDecisionRecordsForFile(file, state, snapshot)),
-  reportError: (applyError) => useStore.setState({ applyError }),
-});
-const changeReviewFileDecisionPolicy: ChangeReviewFileDecisionPolicy = {
-  getHunkCount: (file, state) =>
-    getFileHunkCount(file.filePath, file.snippets.length, state.fileChunkCounts),
-  getFileDecision: (file, state) =>
-    state.fileDecisions[getFileReviewKey(file)] ?? state.fileDecisions[file.filePath],
-  resolveModifiedContent: getResolvedReviewModifiedContent,
-  resolveFileIsNew: resolveReviewFileIsNew,
-  isExpectedDeletion: isReviewFileExpectedDeleted,
-  isAcceptDisabled: (_file, content, fileDecision) =>
-    isReviewAcceptDisabled({
-      hasEdits: false,
-      isMissingOnDisk: isReviewFileMissingOnDisk(content),
-      isContentUnavailable: isReviewTextContentUnavailable(_file, content),
-      fileDecision,
-    }),
-  isRejectable: isReviewRejectable,
-  hasFileRejections: hasReviewFileRejections,
-  isFileFullyRejected: isReviewFileFullyRejected,
-  shouldDeleteWhenUndoingReject: shouldDeleteFileWhenUndoingReject,
-  hasUnresolvedExternalChange: hasUnresolvedReviewExternalChange,
-  getRenameRecoveryExpectation: getReviewRenameRecoveryExpectation,
-};
-const changeReviewHunkDecisionStatePort = createChangeReviewHunkDecisionStatePort(
-  useStore.getState
-);
-const changeReviewHunkDecisionPolicy: ChangeReviewHunkDecisionPolicy = {
-  getHunkCount: (file, state) =>
-    getFileHunkCount(file.filePath, file.snippets.length, state.fileChunkCounts),
-  resolveFileIsNew: resolveReviewFileIsNew,
-  shouldDeleteWhenUndoingReject: shouldDeleteFileWhenUndoingReject,
-  shouldCreateWhenUndoingReject: shouldCreateFileWhenUndoingReject,
-  getRenameRecoveryExpectation: getReviewRenameRecoveryExpectation,
-};
-const changeReviewDialogViewStatePolicy: ChangeReviewDialogViewStatePolicy = {
-  buildInitialScrollKey: buildInitialReviewFileScrollKey,
-  getHistoryActionFilePath: getReviewActionFilePath,
-  resolveFilePath: resolveReviewFilePath,
-};
-const changeReviewDialogLifecycleStatePort = createChangeReviewDialogLifecycleStatePort({
-  getStore: useStore.getState,
-  reportError: (applyError) => useStore.setState({ applyError }),
-  completeSavedStateDiscard: (markDecisionHydrationLoaded) =>
-    useStore.setState({
-      ...(markDecisionHydrationLoaded ? { decisionHydrationStatus: 'loaded' as const } : {}),
-      applyError: null,
-    }),
-});
-const changeReviewHistoryMutationCommandPort = createChangeReviewHistoryMutationCommandPort(
-  () => api.review
-);
-const changeReviewHistoryMutationStatePort = createChangeReviewHistoryMutationStatePort({
-  getSnapshot: () => useStore.getState(),
-  quiesceDecisionPersistence: ({ teamName, scopeKey, scopeToken }) =>
-    useStore.getState().quiesceDecisionPersistence(teamName, scopeKey, scopeToken),
-  recordDecisionRevision: ({ teamName, scopeKey, scopeToken }, revision) =>
-    useStore.getState().recordDecisionRevision(teamName, scopeKey, scopeToken, revision),
-  applyDecisionState: ({ hunkDecisions, fileDecisions, hunkContextHashesByFile }) =>
-    useStore.setState({
-      hunkDecisions,
-      fileDecisions,
-      ...(hunkContextHashesByFile ? { hunkContextHashesByFile } : {}),
-    }),
-  applyPersistedState: (state, applyError) =>
-    useStore.setState({
-      hunkDecisions: state.hunkDecisions,
-      fileDecisions: state.fileDecisions,
-      hunkContextHashesByFile: state.hunkContextHashesByFile ?? {},
-      applyError,
-    }),
-  reportError: (applyError) => useStore.setState({ applyError }),
-  clearExternalChange: (filePath) => useStore.getState().clearReviewFileExternalChange(filePath),
-  invalidateResolvedFileContent: (filePath) =>
-    useStore.getState().invalidateResolvedFileContent(filePath),
-});
 
 interface ChangeReviewDialogProps {
   open: boolean;

--- a/src/renderer/components/team/review/ChangeReviewDialog.tsx
+++ b/src/renderer/components/team/review/ChangeReviewDialog.tsx
@@ -22,7 +22,6 @@ import {
   createChangeReviewDialogViewPorts,
   createChangeReviewFileDecisionCommandPort,
   createChangeReviewHunkDecisionCommandPort,
-  isReviewActionPersistenceBlocking,
   shouldShowTaskScopeBanner,
   TaskChangesEmptyState,
   toTaskChangeSetV2,
@@ -35,12 +34,13 @@ import {
   useChangeReviewDialogLifecycleController,
   useChangeReviewDialogViewState,
   useChangeReviewDraftHistoryController,
-  useChangeReviewExternalFileWatcher,
+  useChangeReviewExternalChangeController,
   useChangeReviewFileDecisionController,
   useChangeReviewFileDraftController,
   useChangeReviewHistoryMutationController,
   useChangeReviewHunkDecisionController,
-  useChangeReviewOperationGeneration,
+  useChangeReviewMutationGuards,
+  useChangeReviewOperationState,
   useChangeReviewScopeIdentity,
 } from '@features/change-review/renderer';
 import { api, isElectronMode } from '@renderer/api';
@@ -53,7 +53,6 @@ import {
   registerChangeReviewLifecycleOwner,
 } from '@renderer/utils/changeReviewLifecycleCoordinator';
 import { getFileReviewKey } from '@renderer/utils/reviewKey';
-import { normalizePathForComparison } from '@shared/utils/platformPath';
 import { X } from 'lucide-react';
 
 import {
@@ -66,6 +65,8 @@ import {
   changeReviewDialogLifecycleStatePort,
   changeReviewDialogViewStatePolicy,
   changeReviewDraftHistoryPort,
+  changeReviewExternalChangePolicy,
+  changeReviewExternalChangeStatePort,
   changeReviewExternalFileWatcherPort,
   changeReviewFileDecisionPolicy,
   changeReviewFileDecisionStatePort,
@@ -75,6 +76,7 @@ import {
   changeReviewHistoryMutationStatePort,
   changeReviewHunkDecisionPolicy,
   changeReviewHunkDecisionStatePort,
+  changeReviewOperationStatePort,
 } from './changeReviewDialogComposition';
 import { ChangesLoadingAnimation } from './ChangesLoadingAnimation';
 import {
@@ -90,7 +92,6 @@ import { buildPathChangeLabels } from './pathChangeLabels';
 import {
   getReviewRenameRecoveryExpectation,
   hasUnresolvedReviewExternalChange,
-  isReviewActionLocked,
   isReviewFileFullyRejected,
   replaceReviewScopedRecord,
   resolveReviewFileIsNew,
@@ -108,13 +109,9 @@ import { SavedReviewStateRecoveryGate } from './SavedReviewStateRecoveryGate';
 import { ScopeWarningBanner } from './ScopeWarningBanner';
 import { ViewedProgressBar } from './ViewedProgressBar';
 
-import type {
-  ChangeReviewRecentWrite,
-  ReviewDraftHistoryHydrationState,
-} from '@features/change-review/renderer';
+import type { ReviewDraftHistoryHydrationState } from '@features/change-review/renderer';
 import type { TaskChangeRequestOptions } from '@renderer/utils/taskChangeRequest';
 import type {
-  EditorFileChangeEvent,
   FileChangeSummary,
   ReviewDecisionSnapshot,
   ReviewDiskUndoSnapshot,
@@ -246,17 +243,19 @@ export const ChangeReviewDialog = ({
   });
 
   const [discardCounters, setDiscardCounters] = useState<Record<string, number>>({});
-  const [filesApplying, setFilesApplying] = useState<Set<string>>(() => new Set());
-  const [undoing, setUndoing] = useState(false);
-  const [closing, setClosing] = useState(false);
-  const fileApplyInFlightRef = useRef(new Set<string>());
-  const undoInFlightRef = useRef(false);
-  const closingRef = useRef(false);
-  const pendingApplyCleanupKeyRef = useRef<string | null>(null);
-  const recentReviewWritesRef = useRef(new Map<string, ChangeReviewRecentWrite>());
   // Exact disk state on which each manual draft started. Map.has() distinguishes
   // a genuinely missing file (null baseline) from an uncaptured baseline.
   const expectedDraftHistoryKeyRef = useRef<string | null>(null);
+  const operationState = useChangeReviewOperationState({
+    active: open && lifecycleAuthorized,
+    decisionHydrationKey,
+    fallbackScopeKey: `unscoped:${teamName}:${scopeKey}`,
+    changeSetEpoch,
+    resetKey: `${teamName}\0${scopeKey}\0${changeSetEpoch}`,
+    port: changeReviewOperationStatePort,
+  });
+  const { filesApplying, captureReviewOperationScope, isCurrentReviewOperationScope } =
+    operationState;
 
   useLayoutEffect(() => {
     const activeHydrationKey = open && lifecycleAuthorized ? decisionHydrationKey : null;
@@ -267,27 +266,6 @@ export const ChangeReviewDialog = ({
       }
     };
   }, [decisionHydrationKey, lifecycleAuthorized, open]);
-
-  const resetReviewOperationGenerationState = useCallback((): void => {
-    // Busy state belongs to one operation generation. Never carry it into a
-    // reopened or re-hydrated scope, but preserve recent-write evidence so late
-    // filesystem events from our own committed mutation remain suppressible.
-    fileApplyInFlightRef.current.clear();
-    undoInFlightRef.current = false;
-    closingRef.current = false;
-    setFilesApplying(new Set());
-    setUndoing(false);
-    setClosing(false);
-  }, []);
-
-  const { captureReviewOperationScope, isCurrentReviewOperationScope } =
-    useChangeReviewOperationGeneration({
-      active: open && lifecycleAuthorized,
-      decisionHydrationKey,
-      fallbackScopeKey: `unscoped:${teamName}:${scopeKey}`,
-      changeSetEpoch,
-      resetGenerationState: resetReviewOperationGenerationState,
-    });
 
   const isExpectedDraftHistoryKey = useCallback(
     (hydrationKey: string): boolean => expectedDraftHistoryKeyRef.current === hydrationKey,
@@ -457,12 +435,6 @@ export const ChangeReviewDialog = ({
     resetReviewConflictCandidates,
   ]);
 
-  useEffect(() => {
-    if (pendingApplyCleanupKeyRef.current !== decisionHydrationKey) {
-      pendingApplyCleanupKeyRef.current = null;
-    }
-  }, [decisionHydrationKey]);
-
   const readCurrentReviewDiskContent = useCallback(
     async (filePath: string, fallback: string): Promise<string> => {
       try {
@@ -480,76 +452,30 @@ export const ChangeReviewDialog = ({
     [memberName, taskId, teamName]
   );
 
-  useEffect(() => {
-    fileApplyInFlightRef.current.clear();
-    recentReviewWritesRef.current.clear();
-    undoInFlightRef.current = false;
-    closingRef.current = false;
-    setUndoing(false);
-    setClosing(false);
-    setFilesApplying(new Set());
-  }, [changeSetEpoch, scopeKey, teamName]);
-
-  const ensureDurableReviewScope = useCallback((): boolean => {
-    if (!decisionScopeToken) {
-      useStore.setState({
-        applyError: 'Durable review scope is unavailable; refusing an unsafe disk mutation.',
-      });
-      return false;
-    }
-    return true;
-  }, [decisionScopeToken]);
-
-  const reviewMutationBusy = isReviewActionLocked({
+  const {
+    reviewMutationBusy,
+    reviewActionsBusy,
+    reviewCloseBusy,
+    hasReviewActionInFlight,
+    ensureDurableReviewScope,
+  } = useChangeReviewMutationGuards({
     applying,
-    fileApplyCount: filesApplying.size,
-    undoing,
-    closing,
-  });
-  const reviewActionsBusy =
-    reviewMutationBusy ||
-    reviewConflictRefreshPending ||
-    reviewConflictLoadError !== null ||
-    reviewConflictCandidateCount > 0 ||
-    resolvingConflictCandidateId !== null ||
-    isReviewActionPersistenceBlocking(reviewActionPersistenceStatus) ||
-    (decisionHydrationKey !== null && (!decisionHydrationReady || !draftHistoryHydrationReady));
-  // Candidate discovery and persistence drains are safe to finish in the close flush.
-  // Only an active mutation or conflict resolution must keep the close control locked.
-  const reviewCloseBusy = reviewMutationBusy || resolvingConflictCandidateId !== null;
-
-  const hasReviewActionInFlight = useCallback(() => {
-    const state = useStore.getState();
-    const hydrationReady =
-      decisionHydrationKey === null ||
-      (state.decisionHydrationScopeKey === decisionHydrationKey &&
-        state.decisionHydrationStatus === 'loaded' &&
-        draftHistoryHydration.key === decisionHydrationKey &&
-        draftHistoryHydration.status === 'loaded');
-    return (
-      !hydrationReady ||
-      reviewConflictRefreshPending ||
-      reviewConflictLoadError !== null ||
-      reviewConflictCandidateCount > 0 ||
-      resolvingConflictCandidateId !== null ||
-      isReviewActionPersistenceBlocking(getReviewActionPersistenceStatus()) ||
-      isReviewActionLocked({
-        applying: state.applying,
-        fileApplyCount: fileApplyInFlightRef.current.size,
-        undoing: undoInFlightRef.current,
-        closing: closingRef.current,
-      })
-    );
-  }, [
+    operation: operationState,
+    decisionScopeToken,
     decisionHydrationKey,
-    draftHistoryHydration.key,
-    draftHistoryHydration.status,
-    getReviewActionPersistenceStatus,
-    reviewConflictLoadError,
-    reviewConflictRefreshPending,
-    resolvingConflictCandidateId,
-    reviewConflictCandidateCount,
-  ]);
+    decisionHydrationReady,
+    draftHistoryHydration,
+    draftHistoryHydrationReady,
+    conflict: {
+      refreshPending: reviewConflictRefreshPending,
+      loadError: reviewConflictLoadError,
+      candidateCount: reviewConflictCandidateCount,
+      resolvingCandidateId: resolvingConflictCandidateId,
+    },
+    persistenceStatus: reviewActionPersistenceStatus,
+    getPersistenceStatus: getReviewActionPersistenceStatus,
+    port: changeReviewOperationStatePort,
+  });
 
   const hasReviewDraft = useCallback(
     (filePath: string): boolean => filePath in useStore.getState().editedContents,
@@ -653,59 +579,21 @@ export const ChangeReviewDialog = ({
     [editedContents, fileContents, fileDecisions, sortedFiles]
   );
   const editedCount = Object.keys(editedContents).length;
-  const reviewMutationBlockedByExternalChange = Object.keys(reviewExternalChangesByFile).length > 0;
-  const blockReviewMutationForExternalChange = useCallback((filePath?: string): boolean => {
-    const externalChanges = useStore.getState().reviewExternalChangesByFile;
-    const blocked = filePath
-      ? hasUnresolvedReviewExternalChange(filePath, externalChanges)
-      : Object.keys(externalChanges).length > 0;
-    if (blocked) {
-      useStore.setState({
-        applyError: 'Reload files changed outside Changes before continuing review actions.',
-      });
-    }
-    return blocked;
-  }, []);
-  const processReviewExternalFileChange = useCallback(
-    (event: EditorFileChangeEvent): void => {
-      const normalizedPath = normalizePathForComparison(event.path);
-      const state = useStore.getState();
-      const active = state.activeChangeSet;
-      if (!active) return;
-      const file = active.files.find(
-        (entry) => normalizePathForComparison(entry.filePath) === normalizedPath
-      );
-      if (!file) return;
-      const durableDraftHistory = getDraftHistoryEntry(file.filePath);
-      if (!(file.filePath in state.editedContents) && durableDraftHistory) {
-        state.updateEditedContent(file.filePath, durableDraftHistory.editorState.doc);
-      }
-      const changeType =
-        event.type === 'create' ? 'add' : event.type === 'delete' ? 'unlink' : 'change';
-      state.markReviewFileExternallyChanged(file.filePath, changeType);
-      reportReviewInteractionError(
-        'A reviewed file changed outside Changes. Reload it from disk before continuing review actions.'
-      );
-    },
-    [getDraftHistoryEntry, reportReviewInteractionError]
-  );
-  const isReviewMutationInFlightForPath = useCallback((normalizedPath: string): boolean => {
-    const pathBusy = [...fileApplyInFlightRef.current].some(
-      (filePath) => normalizePathForComparison(filePath) === normalizedPath
-    );
-    return pathBusy || undoInFlightRef.current || useStore.getState().applying;
-  }, []);
-  useChangeReviewExternalFileWatcher({
-    open,
-    enabled: isElectronMode(),
-    projectPath,
-    watchedFilePathsKey: watchedReviewFilePathsKey,
-    reviewScope,
-    recentWritesRef: recentReviewWritesRef,
-    isMutationInFlight: isReviewMutationInFlightForPath,
-    processExternalChange: processReviewExternalFileChange,
-    port: changeReviewExternalFileWatcherPort,
-  });
+  const { reviewMutationBlockedByExternalChange, blockReviewMutationForExternalChange } =
+    useChangeReviewExternalChangeController({
+      open,
+      enabled: isElectronMode(),
+      projectPath,
+      watchedFilePathsKey: watchedReviewFilePathsKey,
+      reviewScope,
+      externalChangesByFile: reviewExternalChangesByFile,
+      recentWritesRef: operationState.viewPortBindings.recentReviewWritesRef,
+      isMutationInFlight: operationState.isPathMutationInFlight,
+      getDraftHistoryEntry,
+      statePort: changeReviewExternalChangeStatePort,
+      policy: changeReviewExternalChangePolicy,
+      watcherPort: changeReviewExternalFileWatcherPort,
+    });
   const dialogViewPorts = useMemo(
     () =>
       // eslint-disable-next-line react-hooks/refs -- Factory only captures refs for later callbacks.
@@ -719,16 +607,9 @@ export const ChangeReviewDialog = ({
           rejectChunk,
         },
         subscribeToRejectCurrentHunk: (callback) => window.electronAPI?.review.onCmdN?.(callback),
-        fileApplyInFlightRef,
-        undoInFlightRef,
-        closingRef,
-        pendingApplyCleanupKeyRef,
+        ...operationState.viewPortBindings,
         expectedDraftHistoryKeyRef,
-        recentReviewWritesRef,
-        setFilesApplying,
         setDiscardCounters,
-        setUndoing,
-        setClosing,
         handleSerializedStateChanged,
         addReviewFile,
         fetchFileContent,
@@ -740,6 +621,7 @@ export const ChangeReviewDialog = ({
       fetchFileContent,
       handleHistoryActionNavigation,
       handleSerializedStateChanged,
+      operationState.viewPortBindings,
     ]
   );
   const buildBulkRejectDiskSnapshot = useCallback(
@@ -1019,10 +901,6 @@ export const ChangeReviewDialog = ({
       replaceReviewActionHistories,
     ]
   );
-  const isReviewFileMutationInFlight = useCallback(
-    (filePath: string): boolean => fileApplyInFlightRef.current.has(filePath),
-    []
-  );
   const {
     undoLatest: handleUndoLatestReviewAction,
     redoLatest: handleRedoLatestReviewAction,
@@ -1043,7 +921,7 @@ export const ChangeReviewDialog = ({
     captureOperationScope: captureReviewOperationScope,
     isCurrentOperationScope: isCurrentReviewOperationScope,
     hasActionInFlight: hasReviewActionInFlight,
-    isFileMutationInFlight: isReviewFileMutationInFlight,
+    isFileMutationInFlight: operationState.isFileMutationInFlight,
     blockForExternalChange: blockReviewMutationForExternalChange,
     getPersistenceStatus: getReviewActionPersistenceStatus,
   });

--- a/src/renderer/components/team/review/changeReviewDialogComposition.ts
+++ b/src/renderer/components/team/review/changeReviewDialogComposition.ts
@@ -1,3 +1,4 @@
+import { resolveChangeReviewFileHunkCount } from '@features/change-review';
 import {
   createChangeReviewActionHistoryStorePort,
   createChangeReviewBulkDecisionStatePort,
@@ -18,7 +19,6 @@ import {
 import { buildReviewRestoreDecisionState } from '@features/review-mutations';
 import { api } from '@renderer/api';
 import { useStore } from '@renderer/store';
-import { getFileHunkCount } from '@renderer/store/slices/changeReviewSlice';
 import { getFileReviewKey } from '@renderer/utils/reviewKey';
 
 import { buildInitialReviewFileScrollKey } from './initialReviewFileScroll';
@@ -130,7 +130,7 @@ export const changeReviewFileDecisionStatePort = createChangeReviewFileDecisionS
 });
 export const changeReviewFileDecisionPolicy: ChangeReviewFileDecisionPolicy = {
   getHunkCount: (file, state) =>
-    getFileHunkCount(file.filePath, file.snippets.length, state.fileChunkCounts),
+    resolveChangeReviewFileHunkCount(file.filePath, file.snippets.length, state.fileChunkCounts),
   getFileDecision: (file, state) =>
     state.fileDecisions[getFileReviewKey(file)] ?? state.fileDecisions[file.filePath],
   resolveModifiedContent: getResolvedReviewModifiedContent,
@@ -155,7 +155,7 @@ export const changeReviewHunkDecisionStatePort = createChangeReviewHunkDecisionS
 );
 export const changeReviewHunkDecisionPolicy: ChangeReviewHunkDecisionPolicy = {
   getHunkCount: (file, state) =>
-    getFileHunkCount(file.filePath, file.snippets.length, state.fileChunkCounts),
+    resolveChangeReviewFileHunkCount(file.filePath, file.snippets.length, state.fileChunkCounts),
   resolveFileIsNew: resolveReviewFileIsNew,
   shouldDeleteWhenUndoingReject: shouldDeleteFileWhenUndoingReject,
   shouldCreateWhenUndoingReject: shouldCreateFileWhenUndoingReject,

--- a/src/renderer/components/team/review/changeReviewDialogComposition.ts
+++ b/src/renderer/components/team/review/changeReviewDialogComposition.ts
@@ -45,8 +45,11 @@ import { resolveReviewFilePath } from './reviewFilePathResolution';
 
 import type {
   ChangeReviewDialogViewStatePolicy,
+  ChangeReviewExternalChangePolicy,
+  ChangeReviewExternalChangeStatePort,
   ChangeReviewFileDecisionPolicy,
   ChangeReviewHunkDecisionPolicy,
+  ChangeReviewOperationStatePort,
 } from '@features/change-review/renderer';
 
 export const changeReviewConflictQueryPort = createChangeReviewConflictQueryPort(() => api.review);
@@ -61,6 +64,34 @@ export const changeReviewDraftHistoryPort = createChangeReviewDraftHistoryPort((
 export const changeReviewExternalFileWatcherPort = createChangeReviewExternalFileWatcherPort(
   () => api.review
 );
+export const changeReviewOperationStatePort: ChangeReviewOperationStatePort = {
+  getSnapshot: () => {
+    const state = useStore.getState();
+    return {
+      applying: state.applying,
+      decisionHydrationScopeKey: state.decisionHydrationScopeKey,
+      decisionHydrationStatus: state.decisionHydrationStatus,
+    };
+  },
+  reportError: (message) => useStore.setState({ applyError: message }),
+};
+export const changeReviewExternalChangeStatePort: ChangeReviewExternalChangeStatePort = {
+  getSnapshot: () => {
+    const state = useStore.getState();
+    return {
+      activeChangeSet: state.activeChangeSet,
+      editedContents: state.editedContents,
+      reviewExternalChangesByFile: state.reviewExternalChangesByFile,
+    };
+  },
+  restoreDraft: (filePath, content) => useStore.getState().updateEditedContent(filePath, content),
+  markExternalChange: (filePath, changeType) =>
+    useStore.getState().markReviewFileExternallyChanged(filePath, changeType),
+  reportError: (message) => useStore.setState({ applyError: message }),
+};
+export const changeReviewExternalChangePolicy: ChangeReviewExternalChangePolicy = {
+  hasUnresolvedExternalChange: hasUnresolvedReviewExternalChange,
+};
 export const changeReviewActionHistoryStorePort = createChangeReviewActionHistoryStorePort({
   getStore: useStore.getState,
   clearLegacyUndoStack: () => useStore.setState({ reviewUndoStack: [] }),

--- a/src/renderer/components/team/review/changeReviewDialogComposition.ts
+++ b/src/renderer/components/team/review/changeReviewDialogComposition.ts
@@ -1,0 +1,173 @@
+import {
+  createChangeReviewActionHistoryStorePort,
+  createChangeReviewBulkDecisionStatePort,
+  createChangeReviewConflictCommandPort,
+  createChangeReviewConflictQueryPort,
+  createChangeReviewConflictStateBridge,
+  createChangeReviewDecisionPersistencePort,
+  createChangeReviewDialogLifecycleStatePort,
+  createChangeReviewDraftHistoryPort,
+  createChangeReviewExternalFileWatcherPort,
+  createChangeReviewFileDecisionStatePort,
+  createChangeReviewFileDraftCommandPort,
+  createChangeReviewFileDraftStatePort,
+  createChangeReviewHistoryMutationCommandPort,
+  createChangeReviewHistoryMutationStatePort,
+  createChangeReviewHunkDecisionStatePort,
+} from '@features/change-review/renderer';
+import { buildReviewRestoreDecisionState } from '@features/review-mutations';
+import { api } from '@renderer/api';
+import { useStore } from '@renderer/store';
+import { getFileHunkCount } from '@renderer/store/slices/changeReviewSlice';
+import { getFileReviewKey } from '@renderer/utils/reviewKey';
+
+import { buildInitialReviewFileScrollKey } from './initialReviewFileScroll';
+import { getReviewActionFilePath } from './reviewActionPresentation';
+import {
+  getReviewRenameRecoveryExpectation,
+  hasReviewFileRejections,
+  hasUnresolvedReviewExternalChange,
+  isReviewFileFullyRejected,
+  resolveReviewFileIsNew,
+  restoreReviewDecisionRecordsForFile,
+  shouldCreateFileWhenUndoingReject,
+  shouldDeleteFileWhenUndoingReject,
+} from './reviewActionState';
+import {
+  getResolvedReviewModifiedContent,
+  isReviewAcceptDisabled,
+  isReviewFileExpectedDeleted,
+  isReviewFileMissingOnDisk,
+  isReviewRejectable,
+  isReviewTextContentUnavailable,
+} from './reviewContentPreview';
+import { resolveReviewFilePath } from './reviewFilePathResolution';
+
+import type {
+  ChangeReviewDialogViewStatePolicy,
+  ChangeReviewFileDecisionPolicy,
+  ChangeReviewHunkDecisionPolicy,
+} from '@features/change-review/renderer';
+
+export const changeReviewConflictQueryPort = createChangeReviewConflictQueryPort(() => api.review);
+export const changeReviewConflictCommandPort = createChangeReviewConflictCommandPort(
+  () => api.review
+);
+export const changeReviewConflictStateBridge = createChangeReviewConflictStateBridge({
+  getSnapshot: useStore.getState,
+  setApplyError: (applyError) => useStore.setState({ applyError }),
+});
+export const changeReviewDraftHistoryPort = createChangeReviewDraftHistoryPort(() => api.review);
+export const changeReviewExternalFileWatcherPort = createChangeReviewExternalFileWatcherPort(
+  () => api.review
+);
+export const changeReviewActionHistoryStorePort = createChangeReviewActionHistoryStorePort({
+  getStore: useStore.getState,
+  clearLegacyUndoStack: () => useStore.setState({ reviewUndoStack: [] }),
+});
+export const changeReviewDecisionPersistencePort = createChangeReviewDecisionPersistencePort({
+  getStore: useStore.getState,
+  setApplyError: (applyError) => useStore.setState({ applyError }),
+});
+export const changeReviewBulkDecisionStatePort = createChangeReviewBulkDecisionStatePort({
+  getStore: useStore.getState,
+  restoreDecisionSnapshot: ({ hunkDecisions, fileDecisions }) =>
+    useStore.setState({ hunkDecisions, fileDecisions }),
+});
+export const changeReviewFileDraftStatePort = createChangeReviewFileDraftStatePort({
+  getStore: useStore.getState,
+  applyReloadedReviewState: (state) =>
+    useStore.setState({
+      hunkDecisions: state.hunkDecisions,
+      fileDecisions: state.fileDecisions,
+      hunkContextHashesByFile: state.hunkContextHashesByFile ?? {},
+      applyError: null,
+    }),
+  reportError: (applyError) => useStore.setState({ applyError }),
+});
+export const changeReviewFileDraftCommandPort = createChangeReviewFileDraftCommandPort({
+  getStore: useStore.getState,
+  getReviewApi: () => api.review,
+});
+export const changeReviewFileDecisionStatePort = createChangeReviewFileDecisionStatePort({
+  getStore: useStore.getState,
+  applyRestoredDecisionState: (file) =>
+    useStore.setState((state) => buildReviewRestoreDecisionState(file, state)),
+  restoreFileDecisions: (file, snapshot) =>
+    useStore.setState((state) => restoreReviewDecisionRecordsForFile(file, state, snapshot)),
+  reportError: (applyError) => useStore.setState({ applyError }),
+});
+export const changeReviewFileDecisionPolicy: ChangeReviewFileDecisionPolicy = {
+  getHunkCount: (file, state) =>
+    getFileHunkCount(file.filePath, file.snippets.length, state.fileChunkCounts),
+  getFileDecision: (file, state) =>
+    state.fileDecisions[getFileReviewKey(file)] ?? state.fileDecisions[file.filePath],
+  resolveModifiedContent: getResolvedReviewModifiedContent,
+  resolveFileIsNew: resolveReviewFileIsNew,
+  isExpectedDeletion: isReviewFileExpectedDeleted,
+  isAcceptDisabled: (_file, content, fileDecision) =>
+    isReviewAcceptDisabled({
+      hasEdits: false,
+      isMissingOnDisk: isReviewFileMissingOnDisk(content),
+      isContentUnavailable: isReviewTextContentUnavailable(_file, content),
+      fileDecision,
+    }),
+  isRejectable: isReviewRejectable,
+  hasFileRejections: hasReviewFileRejections,
+  isFileFullyRejected: isReviewFileFullyRejected,
+  shouldDeleteWhenUndoingReject: shouldDeleteFileWhenUndoingReject,
+  hasUnresolvedExternalChange: hasUnresolvedReviewExternalChange,
+  getRenameRecoveryExpectation: getReviewRenameRecoveryExpectation,
+};
+export const changeReviewHunkDecisionStatePort = createChangeReviewHunkDecisionStatePort(
+  useStore.getState
+);
+export const changeReviewHunkDecisionPolicy: ChangeReviewHunkDecisionPolicy = {
+  getHunkCount: (file, state) =>
+    getFileHunkCount(file.filePath, file.snippets.length, state.fileChunkCounts),
+  resolveFileIsNew: resolveReviewFileIsNew,
+  shouldDeleteWhenUndoingReject: shouldDeleteFileWhenUndoingReject,
+  shouldCreateWhenUndoingReject: shouldCreateFileWhenUndoingReject,
+  getRenameRecoveryExpectation: getReviewRenameRecoveryExpectation,
+};
+export const changeReviewDialogViewStatePolicy: ChangeReviewDialogViewStatePolicy = {
+  buildInitialScrollKey: buildInitialReviewFileScrollKey,
+  getHistoryActionFilePath: getReviewActionFilePath,
+  resolveFilePath: resolveReviewFilePath,
+};
+export const changeReviewDialogLifecycleStatePort = createChangeReviewDialogLifecycleStatePort({
+  getStore: useStore.getState,
+  reportError: (applyError) => useStore.setState({ applyError }),
+  completeSavedStateDiscard: (markDecisionHydrationLoaded) =>
+    useStore.setState({
+      ...(markDecisionHydrationLoaded ? { decisionHydrationStatus: 'loaded' as const } : {}),
+      applyError: null,
+    }),
+});
+export const changeReviewHistoryMutationCommandPort = createChangeReviewHistoryMutationCommandPort(
+  () => api.review
+);
+export const changeReviewHistoryMutationStatePort = createChangeReviewHistoryMutationStatePort({
+  getSnapshot: () => useStore.getState(),
+  quiesceDecisionPersistence: ({ teamName, scopeKey, scopeToken }) =>
+    useStore.getState().quiesceDecisionPersistence(teamName, scopeKey, scopeToken),
+  recordDecisionRevision: ({ teamName, scopeKey, scopeToken }, revision) =>
+    useStore.getState().recordDecisionRevision(teamName, scopeKey, scopeToken, revision),
+  applyDecisionState: ({ hunkDecisions, fileDecisions, hunkContextHashesByFile }) =>
+    useStore.setState({
+      hunkDecisions,
+      fileDecisions,
+      ...(hunkContextHashesByFile ? { hunkContextHashesByFile } : {}),
+    }),
+  applyPersistedState: (state, applyError) =>
+    useStore.setState({
+      hunkDecisions: state.hunkDecisions,
+      fileDecisions: state.fileDecisions,
+      hunkContextHashesByFile: state.hunkContextHashesByFile ?? {},
+      applyError,
+    }),
+  reportError: (applyError) => useStore.setState({ applyError }),
+  clearExternalChange: (filePath) => useStore.getState().clearReviewFileExternalChange(filePath),
+  invalidateResolvedFileContent: (filePath) =>
+    useStore.getState().invalidateResolvedFileContent(filePath),
+});

--- a/test/features/change-review/renderer/useChangeReviewExternalChangeController.test.tsx
+++ b/test/features/change-review/renderer/useChangeReviewExternalChangeController.test.tsx
@@ -1,0 +1,150 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { useChangeReviewExternalChangeController } from '@features/change-review/renderer';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  ChangeReviewExternalChangeController,
+  ChangeReviewExternalChangePolicy,
+  ChangeReviewExternalChangeStatePort,
+  ChangeReviewExternalFileWatcherPort,
+} from '@features/change-review/renderer';
+import type { ReviewDraftHistoryEntry } from '@features/change-review-history/contracts';
+import type { EditorFileChangeEvent } from '@shared/types';
+
+interface Harness {
+  listener: ((event: EditorFileChangeEvent) => void) | null;
+  snapshot: ReturnType<ChangeReviewExternalChangeStatePort['getSnapshot']>;
+  statePort: ChangeReviewExternalChangeStatePort;
+  watcherPort: ChangeReviewExternalFileWatcherPort;
+  policy: ChangeReviewExternalChangePolicy;
+}
+
+function makeEntry(filePath: string): ReviewDraftHistoryEntry {
+  return {
+    filePath,
+    codec: 'codemirror-history-v1',
+    revision: 1,
+    generation: 'generation-1',
+    diskBaseline: 'disk',
+    editorState: { doc: 'durable draft', history: { done: [], undone: [] } },
+    updatedAt: '2026-07-24T00:00:00.000Z',
+  };
+}
+
+function createHarness(): Harness {
+  let listener: ((event: EditorFileChangeEvent) => void) | null = null;
+  const snapshot: Harness['snapshot'] = {
+    activeChangeSet: { files: [{ filePath: '/repo/a.ts' }] },
+    editedContents: {},
+    reviewExternalChangesByFile: {},
+  };
+  const statePort: ChangeReviewExternalChangeStatePort = {
+    getSnapshot: () => snapshot,
+    restoreDraft: vi.fn(),
+    markExternalChange: vi.fn(),
+    reportError: vi.fn(),
+  };
+  const watcherPort: ChangeReviewExternalFileWatcherPort = {
+    checkConflict: vi.fn(() =>
+      Promise.resolve({
+        hasConflict: false,
+        conflictContent: null,
+        currentContent: 'after',
+        originalContent: 'before',
+      })
+    ),
+    subscribe: vi.fn((nextListener: (event: EditorFileChangeEvent) => void) => {
+      listener = nextListener;
+      return vi.fn();
+    }),
+    watchFiles: vi.fn(() => Promise.resolve()),
+    unwatchFiles: vi.fn(() => Promise.resolve()),
+  };
+  const policy: ChangeReviewExternalChangePolicy = {
+    hasUnresolvedExternalChange: (filePath, changes) => filePath in changes,
+  };
+  return {
+    get listener() {
+      return listener;
+    },
+    set listener(nextListener) {
+      listener = nextListener;
+    },
+    snapshot,
+    statePort,
+    watcherPort,
+    policy,
+  };
+}
+
+let latest: ChangeReviewExternalChangeController | null = null;
+
+function Probe({ harness }: Readonly<{ harness: Harness }>): React.JSX.Element {
+  latest = useChangeReviewExternalChangeController({
+    open: true,
+    enabled: true,
+    projectPath: '/repo',
+    watchedFilePathsKey: '/repo/a.ts',
+    reviewScope: { teamName: 'team' },
+    externalChangesByFile: {},
+    recentWritesRef: { current: new Map() },
+    isMutationInFlight: () => false,
+    getDraftHistoryEntry: (filePath) =>
+      filePath === '/repo/a.ts' ? makeEntry(filePath) : undefined,
+    statePort: harness.statePort,
+    policy: harness.policy,
+    watcherPort: harness.watcherPort,
+  });
+  return <div />;
+}
+
+describe('useChangeReviewExternalChangeController', () => {
+  afterEach(() => {
+    latest = null;
+    document.body.innerHTML = '';
+    vi.unstubAllGlobals();
+  });
+
+  it('restores a durable draft and blocks mutations using the live external-change map', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    const harness = createHarness();
+    const root = createRoot(document.body.appendChild(document.createElement('div')));
+
+    await act(async () => {
+      root.render(<Probe harness={harness} />);
+      await Promise.resolve();
+    });
+    expect(latest!.reviewMutationBlockedByExternalChange).toBe(false);
+
+    const subscribedListener = harness.listener!;
+    harness.snapshot.activeChangeSet = { files: [{ filePath: '/repo/b.ts' }] };
+    act(() => subscribedListener({ type: 'create', path: '/repo/a.ts' }));
+    expect(harness.statePort.restoreDraft).not.toHaveBeenCalled();
+    expect(harness.statePort.markExternalChange).not.toHaveBeenCalled();
+
+    harness.snapshot.activeChangeSet = { files: [{ filePath: '/repo/a.ts' }] };
+    act(() => harness.listener?.({ type: 'create', path: '/repo/a.ts' }));
+
+    expect(harness.statePort.restoreDraft).toHaveBeenCalledWith('/repo/a.ts', 'durable draft');
+    expect(harness.statePort.markExternalChange).toHaveBeenCalledWith('/repo/a.ts', 'add');
+    expect(harness.statePort.reportError).toHaveBeenCalledWith(
+      'A reviewed file changed outside Changes. Reload it from disk before continuing review actions.'
+    );
+
+    harness.snapshot.reviewExternalChangesByFile = { '/repo/a.ts': { type: 'add' } };
+    expect(latest!.blockReviewMutationForExternalChange('/repo/a.ts')).toBe(true);
+    expect(harness.statePort.reportError).toHaveBeenLastCalledWith(
+      'Reload files changed outside Changes before continuing review actions.'
+    );
+
+    await act(async () => {
+      root.unmount();
+      await Promise.resolve();
+    });
+    vi.mocked(harness.statePort.markExternalChange).mockClear();
+    act(() => subscribedListener({ type: 'delete', path: '/repo/a.ts' }));
+    expect(harness.statePort.markExternalChange).not.toHaveBeenCalled();
+  });
+});

--- a/test/features/change-review/renderer/useChangeReviewMutationGuards.test.tsx
+++ b/test/features/change-review/renderer/useChangeReviewMutationGuards.test.tsx
@@ -1,0 +1,131 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import {
+  useChangeReviewMutationGuards,
+  useChangeReviewOperationState,
+} from '@features/change-review/renderer';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  ChangeReviewMutationGuards,
+  ChangeReviewOperationState,
+  ChangeReviewOperationStatePort,
+} from '@features/change-review/renderer';
+
+interface ProbeProps {
+  decisionScopeToken: string | null;
+  conflictCandidateCount: number;
+  port: ChangeReviewOperationStatePort;
+}
+
+let latestGuards: ChangeReviewMutationGuards | null = null;
+let latestOperation: ChangeReviewOperationState | null = null;
+
+function Probe({
+  decisionScopeToken,
+  conflictCandidateCount,
+  port,
+}: Readonly<ProbeProps>): React.JSX.Element {
+  latestOperation = useChangeReviewOperationState({
+    active: true,
+    decisionHydrationKey: 'scope-a',
+    fallbackScopeKey: 'unscoped:team-a:task:task-a',
+    changeSetEpoch: 1,
+    resetKey: 'scope-a:1',
+    port,
+  });
+  latestGuards = useChangeReviewMutationGuards({
+    applying: false,
+    operation: latestOperation,
+    decisionScopeToken,
+    decisionHydrationKey: 'scope-a',
+    decisionHydrationReady: true,
+    draftHistoryHydration: { key: 'scope-a', status: 'loaded' },
+    draftHistoryHydrationReady: true,
+    conflict: {
+      refreshPending: false,
+      loadError: null,
+      candidateCount: conflictCandidateCount,
+      resolvingCandidateId: null,
+    },
+    persistenceStatus: 'saved',
+    getPersistenceStatus: () => 'saved',
+    port,
+  });
+  return <div />;
+}
+
+async function flushReact(action: () => void): Promise<void> {
+  await act(async () => {
+    action();
+    await Promise.resolve();
+  });
+}
+
+describe('useChangeReviewMutationGuards', () => {
+  afterEach(() => {
+    latestGuards = null;
+    latestOperation = null;
+    document.body.innerHTML = '';
+    vi.unstubAllGlobals();
+  });
+
+  it('separates action locks from close locks and rejects an unsafe durable mutation', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    const reportError = vi.fn();
+    const snapshot = {
+      applying: false,
+      decisionHydrationScopeKey: 'scope-a',
+      decisionHydrationStatus: 'loaded' as const,
+    };
+    const port: ChangeReviewOperationStatePort = {
+      getSnapshot: () => snapshot,
+      reportError,
+    };
+    const root = createRoot(document.body.appendChild(document.createElement('div')));
+
+    await flushReact(() =>
+      root.render(<Probe decisionScopeToken={null} conflictCandidateCount={1} port={port} />)
+    );
+
+    expect(latestGuards!.reviewActionsBusy).toBe(true);
+    expect(latestGuards!.reviewCloseBusy).toBe(false);
+    expect(latestGuards!.ensureDurableReviewScope()).toBe(false);
+    expect(reportError).toHaveBeenCalledWith(
+      'Durable review scope is unavailable; refusing an unsafe disk mutation.'
+    );
+
+    latestOperation!.viewPortBindings.fileApplyInFlightRef.current.add('/repo/a.ts');
+    expect(latestGuards!.hasReviewActionInFlight()).toBe(true);
+
+    await flushReact(() => root.unmount());
+  });
+
+  it('reads live hydration state before allowing close-time work to finish', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    const snapshot = {
+      applying: false,
+      decisionHydrationScopeKey: 'scope-a',
+      decisionHydrationStatus: 'loaded' as const,
+    };
+    const port: ChangeReviewOperationStatePort = {
+      getSnapshot: () => snapshot,
+      reportError: vi.fn(),
+    };
+    const root = createRoot(document.body.appendChild(document.createElement('div')));
+
+    await flushReact(() =>
+      root.render(
+        <Probe decisionScopeToken="durable-scope" conflictCandidateCount={0} port={port} />
+      )
+    );
+    expect(latestGuards!.hasReviewActionInFlight()).toBe(false);
+    expect(latestGuards!.ensureDurableReviewScope()).toBe(true);
+
+    snapshot.decisionHydrationScopeKey = 'scope-b';
+    expect(latestGuards!.hasReviewActionInFlight()).toBe(true);
+
+    await flushReact(() => root.unmount());
+  });
+});

--- a/test/features/change-review/renderer/useChangeReviewOperationState.test.tsx
+++ b/test/features/change-review/renderer/useChangeReviewOperationState.test.tsx
@@ -1,0 +1,98 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { useChangeReviewOperationState } from '@features/change-review/renderer';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  ChangeReviewOperationState,
+  ChangeReviewOperationStatePort,
+} from '@features/change-review/renderer';
+
+interface ProbeProps {
+  decisionHydrationKey: string;
+  resetKey: string;
+  port: ChangeReviewOperationStatePort;
+}
+
+let latest: ChangeReviewOperationState | null = null;
+
+function Probe({ decisionHydrationKey, resetKey, port }: Readonly<ProbeProps>): React.JSX.Element {
+  latest = useChangeReviewOperationState({
+    active: true,
+    decisionHydrationKey,
+    fallbackScopeKey: 'unscoped:team-a:task:task-a',
+    changeSetEpoch: 1,
+    resetKey,
+    port,
+  });
+  return <div />;
+}
+
+async function flushReact(action: () => void): Promise<void> {
+  await act(async () => {
+    action();
+    await Promise.resolve();
+  });
+}
+
+describe('useChangeReviewOperationState', () => {
+  afterEach(() => {
+    latest = null;
+    document.body.innerHTML = '';
+    vi.unstubAllGlobals();
+  });
+
+  it('tracks exact file work and resets mutation latches with the review scope', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    const snapshot = {
+      applying: false,
+      decisionHydrationScopeKey: 'scope-a',
+      decisionHydrationStatus: 'loaded' as const,
+    };
+    const port: ChangeReviewOperationStatePort = {
+      getSnapshot: () => snapshot,
+      reportError: vi.fn(),
+    };
+    const root = createRoot(document.body.appendChild(document.createElement('div')));
+
+    await flushReact(() =>
+      root.render(<Probe decisionHydrationKey="scope-a" resetKey="team-a:task-a:1" port={port} />)
+    );
+    expect(latest!.captureReviewOperationScope()).toMatchObject({ hydrationKey: 'scope-a' });
+
+    act(() => {
+      latest!.viewPortBindings.fileApplyInFlightRef.current.add('/repo/src/a.ts');
+      latest!.viewPortBindings.undoInFlightRef.current = true;
+      latest!.viewPortBindings.recentReviewWritesRef.current.set('/repo/src/a.ts', {
+        at: 1000,
+        expectedContent: 'committed',
+      });
+      latest!.viewPortBindings.setFilesApplying(new Set(['/repo/src/a.ts']));
+    });
+
+    expect(latest!.isFileMutationInFlight('/repo/src/a.ts')).toBe(true);
+    expect(latest!.isPathMutationInFlight('/repo/src/a.ts')).toBe(true);
+    expect(latest!.isPathMutationInFlight('/repo/src/b.ts')).toBe(true);
+    expect(latest!.filesApplying).toEqual(new Set(['/repo/src/a.ts']));
+
+    await flushReact(() =>
+      root.render(<Probe decisionHydrationKey="scope-b" resetKey="team-a:task-a:1" port={port} />)
+    );
+
+    expect(latest!.viewPortBindings.fileApplyInFlightRef.current.size).toBe(0);
+    expect(latest!.viewPortBindings.undoInFlightRef.current).toBe(false);
+    expect(latest!.filesApplying.size).toBe(0);
+    expect(latest!.viewPortBindings.recentReviewWritesRef.current.has('/repo/src/a.ts')).toBe(true);
+
+    await flushReact(() =>
+      root.render(<Probe decisionHydrationKey="scope-b" resetKey="team-a:task-b:1" port={port} />)
+    );
+    expect(latest!.viewPortBindings.recentReviewWritesRef.current.size).toBe(0);
+
+    snapshot.applying = true;
+    expect(latest!.isPathMutationInFlight('/repo/src/b.ts')).toBe(true);
+
+    await flushReact(() => root.unmount());
+  });
+});


### PR DESCRIPTION
## Summary

- extract the legacy dialog composition bindings into an outer app-shell composition module
- centralize operation-generation state, mutation guards, and external-change orchestration behind narrow feature ports
- keep Zustand and renderer API wiring outside the feature hooks
- consume the shared hunk-count policy through the public change-review feature API

## Safety

- reduce ChangeReviewDialog.tsx from 1540 to 1291 lines and lower the legacy size ratchet
- preserve one watcher subscription and one shared set of mutation refs
- preserve live hydration/applying snapshots, late-write suppression, and detached CodeMirror guards
- independent audit: P1 0, P2 0, P3 0

## Validation

- focused Vitest: 9 files, 65 tests
- architecture Vitest: 2 files, 8 tests
- pnpm typecheck
- focused fast lint
- pnpm guard:source-file-size
- Prettier and git diff checks

Desktop Changes E2E is intentionally deferred to the final less-than-800-line slice, so this intermediate PR does not repeat the same expensive flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection against applying or closing reviews while operations, conflicts, or external file changes are unresolved.
  * Restores eligible draft content and prompts users to reload files changed on disk.
  * Improved operation tracking when switching review scopes or hydration states.

* **Documentation**
  * Clarified Change Review responsibilities and remaining legacy behavior.

* **Tests**
  * Added coverage for external changes, mutation safeguards, operation tracking, draft restoration, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->