### PR TITLE
refactor(terminal-workspace): extract settings view

### DIFF
--- a/scripts/ci/source-file-size-legacy.json
+++ b/scripts/ci/source-file-size-legacy.json
@@ -46,7 +46,7 @@
   "src/features/team-lifecycle/contracts/team-lifecycle-read.ts": 816,
   "src/features/team-lifecycle/main/infrastructure/TeamDirectoryLifecycleAdapter.ts": 1606,
   "src/features/team-runtime-control/core/application/planning/createCompositeRuntimePlan.ts": 1195,
-  "src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx": 3118,
+  "src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx": 3064,
   "src/features/token-usage/core/domain/snapshotProjection.ts": 937,
   "src/features/token-usage/renderer/adapters/tokenUsageViewModel.ts": 1481,
   "src/features/token-usage/renderer/ui/TokenUsageDashboard.tsx": 2170,

--- a/scripts/ci/source-file-size-legacy.json
+++ b/scripts/ci/source-file-size-legacy.json
@@ -46,7 +46,7 @@
   "src/features/team-lifecycle/contracts/team-lifecycle-read.ts": 816,
   "src/features/team-lifecycle/main/infrastructure/TeamDirectoryLifecycleAdapter.ts": 1606,
   "src/features/team-runtime-control/core/application/planning/createCompositeRuntimePlan.ts": 1195,
-  "src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx": 3608,
+  "src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx": 3118,
   "src/features/token-usage/core/domain/snapshotProjection.ts": 937,
   "src/features/token-usage/renderer/adapters/tokenUsageViewModel.ts": 1481,
   "src/features/token-usage/renderer/ui/TokenUsageDashboard.tsx": 2170,

--- a/src/features/terminal-workspace/renderer/model/terminalAppearanceSettings.ts
+++ b/src/features/terminal-workspace/renderer/model/terminalAppearanceSettings.ts
@@ -73,6 +73,23 @@ export function normalizeTerminalAppearanceColor(value: string): string {
     : DEFAULT_TERMINAL_APPEARANCE_SETTINGS.backgroundColor;
 }
 
+export function resolveTerminalBackgroundImageUrl(value: string): string {
+  const trimmedValue = value.trim().slice(0, TERMINAL_BACKGROUND_IMAGE_URL_MAX_LENGTH);
+  if (!trimmedValue) {
+    return '';
+  }
+
+  try {
+    const url = new URL(trimmedValue);
+    if (url.protocol !== 'https:' || url.username || url.password) {
+      return '';
+    }
+    return url.href;
+  } catch {
+    return '';
+  }
+}
+
 export function isTerminalBackgroundMode(value: unknown): value is TerminalBackgroundMode {
   return TERMINAL_BACKGROUND_MODE_OPTIONS.some((option) => option.id === value);
 }

--- a/src/features/terminal-workspace/renderer/model/terminalAppearanceSettings.ts
+++ b/src/features/terminal-workspace/renderer/model/terminalAppearanceSettings.ts
@@ -1,7 +1,26 @@
 const TERMINAL_APPEARANCE_SETTINGS_VERSION = 1;
+const TERMINAL_BACKGROUND_IMAGE_URL_MAX_LENGTH = 2048;
 
 export type TerminalBackgroundMode = 'transparent' | 'solid' | 'image';
 export type TerminalBackgroundImageFit = 'cover' | 'contain' | 'stretch' | 'tile' | 'center';
+
+export interface TerminalAppearanceNumberRange {
+  min: number;
+  max: number;
+}
+
+export const TERMINAL_FONT_SIZE_RANGE: TerminalAppearanceNumberRange = {
+  min: 11,
+  max: 24,
+};
+export const TERMINAL_OPACITY_RANGE: TerminalAppearanceNumberRange = {
+  min: 35,
+  max: 100,
+};
+export const TERMINAL_BACKDROP_BLUR_RANGE: TerminalAppearanceNumberRange = {
+  min: 0,
+  max: 40,
+};
 
 export interface TerminalAppearanceSettings {
   version: number;
@@ -37,14 +56,13 @@ export const TERMINAL_BACKGROUND_IMAGE_FIT_OPTIONS: readonly {
 
 export function clampTerminalAppearanceNumberInput(
   value: string,
-  min: number,
-  max: number
+  range: TerminalAppearanceNumberRange
 ): number {
   const numberValue = Number(value);
   if (!Number.isFinite(numberValue)) {
-    return min;
+    return range.min;
   }
-  return Math.min(Math.max(Math.round(numberValue), min), max);
+  return Math.min(Math.max(Math.round(numberValue), range.min), range.max);
 }
 
 export function normalizeTerminalAppearanceColor(value: string): string {
@@ -59,4 +77,63 @@ export function isTerminalBackgroundMode(value: unknown): value is TerminalBackg
 
 export function isTerminalBackgroundImageFit(value: unknown): value is TerminalBackgroundImageFit {
   return TERMINAL_BACKGROUND_IMAGE_FIT_OPTIONS.some((option) => option.id === value);
+}
+
+export function normalizeTerminalAppearanceSettings(value: unknown): TerminalAppearanceSettings {
+  if (!isRecord(value)) {
+    return DEFAULT_TERMINAL_APPEARANCE_SETTINGS;
+  }
+
+  return {
+    version: DEFAULT_TERMINAL_APPEARANCE_SETTINGS.version,
+    fontSizePx: clampFiniteNumber(
+      value.fontSizePx,
+      TERMINAL_FONT_SIZE_RANGE,
+      DEFAULT_TERMINAL_APPEARANCE_SETTINGS.fontSizePx
+    ),
+    opacityPercent: clampFiniteNumber(
+      value.opacityPercent,
+      TERMINAL_OPACITY_RANGE,
+      DEFAULT_TERMINAL_APPEARANCE_SETTINGS.opacityPercent
+    ),
+    backgroundMode: isTerminalBackgroundMode(value.backgroundMode)
+      ? value.backgroundMode
+      : DEFAULT_TERMINAL_APPEARANCE_SETTINGS.backgroundMode,
+    backgroundColor:
+      typeof value.backgroundColor === 'string'
+        ? normalizeTerminalAppearanceColor(value.backgroundColor)
+        : DEFAULT_TERMINAL_APPEARANCE_SETTINGS.backgroundColor,
+    backgroundImageUrl:
+      typeof value.backgroundImageUrl === 'string'
+        ? value.backgroundImageUrl.slice(0, TERMINAL_BACKGROUND_IMAGE_URL_MAX_LENGTH)
+        : '',
+    backgroundImageFit: isTerminalBackgroundImageFit(value.backgroundImageFit)
+      ? value.backgroundImageFit
+      : DEFAULT_TERMINAL_APPEARANCE_SETTINGS.backgroundImageFit,
+    backdropBlurPx: clampFiniteNumber(
+      value.backdropBlurPx,
+      TERMINAL_BACKDROP_BLUR_RANGE,
+      DEFAULT_TERMINAL_APPEARANCE_SETTINGS.backdropBlurPx
+    ),
+    dimBackgroundImage:
+      typeof value.dimBackgroundImage === 'boolean'
+        ? value.dimBackgroundImage
+        : DEFAULT_TERMINAL_APPEARANCE_SETTINGS.dimBackgroundImage,
+  };
+}
+
+function clampFiniteNumber(
+  value: unknown,
+  range: TerminalAppearanceNumberRange,
+  fallback: number
+): number {
+  const numberValue = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(numberValue)) {
+    return fallback;
+  }
+  return Math.min(Math.max(Math.round(numberValue), range.min), range.max);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
 }

--- a/src/features/terminal-workspace/renderer/model/terminalAppearanceSettings.ts
+++ b/src/features/terminal-workspace/renderer/model/terminalAppearanceSettings.ts
@@ -1,0 +1,62 @@
+const TERMINAL_APPEARANCE_SETTINGS_VERSION = 1;
+
+export type TerminalBackgroundMode = 'transparent' | 'solid' | 'image';
+export type TerminalBackgroundImageFit = 'cover' | 'contain' | 'stretch' | 'tile' | 'center';
+
+export interface TerminalAppearanceSettings {
+  version: number;
+  fontSizePx: number;
+  opacityPercent: number;
+  backgroundMode: TerminalBackgroundMode;
+  backgroundColor: string;
+  backgroundImageUrl: string;
+  backgroundImageFit: TerminalBackgroundImageFit;
+  backdropBlurPx: number;
+  dimBackgroundImage: boolean;
+}
+
+export const DEFAULT_TERMINAL_APPEARANCE_SETTINGS: TerminalAppearanceSettings = {
+  version: TERMINAL_APPEARANCE_SETTINGS_VERSION,
+  fontSizePx: 15,
+  opacityPercent: 74,
+  backgroundMode: 'transparent',
+  backgroundColor: '#080c14',
+  backgroundImageUrl: '',
+  backgroundImageFit: 'cover',
+  backdropBlurPx: 20,
+  dimBackgroundImage: true,
+};
+
+export const TERMINAL_BACKGROUND_MODE_OPTIONS: readonly {
+  id: TerminalBackgroundMode;
+}[] = [{ id: 'transparent' }, { id: 'solid' }, { id: 'image' }];
+
+export const TERMINAL_BACKGROUND_IMAGE_FIT_OPTIONS: readonly {
+  id: TerminalBackgroundImageFit;
+}[] = [{ id: 'cover' }, { id: 'contain' }, { id: 'stretch' }, { id: 'tile' }, { id: 'center' }];
+
+export function clampTerminalAppearanceNumberInput(
+  value: string,
+  min: number,
+  max: number
+): number {
+  const numberValue = Number(value);
+  if (!Number.isFinite(numberValue)) {
+    return min;
+  }
+  return Math.min(Math.max(Math.round(numberValue), min), max);
+}
+
+export function normalizeTerminalAppearanceColor(value: string): string {
+  return /^#[\da-f]{6}$/iu.test(value)
+    ? value
+    : DEFAULT_TERMINAL_APPEARANCE_SETTINGS.backgroundColor;
+}
+
+export function isTerminalBackgroundMode(value: unknown): value is TerminalBackgroundMode {
+  return TERMINAL_BACKGROUND_MODE_OPTIONS.some((option) => option.id === value);
+}
+
+export function isTerminalBackgroundImageFit(value: unknown): value is TerminalBackgroundImageFit {
+  return TERMINAL_BACKGROUND_IMAGE_FIT_OPTIONS.some((option) => option.id === value);
+}

--- a/src/features/terminal-workspace/renderer/model/terminalAppearanceSettings.ts
+++ b/src/features/terminal-workspace/renderer/model/terminalAppearanceSettings.ts
@@ -1,3 +1,5 @@
+import { isRecord } from '../utils/valueGuards';
+
 const TERMINAL_APPEARANCE_SETTINGS_VERSION = 1;
 const TERMINAL_BACKGROUND_IMAGE_URL_MAX_LENGTH = 2048;
 
@@ -132,8 +134,4 @@ function clampFiniteNumber(
     return fallback;
   }
   return Math.min(Math.max(Math.round(numberValue), range.min), range.max);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
 }

--- a/src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx
+++ b/src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx
@@ -68,9 +68,7 @@ import {
 import { normalizeTerminalCommandRunEventDetail } from '../adapters/terminalCommandRunEvents';
 import {
   DEFAULT_TERMINAL_APPEARANCE_SETTINGS,
-  isTerminalBackgroundImageFit,
-  isTerminalBackgroundMode,
-  normalizeTerminalAppearanceColor,
+  normalizeTerminalAppearanceSettings,
   type TerminalAppearanceSettings,
   type TerminalBackgroundImageFit,
 } from '../model/terminalAppearanceSettings';
@@ -2611,50 +2609,6 @@ function readStoredTerminalAppearanceSettings(teamName: string): TerminalAppeara
   }
 }
 
