### PR TITLE
refactor(terminal-workspace): extract command lifecycle

### DIFF
--- a/scripts/ci/source-file-size-legacy.json
+++ b/scripts/ci/source-file-size-legacy.json
@@ -46,7 +46,7 @@
   "src/features/team-lifecycle/contracts/team-lifecycle-read.ts": 816,
   "src/features/team-lifecycle/main/infrastructure/TeamDirectoryLifecycleAdapter.ts": 1606,
   "src/features/team-runtime-control/core/application/planning/createCompositeRuntimePlan.ts": 1195,
-  "src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx": 2660,
+  "src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx": 2432,
   "src/features/token-usage/core/domain/snapshotProjection.ts": 937,
   "src/features/token-usage/renderer/adapters/tokenUsageViewModel.ts": 1481,
   "src/features/token-usage/renderer/ui/TokenUsageDashboard.tsx": 2170,

--- a/src/features/terminal-workspace/renderer/adapters/terminalCommandRunsStorage.ts
+++ b/src/features/terminal-workspace/renderer/adapters/terminalCommandRunsStorage.ts
@@ -1,0 +1,88 @@
+import {
+  capTerminalCommandRuns,
+  type TerminalCommandRunPresentation,
+} from '../model/terminalCommandRuns';
+import { isRecord } from '../utils/valueGuards';
+
+export function readStoredTerminalCommandRuns(teamName: string): TerminalCommandRunPresentation[] {
+  try {
+    const raw = window.localStorage.getItem(storageKey(teamName));
+    if (!raw) return [];
+
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return capTerminalCommandRuns(
+      parsed
+        .map((entry) => normalizeStoredTerminalCommandRun(entry))
+        .filter((entry): entry is TerminalCommandRunPresentation => entry !== null)
+    );
+  } catch {
+    return [];
+  }
+}
+
+export function persistTerminalCommandRuns(
+  teamName: string,
+  runs: readonly TerminalCommandRunPresentation[]
+): void {
+  try {
+    window.localStorage.setItem(storageKey(teamName), JSON.stringify(capTerminalCommandRuns(runs)));
+  } catch {
+    // Best-effort command presentation persistence.
+  }
+}
+
+function normalizeStoredTerminalCommandRun(value: unknown): TerminalCommandRunPresentation | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const clientEventId =
+    typeof value.clientEventId === 'string' && value.clientEventId.trim()
+      ? value.clientEventId.trim()
+      : null;
+  const command = typeof value.command === 'string' ? value.command.trim() : '';
+  const paneId = typeof value.paneId === 'string' && value.paneId.trim() ? value.paneId : null;
+  const sessionId =
+    typeof value.sessionId === 'string' && value.sessionId.trim() ? value.sessionId : null;
+  const startedAtMs =
+    typeof value.startedAtMs === 'number' && Number.isFinite(value.startedAtMs)
+      ? value.startedAtMs
+      : 0;
+  const storedStatus = isTerminalCommandRunPresentationStatus(value.status)
+    ? value.status
+    : 'unknown';
+  const status = storedStatus === 'running' ? 'unknown' : storedStatus;
+
+  if (!clientEventId || !command || !paneId || !sessionId) {
+    return null;
+  }
+
+  const run: TerminalCommandRunPresentation = {
+    clientEventId,
+    command,
+    paneId,
+    sessionId,
+    startedAtMs,
+    status,
+  };
+
+  if (typeof value.durationMs === 'number' && Number.isFinite(value.durationMs)) {
+    run.durationMs = Math.max(0, value.durationMs);
+  }
+  if (typeof value.exitCode === 'number' && Number.isFinite(value.exitCode)) {
+    run.exitCode = Math.trunc(value.exitCode);
+  }
+
+  return run;
+}
+
+function isTerminalCommandRunPresentationStatus(
+  value: unknown
+): value is TerminalCommandRunPresentation['status'] {
+  return value === 'failed' || value === 'running' || value === 'succeeded' || value === 'unknown';
+}
+
+function storageKey(teamName: string): string {
+  return `agent-teams:terminal-workspace:${teamName}:command-runs`;
+}

