### PR TITLE
refactor(terminal-workspace): extract tab preferences

### DIFF
--- a/scripts/ci/source-file-size-legacy.json
+++ b/scripts/ci/source-file-size-legacy.json
@@ -46,7 +46,7 @@
   "src/features/team-lifecycle/contracts/team-lifecycle-read.ts": 816,
   "src/features/team-lifecycle/main/infrastructure/TeamDirectoryLifecycleAdapter.ts": 1606,
   "src/features/team-runtime-control/core/application/planning/createCompositeRuntimePlan.ts": 1195,
-  "src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx": 3064,
+  "src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx": 2660,
   "src/features/token-usage/core/domain/snapshotProjection.ts": 937,
   "src/features/token-usage/renderer/adapters/tokenUsageViewModel.ts": 1481,
   "src/features/token-usage/renderer/ui/TokenUsageDashboard.tsx": 2170,

--- a/src/features/terminal-workspace/renderer/adapters/terminalTabPreferencesStorage.ts
+++ b/src/features/terminal-workspace/renderer/adapters/terminalTabPreferencesStorage.ts
@@ -1,0 +1,27 @@
+import {
+  parseTerminalTabPreferences,
+  type TerminalTabPreferences,
+} from '../model/terminalTabPreferences';
+
+export function readStoredTerminalTabPreferences(teamName: string): TerminalTabPreferences {
+  try {
+    return parseTerminalTabPreferences(window.localStorage.getItem(storageKey(teamName)));
+  } catch {
+    return parseTerminalTabPreferences(null);
+  }
+}
+
+export function persistTerminalTabPreferences(
+  teamName: string,
+  preferences: TerminalTabPreferences
+): void {
+  try {
+    window.localStorage.setItem(storageKey(teamName), JSON.stringify(preferences));
+  } catch {
+    // Best-effort tab UI preference persistence.
+  }
+}
+
+function storageKey(teamName: string): string {
+  return `agent-teams:terminal-workspace:${teamName}:tab-preferences`;
+}

--- a/src/features/terminal-workspace/renderer/hooks/useTerminalTabReorderMotion.ts
+++ b/src/features/terminal-workspace/renderer/hooks/useTerminalTabReorderMotion.ts
@@ -1,0 +1,90 @@
+import { type RefObject, useCallback, useLayoutEffect, useRef } from 'react';
+
+export function useTerminalTabReorderMotion({
+  draggingTabId,
+  orderedTabIdsKey,
+  tabElementRefs,
+}: Readonly<{
+  draggingTabId: string | null;
+  orderedTabIdsKey: string;
+  tabElementRefs: RefObject<Map<string, HTMLDivElement>>;
+}>): {
+  captureTabRectsBeforeReorder: () => void;
+  clearCapturedTabRects: () => void;
+} {
+  const tabRectsBeforeReorderRef = useRef<Map<string, DOMRect> | null>(null);
+  const prefersReducedMotion = useCallback(
+    () =>
+      typeof window !== 'undefined' &&
+      window.matchMedia?.('(prefers-reduced-motion: reduce)').matches,
+    []
+  );
+
+  const clearCapturedTabRects = useCallback((): void => {
+    tabRectsBeforeReorderRef.current = null;
+  }, []);
+
+  const captureTabRectsBeforeReorder = useCallback((): void => {
+    if (prefersReducedMotion()) {
+      clearCapturedTabRects();
+      return;
+    }
+
+    const rects = new Map<string, DOMRect>();
+    tabElementRefs.current.forEach((element, tabId) => {
+      rects.set(tabId, element.getBoundingClientRect());
+    });
+    tabRectsBeforeReorderRef.current = rects.size > 1 ? rects : null;
+  }, [clearCapturedTabRects, prefersReducedMotion, tabElementRefs]);
+
+  useLayoutEffect(() => {
+    const previousRects = tabRectsBeforeReorderRef.current;
+    if (!previousRects || prefersReducedMotion()) {
+      clearCapturedTabRects();
+      return;
+    }
+
+    clearCapturedTabRects();
+    tabElementRefs.current.forEach((element, tabId) => {
+      if (tabId === draggingTabId) {
+        return;
+      }
+
+      const previousRect = previousRects.get(tabId);
+      if (!previousRect) {
+        return;
+      }
+
+      const nextRect = element.getBoundingClientRect();
+      const deltaX = previousRect.left - nextRect.left;
+      const deltaY = previousRect.top - nextRect.top;
+      if (Math.abs(deltaX) < 0.5 && Math.abs(deltaY) < 0.5) {
+        return;
+      }
+
+      if (typeof element.animate !== 'function') {
+        return;
+      }
+
+      element.getAnimations?.().forEach((animation) => animation.cancel());
+      element.animate(
+        [{ transform: `translate(${deltaX}px, ${deltaY}px)` }, { transform: 'translate(0, 0)' }],
+        {
+          duration: 180,
+          easing: 'cubic-bezier(0.22, 1, 0.36, 1)',
+        }
+      );
+    });
+  }, [
+    clearCapturedTabRects,
+    draggingTabId,
+    orderedTabIdsKey,
+    prefersReducedMotion,
+    tabElementRefs,
+  ]);
+
+  return {
+    captureTabRectsBeforeReorder,
+    clearCapturedTabRects,
+  };
+}