-function normalizeTerminalAppearanceSettings(value: unknown): TerminalAppearanceSettings {
-  if (!isRecord(value)) {
-    return DEFAULT_TERMINAL_APPEARANCE_SETTINGS;
-  }
-
-  return {
-    version: DEFAULT_TERMINAL_APPEARANCE_SETTINGS.version,
-    fontSizePx: clampFiniteNumber(
-      value.fontSizePx,
-      11,
-      24,
-      DEFAULT_TERMINAL_APPEARANCE_SETTINGS.fontSizePx
-    ),
-    opacityPercent: clampFiniteNumber(
-      value.opacityPercent,
-      35,
-      100,
-      DEFAULT_TERMINAL_APPEARANCE_SETTINGS.opacityPercent
-    ),
-    backgroundMode: isTerminalBackgroundMode(value.backgroundMode)
-      ? value.backgroundMode
-      : DEFAULT_TERMINAL_APPEARANCE_SETTINGS.backgroundMode,
-    backgroundColor:
-      typeof value.backgroundColor === 'string'
-        ? normalizeTerminalAppearanceColor(value.backgroundColor)
-        : DEFAULT_TERMINAL_APPEARANCE_SETTINGS.backgroundColor,
-    backgroundImageUrl:
-      typeof value.backgroundImageUrl === 'string' ? value.backgroundImageUrl.slice(0, 2048) : '',
-    backgroundImageFit: isTerminalBackgroundImageFit(value.backgroundImageFit)
-      ? value.backgroundImageFit
-      : DEFAULT_TERMINAL_APPEARANCE_SETTINGS.backgroundImageFit,
-    backdropBlurPx: clampFiniteNumber(
-      value.backdropBlurPx,
-      0,
-      40,
-      DEFAULT_TERMINAL_APPEARANCE_SETTINGS.backdropBlurPx
-    ),
-    dimBackgroundImage:
-      typeof value.dimBackgroundImage === 'boolean'
-        ? value.dimBackgroundImage
-        : DEFAULT_TERMINAL_APPEARANCE_SETTINGS.dimBackgroundImage,
-  };
-}
-
 function readStoredTerminalTabPreferences(teamName: string): TerminalTabPreferences {
   const raw = readStoredValue(storageKey(teamName, 'tab-preferences'));
   if (!raw) return createDefaultTerminalTabPreferences();
@@ -2756,14 +2710,6 @@ function createTerminalAppearanceStyle(settings: TerminalAppearanceSettings): CS
     '--agent-terminal-image-dim-opacity':
       hasImage && normalizedSettings.dimBackgroundImage ? '0.42' : '0',
   } as CSSProperties;