--- a/src/features/terminal-workspace/renderer/hooks/useTerminalCommandRuns.ts
+++ b/src/features/terminal-workspace/renderer/hooks/useTerminalCommandRuns.ts
@@ -52,6 +52,7 @@ export function useTerminalCommandRuns({
   const [commandRuns, setCommandRuns] = useState<TerminalCommandRunPresentation[]>(() =>
     readStoredTerminalCommandRuns(teamName)
   );
+  const [hydratedTeamName, setHydratedTeamName] = useState(teamName);
   const latestContextRef = useRef<TerminalCommandRunContext>({
     onCommandStarted,
     onCommandSubmitted,
@@ -173,11 +174,16 @@ export function useTerminalCommandRuns({
 
   useEffect(() => {
     setCommandRuns(readStoredTerminalCommandRuns(teamName));
+    setHydratedTeamName(teamName);
   }, [teamName]);
 
   useEffect(() => {
+    if (hydratedTeamName !== teamName) {
+      return;
+    }
+
     persistTerminalCommandRuns(teamName, commandRuns);
-  }, [commandRuns, teamName]);
+  }, [commandRuns, hydratedTeamName, teamName]);
 
   return {
     activeCommandRuns,

--- a/src/features/terminal-workspace/renderer/hooks/useTerminalCommandRuns.ts
+++ b/src/features/terminal-workspace/renderer/hooks/useTerminalCommandRuns.ts
@@ -1,0 +1,208 @@
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+
+import { normalizeTerminalCommandRunEventDetail } from '../adapters/terminalCommandRunEvents';
+import {
+  persistTerminalCommandRuns,
+  readStoredTerminalCommandRuns,
+} from '../adapters/terminalCommandRunsStorage';
+import {
+  closeSupersededTerminalCommandRuns,
+  settleScopedTerminalCommandRuns,
+  type TerminalCommandRunPresentation,
+  type TerminalCommandScreenLine,
+  upsertTerminalCommandRun,
+} from '../model/terminalCommandRuns';
+
+interface UseTerminalCommandRunsOptions {
+  activePaneId: string | null;
+  activeSessionId: string | null;
+  eventSource: EventTarget | null;
+  onCommandStarted: () => void;
+  onCommandSubmitted: () => void;
+  screenLines: readonly TerminalCommandScreenLine[];
+  screenSequence: unknown;
+  teamName: string;
+}
+
+interface UseTerminalCommandRunsResult {
+  activeCommandRuns: TerminalCommandRunPresentation[];
+  commandRuns: TerminalCommandRunPresentation[];
+}
+
+interface TerminalCommandRunContext {
+  onCommandStarted: () => void;
+  onCommandSubmitted: () => void;
+  paneId: string | null;
+  screenLines: readonly TerminalCommandScreenLine[];
+  sessionId: string | null;
+}
+
+const useCommitPhaseLayoutEffect = typeof window === 'undefined' ? useEffect : useLayoutEffect;
+
+export function useTerminalCommandRuns({
+  activePaneId,
+  activeSessionId,
+  eventSource,
+  onCommandStarted,
+  onCommandSubmitted,
+  screenLines,
+  screenSequence,
+  teamName,
+}: UseTerminalCommandRunsOptions): UseTerminalCommandRunsResult {
+  const [commandRuns, setCommandRuns] = useState<TerminalCommandRunPresentation[]>(() =>
+    readStoredTerminalCommandRuns(teamName)
+  );
+  const latestContextRef = useRef<TerminalCommandRunContext>({
+    onCommandStarted,
+    onCommandSubmitted,
+    paneId: activePaneId,
+    screenLines,
+    sessionId: activeSessionId,
+  });
+  useCommitPhaseLayoutEffect(() => {
+    latestContextRef.current = {
+      onCommandStarted,
+      onCommandSubmitted,
+      paneId: activePaneId,
+      screenLines,
+      sessionId: activeSessionId,
+    };
+  }, [activePaneId, activeSessionId, onCommandStarted, onCommandSubmitted, screenLines]);
+
+  const activeCommandRuns = useMemo(
+    () =>
+      commandRuns.filter((run) => run.sessionId === activeSessionId && run.paneId === activePaneId),
+    [activePaneId, activeSessionId, commandRuns]
+  );
+
+  useEffect(() => {
+    if (!eventSource) {
+      return undefined;
+    }
+
+    const handleCommandSubmitted = (event: Event): void => {
+      const context = latestContextRef.current;
+      const detail = normalizeTerminalCommandRunEventDetail(event);
+      if (detail) {
+        setCommandRuns((current) =>
+          upsertTerminalCommandRun(
+            closeSupersededTerminalCommandRuns(current, detail, context.screenLines, Date.now()),
+            detail,
+            'running'
+          )
+        );
+      }
+      context.onCommandSubmitted();
+    };
+    const handleCommandStarted = (event: Event): void => {
+      const detail = normalizeTerminalCommandRunEventDetail(event);
+      if (!detail) {
+        return;
+      }
+
+      const context = latestContextRef.current;
+      context.onCommandStarted();
+      setCommandRuns((current) =>
+        upsertTerminalCommandRun(
+          closeSupersededTerminalCommandRuns(current, detail, context.screenLines, Date.now()),
+          detail,
+          'running'
+        )
+      );
+    };
+    const handleCommandFailed = (event: Event): void => {
+      const detail = normalizeTerminalCommandRunEventDetail(event);
+      if (!detail) {
+        return;
+      }
+
+      setCommandRuns((current) =>
+        upsertTerminalCommandRun(
+          current,
+          {
+            ...detail,
+            durationMs: Math.max(0, Date.now() - detail.startedAtMs),
+          },
+          'failed'
+        )
+      );
+    };
+
+    eventSource.addEventListener('tp-terminal-command-started', handleCommandStarted);
+    eventSource.addEventListener('tp-terminal-command-submitted', handleCommandSubmitted);
+    eventSource.addEventListener('tp-terminal-command-failed', handleCommandFailed);
+    eventSource.addEventListener('tp-terminal-paste-submitted', handleCommandSubmitted);
+
+    return () => {
+      eventSource.removeEventListener('tp-terminal-command-started', handleCommandStarted);
+      eventSource.removeEventListener('tp-terminal-command-submitted', handleCommandSubmitted);
+      eventSource.removeEventListener('tp-terminal-command-failed', handleCommandFailed);
+      eventSource.removeEventListener('tp-terminal-paste-submitted', handleCommandSubmitted);
+    };
+  }, [eventSource]);
+
+  useEffect(() => {
+    if (screenLines.length === 0) {
+      return;
+    }
+
+    setCommandRuns((current) =>
+      settleScopedTerminalCommandRuns(
+        current,
+        activeSessionId,
+        activePaneId,
+        screenLines,
+        Date.now(),
+        false
+      )
+    );
+  }, [activePaneId, activeSessionId, screenLines, screenSequence]);
+
+  useEffect(() => {
+    const timer = window.setInterval(() => {
+      const context = latestContextRef.current;
+      if (!context.sessionId || !context.paneId || context.screenLines.length === 0) {
+        return;
+      }
+
+      setCommandRuns((current) => settlePendingCommandRuns(current, context));
+    }, 900);
+
+    return () => window.clearInterval(timer);
+  }, []);
+
+  useEffect(() => {
+    setCommandRuns(readStoredTerminalCommandRuns(teamName));
+  }, [teamName]);
+
+  useEffect(() => {
+    persistTerminalCommandRuns(teamName, commandRuns);
+  }, [commandRuns, teamName]);
+
+  return {
+    activeCommandRuns,
+    commandRuns,
+  };
+}
+
+function settlePendingCommandRuns(
+  runs: TerminalCommandRunPresentation[],
+  context: TerminalCommandRunContext
+): TerminalCommandRunPresentation[] {
+  const hasPendingScopedRun = runs.some(
+    (run) =>
+      run.sessionId === context.sessionId &&
+      run.paneId === context.paneId &&
+      (run.status === 'running' || run.status === 'unknown')
+  );
+  return hasPendingScopedRun
+    ? settleScopedTerminalCommandRuns(
+        runs,
+        context.sessionId,
+        context.paneId,
+        context.screenLines,
+        Date.now(),
+        true
+      )
+    : runs;
+}

--- a/src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx
+++ b/src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx
@@ -64,11 +64,11 @@ import {
   X,
 } from 'lucide-react';
 
-import { normalizeTerminalCommandRunEventDetail } from '../adapters/terminalCommandRunEvents';
 import {
   persistTerminalTabPreferences,
   readStoredTerminalTabPreferences,
 } from '../adapters/terminalTabPreferencesStorage';
+import { useTerminalCommandRuns } from '../hooks/useTerminalCommandRuns';
 import { useTerminalTabReorderMotion } from '../hooks/useTerminalTabReorderMotion';
 import {
   DEFAULT_TERMINAL_APPEARANCE_SETTINGS,
@@ -84,14 +84,8 @@ import {
 } from '../model/terminalCommandAutocomplete';
 import { normalizeStoredTerminalCommandHistoryEntry } from '../model/terminalCommandHistory';
 import {
-  capTerminalCommandRuns,
-  closeSupersededTerminalCommandRuns,
   createTerminalCommandScreenLines,
-  settleScopedTerminalCommandRuns,
   TERMINAL_COMMAND_HISTORY_LIMIT,
-  type TerminalCommandRunPresentation,
-  type TerminalCommandScreenLine,
-  upsertTerminalCommandRun,
 } from '../model/terminalCommandRuns';
 import {
   formatTerminalPromptLabel,
@@ -427,14 +421,6 @@ const TerminalWorkspaceKernelView = ({
   const [terminalContentPending, setTerminalContentPending] = useState(false);
   const [commandContextMenu, setCommandContextMenu] =
     useState<TerminalCommandContextMenuState | null>(null);
-  const [commandRuns, setCommandRuns] = useState<TerminalCommandRunPresentation[]>(() =>
-    readStoredTerminalCommandRuns(teamName)
-  );
-  const commandRunSettlementContextRef = useRef<{
-    paneId: string | null;
-    screenLines: readonly TerminalCommandScreenLine[];
-    sessionId: string | null;
-  }>({ paneId: null, screenLines: [], sessionId: null });
   const [commandDraft, setCommandDraft] = useState('');
   const [autocompleteSuggestion, setAutocompleteSuggestion] = useState<string | null>(null);
   const [dismissedAutocompleteDraft, setDismissedAutocompleteDraft] = useState<string | null>(null);
@@ -483,27 +469,6 @@ const TerminalWorkspaceKernelView = ({
   const activeCommandSessionId =
     snapshot.selection.activeSessionId ?? snapshot.catalog.sessions[0]?.session_id ?? null;
   const activeCommandPaneId = activeScreen?.pane_id ?? null;
-  commandRunSettlementContextRef.current = {
-    paneId: activeCommandPaneId,
-    screenLines: activeScreenCommandLines,
-    sessionId: activeCommandSessionId,
-  };
-  const activeCommandRuns = useMemo(
-    () =>
-      commandRuns.filter(
-        (run) => run.sessionId === activeCommandSessionId && run.paneId === activeCommandPaneId
-      ),
-    [activeCommandPaneId, activeCommandSessionId, commandRuns]
-  );
-  const autocompleteCandidates = useMemo(
-    () =>
-      createTerminalLocalAutocompleteCandidates({
-        commandHistory: snapshot.commandHistory.entries,
-        commandRuns,
-        cwd: projectPath,
-      }),
-    [commandRuns, projectPath, snapshot.commandHistory.entries]
-  );
   const terminalAppearanceStyle = useMemo(
     () =>
       ({
@@ -547,6 +512,30 @@ const TerminalWorkspaceKernelView = ({
     window.requestAnimationFrame(scroll);
     window.setTimeout(scroll, 80);
   }, []);
+  const handleCommandRunStarted = useCallback((): void => {
+    setCommandDraft('');
+    setAutocompleteSuggestion(null);
+    setDismissedAutocompleteDraft(null);
+  }, []);
+  const { activeCommandRuns, commandRuns } = useTerminalCommandRuns({
+    activePaneId: activeCommandPaneId,
+    activeSessionId: activeCommandSessionId,
+    eventSource: commandDockElement,
+    onCommandStarted: handleCommandRunStarted,
+    onCommandSubmitted: scrollTerminalToLatest,
+    screenLines: activeScreenCommandLines,
+    screenSequence: activeScreen?.sequence,
+    teamName,
+  });
+  const autocompleteCandidates = useMemo(
+    () =>
+      createTerminalLocalAutocompleteCandidates({
+        commandHistory: snapshot.commandHistory.entries,
+        commandRuns,
+        cwd: projectPath,
+      }),
+    [commandRuns, projectPath, snapshot.commandHistory.entries]
+  );
 
   const terminalScreenRef = useCallback((element: TerminalScreenElementHandle | null): void => {
     terminalScreenElementRef.current = element;
@@ -612,80 +601,6 @@ const TerminalWorkspaceKernelView = ({
       window.removeEventListener('keydown', handleKeyDown);
     };
   }, [commandContextMenu]);
-
-  useEffect(() => {
-    if (!commandDockElement) {
-      return undefined;
-    }
-
-    const handleCommandSubmitted = (event: Event): void => {
-      const detail = normalizeTerminalCommandRunEventDetail(event);
-      if (detail) {
-        setCommandRuns((current) =>
-          upsertTerminalCommandRun(
-            closeSupersededTerminalCommandRuns(
-              current,
-              detail,
-              activeScreenCommandLines,
-              Date.now()
-            ),
-            detail,
-            'running'
-          )
-        );
-      }
-      scrollTerminalToLatest();
-    };
-    const handleCommandStarted = (event: Event): void => {
-      const detail = normalizeTerminalCommandRunEventDetail(event);
-      if (!detail) {
-        return;
-      }
-
-      setCommandDraft('');
-      setAutocompleteSuggestion(null);
-      setDismissedAutocompleteDraft(null);
-      setCommandRuns((current) =>
-        upsertTerminalCommandRun(
-          closeSupersededTerminalCommandRuns(current, detail, activeScreenCommandLines, Date.now()),
-          detail,
-          'running'
-        )
-      );
-    };
-    const handleCommandFailed = (event: Event): void => {
-      const detail = normalizeTerminalCommandRunEventDetail(event);
-      if (!detail) {
-        return;
-      }
-
-      setCommandRuns((current) =>
-        upsertTerminalCommandRun(
-          current,
-          {
-            ...detail,
-            durationMs: Math.max(0, Date.now() - detail.startedAtMs),
-          },
-          'failed'
-        )
-      );
-    };
-
-    commandDockElement.addEventListener('tp-terminal-command-started', handleCommandStarted);
-    commandDockElement.addEventListener('tp-terminal-command-submitted', handleCommandSubmitted);
-    commandDockElement.addEventListener('tp-terminal-command-failed', handleCommandFailed);
-    commandDockElement.addEventListener('tp-terminal-paste-submitted', handleCommandSubmitted);
-
-    return () => {
-      commandDockElement.removeEventListener('tp-terminal-command-started', handleCommandStarted);
-      commandDockElement.removeEventListener(
-        'tp-terminal-command-submitted',
-        handleCommandSubmitted
-      );
-      commandDockElement.removeEventListener('tp-terminal-command-failed', handleCommandFailed);
-      commandDockElement.removeEventListener('tp-terminal-paste-submitted', handleCommandSubmitted);
-    };
-  }, [activeScreenCommandLines, commandDockElement, scrollTerminalToLatest]);
 
   useEffect(() => {
     if (!commandDockElement) {
@@ -766,67 +681,6 @@ const TerminalWorkspaceKernelView = ({
     dismissedAutocompleteDraft,
     projectPath,
   ]);
-
-  useEffect(() => {
-    const screenLines = activeScreenCommandLines;
-    if (screenLines.length === 0) {
-      return;
-    }
-
-    setCommandRuns((current) =>
-      settleScopedTerminalCommandRuns(
-        current,
-        activeCommandSessionId,
-        activeCommandPaneId,
-        screenLines,
-        Date.now(),
-        false
-      )
-    );
-  }, [
-    activeCommandPaneId,
-    activeCommandSessionId,
-    activeScreen?.sequence,
-    activeScreenCommandLines,
-  ]);
-
-  useEffect(() => {
-    const timer = window.setInterval(() => {
-      const context = commandRunSettlementContextRef.current;
-      if (!context.sessionId || !context.paneId || context.screenLines.length === 0) {
-        return;
-      }
-
-      setCommandRuns((current) => {
-        const hasPendingScopedRun = current.some(
-          (run) =>
-            run.sessionId === context.sessionId &&
-            run.paneId === context.paneId &&
-            (run.status === 'running' || run.status === 'unknown')
-        );
-        return hasPendingScopedRun
-          ? settleScopedTerminalCommandRuns(
-              current,
-              context.sessionId,
-              context.paneId,
-              context.screenLines,
-              Date.now(),
-              true
-            )
-          : current;
-      });
-    }, 900);
-
-    return () => window.clearInterval(timer);
-  }, []);
-
-  useEffect(() => {
-    setCommandRuns(readStoredTerminalCommandRuns(teamName));
-  }, [teamName]);
-
-  useEffect(() => {
-    persistTerminalCommandRuns(teamName, commandRuns);
-  }, [commandRuns, teamName]);
 
   useEffect(() => {
     setAppearanceSettings(readStoredTerminalAppearanceSettings(teamName));
@@ -2554,88 +2408,6 @@ function persistCommandHistory(teamName: string, entries: readonly string[]): vo
     );
   } catch {
     // Best-effort command history persistence.
-  }
-}
-
-function readStoredTerminalCommandRuns(teamName: string): TerminalCommandRunPresentation[] {
-  const raw = readStoredValue(storageKey(teamName, 'command-runs'));
-  if (!raw) return [];
-
-  try {
-    const parsed: unknown = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-    return capTerminalCommandRuns(
-      parsed
-        .map((entry) => normalizeStoredTerminalCommandRun(entry))
-        .filter((entry): entry is TerminalCommandRunPresentation => entry !== null)
-    );
-  } catch {
-    return [];
-  }
-}
-
-function normalizeStoredTerminalCommandRun(value: unknown): TerminalCommandRunPresentation | null {
-  if (!isRecord(value)) {
-    return null;
-  }
-
-  const clientEventId =
-    typeof value.clientEventId === 'string' && value.clientEventId.trim()
-      ? value.clientEventId.trim()
-      : null;
-  const command = typeof value.command === 'string' ? value.command.trim() : '';
-  const paneId = typeof value.paneId === 'string' && value.paneId.trim() ? value.paneId : null;
-  const sessionId =
-    typeof value.sessionId === 'string' && value.sessionId.trim() ? value.sessionId : null;
-  const startedAtMs =
-    typeof value.startedAtMs === 'number' && Number.isFinite(value.startedAtMs)
-      ? value.startedAtMs
-      : 0;
-  const storedStatus = isTerminalCommandRunPresentationStatus(value.status)
-    ? value.status
-    : 'unknown';
-  const status = storedStatus === 'running' ? 'unknown' : storedStatus;
-
-  if (!clientEventId || !command || !paneId || !sessionId) {
-    return null;
-  }
-
-  const run: TerminalCommandRunPresentation = {
-    clientEventId,
-    command,
-    paneId,
-    sessionId,
-    startedAtMs,
-    status,
-  };
-
-  if (typeof value.durationMs === 'number' && Number.isFinite(value.durationMs)) {
-    run.durationMs = Math.max(0, value.durationMs);
-  }
-  if (typeof value.exitCode === 'number' && Number.isFinite(value.exitCode)) {
-    run.exitCode = Math.trunc(value.exitCode);
-  }
-
-  return run;
-}
-
-function isTerminalCommandRunPresentationStatus(
-  value: unknown
-): value is TerminalCommandRunPresentation['status'] {
-  return value === 'failed' || value === 'running' || value === 'succeeded' || value === 'unknown';
-}
-
-function persistTerminalCommandRuns(
-  teamName: string,
-  runs: readonly TerminalCommandRunPresentation[]
-): void {
-  try {
-    window.localStorage.setItem(
-      storageKey(teamName, 'command-runs'),
-      JSON.stringify(capTerminalCommandRuns(runs))
-    );
-  } catch {
-    // Best-effort command presentation persistence.
   }
 }
 

--- a/test/renderer/features/terminal-workspace/terminalCommandRunsStorage.test.ts
+++ b/test/renderer/features/terminal-workspace/terminalCommandRunsStorage.test.ts
@@ -1,0 +1,113 @@
+import {
+  persistTerminalCommandRuns,
+  readStoredTerminalCommandRuns,
+} from '@features/terminal-workspace/renderer/adapters/terminalCommandRunsStorage';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { TerminalCommandRunPresentation } from '@features/terminal-workspace/renderer/model/terminalCommandRuns';
+
+const TEAM_NAME = 'terminal-command-runs-storage-fixture';
+const OTHER_TEAM_NAME = 'terminal-command-runs-storage-other-fixture';
+const STORAGE_KEY = `agent-teams:terminal-workspace:${TEAM_NAME}:command-runs`;
+
+describe('terminal command runs storage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('ignores corrupt and unsupported persisted values', () => {
+    window.localStorage.setItem(STORAGE_KEY, '{broken');
+    expect(readStoredTerminalCommandRuns(TEAM_NAME)).toEqual([]);
+
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ command: 'pnpm test' }));
+    expect(readStoredTerminalCommandRuns(TEAM_NAME)).toEqual([]);
+  });
+
+  it('normalizes recovered runs without restarting interrupted timers', () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify([
+        {
+          clientEventId: ' run-1 ',
+          command: ' pnpm test ',
+          durationMs: -12,
+          exitCode: 1.8,
+          paneId: 'pane-1',
+          sessionId: 'session-1',
+          startedAtMs: 100,
+          status: 'running',
+        },
+        { command: 'missing identity' },
+      ])
+    );
+
+    expect(readStoredTerminalCommandRuns(TEAM_NAME)).toEqual([
+      {
+        clientEventId: 'run-1',
+        command: 'pnpm test',
+        durationMs: 0,
+        exitCode: 1,
+        paneId: 'pane-1',
+        sessionId: 'session-1',
+        startedAtMs: 100,
+        status: 'unknown',
+      },
+    ]);
+  });
+
+  it('persists only the latest command presentation limit per pane', () => {
+    const runs = Array.from({ length: 96 }, (_, index) => createRun(index));
+
+    persistTerminalCommandRuns(TEAM_NAME, runs);
+
+    const stored = readStoredTerminalCommandRuns(TEAM_NAME);
+    expect(stored).toHaveLength(80);
+    expect(stored[0]?.clientEventId).toBe('run-16');
+    expect(stored.at(-1)?.clientEventId).toBe('run-95');
+  });
+
+  it('keeps command runs isolated by team storage key', () => {
+    const teamRun = createRun(1);
+    const otherTeamRun = {
+      ...createRun(2),
+      clientEventId: 'other-team-run',
+      command: 'printf other',
+    };
+
+    persistTerminalCommandRuns(TEAM_NAME, [teamRun]);
+    persistTerminalCommandRuns(OTHER_TEAM_NAME, [otherTeamRun]);
+
+    expect(readStoredTerminalCommandRuns(TEAM_NAME)).toEqual([teamRun]);
+    expect(readStoredTerminalCommandRuns(OTHER_TEAM_NAME)).toEqual([otherTeamRun]);
+  });
+
+  it('fails closed when local storage access throws', () => {
+    const getItem = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('fixture read failure');
+    });
+
+    expect(readStoredTerminalCommandRuns(TEAM_NAME)).toEqual([]);
+
+    getItem.mockRestore();
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('fixture write failure');
+    });
+
+    expect(() => persistTerminalCommandRuns(TEAM_NAME, [createRun(1)])).not.toThrow();
+  });
+});
+
+function createRun(index: number): TerminalCommandRunPresentation {
+  return {
+    clientEventId: `run-${index}`,
+    command: `printf ${index}`,
+    paneId: 'pane-1',
+    sessionId: 'session-1',
+    startedAtMs: index,
+    status: 'succeeded',
+  };
+}

--- a/test/renderer/features/terminal-workspace/useTerminalCommandRuns.test.tsx
+++ b/test/renderer/features/terminal-workspace/useTerminalCommandRuns.test.tsx
@@ -1,0 +1,371 @@
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { useTerminalCommandRuns } from '@features/terminal-workspace/renderer/hooks/useTerminalCommandRuns';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  TerminalCommandRunPresentation,
+  TerminalCommandScreenLine,
+} from '@features/terminal-workspace/renderer/model/terminalCommandRuns';
+
+interface HarnessProps {
+  activePaneId: string | null;
+  activeSessionId: string | null;
+  eventSource: EventTarget | null;
+  onCommandStarted: () => void;
+  onCommandSubmitted: () => void;
+  renderGate?: RenderGate;
+  screenLines: readonly TerminalCommandScreenLine[];
+  screenSequence: unknown;
+  teamName: string;
+}
+
+interface RenderGate {
+  read: () => void;
+  resolve: () => void;
+}
+
+type HookResult = ReturnType<typeof useTerminalCommandRuns>;
+
+const TEAM_NAME = 'terminal-command-runs-hook-fixture';
+
+describe('useTerminalCommandRuns', () => {
+  let host: HTMLDivElement;
+  let root: Root;
+  let mounted: boolean;
+  let result: HookResult | null;
+
+  function Harness(props: HarnessProps): null {
+    result = useTerminalCommandRuns(props);
+    props.renderGate?.read();
+    return null;
+  }
+
+  beforeEach(() => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    window.localStorage.clear();
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+    mounted = true;
+    result = null;
+  });
+
+  afterEach(async () => {
+    if (mounted) {
+      await unmountHarness();
+    }
+    host.remove();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('tracks lifecycle events and calls the matching presentation callbacks', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(2_000);
+    const eventSource = new EventTarget();
+    const onCommandStarted = vi.fn();
+    const onCommandSubmitted = vi.fn();
+    const props = createProps({ eventSource, onCommandStarted, onCommandSubmitted });
+    const detail = createEventDetail({ startedAtMs: 1_750 });
+
+    await renderHarness(props);
+    await dispatchCommandEvent(eventSource, 'tp-terminal-command-started', detail);
+
+    expect(onCommandStarted).toHaveBeenCalledOnce();
+    expect(requireResult().commandRuns).toEqual([
+      expect.objectContaining({
+        clientEventId: detail.clientEventId,
+        command: detail.command,
+        status: 'running',
+      }),
+    ]);
+
+    await dispatchCommandEvent(eventSource, 'tp-terminal-command-submitted', detail);
+    expect(onCommandSubmitted).toHaveBeenCalledOnce();
+
+    await dispatchCommandEvent(eventSource, 'tp-terminal-command-failed', detail);
+    expect(requireResult().commandRuns[0]).toMatchObject({
+      clientEventId: detail.clientEventId,
+      durationMs: 250,
+      status: 'failed',
+    });
+  });
+
+  it('cleans listeners and its interval when the event source changes or unmounts', async () => {
+    vi.useFakeTimers();
+    const firstSource = new EventTarget();
+    const secondSource = new EventTarget();
+    const firstAdd = vi.spyOn(firstSource, 'addEventListener');
+    const firstRemove = vi.spyOn(firstSource, 'removeEventListener');
+    const secondAdd = vi.spyOn(secondSource, 'addEventListener');
+    const secondRemove = vi.spyOn(secondSource, 'removeEventListener');
+    const clearInterval = vi.spyOn(window, 'clearInterval');
+    const onCommandStarted = vi.fn();
+    const props = createProps({ eventSource: firstSource, onCommandStarted });
+
+    await renderHarness(props);
+    expect(firstAdd).toHaveBeenCalledTimes(4);
+    expect(vi.getTimerCount()).toBe(1);
+
+    await renderHarness({ ...props, eventSource: secondSource });
+    expect(firstRemove).toHaveBeenCalledTimes(4);
+    expect(secondAdd).toHaveBeenCalledTimes(4);
+
+    await dispatchCommandEvent(firstSource, 'tp-terminal-command-started', createEventDetail());
+    expect(onCommandStarted).not.toHaveBeenCalled();
+    expect(requireResult().commandRuns).toEqual([]);
+
+    await dispatchCommandEvent(
+      secondSource,
+      'tp-terminal-command-started',
+      createEventDetail({ clientEventId: 'active-source-run' })
+    );
+    expect(onCommandStarted).toHaveBeenCalledOnce();
+    expect(requireResult().commandRuns).toHaveLength(1);
+
+    await unmountHarness();
+    expect(secondRemove).toHaveBeenCalledTimes(4);
+    expect(clearInterval).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+
+    secondSource.dispatchEvent(
+      createCommandEvent(
+        'tp-terminal-command-started',
+        createEventDetail({ clientEventId: 'post-unmount-run' })
+      )
+    );
+    vi.advanceTimersByTime(1_800);
+    expect(onCommandStarted).toHaveBeenCalledOnce();
+    expect(requireResult().commandRuns).toHaveLength(1);
+  });
+
+  it('uses the latest pane, session, screen, and callbacks without rebinding listeners', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(2_100);
+    const eventSource = new EventTarget();
+    const addEventListener = vi.spyOn(eventSource, 'addEventListener');
+    const removeEventListener = vi.spyOn(eventSource, 'removeEventListener');
+    const firstSubmitted = vi.fn();
+    const latestSubmitted = vi.fn();
+    const props = createProps({
+      activePaneId: 'pane-1',
+      activeSessionId: 'session-1',
+      eventSource,
+      onCommandSubmitted: firstSubmitted,
+    });
+
+    await renderHarness(props);
+    await dispatchCommandEvent(
+      eventSource,
+      'tp-terminal-command-started',
+      createEventDetail({ command: 'true', startedAtMs: 1_000 })
+    );
+
+    await renderHarness({
+      ...props,
+      activePaneId: 'pane-2',
+      activeSessionId: 'session-2',
+      onCommandSubmitted: latestSubmitted,
+      screenLines: ['shell % true', 'shell %'],
+      screenSequence: 2,
+    });
+    expect(addEventListener).toHaveBeenCalledTimes(4);
+    expect(removeEventListener).not.toHaveBeenCalled();
+
+    await advanceTimers(900);
+    expect(requireResult().commandRuns[0]?.status).toBe('running');
+
+    await dispatchCommandEvent(eventSource, 'tp-terminal-paste-submitted');
+    expect(firstSubmitted).not.toHaveBeenCalled();
+    expect(latestSubmitted).toHaveBeenCalledOnce();
+
+    await renderHarness({
+      ...props,
+      onCommandSubmitted: latestSubmitted,
+      screenLines: ['shell % true', 'shell %'],
+      screenSequence: 3,
+    });
+    expect(addEventListener).toHaveBeenCalledTimes(4);
+    expect(removeEventListener).not.toHaveBeenCalled();
+
+    await advanceTimers(900);
+    expect(requireResult().commandRuns[0]).toMatchObject({
+      command: 'true',
+      status: 'unknown',
+    });
+  });
+
+  it('publishes listener context only after a render commits', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(2_100);
+    const eventSource = new EventTarget();
+    const addEventListener = vi.spyOn(eventSource, 'addEventListener');
+    const removeEventListener = vi.spyOn(eventSource, 'removeEventListener');
+    const committedStarted = vi.fn();
+    const pendingStarted = vi.fn();
+    const committedProps = createProps({
+      eventSource,
+      onCommandStarted: committedStarted,
+      screenLines: ['shell % true', 'completed', 'shell %'],
+    });
+
+    await renderHarness(committedProps);
+    await dispatchCommandEvent(
+      eventSource,
+      'tp-terminal-command-started',
+      createEventDetail({ clientEventId: 'first-run', command: 'true', startedAtMs: 1_000 })
+    );
+
+    const renderGate = createRenderGate();
+    act(() => {
+      React.startTransition(() => {
+        renderHarnessTree({
+          ...committedProps,
+          onCommandStarted: pendingStarted,
+          renderGate,
+          screenLines: ['shell % true'],
+          screenSequence: 2,
+        });
+      });
+    });
+    expect(addEventListener).toHaveBeenCalledTimes(4);
+    expect(removeEventListener).not.toHaveBeenCalled();
+
+    await dispatchCommandEvent(
+      eventSource,
+      'tp-terminal-command-started',
+      createEventDetail({ clientEventId: 'second-run', command: 'true', startedAtMs: 2_000 })
+    );
+    expect(committedStarted).toHaveBeenCalledTimes(2);
+    expect(pendingStarted).not.toHaveBeenCalled();
+    expect(requireResult().commandRuns[0]).toMatchObject({
+      clientEventId: 'first-run',
+      status: 'succeeded',
+    });
+
+    await act(async () => {
+      renderGate.resolve();
+      await Promise.resolve();
+    });
+    expect(addEventListener).toHaveBeenCalledTimes(4);
+    expect(removeEventListener).not.toHaveBeenCalled();
+
+    await dispatchCommandEvent(
+      eventSource,
+      'tp-terminal-command-started',
+      createEventDetail({ clientEventId: 'third-run', command: 'true', startedAtMs: 2_100 })
+    );
+    expect(committedStarted).toHaveBeenCalledTimes(2);
+    expect(pendingStarted).toHaveBeenCalledOnce();
+    expect(requireResult().commandRuns[1]).toMatchObject({
+      clientEventId: 'second-run',
+      status: 'unknown',
+    });
+  });
+
+  function createProps(overrides: Partial<HarnessProps> = {}): HarnessProps {
+    return {
+      activePaneId: 'pane-1',
+      activeSessionId: 'session-1',
+      eventSource: new EventTarget(),
+      onCommandStarted: vi.fn(),
+      onCommandSubmitted: vi.fn(),
+      screenLines: [],
+      screenSequence: 1,
+      teamName: TEAM_NAME,
+      ...overrides,
+    };
+  }
+
+  async function renderHarness(props: HarnessProps): Promise<void> {
+    await act(async () => {
+      renderHarnessTree(props);
+      await Promise.resolve();
+    });
+  }
+
+  function renderHarnessTree(props: HarnessProps): void {
+    root.render(
+      <React.Suspense fallback={null}>
+        <Harness {...props} />
+      </React.Suspense>
+    );
+  }
+
+  async function unmountHarness(): Promise<void> {
+    await act(async () => {
+      root.unmount();
+      await Promise.resolve();
+    });
+    mounted = false;
+  }
+
+  async function dispatchCommandEvent(
+    eventSource: EventTarget,
+    type: string,
+    detail?: ReturnType<typeof createEventDetail>
+  ): Promise<void> {
+    await act(async () => {
+      eventSource.dispatchEvent(createCommandEvent(type, detail));
+      await Promise.resolve();
+    });
+  }
+
+  async function advanceTimers(durationMs: number): Promise<void> {
+    await act(async () => {
+      vi.advanceTimersByTime(durationMs);
+      await Promise.resolve();
+    });
+  }
+
+  function requireResult(): HookResult {
+    if (!result) {
+      throw new Error('Expected the hook harness to render');
+    }
+    return result;
+  }
+});
+
+function createCommandEvent(
+  type: string,
+  detail?: ReturnType<typeof createEventDetail>
+): CustomEvent<unknown> {
+  return new CustomEvent(type, { detail });
+}
+
+function createEventDetail(
+  overrides: Partial<TerminalCommandRunPresentation> = {}
+): TerminalCommandRunPresentation {
+  return {
+    clientEventId: 'command-run-1',
+    command: 'pnpm test',
+    paneId: 'pane-1',
+    sessionId: 'session-1',
+    startedAtMs: 1_000,
+    status: 'running',
+    ...overrides,
+  };
+}
+
+function createRenderGate(): RenderGate {
+  let isResolved = false;
+  let resolvePromise: (() => void) | null = null;
+  const promise = new Promise<void>((resolve) => {
+    resolvePromise = resolve;
+  });
+
+  return {
+    read: () => {
+      if (!isResolved) {
+        throw promise;
+      }
+    },
+    resolve: () => {
+      isResolved = true;
+      resolvePromise?.();
+    },
+  };
+}

--- a/test/renderer/features/terminal-workspace/useTerminalCommandRuns.test.tsx
+++ b/test/renderer/features/terminal-workspace/useTerminalCommandRuns.test.tsx
@@ -266,6 +266,48 @@ describe('useTerminalCommandRuns', () => {
     });
   });
 
