### PR TITLE
test(review): verify cross-revision evidence reuse

### DIFF
--- a/src/features/agent-graph/core/domain/graphOwnerIdentity.test.ts
+++ b/src/features/agent-graph/core/domain/graphOwnerIdentity.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildGraphMemberNodeId } from './graphOwnerIdentity';
+
+describe('buildGraphMemberNodeId', () => {
+  it('normalizes surrounding whitespace in identity parts', () => {
+    expect(buildGraphMemberNodeId(' team-alpha ', ' owner-1 ')).toBe('member:team-alpha:owner-1');
+  });
+
+  it.each([
+    ['', 'owner-1'],
+    ['team-alpha', '  '],
+  ])('rejects an incomplete identity', (teamName, ownerId) => {
+    expect(() => buildGraphMemberNodeId(teamName, ownerId)).toThrow(
+      'Graph member node identity requires a team and owner'
+    );
+  });
+});

--- a/src/features/agent-graph/core/domain/graphOwnerIdentity.ts
+++ b/src/features/agent-graph/core/domain/graphOwnerIdentity.ts
@@ -5,7 +5,12 @@ export function getGraphStableOwnerId(member: StableTeamOwnerLike): string {
 }
 
 export function buildGraphMemberNodeId(teamName: string, stableOwnerId: string): string {
-  return `member:${teamName}:${stableOwnerId}`;
+  const normalizedTeamName = teamName.trim();
+  const normalizedOwnerId = stableOwnerId.trim();
+  if (!normalizedTeamName || !normalizedOwnerId) {
+    throw new Error('Graph member node identity requires a team and owner');
+  }
+  return `member:${normalizedTeamName}:${normalizedOwnerId}`;
 }
 
 export function buildGraphMemberNodeIdForMember(


### PR DESCRIPTION
Temporary production E2E for ReviewRouter revision-aware reuse.

- small domain change with focused tests
- first revision establishes attested evidence
- follow-up empty revision verifies reuse with a different SHA and identical tree

Do not merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved identity handling by removing unnecessary whitespace from team and owner values.
  * Added validation to prevent incomplete identities from generating invalid graph member IDs.
* **Tests**
  * Added coverage for whitespace normalization and validation of missing identity details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->