-}
-
-function clampFiniteNumber(value: unknown, min: number, max: number, fallback: number): number {
-  const numberValue = typeof value === 'number' ? value : Number(value);
-  if (!Number.isFinite(numberValue)) {
-    return fallback;
-  }
-  return Math.min(Math.max(Math.round(numberValue), min), max);
 }
 
 function createCssUrl(value: string): string {

--- a/src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx
+++ b/src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx
@@ -22,7 +22,6 @@ import {
   AlertDialogTitle,
 } from '@renderer/components/ui/alert-dialog';
 import { Button } from '@renderer/components/ui/button';
-import { Checkbox } from '@renderer/components/ui/checkbox';
 import {
   ContextMenu,
   ContextMenuContent,
@@ -34,15 +33,6 @@ import {
   ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from '@renderer/components/ui/context-menu';
-import { Input } from '@renderer/components/ui/input';
-import { Label } from '@renderer/components/ui/label';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@renderer/components/ui/select';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@renderer/components/ui/tooltip';
 import { cn } from '@renderer/lib/utils';
 import { terminalPlatformThemeManifests } from '@terminal-platform/design-tokens';
@@ -65,7 +55,6 @@ import {
   Folder,
   GitBranch,
   Github,
-  Image,
   Loader2,
   Palette,
   Pencil,
@@ -77,6 +66,14 @@ import {
 } from 'lucide-react';
 
 import { normalizeTerminalCommandRunEventDetail } from '../adapters/terminalCommandRunEvents';
+import {
+  DEFAULT_TERMINAL_APPEARANCE_SETTINGS,
+  isTerminalBackgroundImageFit,
+  isTerminalBackgroundMode,
+  normalizeTerminalAppearanceColor,
+  type TerminalAppearanceSettings,
+  type TerminalBackgroundImageFit,
+} from '../model/terminalAppearanceSettings';
 import {
   createTerminalLocalAutocompleteCandidates,
   isTerminalLocalAutocompleteDraftEligible,
@@ -98,6 +95,11 @@ import {
   formatWorkingDirectory,
 } from '../model/terminalPathPresentation';
 import { isRecord } from '../utils/valueGuards';
+
+import {
+  type TerminalWorkspaceSettingsActionId,
+  TerminalWorkspaceSettingsView,
+} from './TerminalWorkspaceSettingsView';
 
 import type {
   TerminalWorkspaceBootstrap,
@@ -125,7 +127,6 @@ const TERMINAL_LOCAL_AUTOCOMPLETE_THROTTLE_MS = 75;
 const PREWARMED_TERMINAL_TAB_TITLE = '__tp_prewarmed_shell__';
 const TERMINAL_TAB_PREFERENCES_VERSION = 1;
 const TERMINAL_PLATFORM_GITHUB_URL = 'https://github.com/777genius/terminal-platform';
-const TERMINAL_APPEARANCE_SETTINGS_VERSION = 1;
 type TerminalWorkspaceSnapshot = ReturnType<WorkspaceKernel['getSnapshot']>;
 type TerminalMuxCommand = Parameters<WorkspaceKernel['commands']['dispatchMuxCommand']>[1];
 type TerminalScreenElementHandle = ComponentRef<typeof TerminalScreen> & {
@@ -148,41 +149,6 @@ interface TerminalTabColorOption {
   background: string;
   hoverBackground: string;
 }
-
-type TerminalBackgroundMode = 'transparent' | 'solid' | 'image';
-type TerminalBackgroundImageFit = 'cover' | 'contain' | 'stretch' | 'tile' | 'center';
-
-interface TerminalAppearanceSettings {
-  version: number;
-  fontSizePx: number;
-  opacityPercent: number;
-  backgroundMode: TerminalBackgroundMode;
-  backgroundColor: string;
-  backgroundImageUrl: string;
-  backgroundImageFit: TerminalBackgroundImageFit;
-  backdropBlurPx: number;
-  dimBackgroundImage: boolean;
-}
-
-const DEFAULT_TERMINAL_APPEARANCE_SETTINGS: TerminalAppearanceSettings = {
-  version: TERMINAL_APPEARANCE_SETTINGS_VERSION,
-  fontSizePx: 15,
-  opacityPercent: 74,
-  backgroundMode: 'transparent',
-  backgroundColor: '#080c14',
-  backgroundImageUrl: '',
-  backgroundImageFit: 'cover',
-  backdropBlurPx: 20,
-  dimBackgroundImage: true,
-};
-
-const TERMINAL_BACKGROUND_MODE_OPTIONS: Array<{
-  id: TerminalBackgroundMode;
-}> = [{ id: 'transparent' }, { id: 'solid' }, { id: 'image' }];
-
-const TERMINAL_BACKGROUND_IMAGE_FIT_OPTIONS: Array<{
-  id: TerminalBackgroundImageFit;
-}> = [{ id: 'cover' }, { id: 'contain' }, { id: 'stretch' }, { id: 'tile' }, { id: 'center' }];
 
 interface TerminalTabPreferences {
   version: number;
@@ -2415,12 +2381,15 @@ const TerminalWorkspaceSettingsPage = ({
   snapshot: TerminalWorkspaceSnapshot;
 }): React.JSX.Element => {
   const { t } = useAppTranslation('team');
-  const [pendingAction, setPendingAction] = useState<string | null>(null);
+  const [pendingAction, setPendingAction] = useState<TerminalWorkspaceSettingsActionId | null>(
+    null
+  );
   const display = snapshot.terminalDisplay;
-  const showBackgroundColor = appearanceSettings.backgroundMode !== 'transparent';
-  const showBackgroundImageControls = appearanceSettings.backgroundMode === 'image';
 
-  const runAction = async (actionId: string, action: () => Promise<void> | void): Promise<void> => {
+  const runAction = async (
+    actionId: TerminalWorkspaceSettingsActionId,
+    action: () => Promise<void> | void
+  ): Promise<void> => {
     setPendingAction(actionId);
     try {
       await action();
@@ -2432,449 +2401,37 @@ const TerminalWorkspaceSettingsPage = ({
   };
 
   return (
-    <div
-      className="flex min-h-0 flex-1 flex-col overflow-hidden border-t border-white/10 bg-transparent text-slate-100"
-      data-testid="agent-team-terminal-settings"
-    >
-      <div className="flex shrink-0 items-center justify-between gap-3 border-b border-white/10 bg-white/[0.025] px-5 py-4 backdrop-blur-xl">
-        <div className="min-w-0">
-          <p className="text-sm font-semibold text-slate-100">
-            {t('terminalWorkspace.settingsTitle')}
-          </p>
-          <p className="mt-0.5 text-xs text-slate-400">
-            {t('terminalWorkspace.settingsDescription')}
-          </p>
-        </div>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className="size-7 shrink-0 text-slate-400 hover:bg-white/[0.07] hover:text-slate-100"
-          aria-label={t('terminalWorkspace.closeTerminalSettings')}
-          onClick={onClose}
-        >
-          <X size={14} />
-        </Button>
-      </div>
-
-      <div className="min-h-0 flex-1 overflow-y-auto px-5 py-5">
-        <div className="mx-auto grid max-w-5xl gap-5 lg:grid-cols-2">
-          <TerminalSettingsSection
-            icon={<Palette size={14} />}
-            title={t('terminalWorkspace.settingsThemeTitle')}
-            description={t('terminalWorkspace.settingsThemeDescription')}
-          >
-            <Select
-              value={snapshot.theme.themeId}
-              onValueChange={(themeId) => kernel.commands.setTheme(themeId)}
-            >
-              <SelectTrigger
-                aria-label={t('terminalWorkspace.settingsThemeAria')}
-                className="border-white/10 bg-white/[0.035]"
-              >
-                <SelectValue placeholder={t('terminalWorkspace.settingsThemePlaceholder')} />
-              </SelectTrigger>
-              <SelectContent className="z-[100]">
-                {terminalPlatformThemeManifests.map((theme) => (
-                  <SelectItem key={theme.id} value={theme.id}>
-                    {formatThemeLabel(t, theme.displayName, theme.id)}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </TerminalSettingsSection>
-
-          <TerminalSettingsSection
-            icon={<Terminal size={14} />}
-            title={t('terminalWorkspace.settingsFontTitle')}
-            description={t('terminalWorkspace.settingsFontDescription')}
-          >
-            <div className="grid grid-cols-[minmax(0,1fr)_6rem] items-end gap-3">
-              <div className="grid gap-1.5">
-                <Label htmlFor="terminal-settings-font-preset" className="text-xs text-slate-300">
-                  {t('terminalWorkspace.settingsFontPreset')}
-                </Label>
-                <Select
-                  value={display.fontScale}
-                  onValueChange={(fontScale) => kernel.commands.setTerminalFontScale(fontScale)}
-                >
-                  <SelectTrigger
-                    id="terminal-settings-font-preset"
-                    aria-label={t('terminalWorkspace.settingsFontPresetAria')}
-                    className="border-white/10 bg-white/[0.035]"
-                  >
-                    <SelectValue
-                      placeholder={t('terminalWorkspace.settingsFontPresetPlaceholder')}
-                    />
-                  </SelectTrigger>
-                  <SelectContent className="z-[100]">
-                    {terminalPlatformTerminalFontScales.map((fontScale) => (
-                      <SelectItem key={fontScale} value={fontScale}>
-                        {formatFontScaleLabel(t, fontScale)}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-              <div className="grid gap-1.5">
-                <Label htmlFor="terminal-settings-font-size" className="text-xs text-slate-300">
-                  {t('terminalWorkspace.settingsFontSize')}
-                </Label>
-                <Input
-                  id="terminal-settings-font-size"
-                  type="number"
-                  inputMode="numeric"
-                  min={11}
-                  max={24}
-                  step={1}
-                  className="border-white/10 bg-white/[0.035] text-right"
-                  value={appearanceSettings.fontSizePx}
-                  onChange={(event) =>
-                    onAppearanceSettingsChange({
-                      fontSizePx: clampNumberInput(event.currentTarget.value, 11, 24),
-                    })
-                  }
-                />
-              </div>
-            </div>
-          </TerminalSettingsSection>
-
-          <TerminalSettingsSection
-            icon={<Image size={14} />}
-            title={t('terminalWorkspace.settingsBackgroundTitle')}
-            description={t('terminalWorkspace.settingsBackgroundDescription')}
-          >
-            <div className="grid gap-3">
-              <div
-                className={cn(
-                  'grid items-end gap-3',
-                  showBackgroundColor ? 'grid-cols-[minmax(0,1fr)_6rem]' : 'grid-cols-1'
-                )}
-              >
-                <div className="grid gap-1.5">
-                  <Label htmlFor="terminal-settings-opacity" className="text-xs text-slate-300">
-                    {t('terminalWorkspace.settingsOpacity')}
-                  </Label>
-                  <input
-                    id="terminal-settings-opacity-range"
-                    type="range"
-                    min={35}
-                    max={100}
-                    step={1}
-                    className="h-9 w-full accent-sky-300"
-                    aria-label={t('terminalWorkspace.settingsOpacityAria')}
-                    value={appearanceSettings.opacityPercent}
-                    onChange={(event) =>
-                      onAppearanceSettingsChange({
-                        opacityPercent: clampNumberInput(event.currentTarget.value, 35, 100),
-                      })
-                    }
-                  />
-                </div>
-                <Input
-                  id="terminal-settings-opacity"
-                  type="number"
-                  inputMode="numeric"
-                  min={35}
-                  max={100}
-                  step={1}
-                  className="border-white/10 bg-white/[0.035] text-right"
-                  value={appearanceSettings.opacityPercent}
-                  onChange={(event) =>
-                    onAppearanceSettingsChange({
-                      opacityPercent: clampNumberInput(event.currentTarget.value, 35, 100),
-                    })
-                  }
-                />
-              </div>
-
-              <div className="grid grid-cols-[minmax(0,1fr)_6rem] items-end gap-3">
-                <div className="grid gap-1.5">
-                  <Label
-                    htmlFor="terminal-settings-background-mode"
-                    className="text-xs text-slate-300"
-                  >
-                    {t('terminalWorkspace.settingsBackgroundMode')}
-                  </Label>
-                  <Select
-                    value={appearanceSettings.backgroundMode}
-                    onValueChange={(backgroundMode) =>
-                      onAppearanceSettingsChange({
-                        backgroundMode: backgroundMode as TerminalBackgroundMode,
-                      })
-                    }
-                  >
-                    <SelectTrigger
-                      id="terminal-settings-background-mode"
-                      aria-label={t('terminalWorkspace.settingsBackgroundModeAria')}
-                      className="border-white/10 bg-white/[0.035]"
-                    >
-                      <SelectValue placeholder={t('terminalWorkspace.settingsBackgroundMode')} />
-                    </SelectTrigger>
-                    <SelectContent className="z-[100]">
-                      {TERMINAL_BACKGROUND_MODE_OPTIONS.map((option) => (
-                        <SelectItem key={option.id} value={option.id}>
-                          {formatTerminalBackgroundModeLabel(t, option.id)}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-                {showBackgroundColor ? (
-                  <Input
-                    type="color"
-                    aria-label={t('terminalWorkspace.settingsBackgroundColorAria')}
-                    className="h-9 border-white/10 bg-white/[0.035] p-1"
-                    value={appearanceSettings.backgroundColor}
-                    onChange={(event) =>
-                      onAppearanceSettingsChange({
-                        backgroundColor: normalizeColorInput(event.currentTarget.value),
-                      })
-                    }
-                  />
-                ) : null}
-              </div>
-
-              {appearanceSettings.backgroundMode === 'transparent' ? (
-                <div className="grid gap-1.5">
-                  <Label
-                    htmlFor="terminal-settings-backdrop-blur"
-                    className="text-xs text-slate-300"
-                  >
-                    {t('terminalWorkspace.settingsBackdropBlur')}
-                  </Label>
-                  <Input
-                    id="terminal-settings-backdrop-blur"
-                    type="number"
-                    inputMode="numeric"
-                    min={0}
-                    max={40}
-                    step={1}
-                    className="max-w-24 border-white/10 bg-white/[0.035] text-right"
-                    value={appearanceSettings.backdropBlurPx}
-                    onChange={(event) =>
-                      onAppearanceSettingsChange({
-                        backdropBlurPx: clampNumberInput(event.currentTarget.value, 0, 40),
-                      })
-                    }
-                  />
-                </div>
-              ) : null}
-
-              {showBackgroundImageControls ? (
-                <>
-                  <div className="grid gap-1.5">
-                    <Label
-                      htmlFor="terminal-settings-background-image"
-                      className="text-xs text-slate-300"
-                    >
-                      {t('terminalWorkspace.settingsImageUrl')}
-                    </Label>
-                    <Input
-                      id="terminal-settings-background-image"
-                      type="url"
-                      className="border-white/10 bg-white/[0.035]"
-                      placeholder="https://..."
-                      value={appearanceSettings.backgroundImageUrl}
-                      onChange={(event) =>
-                        onAppearanceSettingsChange({
-                          backgroundImageUrl: event.currentTarget.value,
-                        })
-                      }
-                    />
-                  </div>
-
-                  <div className="grid grid-cols-[minmax(0,1fr)_6rem] items-end gap-3">
-                    <div className="grid gap-1.5">
-                      <Label
-                        htmlFor="terminal-settings-background-fit"
-                        className="text-xs text-slate-300"
-                      >
-                        {t('terminalWorkspace.settingsImageFit')}
-                      </Label>
-                      <Select
-                        value={appearanceSettings.backgroundImageFit}
-                        onValueChange={(backgroundImageFit) =>
-                          onAppearanceSettingsChange({
-                            backgroundImageFit: backgroundImageFit as TerminalBackgroundImageFit,
-                          })
-                        }
-                      >
-                        <SelectTrigger
-                          id="terminal-settings-background-fit"
-                          aria-label={t('terminalWorkspace.settingsImageFitAria')}
-                          className="border-white/10 bg-white/[0.035]"
-                        >
-                          <SelectValue placeholder={t('terminalWorkspace.settingsImageFit')} />
-                        </SelectTrigger>
-                        <SelectContent className="z-[100]">
-                          {TERMINAL_BACKGROUND_IMAGE_FIT_OPTIONS.map((option) => (
-                            <SelectItem key={option.id} value={option.id}>
-                              {formatTerminalBackgroundImageFitLabel(t, option.id)}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </div>
-                    <div className="grid gap-1.5">
-                      <Label htmlFor="terminal-settings-blur" className="text-xs text-slate-300">
-                        {t('terminalWorkspace.settingsImageBlur')}
-                      </Label>
-                      <Input
-                        id="terminal-settings-blur"
-                        type="number"
-                        inputMode="numeric"
-                        min={0}
-                        max={40}
-                        step={1}
-                        className="border-white/10 bg-white/[0.035] text-right"
-                        value={appearanceSettings.backdropBlurPx}
-                        onChange={(event) =>
-                          onAppearanceSettingsChange({
-                            backdropBlurPx: clampNumberInput(event.currentTarget.value, 0, 40),
-                          })
-                        }
-                      />
-                    </div>
-                  </div>
-
-                  <label className="flex items-center gap-2 rounded-md border border-white/10 bg-white/[0.025] px-3 py-2 text-xs text-slate-300">
-                    <Checkbox
-                      checked={appearanceSettings.dimBackgroundImage}
-                      onCheckedChange={(checked) =>
-                        onAppearanceSettingsChange({ dimBackgroundImage: checked === true })
-                      }
-                    />
-                    {t('terminalWorkspace.settingsDimImage')}
-                  </label>
-                </>
-              ) : null}
-            </div>
-          </TerminalSettingsSection>
-
-          <TerminalSettingsSection
-            icon={<Check size={14} />}
-            title={t('terminalWorkspace.settingsBehaviorTitle')}
-            description={t('terminalWorkspace.settingsBehaviorDescription')}
-          >
-            <label className="flex items-center gap-2 rounded-md border border-white/10 bg-white/[0.025] px-3 py-2 text-xs text-slate-300">
-              <Checkbox
-                checked={display.lineWrap}
-                onCheckedChange={(checked) => kernel.commands.setTerminalLineWrap(checked === true)}
-              />
-              {t('terminalWorkspace.settingsWrapLongOutput')}
-            </label>
-          </TerminalSettingsSection>
-
-          <TerminalSettingsSection
-            icon={<RefreshCw size={14} />}
-            title={t('terminalWorkspace.settingsRuntimeTitle')}
-            description={t('terminalWorkspace.settingsRuntimeDescription')}
-          >
-            <div className="grid grid-cols-2 gap-2">
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="border-white/10 bg-white/[0.025] text-slate-200 hover:bg-white/[0.07]"
-                disabled={pendingAction !== null}
-                onClick={() => void runAction('bootstrap', () => kernel.commands.bootstrap())}
-              >
-                {pendingAction === 'bootstrap' ? (
-                  <Loader2 size={13} className="mr-1.5 animate-spin" />
-                ) : (
-                  <RefreshCw size={13} className="mr-1.5" />
-                )}
-                {t('terminalWorkspace.settingsReconnect')}
-              </Button>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="border-white/10 bg-white/[0.025] text-slate-200 hover:bg-white/[0.07]"
-                disabled={pendingAction !== null}
-                onClick={() =>
-                  void runAction('refresh-sessions', () => kernel.commands.refreshSessions())
-                }
-              >
-                {pendingAction === 'refresh-sessions' ? (
-                  <Loader2 size={13} className="mr-1.5 animate-spin" />
-                ) : (
-                  <Terminal size={13} className="mr-1.5" />
-                )}
-                {t('terminalWorkspace.settingsSessions')}
-              </Button>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="border-white/10 bg-white/[0.025] text-slate-200 hover:bg-white/[0.07]"
-                disabled={pendingAction !== null}
-                onClick={onReload}
-              >
-                <RefreshCw size={13} className="mr-1.5" />
-                {t('terminalWorkspace.settingsReload')}
-              </Button>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="border-red-500/25 bg-red-500/10 text-red-200 hover:bg-red-500/15"
-                disabled={pendingAction !== null}
-                onClick={() => void runAction('stop-runtime', onStopRuntime)}
-              >
-                {pendingAction === 'stop-runtime' ? (
-                  <Loader2 size={13} className="mr-1.5 animate-spin" />
-                ) : (
-                  <Square size={12} className="mr-1.5" />
-                )}
-                {t('terminalWorkspace.settingsStop')}
-              </Button>
-            </div>
-          </TerminalSettingsSection>
-
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="w-full text-slate-400 hover:bg-white/[0.06] hover:text-slate-100 lg:col-span-2"
-            onClick={() => onAppearanceSettingsChange(DEFAULT_TERMINAL_APPEARANCE_SETTINGS)}
-          >
-            {t('terminalWorkspace.settingsResetAppearance')}
-          </Button>
-        </div>
-      </div>
-    </div>
+    <TerminalWorkspaceSettingsView
+      appearanceSettings={appearanceSettings}
+      display={{
+        fontScale: display.fontScale,
+        lineWrap: display.lineWrap,
+        themeId: snapshot.theme.themeId,
+      }}
+      fontScaleOptions={terminalPlatformTerminalFontScales.map((fontScale) => ({
+        id: fontScale,
+        label: formatFontScaleLabel(t, fontScale),
+      }))}
+      onAppearanceSettingsChange={onAppearanceSettingsChange}
+      onClose={onClose}
+      onFontScaleChange={(fontScale) => kernel.commands.setTerminalFontScale(fontScale)}
+      onLineWrapChange={(lineWrap) => kernel.commands.setTerminalLineWrap(lineWrap)}
+      onReconnect={() => void runAction('bootstrap', () => kernel.commands.bootstrap())}
+      onRefreshSessions={() =>
+        void runAction('refresh-sessions', () => kernel.commands.refreshSessions())
+      }
+      onReload={onReload}
+      onResetAppearance={() => onAppearanceSettingsChange(DEFAULT_TERMINAL_APPEARANCE_SETTINGS)}
+      onStopRuntime={() => void runAction('stop-runtime', onStopRuntime)}
+      onThemeChange={(themeId) => kernel.commands.setTheme(themeId)}
+      pendingAction={pendingAction}
+      themeOptions={terminalPlatformThemeManifests.map((theme) => ({
+        id: theme.id,
+        label: formatThemeLabel(t, theme.displayName, theme.id),
+      }))}
+    />
   );
 };
-
-const TerminalSettingsSection = ({
-  children,
-  description,
-  icon,
-  title,
-}: {
-  children: React.ReactNode;
-  description: string;
-  icon: React.ReactNode;
-  title: string;
-}): React.JSX.Element => {
-  return (
-    <section className="grid gap-3 rounded-md border border-white/10 bg-white/[0.025] p-4">
-      <div className="flex items-start gap-2">
-        <span className="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-md border border-white/10 bg-white/[0.04] text-sky-200">
-          {icon}
-        </span>
-        <div className="min-w-0">
-          <p className="text-sm font-medium text-slate-100">{title}</p>
-          <p className="mt-0.5 text-xs leading-5 text-slate-400">{description}</p>
-        </div>
-      </div>
-      {children}
-    </section>
-  );
-};
-
 const TerminalWorkspaceStatus = ({
   icon,
   title,
@@ -3060,7 +2617,7 @@ function normalizeTerminalAppearanceSettings(value: unknown): TerminalAppearance
   }
 
   return {
-    version: TERMINAL_APPEARANCE_SETTINGS_VERSION,
+    version: DEFAULT_TERMINAL_APPEARANCE_SETTINGS.version,
     fontSizePx: clampFiniteNumber(
       value.fontSizePx,
       11,
@@ -3078,7 +2635,7 @@ function normalizeTerminalAppearanceSettings(value: unknown): TerminalAppearance
       : DEFAULT_TERMINAL_APPEARANCE_SETTINGS.backgroundMode,
     backgroundColor:
       typeof value.backgroundColor === 'string'
-        ? normalizeColorInput(value.backgroundColor)
+        ? normalizeTerminalAppearanceColor(value.backgroundColor)
         : DEFAULT_TERMINAL_APPEARANCE_SETTINGS.backgroundColor,
     backgroundImageUrl:
       typeof value.backgroundImageUrl === 'string' ? value.backgroundImageUrl.slice(0, 2048) : '',
@@ -3201,30 +2758,12 @@ function createTerminalAppearanceStyle(settings: TerminalAppearanceSettings): CS
   } as CSSProperties;
 }
 
-function clampNumberInput(value: string, min: number, max: number): number {
-  return clampFiniteNumber(Number(value), min, max, min);
-}
-
 function clampFiniteNumber(value: unknown, min: number, max: number, fallback: number): number {
   const numberValue = typeof value === 'number' ? value : Number(value);
   if (!Number.isFinite(numberValue)) {
     return fallback;
   }
   return Math.min(Math.max(Math.round(numberValue), min), max);
-}
-
-function normalizeColorInput(value: string): string {
-  return /^#[\da-f]{6}$/iu.test(value)
-    ? value
-    : DEFAULT_TERMINAL_APPEARANCE_SETTINGS.backgroundColor;
-}
-
-function isTerminalBackgroundMode(value: unknown): value is TerminalBackgroundMode {
-  return TERMINAL_BACKGROUND_MODE_OPTIONS.some((option) => option.id === value);
-}
-
-function isTerminalBackgroundImageFit(value: unknown): value is TerminalBackgroundImageFit {
-  return TERMINAL_BACKGROUND_IMAGE_FIT_OPTIONS.some((option) => option.id === value);
 }
 
 function createCssUrl(value: string): string {
@@ -3545,35 +3084,6 @@ function formatFontScaleLabel(t: TeamTFunction, fontScale: string): string {
   if (fontScale === 'compact') return t('terminalWorkspace.fontScaleCompact');
   if (fontScale === 'large') return t('terminalWorkspace.fontScaleLarge');
   return t('terminalWorkspace.fontScaleDefault');
-}
-
-function formatTerminalBackgroundModeLabel(t: TeamTFunction, mode: TerminalBackgroundMode): string {
-  switch (mode) {
-    case 'transparent':
-      return t('terminalWorkspace.backgroundModeTransparent');
-    case 'solid':
-      return t('terminalWorkspace.backgroundModeSolid');
-    case 'image':
-      return t('terminalWorkspace.backgroundModeImage');
-  }
-}
-
-function formatTerminalBackgroundImageFitLabel(
-  t: TeamTFunction,
-  fit: TerminalBackgroundImageFit
-): string {
-  switch (fit) {
-    case 'cover':
-      return t('terminalWorkspace.imageFitCover');
-    case 'contain':
-      return t('terminalWorkspace.imageFitContain');
-    case 'stretch':
-      return t('terminalWorkspace.imageFitStretch');
-    case 'tile':
-      return t('terminalWorkspace.imageFitTile');
-    case 'center':
-      return t('terminalWorkspace.imageFitCenter');
-  }
 }
 
 function formatTerminalTabColorLabel(t: TeamTFunction, colorId: TerminalTabColorId): string {

--- a/src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx
+++ b/src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx
@@ -69,6 +69,7 @@ import { normalizeTerminalCommandRunEventDetail } from '../adapters/terminalComm
 import {
   DEFAULT_TERMINAL_APPEARANCE_SETTINGS,
   normalizeTerminalAppearanceSettings,
+  resolveTerminalBackgroundImageUrl,
   type TerminalAppearanceSettings,
   type TerminalBackgroundImageFit,
 } from '../model/terminalAppearanceSettings';
@@ -2686,9 +2687,8 @@ function persistTerminalAppearanceSettings(
 
 function createTerminalAppearanceStyle(settings: TerminalAppearanceSettings): CSSProperties {
   const normalizedSettings = normalizeTerminalAppearanceSettings(settings);
-  const imageUrl = normalizedSettings.backgroundImageUrl.trim();
+  const imageUrl = resolveTerminalBackgroundImageUrl(normalizedSettings.backgroundImageUrl);
   const hasImage = normalizedSettings.backgroundMode === 'image' && imageUrl.length > 0;
-
   return {
     '--agent-terminal-font-size': `${normalizedSettings.fontSizePx}px`,
     '--agent-terminal-panel-opacity': String(normalizedSettings.opacityPercent / 100),

--- a/src/features/terminal-workspace/renderer/ui/TerminalWorkspaceSettingsView.tsx
+++ b/src/features/terminal-workspace/renderer/ui/TerminalWorkspaceSettingsView.tsx
@@ -16,8 +16,11 @@ import { Check, Image, Loader2, Palette, RefreshCw, Square, Terminal, X } from '
 import {
   clampTerminalAppearanceNumberInput,
   normalizeTerminalAppearanceColor,
+  TERMINAL_BACKDROP_BLUR_RANGE,
   TERMINAL_BACKGROUND_IMAGE_FIT_OPTIONS,
   TERMINAL_BACKGROUND_MODE_OPTIONS,
+  TERMINAL_FONT_SIZE_RANGE,
+  TERMINAL_OPACITY_RANGE,
   type TerminalAppearanceSettings,
   type TerminalBackgroundImageFit,
   type TerminalBackgroundMode,
@@ -162,8 +165,8 @@ export const TerminalWorkspaceSettingsView = ({
                   id="terminal-settings-font-size"
                   type="number"
                   inputMode="numeric"
-                  min={11}
-                  max={24}
+                  min={TERMINAL_FONT_SIZE_RANGE.min}
+                  max={TERMINAL_FONT_SIZE_RANGE.max}
                   step={1}
                   className="border-white/10 bg-white/[0.035] text-right"
                   value={appearanceSettings.fontSizePx}
@@ -171,8 +174,7 @@ export const TerminalWorkspaceSettingsView = ({
                     onAppearanceSettingsChange({
                       fontSizePx: clampTerminalAppearanceNumberInput(
                         event.currentTarget.value,
-                        11,
-                        24
+                        TERMINAL_FONT_SIZE_RANGE
                       ),
                     })
                   }
@@ -200,8 +202,8 @@ export const TerminalWorkspaceSettingsView = ({
                   <input
                     id="terminal-settings-opacity-range"
                     type="range"
-                    min={35}
-                    max={100}
+                    min={TERMINAL_OPACITY_RANGE.min}
+                    max={TERMINAL_OPACITY_RANGE.max}
                     step={1}
                     className="h-9 w-full accent-sky-300"
                     aria-label={t('terminalWorkspace.settingsOpacityAria')}
@@ -210,8 +212,7 @@ export const TerminalWorkspaceSettingsView = ({
                       onAppearanceSettingsChange({
                         opacityPercent: clampTerminalAppearanceNumberInput(
                           event.currentTarget.value,
-                          35,
-                          100
+                          TERMINAL_OPACITY_RANGE
                         ),
                       })
                     }
@@ -221,8 +222,8 @@ export const TerminalWorkspaceSettingsView = ({
                   id="terminal-settings-opacity"
                   type="number"
                   inputMode="numeric"
-                  min={35}
-                  max={100}
+                  min={TERMINAL_OPACITY_RANGE.min}
+                  max={TERMINAL_OPACITY_RANGE.max}
                   step={1}
                   className="border-white/10 bg-white/[0.035] text-right"
                   value={appearanceSettings.opacityPercent}
@@ -230,8 +231,7 @@ export const TerminalWorkspaceSettingsView = ({
                     onAppearanceSettingsChange({
                       opacityPercent: clampTerminalAppearanceNumberInput(
                         event.currentTarget.value,
-                        35,
-                        100
+                        TERMINAL_OPACITY_RANGE
                       ),
                     })
                   }
@@ -299,8 +299,8 @@ export const TerminalWorkspaceSettingsView = ({
                     id="terminal-settings-backdrop-blur"
                     type="number"
                     inputMode="numeric"
-                    min={0}
-                    max={40}
+                    min={TERMINAL_BACKDROP_BLUR_RANGE.min}
+                    max={TERMINAL_BACKDROP_BLUR_RANGE.max}
                     step={1}
                     className="max-w-24 border-white/10 bg-white/[0.035] text-right"
                     value={appearanceSettings.backdropBlurPx}
@@ -308,8 +308,7 @@ export const TerminalWorkspaceSettingsView = ({
                       onAppearanceSettingsChange({
                         backdropBlurPx: clampTerminalAppearanceNumberInput(
                           event.currentTarget.value,
-                          0,
-                          40
+                          TERMINAL_BACKDROP_BLUR_RANGE
                         ),
                       })
                     }
@@ -380,8 +379,8 @@ export const TerminalWorkspaceSettingsView = ({
                         id="terminal-settings-blur"
                         type="number"
                         inputMode="numeric"
-                        min={0}
-                        max={40}
+                        min={TERMINAL_BACKDROP_BLUR_RANGE.min}
+                        max={TERMINAL_BACKDROP_BLUR_RANGE.max}
                         step={1}
                         className="border-white/10 bg-white/[0.035] text-right"
                         value={appearanceSettings.backdropBlurPx}
@@ -389,8 +388,7 @@ export const TerminalWorkspaceSettingsView = ({
                           onAppearanceSettingsChange({
                             backdropBlurPx: clampTerminalAppearanceNumberInput(
                               event.currentTarget.value,
-                              0,
-                              40
+                              TERMINAL_BACKDROP_BLUR_RANGE
                             ),
                           })
                         }

--- a/src/features/terminal-workspace/renderer/ui/TerminalWorkspaceSettingsView.tsx
+++ b/src/features/terminal-workspace/renderer/ui/TerminalWorkspaceSettingsView.tsx
@@ -1,0 +1,563 @@
+import { useAppTranslation } from '@features/localization/renderer';
+import { Button } from '@renderer/components/ui/button';
+import { Checkbox } from '@renderer/components/ui/checkbox';
+import { Input } from '@renderer/components/ui/input';
+import { Label } from '@renderer/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@renderer/components/ui/select';
+import { cn } from '@renderer/lib/utils';
+import { Check, Image, Loader2, Palette, RefreshCw, Square, Terminal, X } from 'lucide-react';
+
+import {
+  clampTerminalAppearanceNumberInput,
+  normalizeTerminalAppearanceColor,
+  TERMINAL_BACKGROUND_IMAGE_FIT_OPTIONS,
+  TERMINAL_BACKGROUND_MODE_OPTIONS,
+  type TerminalAppearanceSettings,
+  type TerminalBackgroundImageFit,
+  type TerminalBackgroundMode,
+} from '../model/terminalAppearanceSettings';
+
+type TeamTFunction = ReturnType<typeof useAppTranslation>['t'];
+
+export type TerminalWorkspaceSettingsActionId = 'bootstrap' | 'refresh-sessions' | 'stop-runtime';
+
+export interface TerminalWorkspaceSettingsOption {
+  id: string;
+  label: string;
+}
+
+export interface TerminalWorkspaceSettingsViewProps {
+  appearanceSettings: TerminalAppearanceSettings;
+  display: {
+    fontScale: string;
+    lineWrap: boolean;
+    themeId: string;
+  };
+  fontScaleOptions: readonly TerminalWorkspaceSettingsOption[];
+  onAppearanceSettingsChange: (updates: Partial<TerminalAppearanceSettings>) => void;
+  onClose: () => void;
+  onFontScaleChange: (fontScale: string) => void;
+  onLineWrapChange: (lineWrap: boolean) => void;
+  onReconnect: () => void;
+  onRefreshSessions: () => void;
+  onReload: () => void;
+  onResetAppearance: () => void;
+  onStopRuntime: () => void;
+  onThemeChange: (themeId: string) => void;
+  pendingAction: TerminalWorkspaceSettingsActionId | null;
+  themeOptions: readonly TerminalWorkspaceSettingsOption[];
+}
+
+export const TerminalWorkspaceSettingsView = ({
+  appearanceSettings,
+  display,
+  fontScaleOptions,
+  onAppearanceSettingsChange,
+  onClose,
+  onFontScaleChange,
+  onLineWrapChange,
+  onReconnect,
+  onRefreshSessions,
+  onReload,
+  onResetAppearance,
+  onStopRuntime,
+  onThemeChange,
+  pendingAction,
+  themeOptions,
+}: TerminalWorkspaceSettingsViewProps): React.JSX.Element => {
+  const { t } = useAppTranslation('team');
+  const showBackgroundColor = appearanceSettings.backgroundMode !== 'transparent';
+  const showBackgroundImageControls = appearanceSettings.backgroundMode === 'image';
+
+  return (
+    <div
+      className="flex min-h-0 flex-1 flex-col overflow-hidden border-t border-white/10 bg-transparent text-slate-100"
+      data-testid="agent-team-terminal-settings"
+    >
+      <div className="flex shrink-0 items-center justify-between gap-3 border-b border-white/10 bg-white/[0.025] px-5 py-4 backdrop-blur-xl">
+        <div className="min-w-0">
+          <p className="text-sm font-semibold text-slate-100">
+            {t('terminalWorkspace.settingsTitle')}
+          </p>
+          <p className="mt-0.5 text-xs text-slate-400">
+            {t('terminalWorkspace.settingsDescription')}
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="size-7 shrink-0 text-slate-400 hover:bg-white/[0.07] hover:text-slate-100"
+          aria-label={t('terminalWorkspace.closeTerminalSettings')}
+          onClick={onClose}
+        >
+          <X size={14} />
+        </Button>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-5 py-5">
+        <div className="mx-auto grid max-w-5xl gap-5 lg:grid-cols-2">
+          <TerminalSettingsSection
+            icon={<Palette size={14} />}
+            title={t('terminalWorkspace.settingsThemeTitle')}
+            description={t('terminalWorkspace.settingsThemeDescription')}
+          >
+            <Select value={display.themeId} onValueChange={onThemeChange}>
+              <SelectTrigger
+                aria-label={t('terminalWorkspace.settingsThemeAria')}
+                className="border-white/10 bg-white/[0.035]"
+              >
+                <SelectValue placeholder={t('terminalWorkspace.settingsThemePlaceholder')} />
+              </SelectTrigger>
+              <SelectContent className="z-[100]">
+                {themeOptions.map((theme) => (
+                  <SelectItem key={theme.id} value={theme.id}>
+                    {theme.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </TerminalSettingsSection>
+
+          <TerminalSettingsSection
+            icon={<Terminal size={14} />}
+            title={t('terminalWorkspace.settingsFontTitle')}
+            description={t('terminalWorkspace.settingsFontDescription')}
+          >
+            <div className="grid grid-cols-[minmax(0,1fr)_6rem] items-end gap-3">
+              <div className="grid gap-1.5">
+                <Label htmlFor="terminal-settings-font-preset" className="text-xs text-slate-300">
+                  {t('terminalWorkspace.settingsFontPreset')}
+                </Label>
+                <Select value={display.fontScale} onValueChange={onFontScaleChange}>
+                  <SelectTrigger
+                    id="terminal-settings-font-preset"
+                    aria-label={t('terminalWorkspace.settingsFontPresetAria')}
+                    className="border-white/10 bg-white/[0.035]"
+                  >
+                    <SelectValue
+                      placeholder={t('terminalWorkspace.settingsFontPresetPlaceholder')}
+                    />
+                  </SelectTrigger>
+                  <SelectContent className="z-[100]">
+                    {fontScaleOptions.map((fontScale) => (
+                      <SelectItem key={fontScale.id} value={fontScale.id}>
+                        {fontScale.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="grid gap-1.5">
+                <Label htmlFor="terminal-settings-font-size" className="text-xs text-slate-300">
+                  {t('terminalWorkspace.settingsFontSize')}
+                </Label>
+                <Input
+                  id="terminal-settings-font-size"
+                  type="number"
+                  inputMode="numeric"
+                  min={11}
+                  max={24}
+                  step={1}
+                  className="border-white/10 bg-white/[0.035] text-right"
+                  value={appearanceSettings.fontSizePx}
+                  onChange={(event) =>
+                    onAppearanceSettingsChange({
+                      fontSizePx: clampTerminalAppearanceNumberInput(
+                        event.currentTarget.value,
+                        11,
+                        24
+                      ),
+                    })
+                  }
+                />
+              </div>
+            </div>
+          </TerminalSettingsSection>
+
+          <TerminalSettingsSection
+            icon={<Image size={14} />}
+            title={t('terminalWorkspace.settingsBackgroundTitle')}
+            description={t('terminalWorkspace.settingsBackgroundDescription')}
+          >
+            <div className="grid gap-3">
+              <div
+                className={cn(
+                  'grid items-end gap-3',
+                  showBackgroundColor ? 'grid-cols-[minmax(0,1fr)_6rem]' : 'grid-cols-1'
+                )}
+              >
+                <div className="grid gap-1.5">
+                  <Label htmlFor="terminal-settings-opacity" className="text-xs text-slate-300">
+                    {t('terminalWorkspace.settingsOpacity')}
+                  </Label>
+                  <input
+                    id="terminal-settings-opacity-range"
+                    type="range"
+                    min={35}
+                    max={100}
+                    step={1}
+                    className="h-9 w-full accent-sky-300"
+                    aria-label={t('terminalWorkspace.settingsOpacityAria')}
+                    value={appearanceSettings.opacityPercent}
+                    onChange={(event) =>
+                      onAppearanceSettingsChange({
+                        opacityPercent: clampTerminalAppearanceNumberInput(
+                          event.currentTarget.value,
+                          35,
+                          100
+                        ),
+                      })
+                    }
+                  />
+                </div>
+                <Input
+                  id="terminal-settings-opacity"
+                  type="number"
+                  inputMode="numeric"
+                  min={35}
+                  max={100}
+                  step={1}
+                  className="border-white/10 bg-white/[0.035] text-right"
+                  value={appearanceSettings.opacityPercent}
+                  onChange={(event) =>
+                    onAppearanceSettingsChange({
+                      opacityPercent: clampTerminalAppearanceNumberInput(
+                        event.currentTarget.value,
+                        35,
+                        100
+                      ),
+                    })
+                  }
+                />
+              </div>
+
+              <div className="grid grid-cols-[minmax(0,1fr)_6rem] items-end gap-3">
+                <div className="grid gap-1.5">
+                  <Label
+                    htmlFor="terminal-settings-background-mode"
+                    className="text-xs text-slate-300"
+                  >
+                    {t('terminalWorkspace.settingsBackgroundMode')}
+                  </Label>
+                  <Select
+                    value={appearanceSettings.backgroundMode}
+                    onValueChange={(backgroundMode) =>
+                      onAppearanceSettingsChange({
+                        backgroundMode: backgroundMode as TerminalBackgroundMode,
+                      })
+                    }
+                  >
+                    <SelectTrigger
+                      id="terminal-settings-background-mode"
+                      aria-label={t('terminalWorkspace.settingsBackgroundModeAria')}
+                      className="border-white/10 bg-white/[0.035]"
+                    >
+                      <SelectValue placeholder={t('terminalWorkspace.settingsBackgroundMode')} />
+                    </SelectTrigger>
+                    <SelectContent className="z-[100]">
+                      {TERMINAL_BACKGROUND_MODE_OPTIONS.map((option) => (
+                        <SelectItem key={option.id} value={option.id}>
+                          {formatTerminalBackgroundModeLabel(t, option.id)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                {showBackgroundColor ? (
+                  <Input
+                    type="color"
+                    aria-label={t('terminalWorkspace.settingsBackgroundColorAria')}
+                    className="h-9 border-white/10 bg-white/[0.035] p-1"
+                    value={appearanceSettings.backgroundColor}
+                    onChange={(event) =>
+                      onAppearanceSettingsChange({
+                        backgroundColor: normalizeTerminalAppearanceColor(
+                          event.currentTarget.value
+                        ),
+                      })
+                    }
+                  />
+                ) : null}
+              </div>
+
+              {appearanceSettings.backgroundMode === 'transparent' ? (
+                <div className="grid gap-1.5">
+                  <Label
+                    htmlFor="terminal-settings-backdrop-blur"
+                    className="text-xs text-slate-300"
+                  >
+                    {t('terminalWorkspace.settingsBackdropBlur')}
+                  </Label>
+                  <Input
+                    id="terminal-settings-backdrop-blur"
+                    type="number"
+                    inputMode="numeric"
+                    min={0}
+                    max={40}
+                    step={1}
+                    className="max-w-24 border-white/10 bg-white/[0.035] text-right"
+                    value={appearanceSettings.backdropBlurPx}
+                    onChange={(event) =>
+                      onAppearanceSettingsChange({
+                        backdropBlurPx: clampTerminalAppearanceNumberInput(
+                          event.currentTarget.value,
+                          0,
+                          40
+                        ),
+                      })
+                    }
+                  />
+                </div>
+              ) : null}
+
+              {showBackgroundImageControls ? (
+                <>
+                  <div className="grid gap-1.5">
+                    <Label
+                      htmlFor="terminal-settings-background-image"
+                      className="text-xs text-slate-300"
+                    >
+                      {t('terminalWorkspace.settingsImageUrl')}
+                    </Label>
+                    <Input
+                      id="terminal-settings-background-image"
+                      type="url"
+                      className="border-white/10 bg-white/[0.035]"
+                      placeholder="https://..."
+                      value={appearanceSettings.backgroundImageUrl}
+                      onChange={(event) =>
+                        onAppearanceSettingsChange({
+                          backgroundImageUrl: event.currentTarget.value,
+                        })
+                      }
+                    />
+                  </div>
+
+                  <div className="grid grid-cols-[minmax(0,1fr)_6rem] items-end gap-3">
+                    <div className="grid gap-1.5">
+                      <Label
+                        htmlFor="terminal-settings-background-fit"
+                        className="text-xs text-slate-300"
+                      >
+                        {t('terminalWorkspace.settingsImageFit')}
+                      </Label>
+                      <Select
+                        value={appearanceSettings.backgroundImageFit}
+                        onValueChange={(backgroundImageFit) =>
+                          onAppearanceSettingsChange({
+                            backgroundImageFit: backgroundImageFit as TerminalBackgroundImageFit,
+                          })
+                        }
+                      >
+                        <SelectTrigger
+                          id="terminal-settings-background-fit"
+                          aria-label={t('terminalWorkspace.settingsImageFitAria')}
+                          className="border-white/10 bg-white/[0.035]"
+                        >
+                          <SelectValue placeholder={t('terminalWorkspace.settingsImageFit')} />
+                        </SelectTrigger>
+                        <SelectContent className="z-[100]">
+                          {TERMINAL_BACKGROUND_IMAGE_FIT_OPTIONS.map((option) => (
+                            <SelectItem key={option.id} value={option.id}>
+                              {formatTerminalBackgroundImageFitLabel(t, option.id)}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="grid gap-1.5">
+                      <Label htmlFor="terminal-settings-blur" className="text-xs text-slate-300">
+                        {t('terminalWorkspace.settingsImageBlur')}
+                      </Label>
+                      <Input
+                        id="terminal-settings-blur"
+                        type="number"
+                        inputMode="numeric"
+                        min={0}
+                        max={40}
+                        step={1}
+                        className="border-white/10 bg-white/[0.035] text-right"
+                        value={appearanceSettings.backdropBlurPx}
+                        onChange={(event) =>
+                          onAppearanceSettingsChange({
+                            backdropBlurPx: clampTerminalAppearanceNumberInput(
+                              event.currentTarget.value,
+                              0,
+                              40
+                            ),
+                          })
+                        }
+                      />
+                    </div>
+                  </div>
+
+                  <label className="flex items-center gap-2 rounded-md border border-white/10 bg-white/[0.025] px-3 py-2 text-xs text-slate-300">
+                    <Checkbox
+                      checked={appearanceSettings.dimBackgroundImage}
+                      onCheckedChange={(checked) =>
+                        onAppearanceSettingsChange({ dimBackgroundImage: checked === true })
+                      }
+                    />
+                    {t('terminalWorkspace.settingsDimImage')}
+                  </label>
+                </>
+              ) : null}
+            </div>
+          </TerminalSettingsSection>
+
+          <TerminalSettingsSection
+            icon={<Check size={14} />}
+            title={t('terminalWorkspace.settingsBehaviorTitle')}
+            description={t('terminalWorkspace.settingsBehaviorDescription')}
+          >
+            <label className="flex items-center gap-2 rounded-md border border-white/10 bg-white/[0.025] px-3 py-2 text-xs text-slate-300">
+              <Checkbox
+                checked={display.lineWrap}
+                onCheckedChange={(checked) => onLineWrapChange(checked === true)}
+              />
+              {t('terminalWorkspace.settingsWrapLongOutput')}
+            </label>
+          </TerminalSettingsSection>
+
+          <TerminalSettingsSection
+            icon={<RefreshCw size={14} />}
+            title={t('terminalWorkspace.settingsRuntimeTitle')}
+            description={t('terminalWorkspace.settingsRuntimeDescription')}
+          >
+            <div className="grid grid-cols-2 gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="border-white/10 bg-white/[0.025] text-slate-200 hover:bg-white/[0.07]"
+                disabled={pendingAction !== null}
+                onClick={onReconnect}
+              >
+                {pendingAction === 'bootstrap' ? (
+                  <Loader2 size={13} className="mr-1.5 animate-spin" />
+                ) : (
+                  <RefreshCw size={13} className="mr-1.5" />
+                )}
+                {t('terminalWorkspace.settingsReconnect')}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="border-white/10 bg-white/[0.025] text-slate-200 hover:bg-white/[0.07]"
+                disabled={pendingAction !== null}
+                onClick={onRefreshSessions}
+              >
+                {pendingAction === 'refresh-sessions' ? (
+                  <Loader2 size={13} className="mr-1.5 animate-spin" />
+                ) : (
+                  <Terminal size={13} className="mr-1.5" />
+                )}
+                {t('terminalWorkspace.settingsSessions')}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="border-white/10 bg-white/[0.025] text-slate-200 hover:bg-white/[0.07]"
+                disabled={pendingAction !== null}
+                onClick={onReload}
+              >
+                <RefreshCw size={13} className="mr-1.5" />
+                {t('terminalWorkspace.settingsReload')}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="border-red-500/25 bg-red-500/10 text-red-200 hover:bg-red-500/15"
+                disabled={pendingAction !== null}
+                onClick={onStopRuntime}
+              >
+                {pendingAction === 'stop-runtime' ? (
+                  <Loader2 size={13} className="mr-1.5 animate-spin" />
+                ) : (
+                  <Square size={12} className="mr-1.5" />
+                )}
+                {t('terminalWorkspace.settingsStop')}
+              </Button>
+            </div>
+          </TerminalSettingsSection>
+
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="w-full text-slate-400 hover:bg-white/[0.06] hover:text-slate-100 lg:col-span-2"
+            onClick={onResetAppearance}
+          >
+            {t('terminalWorkspace.settingsResetAppearance')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const TerminalSettingsSection = ({
+  children,
+  description,
+  icon,
+  title,
+}: {
+  children: React.ReactNode;
+  description: string;
+  icon: React.ReactNode;
+  title: string;
+}): React.JSX.Element => {
+  return (
+    <section className="grid gap-3 rounded-md border border-white/10 bg-white/[0.025] p-4">
+      <div className="flex items-start gap-2">
+        <span className="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-md border border-white/10 bg-white/[0.04] text-sky-200">
+          {icon}
+        </span>
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-slate-100">{title}</p>
+          <p className="mt-0.5 text-xs leading-5 text-slate-400">{description}</p>
+        </div>
+      </div>
+      {children}
+    </section>
+  );
+};
+
+function formatTerminalBackgroundModeLabel(t: TeamTFunction, mode: TerminalBackgroundMode): string {
+  switch (mode) {
+    case 'transparent':
+      return t('terminalWorkspace.backgroundModeTransparent');
+    case 'solid':
+      return t('terminalWorkspace.backgroundModeSolid');
+    case 'image':
+      return t('terminalWorkspace.backgroundModeImage');
+  }
+}
+
+function formatTerminalBackgroundImageFitLabel(
+  t: TeamTFunction,
+  fit: TerminalBackgroundImageFit
+): string {
+  switch (fit) {
+    case 'cover':
+      return t('terminalWorkspace.imageFitCover');
+    case 'contain':
+      return t('terminalWorkspace.imageFitContain');
+    case 'stretch':
+      return t('terminalWorkspace.imageFitStretch');
+    case 'tile':
+      return t('terminalWorkspace.imageFitTile');
+    case 'center':
+      return t('terminalWorkspace.imageFitCenter');
+  }
+}

--- a/test/renderer/features/terminal-workspace/TerminalWorkspacePanel.fixture-e2e.test.tsx
+++ b/test/renderer/features/terminal-workspace/TerminalWorkspacePanel.fixture-e2e.test.tsx
@@ -269,6 +269,7 @@ describe('terminal workspace panel fixture-e2e', () => {
   let root: Root;
   let getBootstrap: ReturnType<typeof vi.fn<() => Promise<TerminalWorkspaceBootstrap>>>;
   let stopTeamRuntime: ReturnType<typeof vi.fn<() => Promise<void>>>;
+  let onSettingsOpenChange: ReturnType<typeof vi.fn<(open: boolean) => void>>;
   let openExternal: ReturnType<typeof vi.fn<(url: string) => Promise<void>>>;
   let nextSnapshot: MockWorkspaceSnapshot;
   let kernelCounter = 0;
@@ -304,6 +305,7 @@ describe('terminal workspace panel fixture-e2e', () => {
     nextSnapshot = createWorkspaceSnapshot();
     getBootstrap = vi.fn().mockResolvedValue(createBootstrap());
     stopTeamRuntime = vi.fn().mockResolvedValue(undefined);
+    onSettingsOpenChange = vi.fn();
     openExternal = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(window, 'electronAPI', {
       configurable: true,
@@ -1661,6 +1663,8 @@ describe('terminal workspace panel fixture-e2e', () => {
 
     await updateInputValue('#terminal-settings-font-size', '18');
     await updateInputValue('#terminal-settings-opacity', '63');
+    await selectRadixOption('Terminal theme', 'Light');
+    await selectRadixOption('Terminal font preset', 'Large');
     await clickCheckboxLabel('Wrap long command output');
     await clickTextButton('Reconnect');
     await clickTextButton('Sessions');
@@ -1678,9 +1682,22 @@ describe('terminal workspace panel fixture-e2e', () => {
       })
     );
     expect(kernel.commands.setTerminalLineWrap).toHaveBeenCalledWith(true);
+    expect(kernel.commands.setTheme).toHaveBeenCalledWith('terminal-platform-light');
+    expect(kernel.commands.setTerminalFontScale).toHaveBeenCalledWith('large');
     expect(kernel.commands.bootstrap).toHaveBeenCalled();
     expect(kernel.commands.refreshSessions).toHaveBeenCalled();
     expect(stopTeamRuntime).toHaveBeenCalledWith(TEAM_NAME);
+
+    await clickTextButton('Reset appearance');
+    expect(consoleElement?.style.getPropertyValue('--agent-terminal-font-size')).toBe('15px');
+    expect(consoleElement?.style.getPropertyValue('--agent-terminal-panel-opacity')).toBe('0.74');
+
+    await clickButton('Close terminal settings');
+    expect(onSettingsOpenChange).toHaveBeenCalledWith(false);
+
+    const bootstrapCallsBeforeReload = getBootstrap.mock.calls.length;
+    await clickTextButton('Reload');
+    expect(getBootstrap).toHaveBeenCalledTimes(bootstrapCallsBeforeReload + 1);
   });
 
   it('shows image-only background controls and applies image blur when image mode is selected', async () => {
@@ -1788,6 +1805,7 @@ describe('terminal workspace panel fixture-e2e', () => {
             getBootstrap,
             gitBranch: 'main',
             isTeamAlive: true,
+            onSettingsOpenChange,
             projectPath: PROJECT_PATH,
             settingsOpen,
             stopTeamRuntime,
@@ -2192,6 +2210,46 @@ async function updateInputValue(selector: string, value: string): Promise<void> 
     )?.set;
     valueSetter?.call(input, value);
     input.dispatchEvent(new Event('input', { bubbles: true, cancelable: true }));
+    await flushMicrotasks();
+  });
+}
+
+async function selectRadixOption(triggerLabel: string, optionText: string): Promise<void> {
+  const trigger = document.querySelector<HTMLButtonElement>(
+    `button[role="combobox"][aria-label="${triggerLabel}"]`
+  );
+  if (!trigger) {
+    throw new Error(`Missing select trigger: ${triggerLabel}`);
+  }
+
+  await act(async () => {
+    trigger.focus();
+    trigger.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        bubbles: true,
+        cancelable: true,
+        key: 'ArrowDown',
+      })
+    );
+    await flushMicrotasks();
+  });
+
+  const option = Array.from(document.querySelectorAll<HTMLElement>('[role="option"]')).find(
+    (candidate) => candidate.textContent?.includes(optionText)
+  );
+  if (!option) {
+    throw new Error(`Missing select option: ${optionText}`);
+  }
+
+  await act(async () => {
+    option.dispatchEvent(
+      new MouseEvent('pointerup', {
+        bubbles: true,
+        button: 0,
+        cancelable: true,
+      })
+    );
+    option.click();
     await flushMicrotasks();
   });
 }

--- a/test/renderer/features/terminal-workspace/TerminalWorkspacePanel.fixture-e2e.test.tsx
+++ b/test/renderer/features/terminal-workspace/TerminalWorkspacePanel.fixture-e2e.test.tsx
@@ -1724,8 +1724,16 @@ describe('terminal workspace panel fixture-e2e', () => {
     await updateInputValue('#terminal-settings-blur', '22');
 
     const consoleElement = document.querySelector<HTMLElement>('.agent-team-terminal-console');
+    expect(consoleElement?.style.getPropertyValue('--agent-terminal-background-image')).toContain(
+      'https://example.test/background.jpg'
+    );
     expect(consoleElement?.style.getPropertyValue('--agent-terminal-background-image-blur')).toBe(
       '22px'
+    );
+
+    await updateInputValue('#terminal-settings-background-image', 'file:///etc/passwd');
+    expect(consoleElement?.style.getPropertyValue('--agent-terminal-background-image')).toBe(
+      'none'
     );
   });
 

--- a/test/renderer/features/terminal-workspace/terminalAppearanceSettings.test.ts
+++ b/test/renderer/features/terminal-workspace/terminalAppearanceSettings.test.ts
@@ -5,6 +5,7 @@ import {
   isTerminalBackgroundMode,
   normalizeTerminalAppearanceColor,
   normalizeTerminalAppearanceSettings,
+  resolveTerminalBackgroundImageUrl,
   TERMINAL_FONT_SIZE_RANGE,
 } from '@features/terminal-workspace/renderer/model/terminalAppearanceSettings';
 import { describe, expect, it } from 'vitest';
@@ -28,6 +29,19 @@ describe('terminal appearance settings', () => {
     expect(isTerminalBackgroundMode('video')).toBe(false);
     expect(isTerminalBackgroundImageFit('tile')).toBe(true);
     expect(isTerminalBackgroundImageFit('zoom')).toBe(false);
+  });
+
+  it('allows only credential-free HTTPS background image URLs', () => {
+    expect(resolveTerminalBackgroundImageUrl(' https://example.test/background image.jpg ')).toBe(
+      'https://example.test/background%20image.jpg'
+    );
+    expect(resolveTerminalBackgroundImageUrl('http://example.test/background.jpg')).toBe('');
+    expect(resolveTerminalBackgroundImageUrl('file:///Users/example/background.jpg')).toBe('');
+    expect(resolveTerminalBackgroundImageUrl('data:image/png;base64,AAAA')).toBe('');
+    expect(resolveTerminalBackgroundImageUrl('https://user:secret@example.test/image.jpg')).toBe(
+      ''
+    );
+    expect(resolveTerminalBackgroundImageUrl('not a url')).toBe('');
   });
 
   it('normalizes persisted settings with canonical defaults and limits', () => {

--- a/test/renderer/features/terminal-workspace/terminalAppearanceSettings.test.ts
+++ b/test/renderer/features/terminal-workspace/terminalAppearanceSettings.test.ts
@@ -1,0 +1,30 @@
+import {
+  clampTerminalAppearanceNumberInput,
+  DEFAULT_TERMINAL_APPEARANCE_SETTINGS,
+  isTerminalBackgroundImageFit,
+  isTerminalBackgroundMode,
+  normalizeTerminalAppearanceColor,
+} from '@features/terminal-workspace/renderer/model/terminalAppearanceSettings';
+import { describe, expect, it } from 'vitest';
+
+describe('terminal appearance settings', () => {
+  it('clamps numeric form input to the supported setting range', () => {
+    expect(clampTerminalAppearanceNumberInput('18.6', 11, 24)).toBe(19);
+    expect(clampTerminalAppearanceNumberInput('100', 11, 24)).toBe(24);
+    expect(clampTerminalAppearanceNumberInput('invalid', 11, 24)).toBe(11);
+  });
+
+  it('normalizes invalid colors to the canonical terminal background', () => {
+    expect(normalizeTerminalAppearanceColor('#a1B2c3')).toBe('#a1B2c3');
+    expect(normalizeTerminalAppearanceColor('red')).toBe(
+      DEFAULT_TERMINAL_APPEARANCE_SETTINGS.backgroundColor
+    );
+  });
+
+  it('recognizes only supported background modes and image fits', () => {
+    expect(isTerminalBackgroundMode('transparent')).toBe(true);
+    expect(isTerminalBackgroundMode('video')).toBe(false);
+    expect(isTerminalBackgroundImageFit('tile')).toBe(true);
+    expect(isTerminalBackgroundImageFit('zoom')).toBe(false);
+  });
+});

--- a/test/renderer/features/terminal-workspace/terminalAppearanceSettings.test.ts
+++ b/test/renderer/features/terminal-workspace/terminalAppearanceSettings.test.ts
@@ -4,14 +4,16 @@ import {
   isTerminalBackgroundImageFit,
   isTerminalBackgroundMode,
   normalizeTerminalAppearanceColor,
+  normalizeTerminalAppearanceSettings,
+  TERMINAL_FONT_SIZE_RANGE,
 } from '@features/terminal-workspace/renderer/model/terminalAppearanceSettings';
 import { describe, expect, it } from 'vitest';
 
 describe('terminal appearance settings', () => {
   it('clamps numeric form input to the supported setting range', () => {
-    expect(clampTerminalAppearanceNumberInput('18.6', 11, 24)).toBe(19);
-    expect(clampTerminalAppearanceNumberInput('100', 11, 24)).toBe(24);
-    expect(clampTerminalAppearanceNumberInput('invalid', 11, 24)).toBe(11);
+    expect(clampTerminalAppearanceNumberInput('18.6', TERMINAL_FONT_SIZE_RANGE)).toBe(19);
+    expect(clampTerminalAppearanceNumberInput('100', TERMINAL_FONT_SIZE_RANGE)).toBe(24);
+    expect(clampTerminalAppearanceNumberInput('invalid', TERMINAL_FONT_SIZE_RANGE)).toBe(11);
   });
 
   it('normalizes invalid colors to the canonical terminal background', () => {
@@ -26,5 +28,27 @@ describe('terminal appearance settings', () => {
     expect(isTerminalBackgroundMode('video')).toBe(false);
     expect(isTerminalBackgroundImageFit('tile')).toBe(true);
     expect(isTerminalBackgroundImageFit('zoom')).toBe(false);
+  });
+
+  it('normalizes persisted settings with canonical defaults and limits', () => {
+    expect(
+      normalizeTerminalAppearanceSettings({
+        backdropBlurPx: -8,
+        backgroundColor: 'red',
+        backgroundImageFit: 'zoom',
+        backgroundImageUrl: 'x'.repeat(2_100),
+        backgroundMode: 'video',
+        dimBackgroundImage: 'yes',
+        fontSizePx: 100,
+        opacityPercent: 'invalid',
+        version: 99,
+      })
+    ).toEqual({
+      ...DEFAULT_TERMINAL_APPEARANCE_SETTINGS,
+      backdropBlurPx: 0,
+      backgroundImageUrl: 'x'.repeat(2_048),
+      fontSizePx: 24,
+    });
+    expect(normalizeTerminalAppearanceSettings(null)).toBe(DEFAULT_TERMINAL_APPEARANCE_SETTINGS);
   });
 });


### PR DESCRIPTION
## Summary
- extract terminal settings presentation into a store-free composed view
- centralize appearance defaults, limits, validation, and persistence normalization in the renderer model
- allow only credential-free HTTPS background image URLs before CSS interpolation
- ratchet TerminalWorkspacePanel from 3608 to 3064 lines
- keep the renderer public entrypoint unchanged

## Verification
- 43 focused unit and jsdom fixture tests passed
- native TypeScript 7 typecheck passed
- fast ESLint passed for changed TypeScript files
- Prettier check passed
- source file size guard passed against base d993e199
- independent audit found 0 remaining P1-P3 before review; the security review thread was fixed and resolved

No desktop, runtime, agent, or Changes E2E was run for this structural slice. Final Terminal E2E remains reserved for the completed less-than-800-line refactor in a fresh sandbox project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a comprehensive terminal settings view for themes, fonts, backgrounds, opacity, image options, line wrapping, runtime actions, and appearance reset.
  * Added validated background mode/image fit controls, plus safer background image URL handling.
* **Bug Fixes**
  * Improved resilience to invalid or out-of-range appearance values (colors, numeric inputs, modes/fit options) by applying safe defaults and limits, including rejecting credentialed/invalid image URLs.
* **Tests**
  * Added unit coverage for terminal appearance normalization/validation and expanded end-to-end tests for settings interactions, reset/close behavior, reload, and image URL handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->