### PR TITLE
refactor(change-review): extract decision actions

### DIFF
--- a/scripts/ci/source-file-size-legacy.json
+++ b/scripts/ci/source-file-size-legacy.json
@@ -150,7 +150,7 @@
   "src/renderer/components/team/members/MemberLogsTab.tsx": 985,
   "src/renderer/components/team/messages/MessageComposer.tsx": 1344,
   "src/renderer/components/team/messages/MessagesPanel.tsx": 1722,
-  "src/renderer/components/team/review/ChangeReviewDialog.tsx": 1291,
+  "src/renderer/components/team/review/ChangeReviewDialog.tsx": 1133,
   "src/renderer/components/team/review/CodeMirrorDiffView.tsx": 975,
   "src/renderer/components/team/useTeamChangesSummaries.ts": 826,
   "src/renderer/components/ui/MentionableTextarea.tsx": 1433,

--- a/src/features/change-review/README.md
+++ b/src/features/change-review/README.md
@@ -24,8 +24,9 @@ main-process review IPC shell.
   decision-persistence coordination behind narrow ports.
 - `main/infrastructure` owns Node path, filesystem, sensitive-path, hardlink, and watcher-root
   validation details.
-- The legacy app-shell composition module binds feature ports and policies to Zustand, the
-  renderer API, and remaining review utilities. The dialog keeps per-instance controller
+- The legacy app-shell composition modules bind feature ports and policies to Zustand, the
+  renderer API, and remaining review utilities. A focused decision-action hook owns
+  per-instance bulk/file/hunk Accept/Reject wiring. The dialog keeps draft/history/lifecycle
   composition, CodeMirror action injection, and the main diff/content rendering while later
   slices move those responsibilities behind focused hooks and use cases.
 

