### PR TITLE
refactor(terminal-workspace): extract autocomplete history

### DIFF
--- a/scripts/ci/source-file-size-legacy.json
+++ b/scripts/ci/source-file-size-legacy.json
@@ -46,7 +46,7 @@
   "src/features/team-lifecycle/contracts/team-lifecycle-read.ts": 816,
   "src/features/team-lifecycle/main/infrastructure/TeamDirectoryLifecycleAdapter.ts": 1606,
   "src/features/team-runtime-control/core/application/planning/createCompositeRuntimePlan.ts": 1195,
-  "src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx": 2432,
+  "src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx": 2278,
   "src/features/token-usage/core/domain/snapshotProjection.ts": 937,
   "src/features/token-usage/renderer/adapters/tokenUsageViewModel.ts": 1481,
   "src/features/token-usage/renderer/ui/TokenUsageDashboard.tsx": 2170,

--- a/src/features/terminal-workspace/renderer/adapters/terminalCommandHistoryStorage.ts
+++ b/src/features/terminal-workspace/renderer/adapters/terminalCommandHistoryStorage.ts
@@ -1,0 +1,34 @@
+import { normalizeStoredTerminalCommandHistoryEntry } from '../model/terminalCommandHistory';
+import { TERMINAL_COMMAND_HISTORY_LIMIT } from '../model/terminalCommandRuns';
+
+export function readStoredTerminalCommandHistory(teamName: string): string[] | null {
+  try {
+    const raw = window.localStorage.getItem(storageKey(teamName));
+    if (!raw) return null;
+
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return null;
+    return parsed
+      .filter((entry): entry is string => typeof entry === 'string')
+      .map((entry) => normalizeStoredTerminalCommandHistoryEntry(entry))
+      .filter((entry): entry is string => Boolean(entry))
+      .slice(-TERMINAL_COMMAND_HISTORY_LIMIT);
+  } catch {
+    return null;
+  }
+}
+
+export function persistTerminalCommandHistory(teamName: string, entries: readonly string[]): void {
+  try {
+    window.localStorage.setItem(
+      storageKey(teamName),
+      JSON.stringify(entries.slice(-TERMINAL_COMMAND_HISTORY_LIMIT))
+    );
+  } catch {
+    // Best-effort command history persistence.
+  }
+}
+
+function storageKey(teamName: string): string {
+  return `agent-teams:terminal-workspace:${teamName}:command-history`;
+}

--- a/src/features/terminal-workspace/renderer/hooks/useTerminalCommandAutocomplete.ts
+++ b/src/features/terminal-workspace/renderer/hooks/useTerminalCommandAutocomplete.ts
@@ -1,0 +1,137 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import { normalizeTerminalCommandRunEventDetail } from '../adapters/terminalCommandRunEvents';
+import {
+  createTerminalLocalAutocompleteCandidates,
+  isTerminalLocalAutocompleteDraftEligible,
+  resolveTerminalLocalAutocompleteSuggestion,
+} from '../model/terminalCommandAutocomplete';
+import { isRecord } from '../utils/valueGuards';
+
+import type { TerminalCommandRunPresentation } from '../model/terminalCommandRuns';
+
+const TERMINAL_LOCAL_AUTOCOMPLETE_THROTTLE_MS = 75;
+
+interface UseTerminalCommandAutocompleteOptions {
+  commandHistory: readonly string[];
+  commandRuns: readonly TerminalCommandRunPresentation[];
+  cwd?: string | null;
+  eventSource: EventTarget | null;
+  paneId: string | null;
+  sessionId: string | null;
+}
+
+interface UseTerminalCommandAutocompleteResult {
+  autocompleteSuggestion: string | null;
+}
+
+export function useTerminalCommandAutocomplete({
+  commandHistory,
+  commandRuns,
+  cwd,
+  eventSource,
+  paneId,
+  sessionId,
+}: UseTerminalCommandAutocompleteOptions): UseTerminalCommandAutocompleteResult {
+  const [draft, setDraft] = useState('');
+  const [autocompleteSuggestion, setAutocompleteSuggestion] = useState<string | null>(null);
+  const [dismissedDraft, setDismissedDraft] = useState<string | null>(null);
+  const candidates = useMemo(
+    () =>
+      createTerminalLocalAutocompleteCandidates({
+        commandHistory,
+        commandRuns,
+        cwd,
+      }),
+    [commandHistory, commandRuns, cwd]
+  );
+
+  useEffect(() => {
+    setDraft('');
+    setDismissedDraft(null);
+    setAutocompleteSuggestion(null);
+
+    if (!eventSource) {
+      return undefined;
+    }
+
+    const handleDraftChange = (event: Event): void => {
+      const detail = (event as CustomEvent<unknown>).detail;
+      const value = isRecord(detail) && typeof detail.value === 'string' ? detail.value : '';
+      setDraft(value);
+      setDismissedDraft((current) => (current === value ? current : null));
+    };
+    const handleAutocompleteAccept = (event: Event): void => {
+      const detail = (event as CustomEvent<unknown>).detail;
+      const value = isRecord(detail) && typeof detail.value === 'string' ? detail.value : '';
+      setDraft(value);
+      setDismissedDraft(null);
+      setAutocompleteSuggestion(null);
+    };
+    const handleAutocompleteDismiss = (event: Event): void => {
+      const detail = (event as CustomEvent<unknown>).detail;
+      const value = isRecord(detail) && typeof detail.draft === 'string' ? detail.draft : '';
+      setDismissedDraft(value);
+      setAutocompleteSuggestion(null);
+    };
+    const handleCommandStarted = (event: Event): void => {
+      if (!normalizeTerminalCommandRunEventDetail(event)) {
+        return;
+      }
+
+      setDraft('');
+      setDismissedDraft(null);
+      setAutocompleteSuggestion(null);
+    };
+
+    eventSource.addEventListener('tp-terminal-command-draft-change', handleDraftChange);
+    eventSource.addEventListener(
+      'tp-terminal-command-autocomplete-accept',
+      handleAutocompleteAccept
+    );
+    eventSource.addEventListener(
+      'tp-terminal-command-autocomplete-dismiss',
+      handleAutocompleteDismiss
+    );
+    eventSource.addEventListener('tp-terminal-command-started', handleCommandStarted);
+
+    return () => {
+      eventSource.removeEventListener('tp-terminal-command-draft-change', handleDraftChange);
+      eventSource.removeEventListener(
+        'tp-terminal-command-autocomplete-accept',
+        handleAutocompleteAccept
+      );
+      eventSource.removeEventListener(
+        'tp-terminal-command-autocomplete-dismiss',
+        handleAutocompleteDismiss
+      );
+      eventSource.removeEventListener('tp-terminal-command-started', handleCommandStarted);
+    };
+  }, [eventSource]);
+
+  useEffect(() => {
+    if (!isTerminalLocalAutocompleteDraftEligible(draft) || dismissedDraft === draft) {
+      setAutocompleteSuggestion(null);
+      return undefined;
+    }
+
+    const timer = window.setTimeout(() => {
+      setAutocompleteSuggestion(
+        resolveTerminalLocalAutocompleteSuggestion({
+          candidates,
+          cwd,
+          dismissedDraft,
+          draft,
+          paneId,
+          sessionId,
+        })
+      );
+    }, TERMINAL_LOCAL_AUTOCOMPLETE_THROTTLE_MS);
+
+    return () => window.clearTimeout(timer);
+  }, [candidates, cwd, dismissedDraft, draft, eventSource, paneId, sessionId]);
+
+  return {
+    autocompleteSuggestion,
+  };
+}