--- a/src/features/terminal-workspace/renderer/model/terminalTabPreferences.ts
+++ b/src/features/terminal-workspace/renderer/model/terminalTabPreferences.ts
@@ -1,0 +1,358 @@
+import type { WorkspaceKernel } from '@terminal-platform/workspace-core';
+
+export const PREWARMED_TERMINAL_TAB_TITLE = '__tp_prewarmed_shell__';
+const TERMINAL_TAB_PREFERENCES_VERSION = 1;
+const TERMINAL_TAB_COLOR_LABEL_KEYS = {
+  amber: 'terminalWorkspace.tabColorAmber',
+  blue: 'terminalWorkspace.tabColorBlue',
+  cyan: 'terminalWorkspace.tabColorCyan',
+  emerald: 'terminalWorkspace.tabColorEmerald',
+  lime: 'terminalWorkspace.tabColorLime',
+  orange: 'terminalWorkspace.tabColorOrange',
+  rose: 'terminalWorkspace.tabColorRose',
+  sky: 'terminalWorkspace.tabColorSky',
+  slate: 'terminalWorkspace.tabColorSlate',
+  teal: 'terminalWorkspace.tabColorTeal',
+  violet: 'terminalWorkspace.tabColorViolet',
+} as const;
+
+export type TerminalWorkspaceSnapshot = ReturnType<WorkspaceKernel['getSnapshot']>;
+export type TerminalMuxTab = NonNullable<
+  TerminalWorkspaceSnapshot['attachedSession']
+>['topology']['tabs'][number];
+type TerminalMuxPaneTreeNode = TerminalMuxTab['root'];
+export type TerminalTabColorId = (typeof TERMINAL_TAB_COLOR_OPTIONS)[number]['id'];
+
+export interface TerminalTabColorOption {
+  id: string;
+  accent: string;
+  border: string;
+  background: string;
+  hoverBackground: string;
+}
+
+export interface TerminalTabPreferences {
+  version: number;
+  order: string[];
+  colors: Record<string, TerminalTabColorId>;
+}
+
+export interface TerminalTabDropIndicator {
+  placementMode: 'before' | 'after';
+  tabId: string;
+}
+
+export interface TerminalTabPointerDrag {
+  active: boolean;
+  grabOffsetX: number;
+  offsetX: number;
+  pointerId: number;
+  startClientX: number;
+  startClientY: number;
+  tabId: string;
+}
+
+export const TERMINAL_TAB_COLOR_OPTIONS = [
+  {
+    id: 'slate',
+    accent: '#94a3b8',
+    border: 'rgba(148, 163, 184, 0.56)',
+    background: 'rgba(148, 163, 184, 0.14)',
+    hoverBackground: 'rgba(148, 163, 184, 0.18)',
+  },
+  {
+    id: 'sky',
+    accent: '#38bdf8',
+    border: 'rgba(56, 189, 248, 0.58)',
+    background: 'rgba(56, 189, 248, 0.15)',
+    hoverBackground: 'rgba(56, 189, 248, 0.2)',
+  },
+  {
+    id: 'blue',
+    accent: '#60a5fa',
+    border: 'rgba(96, 165, 250, 0.58)',
+    background: 'rgba(96, 165, 250, 0.15)',
+    hoverBackground: 'rgba(96, 165, 250, 0.2)',
+  },
+  {
+    id: 'cyan',
+    accent: '#22d3ee',
+    border: 'rgba(34, 211, 238, 0.58)',
+    background: 'rgba(34, 211, 238, 0.14)',
+    hoverBackground: 'rgba(34, 211, 238, 0.19)',
+  },
+  {
+    id: 'teal',
+    accent: '#2dd4bf',
+    border: 'rgba(45, 212, 191, 0.56)',
+    background: 'rgba(45, 212, 191, 0.14)',
+    hoverBackground: 'rgba(45, 212, 191, 0.19)',
+  },
+  {
+    id: 'emerald',
+    accent: '#34d399',
+    border: 'rgba(52, 211, 153, 0.56)',
+    background: 'rgba(52, 211, 153, 0.14)',
+    hoverBackground: 'rgba(52, 211, 153, 0.19)',
+  },
+  {
+    id: 'lime',
+    accent: '#a3e635',
+    border: 'rgba(163, 230, 53, 0.52)',
+    background: 'rgba(163, 230, 53, 0.12)',
+    hoverBackground: 'rgba(163, 230, 53, 0.17)',
+  },
+  {
+    id: 'amber',
+    accent: '#fbbf24',
+    border: 'rgba(251, 191, 36, 0.54)',
+    background: 'rgba(251, 191, 36, 0.13)',
+    hoverBackground: 'rgba(251, 191, 36, 0.18)',
+  },
+  {
+    id: 'orange',
+    accent: '#fb923c',
+    border: 'rgba(251, 146, 60, 0.54)',
+    background: 'rgba(251, 146, 60, 0.13)',
+    hoverBackground: 'rgba(251, 146, 60, 0.18)',
+  },
+  {
+    id: 'rose',
+    accent: '#fb7185',
+    border: 'rgba(251, 113, 133, 0.56)',
+    background: 'rgba(251, 113, 133, 0.14)',
+    hoverBackground: 'rgba(251, 113, 133, 0.19)',
+  },
+  {
+    id: 'violet',
+    accent: '#a78bfa',
+    border: 'rgba(167, 139, 250, 0.56)',
+    background: 'rgba(167, 139, 250, 0.14)',
+    hoverBackground: 'rgba(167, 139, 250, 0.19)',
+  },
+] as const satisfies readonly TerminalTabColorOption[];
+
+export function parseTerminalTabPreferences(raw: string | null): TerminalTabPreferences {
+  if (!raw) return createDefaultTerminalTabPreferences();
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') {
+      return createDefaultTerminalTabPreferences();
+    }
+
+    const source = parsed as {
+      order?: unknown;
+      colors?: unknown;
+    };
+    const order = Array.isArray(source.order)
+      ? source.order.filter((item): item is string => typeof item === 'string')
+      : [];
+    const colors: Record<string, TerminalTabColorId> = {};
+    if (source.colors && typeof source.colors === 'object') {
+      for (const [tabId, colorId] of Object.entries(source.colors)) {
+        if (typeof tabId === 'string' && isTerminalTabColorId(colorId)) {
+          colors[tabId] = colorId;
+        }
+      }
+    }
+
+    return {
+      version: TERMINAL_TAB_PREFERENCES_VERSION,
+      order,
+      colors,
+    };
+  } catch {
+    return createDefaultTerminalTabPreferences();
+  }
+}
+
+export function formatMuxTabTitle(tab: TerminalMuxTab, index: number): string {
+  return tab.title?.trim() || `Tab ${index + 1}`;
+}
+
+export function formatNextMuxTabTitle(tabs: readonly TerminalMuxTab[]): string {
+  const usedTitles = new Set(
+    tabs.map((tab) => tab.title?.trim()).filter((title): title is string => Boolean(title))
+  );
+  let nextNumber = Math.max(tabs.length + 1, 1);
+
+  for (const title of usedTitles) {
+    const match = /^Tab\s+(\d+)$/i.exec(title);
+    if (!match) continue;
+    nextNumber = Math.max(nextNumber, Number(match[1]) + 1);
+  }
+
+  let nextTitle = formatNewMuxTabTitle(nextNumber);
+  while (usedTitles.has(nextTitle)) {
+    nextNumber += 1;
+    nextTitle = formatNewMuxTabTitle(nextNumber);
+  }
+
+  return nextTitle;
+}
+
+export function createDefaultTerminalTabPreferences(): TerminalTabPreferences {
+  return {
+    version: TERMINAL_TAB_PREFERENCES_VERSION,
+    order: [],
+    colors: {},
+  };
+}
+
+export function normalizeTerminalTabPreferences(
+  preferences: TerminalTabPreferences,
+  tabs: readonly TerminalMuxTab[]
+): TerminalTabPreferences {
+  const normalizedOrder = orderTerminalTabsByPreference(tabs, preferences.order).map(
+    (tab) => tab.tab_id
+  );
+  const visibleTabIds = new Set(normalizedOrder);
+  const colors: Record<string, TerminalTabColorId> = {};
+
+  for (const [tabId, colorId] of Object.entries(preferences.colors)) {
+    if (visibleTabIds.has(tabId) && isTerminalTabColorId(colorId)) {
+      colors[tabId] = colorId;
+    }
+  }
+
+  return {
+    version: TERMINAL_TAB_PREFERENCES_VERSION,
+    order: normalizedOrder,
+    colors,
+  };
+}
+
+export function orderTerminalTabsByPreference(
+  tabs: readonly TerminalMuxTab[],
+  order: readonly string[]
+): TerminalMuxTab[] {
+  const remainingTabsById = new Map(tabs.map((tab) => [tab.tab_id, tab]));
+  const orderedTabs: TerminalMuxTab[] = [];
+
+  for (const tabId of order) {
+    const tab = remainingTabsById.get(tabId);
+    if (!tab) continue;
+    orderedTabs.push(tab);
+    remainingTabsById.delete(tabId);
+  }
+
+  return [...orderedTabs, ...tabs.filter((tab) => remainingTabsById.has(tab.tab_id))];
+}
+
+export function resolveVisibleTabToFocusAfterClose(
+  orderedTabs: readonly TerminalMuxTab[],
+  closingTabId: string
+): string | null {
+  const closingIndex = orderedTabs.findIndex((tab) => tab.tab_id === closingTabId);
+  if (closingIndex < 0) {
+    return null;
+  }
+
+  return orderedTabs[closingIndex - 1]?.tab_id ?? orderedTabs[closingIndex + 1]?.tab_id ?? null;
+}
+
+export function reorderTerminalTabsById(
+  currentOrder: readonly string[],
+  tabs: readonly TerminalMuxTab[],
+  sourceTabId: string,
+  targetTabId: string,
+  placementMode: 'before' | 'after'
+): string[] {
+  const order = orderTerminalTabsByPreference(tabs, currentOrder).map((tab) => tab.tab_id);
+  if (!order.includes(sourceTabId) || !order.includes(targetTabId)) {
+    return order;
+  }
+
+  const withoutSource = order.filter((tabId) => tabId !== sourceTabId);
+  const targetIndex = withoutSource.indexOf(targetTabId);
+  if (targetIndex === -1) {
+    return order;
+  }
+
+  withoutSource.splice(placementMode === 'after' ? targetIndex + 1 : targetIndex, 0, sourceTabId);
+  return withoutSource;
+}
+
+export function resolveTerminalTabColor(
+  colorId: TerminalTabColorId | undefined
+): TerminalTabColorOption {
+  return (
+    TERMINAL_TAB_COLOR_OPTIONS.find((option) => option.id === colorId) ??
+    TERMINAL_TAB_COLOR_OPTIONS.find((option) => option.id === 'sky') ??
+    TERMINAL_TAB_COLOR_OPTIONS[0]
+  );
+}
+
+export function getTerminalTabColorLabelKey(
+  colorId: TerminalTabColorId
+): (typeof TERMINAL_TAB_COLOR_LABEL_KEYS)[TerminalTabColorId] {
+  return TERMINAL_TAB_COLOR_LABEL_KEYS[colorId];
+}
+
+export function isTerminalTabColorId(value: unknown): value is TerminalTabColorId {
+  return (
+    typeof value === 'string' && TERMINAL_TAB_COLOR_OPTIONS.some((option) => option.id === value)
+  );
+}
+
+export function areTerminalTabPreferencesEqual(
+  left: TerminalTabPreferences,
+  right: TerminalTabPreferences
+): boolean {
+  if (left.version !== right.version || !areStringArraysEqual(left.order, right.order)) {
+    return false;
+  }
+
+  const leftColors = Object.entries(left.colors);
+  const rightColors = Object.entries(right.colors);
+  if (leftColors.length !== rightColors.length) {
+    return false;
+  }
+
+  return leftColors.every(([tabId, colorId]) => right.colors[tabId] === colorId);
+}
+
+export function areStringArraysEqual(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+export function isPrewarmedTerminalTab(tab: TerminalMuxTab): boolean {
+  return tab.title?.trim() === PREWARMED_TERMINAL_TAB_TITLE;
+}
+
+export function hasTerminalTabHistory(
+  snapshot: TerminalWorkspaceSnapshot,
+  tab: TerminalMuxTab
+): boolean {
+  const paneIds = collectPaneIds(tab.root);
+  const focusedScreen = snapshot.attachedSession?.focused_screen ?? null;
+
+  for (const paneId of paneIds) {
+    const historicalLines = snapshot.historicalPanes?.[paneId]?.lines ?? [];
+    if (historicalLines.some((line) => line.trim().length > 0)) {
+      return true;
+    }
+
+    if (
+      focusedScreen?.pane_id === paneId &&
+      focusedScreen.surface.lines.some((line) => line.text.trim().length > 0)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function formatNewMuxTabTitle(tabNumber: number): string {
+  return `Tab ${tabNumber}`;
+}
+
+function collectPaneIds(node: TerminalMuxPaneTreeNode): string[] {
+  if (node.kind === 'leaf') {
+    return [node.pane_id];
+  }
+
+  return [...collectPaneIds(node.first), ...collectPaneIds(node.second)];
+}

--- a/src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx
+++ b/src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx
@@ -3,7 +3,6 @@ import {
   type CSSProperties,
   useCallback,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -67,6 +66,11 @@ import {
 
 import { normalizeTerminalCommandRunEventDetail } from '../adapters/terminalCommandRunEvents';
 import {
+  persistTerminalTabPreferences,
+  readStoredTerminalTabPreferences,
+} from '../adapters/terminalTabPreferencesStorage';
+import { useTerminalTabReorderMotion } from '../hooks/useTerminalTabReorderMotion';
+import {
   DEFAULT_TERMINAL_APPEARANCE_SETTINGS,
   normalizeTerminalAppearanceSettings,
   resolveTerminalBackgroundImageUrl,
@@ -93,6 +97,28 @@ import {
   formatTerminalPromptLabel,
   formatWorkingDirectory,
 } from '../model/terminalPathPresentation';
+import {
+  areStringArraysEqual,
+  areTerminalTabPreferencesEqual,
+  formatMuxTabTitle,
+  formatNextMuxTabTitle,
+  getTerminalTabColorLabelKey,
+  hasTerminalTabHistory,
+  isPrewarmedTerminalTab,
+  normalizeTerminalTabPreferences,
+  orderTerminalTabsByPreference,
+  PREWARMED_TERMINAL_TAB_TITLE,
+  reorderTerminalTabsById,
+  resolveTerminalTabColor,
+  resolveVisibleTabToFocusAfterClose,
+  TERMINAL_TAB_COLOR_OPTIONS,
+  type TerminalMuxTab,
+  type TerminalTabColorId,
+  type TerminalTabDropIndicator,
+  type TerminalTabPointerDrag,
+  type TerminalTabPreferences,
+  type TerminalWorkspaceSnapshot,
+} from '../model/terminalTabPreferences';
 import { isRecord } from '../utils/valueGuards';
 
 import {
@@ -123,10 +149,7 @@ export interface TerminalWorkspacePanelProps {
 }
 
 const TERMINAL_LOCAL_AUTOCOMPLETE_THROTTLE_MS = 75;
-const PREWARMED_TERMINAL_TAB_TITLE = '__tp_prewarmed_shell__';
-const TERMINAL_TAB_PREFERENCES_VERSION = 1;
 const TERMINAL_PLATFORM_GITHUB_URL = 'https://github.com/777genius/terminal-platform';
-type TerminalWorkspaceSnapshot = ReturnType<WorkspaceKernel['getSnapshot']>;
 type TerminalMuxCommand = Parameters<WorkspaceKernel['commands']['dispatchMuxCommand']>[1];
 type TerminalScreenElementHandle = ComponentRef<typeof TerminalScreen> & {
   followOutput?: boolean;
@@ -135,41 +158,6 @@ type TerminalScreenElementHandle = ComponentRef<typeof TerminalScreen> & {
 };
 type TerminalCommandDockElementHandle = ComponentRef<typeof TerminalCommandDock>;
 type TeamTFunction = ReturnType<typeof useAppTranslation>['t'];
-type TerminalMuxTab = NonNullable<
-  TerminalWorkspaceSnapshot['attachedSession']
->['topology']['tabs'][number];
-type TerminalMuxPaneTreeNode = TerminalMuxTab['root'];
-type TerminalTabColorId = (typeof TERMINAL_TAB_COLOR_OPTIONS)[number]['id'];
-
-interface TerminalTabColorOption {
-  id: string;
-  accent: string;
-  border: string;
-  background: string;
-  hoverBackground: string;
-}
-
-interface TerminalTabPreferences {
-  version: number;
-  order: string[];
-  colors: Record<string, TerminalTabColorId>;
-}
-
-interface TerminalTabDropIndicator {
-  placementMode: 'before' | 'after';
-  tabId: string;
-}
-
-interface TerminalTabPointerDrag {
-  active: boolean;
-  grabOffsetX: number;
-  offsetX: number;
-  pointerId: number;
-  startClientX: number;
-  startClientY: number;
-  tabId: string;
-}
-
 interface TerminalCommandContextMenuState {
   blockText: string;
   commandText: string;
@@ -177,86 +165,6 @@ interface TerminalCommandContextMenuState {
   x: number;
   y: number;
 }
-
-const TERMINAL_TAB_COLOR_OPTIONS = [
-  {
-    id: 'slate',
-    accent: '#94a3b8',
-    border: 'rgba(148, 163, 184, 0.56)',
-    background: 'rgba(148, 163, 184, 0.14)',
-    hoverBackground: 'rgba(148, 163, 184, 0.18)',
-  },
-  {
-    id: 'sky',
-    accent: '#38bdf8',
-    border: 'rgba(56, 189, 248, 0.58)',
-    background: 'rgba(56, 189, 248, 0.15)',
-    hoverBackground: 'rgba(56, 189, 248, 0.2)',
-  },
-  {
-    id: 'blue',
-    accent: '#60a5fa',
-    border: 'rgba(96, 165, 250, 0.58)',
-    background: 'rgba(96, 165, 250, 0.15)',
-    hoverBackground: 'rgba(96, 165, 250, 0.2)',
-  },
-  {
-    id: 'cyan',
-    accent: '#22d3ee',
-    border: 'rgba(34, 211, 238, 0.58)',
-    background: 'rgba(34, 211, 238, 0.14)',
-    hoverBackground: 'rgba(34, 211, 238, 0.19)',
-  },
-  {
-    id: 'teal',
-    accent: '#2dd4bf',
-    border: 'rgba(45, 212, 191, 0.56)',
-    background: 'rgba(45, 212, 191, 0.14)',
-    hoverBackground: 'rgba(45, 212, 191, 0.19)',
-  },
-  {
-    id: 'emerald',
-    accent: '#34d399',
-    border: 'rgba(52, 211, 153, 0.56)',
-    background: 'rgba(52, 211, 153, 0.14)',
-    hoverBackground: 'rgba(52, 211, 153, 0.19)',
-  },
-  {
-    id: 'lime',
-    accent: '#a3e635',
-    border: 'rgba(163, 230, 53, 0.52)',
-    background: 'rgba(163, 230, 53, 0.12)',
-    hoverBackground: 'rgba(163, 230, 53, 0.17)',
-  },
-  {
-    id: 'amber',
-    accent: '#fbbf24',
-    border: 'rgba(251, 191, 36, 0.54)',
-    background: 'rgba(251, 191, 36, 0.13)',
-    hoverBackground: 'rgba(251, 191, 36, 0.18)',
-  },
-  {
-    id: 'orange',
-    accent: '#fb923c',
-    border: 'rgba(251, 146, 60, 0.54)',
-    background: 'rgba(251, 146, 60, 0.13)',
-    hoverBackground: 'rgba(251, 146, 60, 0.18)',
-  },
-  {
-    id: 'rose',
-    accent: '#fb7185',
-    border: 'rgba(251, 113, 133, 0.56)',
-    background: 'rgba(251, 113, 133, 0.14)',
-    hoverBackground: 'rgba(251, 113, 133, 0.19)',
-  },
-  {
-    id: 'violet',
-    accent: '#a78bfa',
-    border: 'rgba(167, 139, 250, 0.56)',
-    background: 'rgba(167, 139, 250, 0.14)',
-    hoverBackground: 'rgba(167, 139, 250, 0.19)',
-  },
-] as const satisfies readonly TerminalTabColorOption[];
 
 const TerminalButtonTooltip = ({
   children,
@@ -1367,7 +1275,6 @@ const TerminalMuxTabs = ({
   const tabListElementRef = useRef<HTMLDivElement | null>(null);
   const tabElementRefs = useRef<Map<string, HTMLDivElement>>(new Map());
   const tabPointerDragRef = useRef<TerminalTabPointerDrag | null>(null);
-  const tabRectsBeforeReorderRef = useRef<Map<string, DOMRect> | null>(null);
   const topology = snapshot.attachedSession?.topology ?? null;
   const controls = resolveTerminalTopologyControlState(snapshot);
   const tabs = topology?.tabs ?? [];
@@ -1389,6 +1296,11 @@ const TerminalMuxTabs = ({
   const busy = pendingAction !== null;
   const headerPlacement = placement === 'sheet-header';
   const canCloseVisibleTabs = controls.canCloseTab && visibleTabs.length > 1;
+  const { captureTabRectsBeforeReorder, clearCapturedTabRects } = useTerminalTabReorderMotion({
+    draggingTabId,
+    orderedTabIdsKey: orderedVisibleTabIdsKey,
+    tabElementRefs,
+  });
 
   const setTabPointerDragState = useCallback((nextDrag: TerminalTabPointerDrag | null): void => {
     tabPointerDragRef.current = nextDrag;
@@ -1417,66 +1329,6 @@ const TerminalMuxTabs = ({
 
     tabElementRefs.current.delete(tabId);
   }, []);
-
-  const prefersReducedMotion = useCallback(
-    () =>
-      typeof window !== 'undefined' &&
-      window.matchMedia?.('(prefers-reduced-motion: reduce)').matches,
-    []
-  );
-
-  const captureTabRectsBeforeReorder = useCallback((): void => {
-    if (prefersReducedMotion()) {
-      tabRectsBeforeReorderRef.current = null;
-      return;
-    }
-
-    const rects = new Map<string, DOMRect>();
-    tabElementRefs.current.forEach((element, tabId) => {
-      rects.set(tabId, element.getBoundingClientRect());
-    });
-    tabRectsBeforeReorderRef.current = rects.size > 1 ? rects : null;
-  }, [prefersReducedMotion]);
-
-  useLayoutEffect(() => {
-    const previousRects = tabRectsBeforeReorderRef.current;
-    if (!previousRects || prefersReducedMotion()) {
-      tabRectsBeforeReorderRef.current = null;
-      return;
-    }
-
-    tabRectsBeforeReorderRef.current = null;
-    tabElementRefs.current.forEach((element, tabId) => {
-      if (tabId === draggingTabId) {
-        return;
-      }
-
-      const previousRect = previousRects.get(tabId);
-      if (!previousRect) {
-        return;
-      }
-
-      const nextRect = element.getBoundingClientRect();
-      const deltaX = previousRect.left - nextRect.left;
-      const deltaY = previousRect.top - nextRect.top;
-      if (Math.abs(deltaX) < 0.5 && Math.abs(deltaY) < 0.5) {
-        return;
-      }
-
-      if (typeof element.animate !== 'function') {
-        return;
-      }
-
-      element.getAnimations?.().forEach((animation) => animation.cancel());
-      element.animate(
-        [{ transform: `translate(${deltaX}px, ${deltaY}px)` }, { transform: 'translate(0, 0)' }],
-        {
-          duration: 180,
-          easing: 'cubic-bezier(0.22, 1, 0.36, 1)',
-        }
-      );
-    });
-  }, [draggingTabId, orderedVisibleTabIdsKey, prefersReducedMotion]);
 
   const runMuxCommands = async (
     actionId: string,
@@ -1745,12 +1597,12 @@ const TerminalMuxTabs = ({
       setTabPointerDragState(null);
       setDraggingTabId(null);
       setDropIndicator(null);
-      tabRectsBeforeReorderRef.current = null;
+      clearCapturedTabRects();
       window.setTimeout(() => {
         suppressNextTabClickRef.current = false;
       }, 0);
     },
-    [setTabPointerDragState]
+    [clearCapturedTabRects, setTabPointerDragState]
   );
 
   const handleTabPointerDown = (
@@ -2189,7 +2041,7 @@ const TerminalMuxTabs = ({
                                 style={{ backgroundColor: option.accent }}
                               />
                               <span className="min-w-0 flex-1">
-                                {formatTerminalTabColorLabel(t, option.id)}
+                                {t(getTerminalTabColorLabelKey(option.id))}
                               </span>
                               {color.id === option.id ? <Check size={13} /> : null}
                             </ContextMenuItem>
@@ -2610,42 +2462,6 @@ function readStoredTerminalAppearanceSettings(teamName: string): TerminalAppeara
   }
 }
 
-function readStoredTerminalTabPreferences(teamName: string): TerminalTabPreferences {
-  const raw = readStoredValue(storageKey(teamName, 'tab-preferences'));
-  if (!raw) return createDefaultTerminalTabPreferences();
-
-  try {
-    const parsed: unknown = JSON.parse(raw);
-    if (!parsed || typeof parsed !== 'object') {
-      return createDefaultTerminalTabPreferences();
-    }
-
-    const source = parsed as {
-      order?: unknown;
-      colors?: unknown;
-    };
-    const order = Array.isArray(source.order)
-      ? source.order.filter((item): item is string => typeof item === 'string')
-      : [];
-    const colors: Record<string, TerminalTabColorId> = {};
-    if (source.colors && typeof source.colors === 'object') {
-      for (const [tabId, colorId] of Object.entries(source.colors)) {
-        if (typeof tabId === 'string' && isTerminalTabColorId(colorId)) {
-          colors[tabId] = colorId;
-        }
-      }
-    }
-
-    return {
-      version: TERMINAL_TAB_PREFERENCES_VERSION,
-      order,
-      colors,
-    };
-  } catch {
-    return createDefaultTerminalTabPreferences();
-  }
-}
-
 function readStoredCommandHistory(teamName: string): string[] | null {
   const raw = readStoredValue(storageKey(teamName, 'command-history'));
   if (!raw) return null;
@@ -2728,20 +2544,6 @@ function getTerminalBackgroundRepeat(fit: TerminalBackgroundImageFit): string {
 
 function getTerminalBackgroundPosition(fit: TerminalBackgroundImageFit): string {
   return fit === 'tile' ? 'top left' : 'center';
-}
-
-function persistTerminalTabPreferences(
-  teamName: string,
-  preferences: TerminalTabPreferences
-): void {
-  try {
-    window.localStorage.setItem(
-      storageKey(teamName, 'tab-preferences'),
-      JSON.stringify(preferences)
-    );
-  } catch {
-    // Best-effort tab UI preference persistence.
-  }
 }
 
 function persistCommandHistory(teamName: string, entries: readonly string[]): void {
@@ -2837,187 +2639,8 @@ function persistTerminalCommandRuns(
   }
 }
 
-function formatMuxTabTitle(tab: TerminalMuxTab, index: number): string {
-  return tab.title?.trim() || `Tab ${index + 1}`;
-}
-
-function formatNewMuxTabTitle(tabNumber: number): string {
-  return `Tab ${tabNumber}`;
-}
-
-function formatNextMuxTabTitle(tabs: readonly TerminalMuxTab[]): string {
-  const usedTitles = new Set(
-    tabs.map((tab) => tab.title?.trim()).filter((title): title is string => Boolean(title))
-  );
-  let nextNumber = Math.max(tabs.length + 1, 1);
-
-  for (const title of usedTitles) {
-    const match = /^Tab\s+(\d+)$/i.exec(title);
-    if (!match) continue;
-    nextNumber = Math.max(nextNumber, Number(match[1]) + 1);
-  }
-
-  let nextTitle = formatNewMuxTabTitle(nextNumber);
-  while (usedTitles.has(nextTitle)) {
-    nextNumber += 1;
-    nextTitle = formatNewMuxTabTitle(nextNumber);
-  }
-
-  return nextTitle;
-}
-
-function createDefaultTerminalTabPreferences(): TerminalTabPreferences {
-  return {
-    version: TERMINAL_TAB_PREFERENCES_VERSION,
-    order: [],
-    colors: {},
-  };
-}
-
-function normalizeTerminalTabPreferences(
-  preferences: TerminalTabPreferences,
-  tabs: readonly TerminalMuxTab[]
-): TerminalTabPreferences {
-  const normalizedOrder = orderTerminalTabsByPreference(tabs, preferences.order).map(
-    (tab) => tab.tab_id
-  );
-  const visibleTabIds = new Set(normalizedOrder);
-  const colors: Record<string, TerminalTabColorId> = {};
-
-  for (const [tabId, colorId] of Object.entries(preferences.colors)) {
-    if (visibleTabIds.has(tabId) && isTerminalTabColorId(colorId)) {
-      colors[tabId] = colorId;
-    }
-  }
-
-  return {
-    version: TERMINAL_TAB_PREFERENCES_VERSION,
-    order: normalizedOrder,
-    colors,
-  };
-}
-
-function orderTerminalTabsByPreference(
-  tabs: readonly TerminalMuxTab[],
-  order: readonly string[]
-): TerminalMuxTab[] {
-  const remainingTabsById = new Map(tabs.map((tab) => [tab.tab_id, tab]));
-  const orderedTabs: TerminalMuxTab[] = [];
-
-  for (const tabId of order) {
-    const tab = remainingTabsById.get(tabId);
-    if (!tab) continue;
-    orderedTabs.push(tab);
-    remainingTabsById.delete(tabId);
-  }
-
-  return [...orderedTabs, ...tabs.filter((tab) => remainingTabsById.has(tab.tab_id))];
-}
-
-function resolveVisibleTabToFocusAfterClose(
-  orderedTabs: readonly TerminalMuxTab[],
-  closingTabId: string
-): string | null {
-  const closingIndex = orderedTabs.findIndex((tab) => tab.tab_id === closingTabId);
-  if (closingIndex < 0) {
-    return null;
-  }
-
-  return orderedTabs[closingIndex - 1]?.tab_id ?? orderedTabs[closingIndex + 1]?.tab_id ?? null;
-}
-
-function reorderTerminalTabsById(
-  currentOrder: readonly string[],
-  tabs: readonly TerminalMuxTab[],
-  sourceTabId: string,
-  targetTabId: string,
-  placementMode: 'before' | 'after'
-): string[] {
-  const order = orderTerminalTabsByPreference(tabs, currentOrder).map((tab) => tab.tab_id);
-  if (!order.includes(sourceTabId) || !order.includes(targetTabId)) {
-    return order;
-  }
-
-  const withoutSource = order.filter((tabId) => tabId !== sourceTabId);
-  const targetIndex = withoutSource.indexOf(targetTabId);
-  if (targetIndex === -1) {
-    return order;
-  }
-
-  withoutSource.splice(placementMode === 'after' ? targetIndex + 1 : targetIndex, 0, sourceTabId);
-  return withoutSource;
-}
-
 function shouldIgnoreTerminalTabDragTarget(target: HTMLElement): boolean {
   return Boolean(target.closest('[data-terminal-tab-drag-ignore="true"],input,textarea,select,a'));
-}
-
-function resolveTerminalTabColor(colorId: TerminalTabColorId | undefined): TerminalTabColorOption {
-  return (
-    TERMINAL_TAB_COLOR_OPTIONS.find((option) => option.id === colorId) ??
-    TERMINAL_TAB_COLOR_OPTIONS.find((option) => option.id === 'sky') ??
-    TERMINAL_TAB_COLOR_OPTIONS[0]
-  );
-}
-
-function isTerminalTabColorId(value: unknown): value is TerminalTabColorId {
-  return (
-    typeof value === 'string' && TERMINAL_TAB_COLOR_OPTIONS.some((option) => option.id === value)
-  );
-}
-
-function areTerminalTabPreferencesEqual(
-  left: TerminalTabPreferences,
-  right: TerminalTabPreferences
-): boolean {
-  if (left.version !== right.version || !areStringArraysEqual(left.order, right.order)) {
-    return false;
-  }
-
-  const leftColors = Object.entries(left.colors);
-  const rightColors = Object.entries(right.colors);
-  if (leftColors.length !== rightColors.length) {
-    return false;
-  }
-
-  return leftColors.every(([tabId, colorId]) => right.colors[tabId] === colorId);
-}
-
-function areStringArraysEqual(left: readonly string[], right: readonly string[]): boolean {
-  return left.length === right.length && left.every((value, index) => value === right[index]);
-}
-
-function isPrewarmedTerminalTab(tab: TerminalMuxTab): boolean {
-  return tab.title?.trim() === PREWARMED_TERMINAL_TAB_TITLE;
-}
-
-function hasTerminalTabHistory(snapshot: TerminalWorkspaceSnapshot, tab: TerminalMuxTab): boolean {
-  const paneIds = collectPaneIds(tab.root);
-  const focusedScreen = snapshot.attachedSession?.focused_screen ?? null;
-
-  for (const paneId of paneIds) {
-    const historicalLines = snapshot.historicalPanes?.[paneId]?.lines ?? [];
-    if (historicalLines.some((line) => line.trim().length > 0)) {
-      return true;
-    }
-
-    if (
-      focusedScreen?.pane_id === paneId &&
-      focusedScreen.surface.lines.some((line) => line.text.trim().length > 0)
-    ) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
-function collectPaneIds(node: TerminalMuxPaneTreeNode): string[] {
-  if (node.kind === 'leaf') {
-    return [node.pane_id];
-  }
-
-  return [...collectPaneIds(node.first), ...collectPaneIds(node.second)];
 }
 
 function formatThemeLabel(t: TeamTFunction, displayName: string, themeId: string): string {
@@ -3030,33 +2653,6 @@ function formatFontScaleLabel(t: TeamTFunction, fontScale: string): string {
   if (fontScale === 'compact') return t('terminalWorkspace.fontScaleCompact');
   if (fontScale === 'large') return t('terminalWorkspace.fontScaleLarge');
   return t('terminalWorkspace.fontScaleDefault');
-}
-
-function formatTerminalTabColorLabel(t: TeamTFunction, colorId: TerminalTabColorId): string {
-  switch (colorId) {
-    case 'slate':
-      return t('terminalWorkspace.tabColorSlate');
-    case 'sky':
-      return t('terminalWorkspace.tabColorSky');
-    case 'blue':
-      return t('terminalWorkspace.tabColorBlue');
-    case 'cyan':
-      return t('terminalWorkspace.tabColorCyan');
-    case 'teal':
-      return t('terminalWorkspace.tabColorTeal');
-    case 'emerald':
-      return t('terminalWorkspace.tabColorEmerald');
-    case 'lime':
-      return t('terminalWorkspace.tabColorLime');
-    case 'amber':
-      return t('terminalWorkspace.tabColorAmber');
-    case 'orange':
-      return t('terminalWorkspace.tabColorOrange');
-    case 'rose':
-      return t('terminalWorkspace.tabColorRose');
-    case 'violet':
-      return t('terminalWorkspace.tabColorViolet');
-  }
 }
 
 function getErrorMessage(reason: unknown): string {

--- a/test/renderer/features/terminal-workspace/terminalTabPreferences.test.ts
+++ b/test/renderer/features/terminal-workspace/terminalTabPreferences.test.ts
@@ -1,0 +1,89 @@
+import {
+  createDefaultTerminalTabPreferences,
+  normalizeTerminalTabPreferences,
+  orderTerminalTabsByPreference,
+  parseTerminalTabPreferences,
+  reorderTerminalTabsById,
+  resolveTerminalTabColor,
+  resolveVisibleTabToFocusAfterClose,
+  type TerminalMuxTab,
+} from '@features/terminal-workspace/renderer/model/terminalTabPreferences';
+import { describe, expect, it } from 'vitest';
+
+describe('terminal tab preferences', () => {
+  const tabs = [createTab('tab-1', 'One'), createTab('tab-2', 'Two'), createTab('tab-3', 'Three')];
+
+  it('parses only supported persisted tab order and color values', () => {
+    expect(
+      parseTerminalTabPreferences(
+        JSON.stringify({
+          colors: { 'tab-1': 'rose', 'tab-2': 'unsupported' },
+          order: ['tab-2', 42, 'tab-1'],
+          version: 0,
+        })
+      )
+    ).toEqual({
+      colors: { 'tab-1': 'rose' },
+      order: ['tab-2', 'tab-1'],
+      version: 1,
+    });
+    expect(parseTerminalTabPreferences('{broken')).toEqual(createDefaultTerminalTabPreferences());
+  });
+
+  it('orders known tabs by preference and appends unmentioned tabs stably', () => {
+    expect(orderTerminalTabsByPreference(tabs, ['tab-3', 'missing', 'tab-1'])).toEqual([
+      tabs[2],
+      tabs[0],
+      tabs[1],
+    ]);
+  });
+
+  it('normalizes stale tab identities and color assignments', () => {
+    expect(
+      normalizeTerminalTabPreferences(
+        {
+          colors: { 'tab-1': 'amber', missing: 'rose' },
+          order: ['tab-2', 'missing'],
+          version: 1,
+        },
+        tabs
+      )
+    ).toEqual({
+      colors: { 'tab-1': 'amber' },
+      order: ['tab-2', 'tab-1', 'tab-3'],
+      version: 1,
+    });
+  });
+
+  it('reorders tabs and resolves the adjacent focus target without mutating inputs', () => {
+    const currentOrder = ['tab-1', 'tab-2', 'tab-3'];
+
+    expect(reorderTerminalTabsById(currentOrder, tabs, 'tab-1', 'tab-3', 'after')).toEqual([
+      'tab-2',
+      'tab-3',
+      'tab-1',
+    ]);
+    expect(currentOrder).toEqual(['tab-1', 'tab-2', 'tab-3']);
+    expect(resolveVisibleTabToFocusAfterClose(tabs, 'tab-2')).toBe('tab-1');
+    expect(resolveVisibleTabToFocusAfterClose(tabs, 'missing')).toBeNull();
+  });
+
+  it('falls back to the canonical sky color for missing preferences', () => {
+    expect(resolveTerminalTabColor(undefined).id).toBe('sky');
+  });
+});
+
+function createTab(tabId: string, title: string): TerminalMuxTab {
+  return {
+    active: false,
+    focused_pane: `pane-${tabId}`,
+    root: {
+      cwd: '/fixtures/terminal-tab',
+      kind: 'leaf',
+      pane_id: `pane-${tabId}`,
+      title,
+    },
+    tab_id: tabId,
+    title,
+  } as TerminalMuxTab;
+}

--- a/test/renderer/features/terminal-workspace/useTerminalTabReorderMotion.test.tsx
+++ b/test/renderer/features/terminal-workspace/useTerminalTabReorderMotion.test.tsx
@@ -1,0 +1,198 @@
+import React, { act, type RefObject } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { useTerminalTabReorderMotion } from '@features/terminal-workspace/renderer/hooks/useTerminalTabReorderMotion';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type ReorderMotionControls = ReturnType<typeof useTerminalTabReorderMotion>;
+interface ReorderMotionHarnessProps {
+  draggingTabId: string | null;
+  orderedTabIdsKey: string;
+  tabElementRefs: RefObject<Map<string, HTMLDivElement>>;
+}
+
+describe('useTerminalTabReorderMotion', () => {
+  let host: HTMLDivElement;
+  let root: Root;
+  let controls: ReorderMotionControls | null;
+
+  function Harness(props: ReorderMotionHarnessProps): null {
+    controls = useTerminalTabReorderMotion(props);
+    return null;
+  }
+
+  beforeEach(() => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => createMediaQueryList(false))
+    );
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+    controls = null;
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    host.remove();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('animates moved tabs from their captured positions and cancels stale animations', async () => {
+    const first = createTabElement(10);
+    const second = createTabElement(110);
+    const staleAnimation = { cancel: vi.fn() } as unknown as Animation;
+    const getAnimations = vi.fn(() => [staleAnimation]);
+    const animate = vi.fn();
+    Object.defineProperties(second.element, {
+      animate: { configurable: true, value: animate },
+      getAnimations: { configurable: true, value: getAnimations },
+    });
+    const tabElementRefs = createTabElementRefs(first.element, second.element);
+
+    await renderHarness({
+      draggingTabId: 'tab-1',
+      orderedTabIdsKey: 'tab-1 tab-2',
+      tabElementRefs,
+    });
+    act(() => controls?.captureTabRectsBeforeReorder());
+
+    first.setLeft(110);
+    second.setLeft(10);
+    await renderHarness({
+      draggingTabId: 'tab-1',
+      orderedTabIdsKey: 'tab-2 tab-1',
+      tabElementRefs,
+    });
+
+    expect(first.animate).not.toHaveBeenCalled();
+    expect(staleAnimation.cancel).toHaveBeenCalledOnce();
+    expect(animate).toHaveBeenCalledWith(
+      [{ transform: 'translate(100px, 0px)' }, { transform: 'translate(0, 0)' }],
+      {
+        duration: 180,
+        easing: 'cubic-bezier(0.22, 1, 0.36, 1)',
+      }
+    );
+  });
+
+  it('does not capture or animate tab positions when reduced motion is preferred', async () => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => createMediaQueryList(true))
+    );
+    const first = createTabElement(10);
+    const second = createTabElement(110);
+    const tabElementRefs = createTabElementRefs(first.element, second.element);
+
+    await renderHarness({ draggingTabId: null, orderedTabIdsKey: 'tab-1 tab-2', tabElementRefs });
+    act(() => controls?.captureTabRectsBeforeReorder());
+    second.setLeft(10);
+    await renderHarness({ draggingTabId: null, orderedTabIdsKey: 'tab-2 tab-1', tabElementRefs });
+
+    expect(first.getBoundingClientRect).not.toHaveBeenCalled();
+    expect(second.getBoundingClientRect).not.toHaveBeenCalled();
+    expect(first.animate).not.toHaveBeenCalled();
+    expect(second.animate).not.toHaveBeenCalled();
+  });
+
+  it('skips moved elements without the Web Animations API', async () => {
+    const first = createTabElement(10);
+    const second = createTabElement(110);
+    Object.defineProperty(second.element, 'animate', {
+      configurable: true,
+      value: undefined,
+    });
+    const tabElementRefs = createTabElementRefs(first.element, second.element);
+
+    await renderHarness({ draggingTabId: null, orderedTabIdsKey: 'tab-1 tab-2', tabElementRefs });
+    act(() => controls?.captureTabRectsBeforeReorder());
+    second.setLeft(10);
+
+    await expect(
+      renderHarness({ draggingTabId: null, orderedTabIdsKey: 'tab-2 tab-1', tabElementRefs })
+    ).resolves.toBeUndefined();
+    expect(first.animate).not.toHaveBeenCalled();
+  });
+
+  async function renderHarness({
+    draggingTabId,
+    orderedTabIdsKey,
+    tabElementRefs,
+  }: ReorderMotionHarnessProps): Promise<void> {
+    await act(async () => {
+      root.render(
+        React.createElement(Harness, { draggingTabId, orderedTabIdsKey, tabElementRefs })
+      );
+      await Promise.resolve();
+    });
+  }
+});
+
+function createTabElement(initialLeft: number): {
+  animate: ReturnType<typeof vi.fn>;
+  element: HTMLDivElement;
+  getBoundingClientRect: ReturnType<typeof vi.fn>;
+  setLeft: (left: number) => void;
+} {
+  let left = initialLeft;
+  const element = document.createElement('div');
+  const animate = vi.fn();
+  const getBoundingClientRect = vi.fn(() => createRect(left));
+  Object.defineProperties(element, {
+    animate: { configurable: true, value: animate },
+    getBoundingClientRect: { configurable: true, value: getBoundingClientRect },
+  });
+
+  return {
+    animate,
+    element,
+    getBoundingClientRect,
+    setLeft: (nextLeft: number) => {
+      left = nextLeft;
+    },
+  };
+}
+
+function createTabElementRefs(
+  first: HTMLDivElement,
+  second: HTMLDivElement
+): RefObject<Map<string, HTMLDivElement>> {
+  return {
+    current: new Map([
+      ['tab-1', first],
+      ['tab-2', second],
+    ]),
+  };
+}
+
+function createRect(left: number): DOMRect {
+  return {
+    bottom: 40,
+    height: 30,
+    left,
+    right: left + 80,
+    toJSON: () => ({}),
+    top: 10,
+    width: 80,
+    x: left,
+    y: 10,
+  };
+}
+
+function createMediaQueryList(matches: boolean): MediaQueryList {
+  return {
+    addEventListener: vi.fn(),
+    addListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+    matches,
+    media: '(prefers-reduced-motion: reduce)',
+    onchange: null,
+    removeEventListener: vi.fn(),
+    removeListener: vi.fn(),
+  };
+}


### PR DESCRIPTION
## Summary

- extract terminal tab preference rules into a pure model
- isolate localStorage access behind a team-scoped adapter
- isolate tab reorder animation in a focused React hook
- reduce TerminalWorkspacePanel from 3064 to 2660 lines and ratchet the legacy cap down

## Verification

- 86 focused model, hook, Panel and PanelInternals tests
- native TypeScript 7 typecheck
- fast ESLint on changed TypeScript files
- Prettier check
- source-size ratchet against exact base 65f0d757e
- independent semantic audit: 0 P1-P3

Desktop/runtime E2E is intentionally deferred until the final TerminalWorkspacePanel slice is below 800 lines.