--- a/src/renderer/components/team/review/ChangeReviewDialog.tsx
+++ b/src/renderer/components/team/review/ChangeReviewDialog.tsx
@@ -17,16 +17,12 @@ import {
   ChangeReviewConflictDiscardDialog,
   ChangeReviewConflictNotices,
   ChangeReviewSidebar,
-  createChangeReviewBulkDecisionCommandPort,
   createChangeReviewDialogLifecycleCommandPort,
   createChangeReviewDialogViewPorts,
-  createChangeReviewFileDecisionCommandPort,
-  createChangeReviewHunkDecisionCommandPort,
   shouldShowTaskScopeBanner,
   TaskChangesEmptyState,
   toTaskChangeSetV2,
   useChangeReviewActionHistoryController,
-  useChangeReviewBulkDecisionController,
   useChangeReviewConflictDiscoveryController,
   useChangeReviewConflictInteractionController,
   useChangeReviewDecisionPersistenceController,
@@ -35,10 +31,8 @@ import {
   useChangeReviewDialogViewState,
   useChangeReviewDraftHistoryController,
   useChangeReviewExternalChangeController,
-  useChangeReviewFileDecisionController,
   useChangeReviewFileDraftController,
   useChangeReviewHistoryMutationController,
-  useChangeReviewHunkDecisionController,
   useChangeReviewMutationGuards,
   useChangeReviewOperationState,
   useChangeReviewScopeIdentity,
@@ -57,7 +51,6 @@ import { X } from 'lucide-react';
 
 import {
   changeReviewActionHistoryStorePort,
-  changeReviewBulkDecisionStatePort,
   changeReviewConflictCommandPort,
   changeReviewConflictQueryPort,
   changeReviewConflictStateBridge,
@@ -68,14 +61,10 @@ import {
   changeReviewExternalChangePolicy,
   changeReviewExternalChangeStatePort,
   changeReviewExternalFileWatcherPort,
-  changeReviewFileDecisionPolicy,
-  changeReviewFileDecisionStatePort,
   changeReviewFileDraftCommandPort,
   changeReviewFileDraftStatePort,
   changeReviewHistoryMutationCommandPort,
   changeReviewHistoryMutationStatePort,
-  changeReviewHunkDecisionPolicy,
-  changeReviewHunkDecisionStatePort,
   changeReviewOperationStatePort,
 } from './changeReviewDialogComposition';
 import { ChangesLoadingAnimation } from './ChangesLoadingAnimation';
@@ -90,12 +79,9 @@ import { ContinuousScrollView } from './ContinuousScrollView';
 import { KeyboardShortcutsHelp } from './KeyboardShortcutsHelp';
 import { buildPathChangeLabels } from './pathChangeLabels';
 import {
-  getReviewRenameRecoveryExpectation,
   hasUnresolvedReviewExternalChange,
   isReviewFileFullyRejected,
   replaceReviewScopedRecord,
-  resolveReviewFileIsNew,
-  shouldDeleteFileWhenUndoingReject,
 } from './reviewActionState';
 import {
   getResolvedReviewModifiedContent,
@@ -107,17 +93,12 @@ import {
 import { ReviewToolbar } from './ReviewToolbar';
 import { SavedReviewStateRecoveryGate } from './SavedReviewStateRecoveryGate';
 import { ScopeWarningBanner } from './ScopeWarningBanner';
+import { useChangeReviewDecisionActions } from './useChangeReviewDecisionActions';
 import { ViewedProgressBar } from './ViewedProgressBar';
 
 import type { ReviewDraftHistoryHydrationState } from '@features/change-review/renderer';
 import type { TaskChangeRequestOptions } from '@renderer/utils/taskChangeRequest';
-import type {
-  FileChangeSummary,
-  ReviewDecisionSnapshot,
-  ReviewDiskUndoSnapshot,
-  ReviewRedoAction,
-  ReviewUndoAction,
-} from '@shared/types';
+import type { ReviewRedoAction, ReviewUndoAction } from '@shared/types';
 import type { EditorSelectionAction } from '@shared/types/editor';
 
 interface ChangeReviewDialogProps {
@@ -217,22 +198,7 @@ export const ChangeReviewDialog = ({
     decisionHydrationStatus,
     draftHistoryHydration,
   });
-  const {
-    undoDepth: reviewUndoDepth,
-    redoDepth: reviewRedoDepth,
-    getUndoHistory: getReviewUndoHistory,
-    getRedoHistory: getReviewRedoHistory,
-    getLatestUndoAction,
-    getLatestRedoAction,
-    pushUndoAction: pushReviewUndoAction,
-    completeUndoAction: completeReviewUndoAction,
-    bindCommittedAction: bindCommittedReviewAction,
-    completeRedoAction: completeReviewRedoAction,
-    discardLatestAction: discardLatestReviewAction,
-    publishUndoHistory: publishReviewUndoHistory,
-    replaceHistories: replaceReviewActionHistories,
-    clearForFile: clearReviewActionHistoryForFile,
-  } = useChangeReviewActionHistoryController({
+  const actionHistory = useChangeReviewActionHistoryController({
     resetKey: `${teamName}\0${scopeKey}\0${changeSetEpoch}`,
     hydrationKey: decisionHydrationKey,
     hydrationScopeKey: decisionHydrationScopeKey,
@@ -241,6 +207,18 @@ export const ChangeReviewDialog = ({
     hydratedRedoHistory: reviewRedoHistory,
     store: changeReviewActionHistoryStorePort,
   });
+  const {
+    undoDepth: reviewUndoDepth,
+    redoDepth: reviewRedoDepth,
+    getUndoHistory: getReviewUndoHistory,
+    getRedoHistory: getReviewRedoHistory,
+    getLatestUndoAction,
+    getLatestRedoAction,
+    completeUndoAction: completeReviewUndoAction,
+    completeRedoAction: completeReviewRedoAction,
+    replaceHistories: replaceReviewActionHistories,
+    clearForFile: clearReviewActionHistoryForFile,
+  } = actionHistory;
 
   const [discardCounters, setDiscardCounters] = useState<Record<string, number>>({});
   // Exact disk state on which each manual draft started. Map.has() distinguishes
@@ -452,13 +430,7 @@ export const ChangeReviewDialog = ({
     [memberName, taskId, teamName]
   );
 
-  const {
-    reviewMutationBusy,
-    reviewActionsBusy,
-    reviewCloseBusy,
-    hasReviewActionInFlight,
-    ensureDurableReviewScope,
-  } = useChangeReviewMutationGuards({
+  const mutationGuards = useChangeReviewMutationGuards({
     applying,
     operation: operationState,
     decisionScopeToken,
@@ -476,6 +448,8 @@ export const ChangeReviewDialog = ({
     getPersistenceStatus: getReviewActionPersistenceStatus,
     port: changeReviewOperationStatePort,
   });
+  const { reviewMutationBusy, reviewActionsBusy, reviewCloseBusy, hasReviewActionInFlight } =
+    mutationGuards;
 
   const hasReviewDraft = useCallback(
     (filePath: string): boolean => filePath in useStore.getState().editedContents,
@@ -579,21 +553,22 @@ export const ChangeReviewDialog = ({
     [editedContents, fileContents, fileDecisions, sortedFiles]
   );
   const editedCount = Object.keys(editedContents).length;
+  const externalChangeController = useChangeReviewExternalChangeController({
+    open,
+    enabled: isElectronMode(),
+    projectPath,
+    watchedFilePathsKey: watchedReviewFilePathsKey,
+    reviewScope,
+    externalChangesByFile: reviewExternalChangesByFile,
+    recentWritesRef: operationState.viewPortBindings.recentReviewWritesRef,
+    isMutationInFlight: operationState.isPathMutationInFlight,
+    getDraftHistoryEntry,
+    statePort: changeReviewExternalChangeStatePort,
+    policy: changeReviewExternalChangePolicy,
+    watcherPort: changeReviewExternalFileWatcherPort,
+  });
   const { reviewMutationBlockedByExternalChange, blockReviewMutationForExternalChange } =
-    useChangeReviewExternalChangeController({
-      open,
-      enabled: isElectronMode(),
-      projectPath,
-      watchedFilePathsKey: watchedReviewFilePathsKey,
-      reviewScope,
-      externalChangesByFile: reviewExternalChangesByFile,
-      recentWritesRef: operationState.viewPortBindings.recentReviewWritesRef,
-      isMutationInFlight: operationState.isPathMutationInFlight,
-      getDraftHistoryEntry,
-      statePort: changeReviewExternalChangeStatePort,
-      policy: changeReviewExternalChangePolicy,
-      watcherPort: changeReviewExternalFileWatcherPort,
-    });
+    externalChangeController;
   const dialogViewPorts = useMemo(
     () =>
       // eslint-disable-next-line react-hooks/refs -- Factory only captures refs for later callbacks.
@@ -624,169 +599,36 @@ export const ChangeReviewDialog = ({
       operationState.viewPortBindings,
     ]
   );
-  const buildBulkRejectDiskSnapshot = useCallback(
-    (
-      file: FileChangeSummary,
-      decisionSnapshot: ReviewDecisionSnapshot
-    ): ReviewDiskUndoSnapshot | null => {
-      const content = fileContents[file.filePath] ?? null;
-      const isNewFile = resolveReviewFileIsNew(file, content);
-      const hunkCount = getFileHunkCount(file.filePath, file.snippets.length, fileChunkCounts);
-      const shouldDeleteOnUndo = shouldDeleteFileWhenUndoingReject(
-        file,
-        hunkCount,
-        decisionSnapshot
-      );
-      const beforeContent =
-        editorViewMapRef.current.get(file.filePath)?.state.doc.toString() ??
-        getResolvedReviewModifiedContent(file, content);
-      const afterContent = isNewFile ? null : (content?.originalFullContent ?? null);
-      if (beforeContent == null || (afterContent == null && !isNewFile)) return null;
-      return {
-        filePath: file.filePath,
-        beforeContent,
-        afterContent,
-        file,
-        restoreMode: isNewFile ? 'create-file' : shouldDeleteOnUndo ? 'delete-file' : undefined,
-        renameExpectation: getReviewRenameRecoveryExpectation(file) ?? undefined,
-        fileIndex: isNewFile
-          ? activeChangeSet?.files.findIndex((candidate) => candidate.filePath === file.filePath)
-          : undefined,
-      };
-    },
-    [activeChangeSet, editorViewMapRef, fileChunkCounts, fileContents]
-  );
-  const bulkDecisionCommandPort = useMemo(
-    () =>
-      createChangeReviewBulkDecisionCommandPort({
-        getStore: useStore.getState,
-        readCurrentDiskContent: readCurrentReviewDiskContent,
-      }),
-    [readCurrentReviewDiskContent]
-  );
-  const { acceptAll: handleAcceptAll, rejectAll: handleRejectAll } =
-    useChangeReviewBulkDecisionController({
-      active: activeChangeSet !== null,
-      files: activeChangeSet?.files ?? [],
-      rejectableFiles: rejectablePendingFiles,
-      canAcceptAll,
-      changeSetEpoch,
-      instantApply: REVIEW_INSTANT_APPLY,
-      teamName,
-      taskId,
-      memberName,
-      history: {
-        pushUndoAction: pushReviewUndoAction,
-        bindCommittedAction: bindCommittedReviewAction,
-        discardLatestAction: discardLatestReviewAction,
-        getLatestUndoAction,
-        publishUndoHistory: publishReviewUndoHistory,
-      },
-      statePort: changeReviewBulkDecisionStatePort,
-      commandPort: bulkDecisionCommandPort,
-      editorPort: dialogViewPorts.bulkDecision.editor,
-      statusPort: dialogViewPorts.bulkDecision.status,
-      writeEvidencePort: dialogViewPorts.bulkDecision.writeEvidence,
-      buildRejectDiskSnapshot: buildBulkRejectDiskSnapshot,
-      persistLatestAcceptedAction: persistLatestAcceptedReviewAction,
-      ensureDurableScope: ensureDurableReviewScope,
-      hasActionInFlight: hasReviewActionInFlight,
-      blockForExternalChange: blockReviewMutationForExternalChange,
-      captureOperationScope: captureReviewOperationScope,
-      isCurrentOperationScope: isCurrentReviewOperationScope,
-    });
-  const fileDecisionCommandPort = useMemo(
-    () =>
-      createChangeReviewFileDecisionCommandPort({
-        getStore: useStore.getState,
-        getReviewApi: () => api.review,
-        readCurrentDiskContent: readCurrentReviewDiskContent,
-      }),
-    [readCurrentReviewDiskContent]
-  );
-  const { acceptFile: handleAcceptFile, rejectFile: handleRejectFile } =
-    useChangeReviewFileDecisionController({
-      files: activeChangeSet?.files ?? [],
-      fileContents,
-      changeSetEpoch,
-      instantApply: REVIEW_INSTANT_APPLY,
-      teamName,
-      taskId,
-      memberName,
-      reviewScope,
-      persistenceScope: decisionScopeToken
-        ? { teamName, scopeKey: decisionScopeKey, scopeToken: decisionScopeToken }
-        : null,
-      history: {
-        pushUndoAction: pushReviewUndoAction,
-        bindCommittedAction: bindCommittedReviewAction,
-        discardLatestAction: discardLatestReviewAction,
-        getUndoHistory: getReviewUndoHistory,
-        getRedoHistory: getReviewRedoHistory,
-        publishUndoHistory: publishReviewUndoHistory,
-      },
-      statePort: changeReviewFileDecisionStatePort,
-      commandPort: fileDecisionCommandPort,
-      editorPort: dialogViewPorts.fileDecision.editor,
-      statusPort: dialogViewPorts.fileDecision.status,
-      writeEvidencePort: dialogViewPorts.fileDecision.writeEvidence,
-      policy: changeReviewFileDecisionPolicy,
-      persistLatestAcceptedAction: persistLatestAcceptedReviewAction,
-      ensureDurableScope: ensureDurableReviewScope,
-      hasDraft: hasReviewDraft,
-      hasActionInFlight: hasReviewActionInFlight,
-      blockForExternalChange: blockReviewMutationForExternalChange,
-      captureOperationScope: captureReviewOperationScope,
-      isCurrentOperationScope: isCurrentReviewOperationScope,
-    });
-
-  // Per-file callbacks for ContinuousScrollView
-  const hunkDecisionCommandPort = useMemo(
-    () =>
-      createChangeReviewHunkDecisionCommandPort({
-        getStore: useStore.getState,
-        readCurrentDiskContent: readCurrentReviewDiskContent,
-      }),
-    [readCurrentReviewDiskContent]
-  );
-  const hunkDecisionHistoryPort = useMemo(
-    () => ({
-      pushUndoAction: pushReviewUndoAction,
-      bindCommittedAction: bindCommittedReviewAction,
-      discardLatestAction: discardLatestReviewAction,
-      publishUndoHistory: publishReviewUndoHistory,
-    }),
-    [
-      bindCommittedReviewAction,
-      discardLatestReviewAction,
-      publishReviewUndoHistory,
-      pushReviewUndoAction,
-    ]
-  );
-  const { acceptHunk: handleHunkAccepted, rejectHunk: handleHunkRejected } =
-    useChangeReviewHunkDecisionController({
-      files: activeChangeSet?.files ?? [],
-      fileContents,
-      changeSetEpoch,
-      instantApply: REVIEW_INSTANT_APPLY,
-      teamName,
-      taskId,
-      memberName,
-      statePort: changeReviewHunkDecisionStatePort,
-      commandPort: hunkDecisionCommandPort,
-      editorPort: dialogViewPorts.hunkDecision.editor,
-      statusPort: dialogViewPorts.hunkDecision.status,
-      historyPort: hunkDecisionHistoryPort,
-      writeEvidencePort: dialogViewPorts.hunkDecision.writeEvidence,
-      policy: changeReviewHunkDecisionPolicy,
-      persistLatestAcceptedAction: persistLatestAcceptedReviewAction,
-      ensureDurableScope: ensureDurableReviewScope,
-      hasDraft: hasReviewDraft,
-      hasActionInFlight: hasReviewActionInFlight,
-      blockForExternalChange: blockReviewMutationForExternalChange,
-      captureOperationScope: captureReviewOperationScope,
-      isCurrentOperationScope: isCurrentReviewOperationScope,
-    });
+  const {
+    acceptAll: handleAcceptAll,
+    rejectAll: handleRejectAll,
+    acceptFile: handleAcceptFile,
+    rejectFile: handleRejectFile,
+    acceptHunk: handleHunkAccepted,
+    rejectHunk: handleHunkRejected,
+  } = useChangeReviewDecisionActions({
+    activeChangeSet,
+    fileContents,
+    fileChunkCounts,
+    rejectableFiles: rejectablePendingFiles,
+    canAcceptAll,
+    changeSetEpoch,
+    teamName,
+    taskId,
+    memberName,
+    reviewScope,
+    decisionScopeKey,
+    decisionScopeToken,
+    editorViewMapRef,
+    readCurrentDiskContent: readCurrentReviewDiskContent,
+    hasDraft: hasReviewDraft,
+    history: actionHistory,
+    persistence: decisionPersistence,
+    mutationGuards,
+    operation: operationState,
+    externalChange: externalChangeController,
+    viewPorts: dialogViewPorts,
+  });
 
   const fileDraftPersistenceScope = useMemo(
     () =>

--- a/src/renderer/components/team/review/useChangeReviewDecisionActions.ts
+++ b/src/renderer/components/team/review/useChangeReviewDecisionActions.ts
@@ -1,0 +1,307 @@
+import { useCallback, useMemo } from 'react';
+
+import { resolveChangeReviewFileHunkCount } from '@features/change-review';
+import {
+  createChangeReviewBulkDecisionCommandPort,
+  createChangeReviewFileDecisionCommandPort,
+  createChangeReviewHunkDecisionCommandPort,
+  useChangeReviewBulkDecisionController,
+  useChangeReviewFileDecisionController,
+  useChangeReviewHunkDecisionController,
+} from '@features/change-review/renderer';
+import { api } from '@renderer/api';
+import { useStore } from '@renderer/store';
+import { REVIEW_INSTANT_APPLY } from '@renderer/store/slices/changeReviewSlice';
+
+import {
+  changeReviewBulkDecisionStatePort,
+  changeReviewFileDecisionPolicy,
+  changeReviewFileDecisionStatePort,
+  changeReviewHunkDecisionPolicy,
+  changeReviewHunkDecisionStatePort,
+} from './changeReviewDialogComposition';
+import {
+  getReviewRenameRecoveryExpectation,
+  resolveReviewFileIsNew,
+  shouldDeleteFileWhenUndoingReject,
+} from './reviewActionState';
+import { getResolvedReviewModifiedContent } from './reviewContentPreview';
+
+import type { EditorView } from '@codemirror/view';
+import type {
+  ChangeReviewActionHistoryController,
+  ChangeReviewBulkDecisionController,
+  ChangeReviewDecisionPersistenceController,
+  ChangeReviewDialogViewPorts,
+  ChangeReviewExternalChangeController,
+  ChangeReviewFileDecisionController,
+  ChangeReviewHunkDecisionController,
+  ChangeReviewMutationGuards,
+  ChangeReviewOperationState,
+} from '@features/change-review/renderer';
+import type {
+  FileChangeSummary,
+  FileChangeWithContent,
+  ReviewDecisionSnapshot,
+  ReviewDiskUndoSnapshot,
+  ReviewFileScope,
+} from '@shared/types';
+import type { RefObject } from 'react';
+
+interface ChangeReviewDecisionChangeSet {
+  files: FileChangeSummary[];
+}
+
+type ChangeReviewDecisionHistory = Pick<
+  ChangeReviewActionHistoryController,
+  | 'pushUndoAction'
+  | 'bindCommittedAction'
+  | 'discardLatestAction'
+  | 'getLatestUndoAction'
+  | 'getUndoHistory'
+  | 'getRedoHistory'
+  | 'publishUndoHistory'
+>;
+
+type ChangeReviewDecisionPersistence = Pick<
+  ChangeReviewDecisionPersistenceController,
+  'persistLatest'
+>;
+
+type ChangeReviewDecisionMutationGuards = Pick<
+  ChangeReviewMutationGuards,
+  'ensureDurableReviewScope' | 'hasReviewActionInFlight'
+>;
+
+type ChangeReviewDecisionOperation = Pick<
+  ChangeReviewOperationState,
+  'captureReviewOperationScope' | 'isCurrentReviewOperationScope'
+>;
+
+type ChangeReviewDecisionExternalChange = Pick<
+  ChangeReviewExternalChangeController,
+  'blockReviewMutationForExternalChange'
+>;
+
+type ChangeReviewDecisionViewPorts = Pick<
+  ChangeReviewDialogViewPorts,
+  'bulkDecision' | 'fileDecision' | 'hunkDecision'
+>;
+
+interface UseChangeReviewDecisionActionsInput {
+  activeChangeSet: ChangeReviewDecisionChangeSet | null;
+  fileContents: Record<string, FileChangeWithContent>;
+  fileChunkCounts: Record<string, number>;
+  rejectableFiles: readonly FileChangeSummary[];
+  canAcceptAll: boolean;
+  changeSetEpoch: number;
+  teamName: string;
+  taskId: string | undefined;
+  memberName: string | undefined;
+  reviewScope: ReviewFileScope;
+  decisionScopeKey: string;
+  decisionScopeToken: string | null;
+  editorViewMapRef: RefObject<Map<string, EditorView>>;
+  readCurrentDiskContent: (filePath: string, fallback: string) => Promise<string>;
+  hasDraft: (filePath: string) => boolean;
+  history: ChangeReviewDecisionHistory;
+  persistence: ChangeReviewDecisionPersistence;
+  mutationGuards: ChangeReviewDecisionMutationGuards;
+  operation: ChangeReviewDecisionOperation;
+  externalChange: ChangeReviewDecisionExternalChange;
+  viewPorts: ChangeReviewDecisionViewPorts;
+}
+
+export interface ChangeReviewDecisionActions {
+  acceptAll: ChangeReviewBulkDecisionController['acceptAll'];
+  rejectAll: ChangeReviewBulkDecisionController['rejectAll'];
+  acceptFile: ChangeReviewFileDecisionController['acceptFile'];
+  rejectFile: ChangeReviewFileDecisionController['rejectFile'];
+  acceptHunk: ChangeReviewHunkDecisionController['acceptHunk'];
+  rejectHunk: ChangeReviewHunkDecisionController['rejectHunk'];
+}
+
+export function useChangeReviewDecisionActions({
+  activeChangeSet,
+  fileContents,
+  fileChunkCounts,
+  rejectableFiles,
+  canAcceptAll,
+  changeSetEpoch,
+  teamName,
+  taskId,
+  memberName,
+  reviewScope,
+  decisionScopeKey,
+  decisionScopeToken,
+  editorViewMapRef,
+  readCurrentDiskContent,
+  hasDraft,
+  history,
+  persistence,
+  mutationGuards,
+  operation,
+  externalChange,
+  viewPorts,
+}: UseChangeReviewDecisionActionsInput): ChangeReviewDecisionActions {
+  const buildBulkRejectDiskSnapshot = useCallback(
+    (
+      file: FileChangeSummary,
+      decisionSnapshot: ReviewDecisionSnapshot
+    ): ReviewDiskUndoSnapshot | null => {
+      const content = fileContents[file.filePath] ?? null;
+      const isNewFile = resolveReviewFileIsNew(file, content);
+      const hunkCount = resolveChangeReviewFileHunkCount(
+        file.filePath,
+        file.snippets.length,
+        fileChunkCounts
+      );
+      const shouldDeleteOnUndo = shouldDeleteFileWhenUndoingReject(
+        file,
+        hunkCount,
+        decisionSnapshot
+      );
+      const beforeContent =
+        editorViewMapRef.current.get(file.filePath)?.state.doc.toString() ??
+        getResolvedReviewModifiedContent(file, content);
+      const afterContent = isNewFile ? null : (content?.originalFullContent ?? null);
+      if (beforeContent == null || (afterContent == null && !isNewFile)) return null;
+      return {
+        filePath: file.filePath,
+        beforeContent,
+        afterContent,
+        file,
+        restoreMode: isNewFile ? 'create-file' : shouldDeleteOnUndo ? 'delete-file' : undefined,
+        renameExpectation: getReviewRenameRecoveryExpectation(file) ?? undefined,
+        fileIndex: isNewFile
+          ? activeChangeSet?.files.findIndex((candidate) => candidate.filePath === file.filePath)
+          : undefined,
+      };
+    },
+    [activeChangeSet, editorViewMapRef, fileChunkCounts, fileContents]
+  );
+  const bulkCommandPort = useMemo(
+    () =>
+      createChangeReviewBulkDecisionCommandPort({
+        getStore: useStore.getState,
+        readCurrentDiskContent,
+      }),
+    [readCurrentDiskContent]
+  );
+  const bulk = useChangeReviewBulkDecisionController({
+    active: activeChangeSet !== null,
+    files: activeChangeSet?.files ?? [],
+    rejectableFiles,
+    canAcceptAll,
+    changeSetEpoch,
+    instantApply: REVIEW_INSTANT_APPLY,
+    teamName,
+    taskId,
+    memberName,
+    history,
+    statePort: changeReviewBulkDecisionStatePort,
+    commandPort: bulkCommandPort,
+    editorPort: viewPorts.bulkDecision.editor,
+    statusPort: viewPorts.bulkDecision.status,
+    writeEvidencePort: viewPorts.bulkDecision.writeEvidence,
+    buildRejectDiskSnapshot: buildBulkRejectDiskSnapshot,
+    persistLatestAcceptedAction: persistence.persistLatest,
+    ensureDurableScope: mutationGuards.ensureDurableReviewScope,
+    hasActionInFlight: mutationGuards.hasReviewActionInFlight,
+    blockForExternalChange: externalChange.blockReviewMutationForExternalChange,
+    captureOperationScope: operation.captureReviewOperationScope,
+    isCurrentOperationScope: operation.isCurrentReviewOperationScope,
+  });
+
+  const fileCommandPort = useMemo(
+    () =>
+      createChangeReviewFileDecisionCommandPort({
+        getStore: useStore.getState,
+        getReviewApi: () => api.review,
+        readCurrentDiskContent,
+      }),
+    [readCurrentDiskContent]
+  );
+  const file = useChangeReviewFileDecisionController({
+    files: activeChangeSet?.files ?? [],
+    fileContents,
+    changeSetEpoch,
+    instantApply: REVIEW_INSTANT_APPLY,
+    teamName,
+    taskId,
+    memberName,
+    reviewScope,
+    persistenceScope: decisionScopeToken
+      ? { teamName, scopeKey: decisionScopeKey, scopeToken: decisionScopeToken }
+      : null,
+    history,
+    statePort: changeReviewFileDecisionStatePort,
+    commandPort: fileCommandPort,
+    editorPort: viewPorts.fileDecision.editor,
+    statusPort: viewPorts.fileDecision.status,
+    writeEvidencePort: viewPorts.fileDecision.writeEvidence,
+    policy: changeReviewFileDecisionPolicy,
+    persistLatestAcceptedAction: persistence.persistLatest,
+    ensureDurableScope: mutationGuards.ensureDurableReviewScope,
+    hasDraft,
+    hasActionInFlight: mutationGuards.hasReviewActionInFlight,
+    blockForExternalChange: externalChange.blockReviewMutationForExternalChange,
+    captureOperationScope: operation.captureReviewOperationScope,
+    isCurrentOperationScope: operation.isCurrentReviewOperationScope,
+  });
+
+  const hunkCommandPort = useMemo(
+    () =>
+      createChangeReviewHunkDecisionCommandPort({
+        getStore: useStore.getState,
+        readCurrentDiskContent,
+      }),
+    [readCurrentDiskContent]
+  );
+  const hunkHistoryPort = useMemo(
+    () => ({
+      pushUndoAction: history.pushUndoAction,
+      bindCommittedAction: history.bindCommittedAction,
+      discardLatestAction: history.discardLatestAction,
+      publishUndoHistory: history.publishUndoHistory,
+    }),
+    [
+      history.bindCommittedAction,
+      history.discardLatestAction,
+      history.publishUndoHistory,
+      history.pushUndoAction,
+    ]
+  );
+  const hunk = useChangeReviewHunkDecisionController({
+    files: activeChangeSet?.files ?? [],
+    fileContents,
+    changeSetEpoch,
+    instantApply: REVIEW_INSTANT_APPLY,
+    teamName,
+    taskId,
+    memberName,
+    statePort: changeReviewHunkDecisionStatePort,
+    commandPort: hunkCommandPort,
+    editorPort: viewPorts.hunkDecision.editor,
+    statusPort: viewPorts.hunkDecision.status,
+    historyPort: hunkHistoryPort,
+    writeEvidencePort: viewPorts.hunkDecision.writeEvidence,
+    policy: changeReviewHunkDecisionPolicy,
+    persistLatestAcceptedAction: persistence.persistLatest,
+    ensureDurableScope: mutationGuards.ensureDurableReviewScope,
+    hasDraft,
+    hasActionInFlight: mutationGuards.hasReviewActionInFlight,
+    blockForExternalChange: externalChange.blockReviewMutationForExternalChange,
+    captureOperationScope: operation.captureReviewOperationScope,
+    isCurrentOperationScope: operation.isCurrentReviewOperationScope,
+  });
+
+  return {
+    acceptAll: bulk.acceptAll,
+    rejectAll: bulk.rejectAll,
+    acceptFile: file.acceptFile,
+    rejectFile: file.rejectFile,
+    acceptHunk: hunk.acceptHunk,
+    rejectHunk: hunk.rejectHunk,
+  };
+}

--- a/test/renderer/components/team/review/useChangeReviewDecisionActions.test.tsx
+++ b/test/renderer/components/team/review/useChangeReviewDecisionActions.test.tsx
@@ -1,0 +1,250 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { useChangeReviewDecisionActions } from '@renderer/components/team/review/useChangeReviewDecisionActions';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { EditorView } from '@codemirror/view';
+import type {
+  ChangeReviewActionHistoryController,
+  ChangeReviewDecisionPersistenceController,
+  ChangeReviewDialogViewPorts,
+  ChangeReviewExternalChangeController,
+  ChangeReviewMutationGuards,
+  ChangeReviewOperationState,
+} from '@features/change-review/renderer';
+import type {
+  FileChangeSummary,
+  FileChangeWithContent,
+  ReviewDecisionSnapshot,
+  ReviewDiskUndoSnapshot,
+} from '@shared/types';
+
+const decisionMocks = vi.hoisted(() => ({
+  bulkCommandPort: { kind: 'bulk-command' },
+  fileCommandPort: { kind: 'file-command' },
+  hunkCommandPort: { kind: 'hunk-command' },
+  createBulkCommandPort: vi.fn(),
+  createFileCommandPort: vi.fn(),
+  createHunkCommandPort: vi.fn(),
+  acceptAll: vi.fn(),
+  rejectAll: vi.fn(),
+  acceptFile: vi.fn(),
+  rejectFile: vi.fn(),
+  acceptHunk: vi.fn(),
+  rejectHunk: vi.fn(),
+  useBulkController: vi.fn(),
+  useFileController: vi.fn(),
+  useHunkController: vi.fn(),
+}));
+
+vi.mock('@features/change-review/renderer', async () => {
+  const actual = await vi.importActual<typeof import('@features/change-review/renderer')>(
+    '@features/change-review/renderer'
+  );
+  decisionMocks.createBulkCommandPort.mockReturnValue(decisionMocks.bulkCommandPort);
+  decisionMocks.createFileCommandPort.mockReturnValue(decisionMocks.fileCommandPort);
+  decisionMocks.createHunkCommandPort.mockReturnValue(decisionMocks.hunkCommandPort);
+  decisionMocks.useBulkController.mockReturnValue({
+    acceptAll: decisionMocks.acceptAll,
+    rejectAll: decisionMocks.rejectAll,
+  });
+  decisionMocks.useFileController.mockReturnValue({
+    acceptFile: decisionMocks.acceptFile,
+    rejectFile: decisionMocks.rejectFile,
+  });
+  decisionMocks.useHunkController.mockReturnValue({
+    acceptHunk: decisionMocks.acceptHunk,
+    rejectHunk: decisionMocks.rejectHunk,
+  });
+  return {
+    ...actual,
+    createChangeReviewBulkDecisionCommandPort: decisionMocks.createBulkCommandPort,
+    createChangeReviewFileDecisionCommandPort: decisionMocks.createFileCommandPort,
+    createChangeReviewHunkDecisionCommandPort: decisionMocks.createHunkCommandPort,
+    useChangeReviewBulkDecisionController: decisionMocks.useBulkController,
+    useChangeReviewFileDecisionController: decisionMocks.useFileController,
+    useChangeReviewHunkDecisionController: decisionMocks.useHunkController,
+  };
+});
+
+const file: FileChangeSummary = {
+  filePath: '/repo/a.ts',
+  relativePath: 'a.ts',
+  snippets: [],
+  linesAdded: 1,
+  linesRemoved: 0,
+  isNewFile: true,
+};
+const fileContent: FileChangeWithContent = {
+  ...file,
+  originalFullContent: '',
+  modifiedFullContent: 'agent content',
+  contentSource: 'ledger-exact',
+};
+const editorViewMapRef = {
+  current: new Map([
+    [
+      file.filePath,
+      {
+        state: { doc: { toString: () => 'current editor content' } },
+      } as unknown as EditorView,
+    ],
+  ]),
+};
+
+const history = {
+  pushUndoAction: vi.fn(),
+  bindCommittedAction: vi.fn(),
+  discardLatestAction: vi.fn(),
+  getLatestUndoAction: vi.fn(),
+  getUndoHistory: vi.fn(),
+  getRedoHistory: vi.fn(),
+  publishUndoHistory: vi.fn(),
+} as unknown as ChangeReviewActionHistoryController;
+const persistence = {
+  persistLatest: vi.fn(() => Promise.resolve(true)),
+} as unknown as ChangeReviewDecisionPersistenceController;
+const mutationGuards = {
+  ensureDurableReviewScope: vi.fn(() => true),
+  hasReviewActionInFlight: vi.fn(() => false),
+} as unknown as ChangeReviewMutationGuards;
+const operation = {
+  captureReviewOperationScope: vi.fn(),
+  isCurrentReviewOperationScope: vi.fn(),
+} as unknown as ChangeReviewOperationState;
+const externalChange = {
+  blockReviewMutationForExternalChange: vi.fn(() => false),
+} as unknown as ChangeReviewExternalChangeController;
+const viewPorts = {
+  bulkDecision: {
+    editor: { kind: 'bulk-editor' },
+    status: { kind: 'bulk-status' },
+    writeEvidence: { kind: 'bulk-write' },
+  },
+  fileDecision: {
+    editor: { kind: 'file-editor' },
+    status: { kind: 'file-status' },
+    writeEvidence: { kind: 'file-write' },
+  },
+  hunkDecision: {
+    editor: { kind: 'hunk-editor' },
+    status: { kind: 'hunk-status' },
+    writeEvidence: { kind: 'hunk-write' },
+  },
+} as unknown as ChangeReviewDialogViewPorts;
+
+let latest: ReturnType<typeof useChangeReviewDecisionActions> | null = null;
+
+function Probe(): React.JSX.Element {
+  latest = useChangeReviewDecisionActions({
+    activeChangeSet: { files: [file] },
+    fileContents: { [file.filePath]: fileContent },
+    fileChunkCounts: {},
+    rejectableFiles: [file],
+    canAcceptAll: true,
+    changeSetEpoch: 3,
+    teamName: 'team-a',
+    taskId: 'task-a',
+    memberName: undefined,
+    reviewScope: { teamName: 'team-a', taskId: 'task-a' },
+    decisionScopeKey: 'task-task-a',
+    decisionScopeToken: 'token-a',
+    editorViewMapRef,
+    readCurrentDiskContent: (_filePath, fallback) => Promise.resolve(fallback),
+    hasDraft: () => false,
+    history,
+    persistence,
+    mutationGuards,
+    operation,
+    externalChange,
+    viewPorts,
+  });
+  return <div />;
+}
+
+describe('useChangeReviewDecisionActions', () => {
+  afterEach(() => {
+    latest = null;
+    document.body.innerHTML = '';
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('wires bulk, file and hunk decision controllers to one review scope', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    const root = createRoot(document.body.appendChild(document.createElement('div')));
+
+    await act(async () => {
+      root.render(<Probe />);
+      await Promise.resolve();
+    });
+
+    expect(latest).toEqual({
+      acceptAll: decisionMocks.acceptAll,
+      rejectAll: decisionMocks.rejectAll,
+      acceptFile: decisionMocks.acceptFile,
+      rejectFile: decisionMocks.rejectFile,
+      acceptHunk: decisionMocks.acceptHunk,
+      rejectHunk: decisionMocks.rejectHunk,
+    });
+    expect(decisionMocks.useBulkController).toHaveBeenCalledWith(
+      expect.objectContaining({
+        active: true,
+        files: [file],
+        history,
+        persistLatestAcceptedAction: persistence.persistLatest,
+        ensureDurableScope: mutationGuards.ensureDurableReviewScope,
+      })
+    );
+    const bulkInput = decisionMocks.useBulkController.mock.calls[0]?.[0] as {
+      buildRejectDiskSnapshot: (
+        file: FileChangeSummary,
+        decisionSnapshot: ReviewDecisionSnapshot
+      ) => ReviewDiskUndoSnapshot | null;
+    };
+    expect(
+      bulkInput.buildRejectDiskSnapshot(file, {
+        hunkDecisions: {},
+        fileDecisions: {},
+      })
+    ).toMatchObject({
+      filePath: file.filePath,
+      beforeContent: 'current editor content',
+      afterContent: null,
+      file,
+      restoreMode: 'create-file',
+      fileIndex: 0,
+    });
+    expect(decisionMocks.useFileController).toHaveBeenCalledWith(
+      expect.objectContaining({
+        files: [file],
+        persistenceScope: {
+          teamName: 'team-a',
+          scopeKey: 'task-task-a',
+          scopeToken: 'token-a',
+        },
+        history,
+        blockForExternalChange: externalChange.blockReviewMutationForExternalChange,
+      })
+    );
+    expect(decisionMocks.useHunkController).toHaveBeenCalledWith(
+      expect.objectContaining({
+        files: [file],
+        captureOperationScope: operation.captureReviewOperationScope,
+        isCurrentOperationScope: operation.isCurrentReviewOperationScope,
+        historyPort: {
+          pushUndoAction: history.pushUndoAction,
+          bindCommittedAction: history.bindCommittedAction,
+          discardLatestAction: history.discardLatestAction,
+          publishUndoHistory: history.publishUndoHistory,
+        },
+      })
+    );
+
+    await act(async () => {
+      root.unmount();
+      await Promise.resolve();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- extract bulk, file, and hunk decision orchestration from ChangeReviewDialog
- keep disk mutation, durable scope, external change, operation scope, and history guards intact
- use the feature-domain hunk count policy and narrow dependency capabilities
- ratchet ChangeReviewDialog from 1291 to 1133 lines

## Verification

- 69 focused tests passed
- pnpm typecheck
- pnpm lint:fast:files on changed TypeScript files
- pnpm guard:source-file-size
- prettier check

Full Changes desktop E2E is intentionally deferred until the final less-than-800-line ChangeReviewDialog head.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined change-review decision handling across bulk, file, and hunk actions.
  * Improved coordination of review history and mutation safeguards during decision workflows.

* **Documentation**
  * Clarified responsibilities between the change-review dialog and its decision-action handling.

* **Tests**
  * Added coverage for decision actions, controller wiring, and undo behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->