--- a/src/features/terminal-workspace/renderer/hooks/useTerminalCommandHistoryPersistence.ts
+++ b/src/features/terminal-workspace/renderer/hooks/useTerminalCommandHistoryPersistence.ts
@@ -1,0 +1,54 @@
+import { useEffect, useRef } from 'react';
+
+import {
+  persistTerminalCommandHistory,
+  readStoredTerminalCommandHistory,
+} from '../adapters/terminalCommandHistoryStorage';
+
+interface CommandHistoryPersistenceState {
+  hasPersistedSnapshot: boolean;
+  hasRestoredHistory: boolean | null;
+  teamName: string;
+}
+
+export function useTerminalCommandHistoryPersistence({
+  entries,
+  teamName,
+}: Readonly<{
+  entries: readonly string[];
+  teamName: string;
+}>): void {
+  const persistenceRef = useRef<CommandHistoryPersistenceState>({
+    hasPersistedSnapshot: false,
+    hasRestoredHistory: null,
+    teamName,
+  });
+
+  useEffect(() => {
+    const persistence = persistenceRef.current;
+    if (persistence.teamName !== teamName) {
+      persistence.teamName = teamName;
+      persistence.hasRestoredHistory = null;
+      persistence.hasPersistedSnapshot = false;
+    }
+
+    if (persistence.hasRestoredHistory === null) {
+      persistence.hasRestoredHistory =
+        (readStoredTerminalCommandHistory(teamName)?.length ?? 0) > 0;
+    }
+
+    if (
+      entries.length === 0 &&
+      persistence.hasRestoredHistory &&
+      !persistence.hasPersistedSnapshot
+    ) {
+      return;
+    }
+
+    persistTerminalCommandHistory(teamName, entries);
+    persistence.hasPersistedSnapshot = true;
+    if (entries.length > 0) {
+      persistence.hasRestoredHistory = false;
+    }
+  }, [entries, teamName]);
+}