+  it('does not persist runs from the previous team during a direct team switch', async () => {
+    const firstTeamName = 'terminal-command-runs-team-a';
+    const secondTeamName = 'terminal-command-runs-team-b';
+    const firstTeamKey = storageKey(firstTeamName);
+    const secondTeamKey = storageKey(secondTeamName);
+    const firstTeamRun = createEventDetail({
+      clientEventId: 'team-a-run',
+      command: 'echo team-a',
+      status: 'succeeded',
+    });
+    const secondTeamRun = createEventDetail({
+      clientEventId: 'team-b-run',
+      command: 'echo team-b',
+      status: 'succeeded',
+    });
+    window.localStorage.setItem(firstTeamKey, JSON.stringify([firstTeamRun]));
+    window.localStorage.setItem(secondTeamKey, JSON.stringify([secondTeamRun]));
+    const setItem = vi.spyOn(window.localStorage, 'setItem');
+    const firstTeamProps = createProps({ teamName: firstTeamName });
+
+    await renderHarness(firstTeamProps);
+    expect(requireResult().commandRuns).toEqual([firstTeamRun]);
+    setItem.mockClear();
+
+    await renderHarness({ ...firstTeamProps, teamName: secondTeamName });
+
+    expect(requireResult().commandRuns).toEqual([secondTeamRun]);
+    const secondTeamWrites = setItem.mock.calls
+      .filter(([key]) => key === secondTeamKey)
+      .map(([, value]) => JSON.parse(String(value)) as TerminalCommandRunPresentation[]);
+    expect(secondTeamWrites).not.toHaveLength(0);
+    expect(
+      secondTeamWrites.every(
+        (runs) => runs.length === 1 && runs[0]?.clientEventId === secondTeamRun.clientEventId
+      )
+    ).toBe(true);
+    expect(JSON.parse(window.localStorage.getItem(firstTeamKey) ?? 'null')).toEqual([firstTeamRun]);
+    expect(JSON.parse(window.localStorage.getItem(secondTeamKey) ?? 'null')).toEqual([
+      secondTeamRun,
+    ]);
+  });
+
   function createProps(overrides: Partial<HarnessProps> = {}): HarnessProps {
     return {
       activePaneId: 'pane-1',
@@ -368,4 +410,8 @@ function createRenderGate(): RenderGate {
       resolvePromise?.();
     },
   };
+}
+
+function storageKey(teamName: string): string {
+  return `agent-teams:terminal-workspace:${teamName}:command-runs`;
 }


### PR DESCRIPTION
## Summary

- extract command-run persistence into a team-scoped localStorage adapter
- extract command event listeners, settlement and quiet-period lifecycle into a focused hook
- keep listener bindings stable while reading only the latest committed screen/session context
- guard direct team transitions so previous-team runs can never be written under the next team key
- reduce TerminalWorkspacePanel from 2660 to 2432 lines and ratchet the legacy cap down

## Verification

- 88 focused hook, storage, Panel and PanelInternals tests
- suspended-render regression proving uncommitted context cannot leak into active listeners
- direct same-root A-to-B storage-write regression
- eventSource swap, unmount and interval cleanup coverage
- native TypeScript 7 typecheck
- fast ESLint and Prettier checks
- source-size ratchet against exact base 41cc4b7e0
- independent final audit and fix re-audit: 0 P1-P3
- CodeRabbit findings addressed and confirmed

Desktop/runtime E2E is intentionally deferred until the final TerminalWorkspacePanel slice is below 800 lines.