--- a/src/features/terminal-workspace/renderer/hooks/useTerminalCommandRuns.ts
+++ b/src/features/terminal-workspace/renderer/hooks/useTerminalCommandRuns.ts
@@ -17,7 +17,6 @@ interface UseTerminalCommandRunsOptions {
   activePaneId: string | null;
   activeSessionId: string | null;
   eventSource: EventTarget | null;
-  onCommandStarted: () => void;
   onCommandSubmitted: () => void;
   screenLines: readonly TerminalCommandScreenLine[];
   screenSequence: unknown;
@@ -30,7 +29,6 @@ interface UseTerminalCommandRunsResult {
 }
 
 interface TerminalCommandRunContext {
-  onCommandStarted: () => void;
   onCommandSubmitted: () => void;
   paneId: string | null;
   screenLines: readonly TerminalCommandScreenLine[];
@@ -43,7 +41,6 @@ export function useTerminalCommandRuns({
   activePaneId,
   activeSessionId,
   eventSource,
-  onCommandStarted,
   onCommandSubmitted,
   screenLines,
   screenSequence,
@@ -54,7 +51,6 @@ export function useTerminalCommandRuns({
   );
   const [hydratedTeamName, setHydratedTeamName] = useState(teamName);
   const latestContextRef = useRef<TerminalCommandRunContext>({
-    onCommandStarted,
     onCommandSubmitted,
     paneId: activePaneId,
     screenLines,
@@ -62,13 +58,12 @@ export function useTerminalCommandRuns({
   });
   useCommitPhaseLayoutEffect(() => {
     latestContextRef.current = {
-      onCommandStarted,
       onCommandSubmitted,
       paneId: activePaneId,
       screenLines,
       sessionId: activeSessionId,
     };
-  }, [activePaneId, activeSessionId, onCommandStarted, onCommandSubmitted, screenLines]);
+  }, [activePaneId, activeSessionId, onCommandSubmitted, screenLines]);
 
   const activeCommandRuns = useMemo(
     () =>
@@ -102,7 +97,6 @@ export function useTerminalCommandRuns({
       }
 
       const context = latestContextRef.current;
-      context.onCommandStarted();
       setCommandRuns((current) =>
         upsertTerminalCommandRun(
           closeSupersededTerminalCommandRuns(current, detail, context.screenLines, Date.now()),

--- a/src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx
+++ b/src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx
@@ -64,10 +64,13 @@ import {
   X,
 } from 'lucide-react';
 
+import { readStoredTerminalCommandHistory } from '../adapters/terminalCommandHistoryStorage';
 import {
   persistTerminalTabPreferences,
   readStoredTerminalTabPreferences,
 } from '../adapters/terminalTabPreferencesStorage';
+import { useTerminalCommandAutocomplete } from '../hooks/useTerminalCommandAutocomplete';
+import { useTerminalCommandHistoryPersistence } from '../hooks/useTerminalCommandHistoryPersistence';
 import { useTerminalCommandRuns } from '../hooks/useTerminalCommandRuns';
 import { useTerminalTabReorderMotion } from '../hooks/useTerminalTabReorderMotion';
 import {
@@ -77,12 +80,6 @@ import {
   type TerminalAppearanceSettings,
   type TerminalBackgroundImageFit,
 } from '../model/terminalAppearanceSettings';
-import {
-  createTerminalLocalAutocompleteCandidates,
-  isTerminalLocalAutocompleteDraftEligible,
-  resolveTerminalLocalAutocompleteSuggestion,
-} from '../model/terminalCommandAutocomplete';
-import { normalizeStoredTerminalCommandHistoryEntry } from '../model/terminalCommandHistory';
 import {
   createTerminalCommandScreenLines,
   TERMINAL_COMMAND_HISTORY_LIMIT,
@@ -113,7 +110,6 @@ import {
   type TerminalTabPreferences,
   type TerminalWorkspaceSnapshot,
 } from '../model/terminalTabPreferences';
-import { isRecord } from '../utils/valueGuards';
 
 import {
   type TerminalWorkspaceSettingsActionId,
@@ -142,7 +138,6 @@ export interface TerminalWorkspacePanelProps {
   stopTeamRuntime: (teamName: string) => Promise<void>;
 }
 
-const TERMINAL_LOCAL_AUTOCOMPLETE_THROTTLE_MS = 75;
 const TERMINAL_PLATFORM_GITHUB_URL = 'https://github.com/777genius/terminal-platform';
 type TerminalMuxCommand = Parameters<WorkspaceKernel['commands']['dispatchMuxCommand']>[1];
 type TerminalScreenElementHandle = ComponentRef<typeof TerminalScreen> & {
@@ -246,7 +241,7 @@ const TerminalWorkspacePanelTeamScope = ({
       initialThemeId: readStoredValue(storageKey(teamName, 'theme')),
       initialTerminalFontScale: readStoredValue(storageKey(teamName, 'font-scale')),
       initialTerminalLineWrap: readStoredBoolean(storageKey(teamName, 'line-wrap')),
-      initialCommandHistoryEntries: readStoredCommandHistory(teamName),
+      initialCommandHistoryEntries: readStoredTerminalCommandHistory(teamName),
       commandHistoryLimit: TERMINAL_COMMAND_HISTORY_LIMIT,
     });
 
@@ -421,18 +416,6 @@ const TerminalWorkspaceKernelView = ({
   const [terminalContentPending, setTerminalContentPending] = useState(false);
   const [commandContextMenu, setCommandContextMenu] =
     useState<TerminalCommandContextMenuState | null>(null);
-  const [commandDraft, setCommandDraft] = useState('');
-  const [autocompleteSuggestion, setAutocompleteSuggestion] = useState<string | null>(null);
-  const [dismissedAutocompleteDraft, setDismissedAutocompleteDraft] = useState<string | null>(null);
-  const commandHistoryPersistenceRef = useRef<{
-    hasPersistedSnapshot: boolean;
-    hasRestoredHistory: boolean | null;
-    teamName: string;
-  }>({
-    hasPersistedSnapshot: false,
-    hasRestoredHistory: null,
-    teamName,
-  });
   const [appearanceSettings, setAppearanceSettings] = useState<TerminalAppearanceSettings>(() =>
     readStoredTerminalAppearanceSettings(teamName)
   );
@@ -512,30 +495,23 @@ const TerminalWorkspaceKernelView = ({
     window.requestAnimationFrame(scroll);
     window.setTimeout(scroll, 80);
   }, []);
-  const handleCommandRunStarted = useCallback((): void => {
-    setCommandDraft('');
-    setAutocompleteSuggestion(null);
-    setDismissedAutocompleteDraft(null);
-  }, []);
   const { activeCommandRuns, commandRuns } = useTerminalCommandRuns({
     activePaneId: activeCommandPaneId,
     activeSessionId: activeCommandSessionId,
     eventSource: commandDockElement,
-    onCommandStarted: handleCommandRunStarted,
     onCommandSubmitted: scrollTerminalToLatest,
     screenLines: activeScreenCommandLines,
     screenSequence: activeScreen?.sequence,
     teamName,
   });
-  const autocompleteCandidates = useMemo(
-    () =>
-      createTerminalLocalAutocompleteCandidates({
-        commandHistory: snapshot.commandHistory.entries,
-        commandRuns,
-        cwd: projectPath,
-      }),
-    [commandRuns, projectPath, snapshot.commandHistory.entries]
-  );
+  const { autocompleteSuggestion } = useTerminalCommandAutocomplete({
+    commandHistory: snapshot.commandHistory.entries,
+    commandRuns,
+    cwd: projectPath,
+    eventSource: commandDockElement,
+    paneId: activeCommandPaneId,
+    sessionId: activeCommandSessionId,
+  });
 
   const terminalScreenRef = useCallback((element: TerminalScreenElementHandle | null): void => {
     terminalScreenElementRef.current = element;
@@ -603,86 +579,6 @@ const TerminalWorkspaceKernelView = ({
   }, [commandContextMenu]);
 
   useEffect(() => {
-    if (!commandDockElement) {
-      return undefined;
-    }
-
-    const handleDraftChange = (event: Event): void => {
-      const detail = (event as CustomEvent<unknown>).detail;
-      const value = isRecord(detail) && typeof detail.value === 'string' ? detail.value : '';
-      setCommandDraft(value);
-      setDismissedAutocompleteDraft((current) => (current === value ? current : null));
-    };
-    const handleAutocompleteAccept = (event: Event): void => {
-      const detail = (event as CustomEvent<unknown>).detail;
-      const value = isRecord(detail) && typeof detail.value === 'string' ? detail.value : '';
-      setCommandDraft(value);
-      setDismissedAutocompleteDraft(null);
-      setAutocompleteSuggestion(null);
-    };
-    const handleAutocompleteDismiss = (event: Event): void => {
-      const detail = (event as CustomEvent<unknown>).detail;
-      const draft = isRecord(detail) && typeof detail.draft === 'string' ? detail.draft : '';
-      setDismissedAutocompleteDraft(draft);
-      setAutocompleteSuggestion(null);
-    };
-
-    commandDockElement.addEventListener('tp-terminal-command-draft-change', handleDraftChange);
-    commandDockElement.addEventListener(
-      'tp-terminal-command-autocomplete-accept',
-      handleAutocompleteAccept
-    );
-    commandDockElement.addEventListener(
-      'tp-terminal-command-autocomplete-dismiss',
-      handleAutocompleteDismiss
-    );
-
-    return () => {
-      commandDockElement.removeEventListener('tp-terminal-command-draft-change', handleDraftChange);
-      commandDockElement.removeEventListener(
-        'tp-terminal-command-autocomplete-accept',
-        handleAutocompleteAccept
-      );
-      commandDockElement.removeEventListener(
-        'tp-terminal-command-autocomplete-dismiss',
-        handleAutocompleteDismiss
-      );
-    };
-  }, [commandDockElement]);
-
-  useEffect(() => {
-    if (
-      !isTerminalLocalAutocompleteDraftEligible(commandDraft) ||
-      dismissedAutocompleteDraft === commandDraft
-    ) {
-      setAutocompleteSuggestion(null);
-      return undefined;
-    }
-
-    const timer = window.setTimeout(() => {
-      setAutocompleteSuggestion(
-        resolveTerminalLocalAutocompleteSuggestion({
-          candidates: autocompleteCandidates,
-          cwd: projectPath,
-          dismissedDraft: dismissedAutocompleteDraft,
-          draft: commandDraft,
-          paneId: activeCommandPaneId,
-          sessionId: activeCommandSessionId,
-        })
-      );
-    }, TERMINAL_LOCAL_AUTOCOMPLETE_THROTTLE_MS);
-
-    return () => window.clearTimeout(timer);
-  }, [
-    activeCommandPaneId,
-    activeCommandSessionId,
-    autocompleteCandidates,
-    commandDraft,
-    dismissedAutocompleteDraft,
-    projectPath,
-  ]);
-
-  useEffect(() => {
     setAppearanceSettings(readStoredTerminalAppearanceSettings(teamName));
   }, [teamName]);
 
@@ -704,32 +600,10 @@ const TerminalWorkspaceKernelView = ({
     persistValue(storageKey(teamName, 'line-wrap'), String(terminalDisplay.lineWrap));
   }, [teamName, terminalDisplay.fontScale, terminalDisplay.lineWrap]);
 
-  useEffect(() => {
-    const persistence = commandHistoryPersistenceRef.current;
-    if (persistence.teamName !== teamName) {
-      persistence.teamName = teamName;
-      persistence.hasRestoredHistory = null;
-      persistence.hasPersistedSnapshot = false;
-    }
-
-    if (persistence.hasRestoredHistory === null) {
-      persistence.hasRestoredHistory = (readStoredCommandHistory(teamName)?.length ?? 0) > 0;
-    }
-
-    if (
-      snapshot.commandHistory.entries.length === 0 &&
-      persistence.hasRestoredHistory &&
-      !persistence.hasPersistedSnapshot
-    ) {
-      return;
-    }
-
-    persistCommandHistory(teamName, snapshot.commandHistory.entries);
-    persistence.hasPersistedSnapshot = true;
-    if (snapshot.commandHistory.entries.length > 0) {
-      persistence.hasRestoredHistory = false;
-    }
-  }, [snapshot.commandHistory.entries, teamName]);
+  useTerminalCommandHistoryPersistence({
+    entries: snapshot.commandHistory.entries,
+    teamName,
+  });
 
   useEffect(() => {
     const targetSessionId =
@@ -2316,23 +2190,6 @@ function readStoredTerminalAppearanceSettings(teamName: string): TerminalAppeara
   }
 }
 
-function readStoredCommandHistory(teamName: string): string[] | null {
-  const raw = readStoredValue(storageKey(teamName, 'command-history'));
-  if (!raw) return null;
-
-  try {
-    const parsed: unknown = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return null;
-    return parsed
-      .filter((entry): entry is string => typeof entry === 'string')
-      .map((entry) => normalizeStoredTerminalCommandHistoryEntry(entry))
-      .filter((entry): entry is string => Boolean(entry))
-      .slice(-TERMINAL_COMMAND_HISTORY_LIMIT);
-  } catch {
-    return null;
-  }
-}
-
 function persistValue(key: string, value: string): void {
   try {
     window.localStorage.setItem(key, value);
@@ -2398,17 +2255,6 @@ function getTerminalBackgroundRepeat(fit: TerminalBackgroundImageFit): string {
 
 function getTerminalBackgroundPosition(fit: TerminalBackgroundImageFit): string {
   return fit === 'tile' ? 'top left' : 'center';
-}
-
-function persistCommandHistory(teamName: string, entries: readonly string[]): void {
-  try {
-    window.localStorage.setItem(
-      storageKey(teamName, 'command-history'),
-      JSON.stringify(entries.slice(-TERMINAL_COMMAND_HISTORY_LIMIT))
-    );
-  } catch {
-    // Best-effort command history persistence.
-  }
 }
 
 function shouldIgnoreTerminalTabDragTarget(target: HTMLElement): boolean {

--- a/src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx
+++ b/src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx
@@ -495,7 +495,7 @@ const TerminalWorkspaceKernelView = ({
     window.requestAnimationFrame(scroll);
     window.setTimeout(scroll, 80);
   }, []);
-  const { activeCommandRuns, commandRuns } = useTerminalCommandRuns({
+  const { activeCommandRuns } = useTerminalCommandRuns({
     activePaneId: activeCommandPaneId,
     activeSessionId: activeCommandSessionId,
     eventSource: commandDockElement,
@@ -506,7 +506,7 @@ const TerminalWorkspaceKernelView = ({
   });
   const { autocompleteSuggestion } = useTerminalCommandAutocomplete({
     commandHistory: snapshot.commandHistory.entries,
-    commandRuns,
+    commandRuns: activeCommandRuns,
     cwd: projectPath,
     eventSource: commandDockElement,
     paneId: activeCommandPaneId,

--- a/test/renderer/features/terminal-workspace/TerminalWorkspacePanel.fixture-e2e.test.tsx
+++ b/test/renderer/features/terminal-workspace/TerminalWorkspacePanel.fixture-e2e.test.tsx
@@ -747,6 +747,51 @@ describe('terminal workspace panel fixture-e2e', () => {
     }
   });
 
+  it('does not autocomplete commands from another pane or session', async () => {
+    vi.useFakeTimers();
+    nextSnapshot = createWorkspaceSnapshot({
+      commandHistoryEntries: [],
+    });
+    window.localStorage.setItem(
+      storageKey('command-runs'),
+      JSON.stringify([
+        {
+          clientEventId: 'other-session-run',
+          command: 'pnpm test --filter other-session',
+          paneId: 'pane-other',
+          sessionId: 'session-other',
+          startedAtMs: 1_000,
+          status: 'succeeded',
+        },
+      ])
+    );
+
+    try {
+      await renderPanel();
+
+      await act(async () => {
+        getRequiredElement('mock-terminal-command-dock').dispatchEvent(
+          new CustomEvent('tp-terminal-command-draft-change', {
+            bubbles: true,
+            detail: {
+              value: 'pnpm t',
+            },
+          })
+        );
+        await flushMicrotasks();
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(80);
+        await flushMicrotasks();
+      });
+
+      expect(panelFixture.commandDockProps.at(-1)?.autocompleteSuggestion).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('shows cwd, git branch, prompt label, and powered-by GitHub link in the command area', async () => {
     await renderPanel();
 

--- a/test/renderer/features/terminal-workspace/terminalCommandHistory.test.ts
+++ b/test/renderer/features/terminal-workspace/terminalCommandHistory.test.ts
@@ -1,7 +1,22 @@
+import {
+  persistTerminalCommandHistory,
+  readStoredTerminalCommandHistory,
+} from '@features/terminal-workspace/renderer/adapters/terminalCommandHistoryStorage';
 import { normalizeStoredTerminalCommandHistoryEntry } from '@features/terminal-workspace/renderer/model/terminalCommandHistory';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const TEAM_NAME = 'terminal-command-history-storage-fixture';
+const STORAGE_KEY = `agent-teams:terminal-workspace:${TEAM_NAME}:command-history`;
 
 describe('terminal command history', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('removes supported shell prompts while retaining the command', () => {
     expect(
       normalizeStoredTerminalCommandHistoryEntry(
@@ -26,5 +41,63 @@ describe('terminal command history', () => {
     expect(normalizeStoredTerminalCommandHistoryEntry('echo cost$estimate')).toBe(
       'echo cost$estimate'
     );
+  });
+
+  it('normalizes and caps restored command history', () => {
+    const entries = Array.from({ length: 96 }, (_, index) =>
+      index % 2 === 0 ? `(env) /fixtures/project % echo ${index}` : `pnpm test ${index}`
+    );
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+
+    const restored = readStoredTerminalCommandHistory(TEAM_NAME);
+
+    expect(restored).toHaveLength(80);
+    expect(restored?.[0]).toBe('echo 16');
+    expect(restored?.at(-1)).toBe('pnpm test 95');
+  });
+
+  it('persists capped history and ignores corrupt storage', () => {
+    const entries = Array.from({ length: 96 }, (_, index) => `command ${index}`);
+    persistTerminalCommandHistory(TEAM_NAME, entries);
+    expect(JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? '[]')).toEqual(
+      entries.slice(-80)
+    );
+
+    window.localStorage.setItem(STORAGE_KEY, '{broken');
+    expect(readStoredTerminalCommandHistory(TEAM_NAME)).toBeNull();
+  });
+
+  it('preserves duplicate history entries as an autocomplete frequency signal', () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify(['pnpm test', 'git status', 'pnpm test'])
+    );
+
+    expect(readStoredTerminalCommandHistory(TEAM_NAME)).toEqual([
+      'pnpm test',
+      'git status',
+      'pnpm test',
+    ]);
+  });
+
+  it('keeps command history isolated by team name', () => {
+    persistTerminalCommandHistory('team-a', ['printf TEAM_A']);
+    persistTerminalCommandHistory('team-b', ['printf TEAM_B']);
+
+    expect(readStoredTerminalCommandHistory('team-a')).toEqual(['printf TEAM_A']);
+    expect(readStoredTerminalCommandHistory('team-b')).toEqual(['printf TEAM_B']);
+  });
+
+  it('degrades safely when local storage access throws', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('storage read denied');
+    });
+    expect(readStoredTerminalCommandHistory(TEAM_NAME)).toBeNull();
+    vi.restoreAllMocks();
+
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('storage write denied');
+    });
+    expect(() => persistTerminalCommandHistory(TEAM_NAME, ['pnpm test'])).not.toThrow();
   });
 });

--- a/test/renderer/features/terminal-workspace/useTerminalCommandAutocomplete.test.tsx
+++ b/test/renderer/features/terminal-workspace/useTerminalCommandAutocomplete.test.tsx
@@ -1,0 +1,201 @@
+import React, { act, useEffect } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { useTerminalCommandAutocomplete } from '@features/terminal-workspace/renderer/hooks/useTerminalCommandAutocomplete';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+interface AutocompleteState {
+  autocompleteSuggestion: string | null;
+}
+
+interface HookProbeOptions {
+  commandHistory?: readonly string[];
+  cwd?: string | null;
+  paneId?: string | null;
+  sessionId?: string | null;
+}
+
+function HookProbe({
+  eventSource,
+  onState,
+  options = {},
+}: {
+  eventSource: EventTarget;
+  onState: (state: AutocompleteState) => void;
+  options?: HookProbeOptions;
+}): null {
+  const state = useTerminalCommandAutocomplete({
+    commandHistory: options.commandHistory ?? ['git status', 'pnpm test'],
+    commandRuns: [],
+    cwd: options.cwd ?? '/fixtures/project',
+    eventSource,
+    paneId: options.paneId ?? 'pane-1',
+    sessionId: options.sessionId ?? 'session-1',
+  });
+  useEffect(() => onState(state), [onState, state]);
+  return null;
+}
+
+describe('useTerminalCommandAutocomplete', () => {
+  beforeEach(() => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    document.body.innerHTML = '';
+  });
+
+  it('clears an active suggestion when a valid command starts', async () => {
+    const eventSource = new EventTarget();
+    const host = document.createElement('div');
+    const root = createRoot(host);
+    let state: AutocompleteState = { autocompleteSuggestion: null };
+
+    await renderProbe(root, eventSource, (next) => {
+      state = next;
+    });
+    await dispatchAutocompleteEvent(eventSource, 'tp-terminal-command-draft-change', {
+      value: 'pnpm t',
+    });
+    await advanceAutocompleteTimer();
+    expect(state.autocompleteSuggestion).toBe('pnpm test');
+
+    await dispatchAutocompleteEvent(eventSource, 'tp-terminal-command-started', {
+      command: 'pnpm test',
+    });
+    expect(state.autocompleteSuggestion).toBe('pnpm test');
+
+    await dispatchAutocompleteEvent(eventSource, 'tp-terminal-command-started', {
+      clientEventId: 'run-1',
+      command: 'pnpm test',
+      paneId: 'pane-1',
+      sessionId: 'session-1',
+      startedAtMs: 100,
+    });
+    expect(state.autocompleteSuggestion).toBeNull();
+
+    act(() => root.unmount());
+  });
+
+  it('uses the latest candidates when inputs change before the throttle expires', async () => {
+    const eventSource = new EventTarget();
+    const addEventListener = vi.spyOn(eventSource, 'addEventListener');
+    const removeEventListener = vi.spyOn(eventSource, 'removeEventListener');
+    const host = document.createElement('div');
+    const root = createRoot(host);
+    let state: AutocompleteState = { autocompleteSuggestion: null };
+    const onState = (next: AutocompleteState): void => {
+      state = next;
+    };
+
+    await renderProbe(root, eventSource, onState, {
+      commandHistory: ['pnpm test'],
+    });
+    expect(addEventListener).toHaveBeenCalledTimes(4);
+    await dispatchAutocompleteEvent(eventSource, 'tp-terminal-command-draft-change', {
+      value: 'pnpm t',
+    });
+    await renderProbe(root, eventSource, onState, {
+      commandHistory: ['pnpm typecheck'],
+    });
+    expect(addEventListener).toHaveBeenCalledTimes(4);
+    expect(removeEventListener).not.toHaveBeenCalled();
+    await advanceAutocompleteTimer();
+
+    expect(state.autocompleteSuggestion).toBe('pnpm typecheck');
+    act(() => root.unmount());
+    expect(removeEventListener).toHaveBeenCalledTimes(4);
+  });
+
+  it('does not leak a pending draft across command dock event sources', async () => {
+    const firstSource = new EventTarget();
+    const secondSource = new EventTarget();
+    const clearTimeout = vi.spyOn(window, 'clearTimeout');
+    const host = document.createElement('div');
+    const root = createRoot(host);
+    let state: AutocompleteState = { autocompleteSuggestion: null };
+    const onState = (next: AutocompleteState): void => {
+      state = next;
+    };
+
+    await renderProbe(root, firstSource, onState);
+    await dispatchAutocompleteEvent(firstSource, 'tp-terminal-command-draft-change', {
+      value: 'pnpm t',
+    });
+    await renderProbe(root, secondSource, onState);
+    expect(clearTimeout).toHaveBeenCalled();
+    await advanceAutocompleteTimer();
+    expect(state.autocompleteSuggestion).toBeNull();
+
+    await dispatchAutocompleteEvent(secondSource, 'tp-terminal-command-draft-change', {
+      value: 'git s',
+    });
+    await advanceAutocompleteTimer();
+    expect(state.autocompleteSuggestion).toBe('git status');
+
+    act(() => root.unmount());
+  });
+
+  it('keeps accepted and dismissed drafts from resurfacing', async () => {
+    const eventSource = new EventTarget();
+    const host = document.createElement('div');
+    const root = createRoot(host);
+    let state: AutocompleteState = { autocompleteSuggestion: null };
+
+    await renderProbe(root, eventSource, (next) => {
+      state = next;
+    });
+    await dispatchAutocompleteEvent(eventSource, 'tp-terminal-command-draft-change', {
+      value: 'git s',
+    });
+    await advanceAutocompleteTimer();
+    expect(state.autocompleteSuggestion).toBe('git status');
+
+    await dispatchAutocompleteEvent(eventSource, 'tp-terminal-command-autocomplete-dismiss', {
+      draft: 'git s',
+    });
+    await advanceAutocompleteTimer();
+    expect(state.autocompleteSuggestion).toBeNull();
+
+    await dispatchAutocompleteEvent(eventSource, 'tp-terminal-command-autocomplete-accept', {
+      value: 'git status',
+    });
+    await advanceAutocompleteTimer();
+    expect(state.autocompleteSuggestion).toBeNull();
+
+    act(() => root.unmount());
+  });
+});
+
+async function renderProbe(
+  root: ReturnType<typeof createRoot>,
+  eventSource: EventTarget,
+  onState: (state: AutocompleteState) => void,
+  options?: HookProbeOptions
+): Promise<void> {
+  await act(async () => {
+    root.render(<HookProbe eventSource={eventSource} onState={onState} options={options} />);
+    await Promise.resolve();
+  });
+}
+
+async function dispatchAutocompleteEvent(
+  eventSource: EventTarget,
+  type: string,
+  detail: Record<string, unknown>
+): Promise<void> {
+  await act(async () => {
+    eventSource.dispatchEvent(new CustomEvent(type, { detail }));
+    await Promise.resolve();
+  });
+}
+
+async function advanceAutocompleteTimer(): Promise<void> {
+  await act(async () => {
+    vi.advanceTimersByTime(80);
+    await Promise.resolve();
+  });
+}

--- a/test/renderer/features/terminal-workspace/useTerminalCommandHistoryPersistence.test.tsx
+++ b/test/renderer/features/terminal-workspace/useTerminalCommandHistoryPersistence.test.tsx
@@ -1,0 +1,87 @@
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { useTerminalCommandHistoryPersistence } from '@features/terminal-workspace/renderer/hooks/useTerminalCommandHistoryPersistence';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const TEAM_A = 'terminal-history-persistence-team-a';
+const TEAM_B = 'terminal-history-persistence-team-b';
+
+function HookProbe({
+  entries,
+  teamName,
+}: Readonly<{
+  entries: readonly string[];
+  teamName: string;
+}>): null {
+  useTerminalCommandHistoryPersistence({ entries, teamName });
+  return null;
+}
+
+describe('useTerminalCommandHistoryPersistence', () => {
+  let host: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    window.localStorage.clear();
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+      await Promise.resolve();
+    });
+    host.remove();
+    window.localStorage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it('preserves restored history during an empty startup snapshot, then persists runtime changes', async () => {
+    const restored = ['git status', 'pnpm test'];
+    window.localStorage.setItem(storageKey(TEAM_A), JSON.stringify(restored));
+
+    await renderProbe(TEAM_A, []);
+    expect(readHistory(TEAM_A)).toEqual(restored);
+
+    const runtimeEntries = Array.from({ length: 96 }, (_, index) => `command ${index}`);
+    await renderProbe(TEAM_A, runtimeEntries);
+    expect(readHistory(TEAM_A)).toEqual(runtimeEntries.slice(-80));
+
+    await renderProbe(TEAM_A, []);
+    expect(readHistory(TEAM_A)).toEqual([]);
+  });
+
+  it('keeps restored histories isolated when the keyed team scope changes', async () => {
+    window.localStorage.setItem(storageKey(TEAM_A), JSON.stringify(['printf TEAM_A']));
+    window.localStorage.setItem(storageKey(TEAM_B), JSON.stringify(['printf TEAM_B']));
+
+    await renderProbe(TEAM_A, []);
+    await renderProbe(TEAM_B, []);
+
+    expect(readHistory(TEAM_A)).toEqual(['printf TEAM_A']);
+    expect(readHistory(TEAM_B)).toEqual(['printf TEAM_B']);
+
+    await renderProbe(TEAM_B, ['printf TEAM_B_NEW']);
+    expect(readHistory(TEAM_A)).toEqual(['printf TEAM_A']);
+    expect(readHistory(TEAM_B)).toEqual(['printf TEAM_B_NEW']);
+  });
+
+  async function renderProbe(teamName: string, entries: readonly string[]): Promise<void> {
+    await act(async () => {
+      root.render(<HookProbe key={teamName} entries={entries} teamName={teamName} />);
+      await Promise.resolve();
+    });
+  }
+});
+
+function storageKey(teamName: string): string {
+  return `agent-teams:terminal-workspace:${teamName}:command-history`;
+}
+
+function readHistory(teamName: string): unknown {
+  return JSON.parse(window.localStorage.getItem(storageKey(teamName)) ?? 'null');
+}

--- a/test/renderer/features/terminal-workspace/useTerminalCommandRuns.test.tsx
+++ b/test/renderer/features/terminal-workspace/useTerminalCommandRuns.test.tsx
@@ -13,7 +13,6 @@ interface HarnessProps {
   activePaneId: string | null;
   activeSessionId: string | null;
   eventSource: EventTarget | null;
-  onCommandStarted: () => void;
   onCommandSubmitted: () => void;
   renderGate?: RenderGate;
   screenLines: readonly TerminalCommandScreenLine[];
@@ -66,15 +65,13 @@ describe('useTerminalCommandRuns', () => {
     vi.useFakeTimers();
     vi.setSystemTime(2_000);
     const eventSource = new EventTarget();
-    const onCommandStarted = vi.fn();
     const onCommandSubmitted = vi.fn();
-    const props = createProps({ eventSource, onCommandStarted, onCommandSubmitted });
+    const props = createProps({ eventSource, onCommandSubmitted });
     const detail = createEventDetail({ startedAtMs: 1_750 });
 
     await renderHarness(props);
     await dispatchCommandEvent(eventSource, 'tp-terminal-command-started', detail);
 
-    expect(onCommandStarted).toHaveBeenCalledOnce();
     expect(requireResult().commandRuns).toEqual([
       expect.objectContaining({
         clientEventId: detail.clientEventId,
@@ -103,8 +100,7 @@ describe('useTerminalCommandRuns', () => {
     const secondAdd = vi.spyOn(secondSource, 'addEventListener');
     const secondRemove = vi.spyOn(secondSource, 'removeEventListener');
     const clearInterval = vi.spyOn(window, 'clearInterval');
-    const onCommandStarted = vi.fn();
-    const props = createProps({ eventSource: firstSource, onCommandStarted });
+    const props = createProps({ eventSource: firstSource });
 
     await renderHarness(props);
     expect(firstAdd).toHaveBeenCalledTimes(4);
@@ -115,7 +111,6 @@ describe('useTerminalCommandRuns', () => {
     expect(secondAdd).toHaveBeenCalledTimes(4);
 
     await dispatchCommandEvent(firstSource, 'tp-terminal-command-started', createEventDetail());
-    expect(onCommandStarted).not.toHaveBeenCalled();
     expect(requireResult().commandRuns).toEqual([]);
 
     await dispatchCommandEvent(
@@ -123,7 +118,6 @@ describe('useTerminalCommandRuns', () => {
       'tp-terminal-command-started',
       createEventDetail({ clientEventId: 'active-source-run' })
     );
-    expect(onCommandStarted).toHaveBeenCalledOnce();
     expect(requireResult().commandRuns).toHaveLength(1);
 
     await unmountHarness();
@@ -138,7 +132,6 @@ describe('useTerminalCommandRuns', () => {
       )
     );
     vi.advanceTimersByTime(1_800);
-    expect(onCommandStarted).toHaveBeenCalledOnce();
     expect(requireResult().commandRuns).toHaveLength(1);
   });
 
@@ -204,11 +197,11 @@ describe('useTerminalCommandRuns', () => {
     const eventSource = new EventTarget();
     const addEventListener = vi.spyOn(eventSource, 'addEventListener');
     const removeEventListener = vi.spyOn(eventSource, 'removeEventListener');
-    const committedStarted = vi.fn();
-    const pendingStarted = vi.fn();
+    const committedSubmitted = vi.fn();
+    const pendingSubmitted = vi.fn();
     const committedProps = createProps({
       eventSource,
-      onCommandStarted: committedStarted,
+      onCommandSubmitted: committedSubmitted,
       screenLines: ['shell % true', 'completed', 'shell %'],
     });
 
@@ -224,7 +217,7 @@ describe('useTerminalCommandRuns', () => {
       React.startTransition(() => {
         renderHarnessTree({
           ...committedProps,
-          onCommandStarted: pendingStarted,
+          onCommandSubmitted: pendingSubmitted,
           renderGate,
           screenLines: ['shell % true'],
           screenSequence: 2,
@@ -239,8 +232,9 @@ describe('useTerminalCommandRuns', () => {
       'tp-terminal-command-started',
       createEventDetail({ clientEventId: 'second-run', command: 'true', startedAtMs: 2_000 })
     );
-    expect(committedStarted).toHaveBeenCalledTimes(2);
-    expect(pendingStarted).not.toHaveBeenCalled();
+    await dispatchCommandEvent(eventSource, 'tp-terminal-paste-submitted');
+    expect(committedSubmitted).toHaveBeenCalledOnce();
+    expect(pendingSubmitted).not.toHaveBeenCalled();
     expect(requireResult().commandRuns[0]).toMatchObject({
       clientEventId: 'first-run',
       status: 'succeeded',
@@ -258,8 +252,9 @@ describe('useTerminalCommandRuns', () => {
       'tp-terminal-command-started',
       createEventDetail({ clientEventId: 'third-run', command: 'true', startedAtMs: 2_100 })
     );
-    expect(committedStarted).toHaveBeenCalledTimes(2);
-    expect(pendingStarted).toHaveBeenCalledOnce();
+    await dispatchCommandEvent(eventSource, 'tp-terminal-paste-submitted');
+    expect(committedSubmitted).toHaveBeenCalledOnce();
+    expect(pendingSubmitted).toHaveBeenCalledOnce();
     expect(requireResult().commandRuns[1]).toMatchObject({
       clientEventId: 'second-run',
       status: 'unknown',
@@ -313,7 +308,6 @@ describe('useTerminalCommandRuns', () => {
       activePaneId: 'pane-1',
       activeSessionId: 'session-1',
       eventSource: new EventTarget(),
-      onCommandStarted: vi.fn(),
       onCommandSubmitted: vi.fn(),
       screenLines: [],
       screenSequence: 1,


### PR DESCRIPTION
## Summary

- extract local command autocomplete orchestration into a focused hook
- extract command-history persistence behind a team-scoped localStorage adapter and hook
- clear pending autocomplete work when the command dock event source changes
- preserve the command-run commit-phase context and team hydration guards
- reduce TerminalWorkspacePanel from 2432 to 2278 lines and ratchet the legacy cap down

## Verification

- 136/136 full Terminal renderer tests
- 58 focused hook, storage and Panel fixture tests in independent audit
- native TypeScript 7 typecheck
- fast ESLint and Prettier checks
- source-size ratchet against exact base 47047e563
- public renderer index remains exactly 3 exports
- independent semantic audit: 0 P1-P3

Desktop/runtime E2E is intentionally deferred until the final TerminalWorkspacePanel slice is below 800 lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added terminal command history persistence across sessions, scoped by team.
  - Added local terminal command autocomplete suggestions based on recent history.

- **Improvements**
  - History is validated, normalized, capped to the most recent entries, and resilient to corrupted/failed storage reads/writes.
  - Autocomplete now avoids suggesting commands from other panes/sessions, preventing cross-context leakage.

- **Tests**
  - Added and updated unit and e2e coverage for persistence, team isolation, limits, storage failure handling, and autocomplete event behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
