### PR TITLE
refactor(terminal-workspace): extract tab pointer reorder

### DIFF
--- a/scripts/ci/source-file-size-legacy.json
+++ b/scripts/ci/source-file-size-legacy.json
@@ -46,7 +46,7 @@
   "src/features/team-lifecycle/contracts/team-lifecycle-read.ts": 816,
   "src/features/team-lifecycle/main/infrastructure/TeamDirectoryLifecycleAdapter.ts": 1606,
   "src/features/team-runtime-control/core/application/planning/createCompositeRuntimePlan.ts": 1195,
-  "src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx": 1792,
+  "src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx": 1576,
   "src/features/token-usage/core/domain/snapshotProjection.ts": 937,
   "src/features/token-usage/renderer/adapters/tokenUsageViewModel.ts": 1481,
   "src/features/token-usage/renderer/ui/TokenUsageDashboard.tsx": 2170,

--- a/src/features/terminal-workspace/renderer/hooks/useTerminalTabPointerReorder.ts
+++ b/src/features/terminal-workspace/renderer/hooks/useTerminalTabPointerReorder.ts
@@ -1,0 +1,411 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import {
+  resolveTerminalTabReorderIntent,
+  type TerminalTabGeometry,
+  type TerminalTabReorderIntent,
+} from '../utils/terminalTabPointerReorder';
+
+import { useTerminalTabReorderMotion } from './useTerminalTabReorderMotion';
+
+import type {
+  TerminalTabDropIndicator,
+  TerminalTabPointerDrag,
+} from '../model/terminalTabPreferences';
+import type {
+  MouseEvent as ReactMouseEvent,
+  PointerEvent as ReactPointerEvent,
+  RefObject,
+} from 'react';
+
+interface TerminalTabPointerDragSession extends TerminalTabPointerDrag {
+  captureElement: HTMLDivElement;
+  scopeKey: string;
+}
+
+export interface UseTerminalTabPointerReorderOptions {
+  activeTabId: string | null;
+  canFocusTab: boolean;
+  disabled: boolean;
+  editingTabId: string | null;
+  orderedTabIds: readonly string[];
+  scopeKey: string;
+  onRequestFocus: (tabId: string) => void | Promise<void>;
+  onRequestReorder: (intent: TerminalTabReorderIntent) => void;
+}
+
+export interface UseTerminalTabPointerReorderResult {
+  draggingTabId: string | null;
+  dropIndicator: TerminalTabDropIndicator | null;
+  endTabPointerDrag: (event?: ReactPointerEvent<HTMLDivElement>) => void;
+  getTabDragOffsetX: (tabId: string) => number;
+  handleTabClick: (event: ReactMouseEvent<HTMLButtonElement>, tabId: string) => void;
+  handleTabLostPointerCapture: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  handleTabPointerDown: (event: ReactPointerEvent<HTMLDivElement>, tabId: string) => void;
+  handleTabPointerMove: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  handleTabPointerUp: (event: ReactPointerEvent<HTMLDivElement>, tabId: string) => void;
+  registerTabElement: (tabId: string, element: HTMLDivElement | null) => void;
+  tabListElementRef: RefObject<HTMLDivElement | null>;
+}
+
+export function useTerminalTabPointerReorder({
+  activeTabId,
+  canFocusTab,
+  disabled,
+  editingTabId,
+  orderedTabIds,
+  scopeKey,
+  onRequestFocus,
+  onRequestReorder,
+}: UseTerminalTabPointerReorderOptions): UseTerminalTabPointerReorderResult {
+  const [dragSession, setDragSession] = useState<TerminalTabPointerDragSession | null>(null);
+  const [dropIndicator, setDropIndicator] = useState<TerminalTabDropIndicator | null>(null);
+  const dragSessionRef = useRef<TerminalTabPointerDragSession | null>(null);
+  const mountedRef = useRef(false);
+  const suppressNextTabClickRef = useRef(false);
+  const suppressionGenerationRef = useRef(0);
+  const suppressionTimerRef = useRef<number | null>(null);
+  const tabListElementRef = useRef<HTMLDivElement | null>(null);
+  const tabElementRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+  const orderedTabIdsKey = orderedTabIds.join('\u001f');
+  const draggingTabId = dragSession?.active ? dragSession.tabId : null;
+  const { captureTabRectsBeforeReorder, clearCapturedTabRects } = useTerminalTabReorderMotion({
+    draggingTabId,
+    orderedTabIdsKey,
+    tabElementRefs,
+  });
+
+  const clearSuppressionTimer = useCallback((): void => {
+    suppressionGenerationRef.current += 1;
+    if (suppressionTimerRef.current !== null) {
+      window.clearTimeout(suppressionTimerRef.current);
+      suppressionTimerRef.current = null;
+    }
+  }, []);
+
+  const scheduleSuppressionReset = useCallback((): void => {
+    clearSuppressionTimer();
+    const generation = suppressionGenerationRef.current;
+    suppressionTimerRef.current = window.setTimeout(() => {
+      if (suppressionGenerationRef.current !== generation || dragSessionRef.current) {
+        return;
+      }
+      suppressionTimerRef.current = null;
+      suppressNextTabClickRef.current = false;
+    }, 0);
+  }, [clearSuppressionTimer]);
+
+  const setDragSessionState = useCallback(
+    (nextSession: TerminalTabPointerDragSession | null): void => {
+      dragSessionRef.current = nextSession;
+      if (mountedRef.current) {
+        setDragSession(nextSession);
+      }
+    },
+    []
+  );
+
+  const resetDragSession = useCallback(
+    ({
+      releaseCapture,
+      resetClickSuppression,
+    }: Readonly<{
+      releaseCapture: boolean;
+      resetClickSuppression: boolean;
+    }>): void => {
+      const activeSession = dragSessionRef.current;
+      if (!activeSession) {
+        return;
+      }
+
+      dragSessionRef.current = null;
+      if (releaseCapture) {
+        releasePointerCapture(activeSession);
+      }
+      clearCapturedTabRects();
+      if (mountedRef.current) {
+        setDragSession(null);
+        setDropIndicator(null);
+      }
+      if (resetClickSuppression) {
+        scheduleSuppressionReset();
+      }
+    },
+    [clearCapturedTabRects, scheduleSuppressionReset]
+  );
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      clearSuppressionTimer();
+      const activeSession = dragSessionRef.current;
+      dragSessionRef.current = null;
+      if (activeSession) {
+        releasePointerCapture(activeSession);
+      }
+      clearCapturedTabRects();
+    };
+  }, [clearCapturedTabRects, clearSuppressionTimer]);
+
+  useEffect(() => {
+    const activeSession = dragSessionRef.current;
+    if (
+      activeSession &&
+      (activeSession.scopeKey !== scopeKey ||
+        disabled ||
+        editingTabId !== null ||
+        !orderedTabIds.includes(activeSession.tabId))
+    ) {
+      resetDragSession({ releaseCapture: true, resetClickSuppression: true });
+    }
+  }, [disabled, editingTabId, orderedTabIds, resetDragSession, scopeKey]);
+
+  const registerTabElement = useCallback((tabId: string, element: HTMLDivElement | null): void => {
+    if (element) {
+      tabElementRefs.current.set(tabId, element);
+      return;
+    }
+    tabElementRefs.current.delete(tabId);
+  }, []);
+
+  const endTabPointerDrag = useCallback(
+    (event?: ReactPointerEvent<HTMLDivElement>): void => {
+      const activeSession = dragSessionRef.current;
+      if (!activeSession || (event && activeSession.pointerId !== event.pointerId)) {
+        return;
+      }
+      if (event && activeSession.active) {
+        event.preventDefault();
+      }
+      resetDragSession({ releaseCapture: true, resetClickSuppression: true });
+    },
+    [resetDragSession]
+  );
+
+  const handleTabLostPointerCapture = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>): void => {
+      const activeSession = dragSessionRef.current;
+      if (activeSession?.pointerId !== event.pointerId) {
+        return;
+      }
+      resetDragSession({ releaseCapture: false, resetClickSuppression: true });
+    },
+    [resetDragSession]
+  );
+
+  const handleTabPointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>, tabId: string): void => {
+      const target = event.target;
+      if (
+        dragSessionRef.current ||
+        event.button !== 0 ||
+        !event.isPrimary ||
+        disabled ||
+        editingTabId !== null ||
+        !orderedTabIds.includes(tabId) ||
+        (target instanceof HTMLElement && shouldIgnoreTerminalTabDragTarget(target))
+      ) {
+        return;
+      }
+
+      clearSuppressionTimer();
+      suppressNextTabClickRef.current = false;
+      const rect = event.currentTarget.getBoundingClientRect();
+      const nextSession: TerminalTabPointerDragSession = {
+        active: false,
+        captureElement: event.currentTarget,
+        grabOffsetX: event.clientX - rect.left,
+        offsetX: 0,
+        pointerId: event.pointerId,
+        scopeKey,
+        startClientX: event.clientX,
+        startClientY: event.clientY,
+        tabId,
+      };
+      setDragSessionState(nextSession);
+      setDropIndicator(null);
+
+      try {
+        event.currentTarget.setPointerCapture(event.pointerId);
+      } catch {
+        // Pointer capture is unavailable in some browser test environments.
+      }
+    },
+    [clearSuppressionTimer, disabled, editingTabId, orderedTabIds, scopeKey, setDragSessionState]
+  );
+
+  const handleTabPointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>): void => {
+      const activeSession = dragSessionRef.current;
+      if (!activeSession || activeSession.pointerId !== event.pointerId) {
+        return;
+      }
+      if (
+        activeSession.scopeKey !== scopeKey ||
+        disabled ||
+        editingTabId !== null ||
+        !orderedTabIds.includes(activeSession.tabId)
+      ) {
+        resetDragSession({ releaseCapture: true, resetClickSuppression: true });
+        return;
+      }
+
+      const deltaX = event.clientX - activeSession.startClientX;
+      const deltaY = event.clientY - activeSession.startClientY;
+      const shouldStartDrag =
+        activeSession.active || (Math.abs(deltaX) >= 4 && Math.abs(deltaX) >= Math.abs(deltaY));
+      if (!shouldStartDrag) {
+        return;
+      }
+
+      event.preventDefault();
+      suppressNextTabClickRef.current = true;
+      const sourceElement = tabElementRefs.current.get(activeSession.tabId);
+      const sourceRect = sourceElement?.getBoundingClientRect();
+      if (!sourceElement || !sourceRect) {
+        resetDragSession({ releaseCapture: true, resetClickSuppression: true });
+        return;
+      }
+
+      const baseLeft = sourceRect.left - activeSession.offsetX;
+      const tabListRect = tabListElementRef.current?.getBoundingClientRect();
+      const unclampedLeft = event.clientX - activeSession.grabOffsetX;
+      const clampedLeft = tabListRect
+        ? Math.min(
+            Math.max(unclampedLeft, tabListRect.left),
+            Math.max(tabListRect.left, tabListRect.right - sourceRect.width)
+          )
+        : unclampedLeft;
+      const nextSession: TerminalTabPointerDragSession = {
+        ...activeSession,
+        active: true,
+        offsetX: clampedLeft - baseLeft,
+      };
+      setDragSessionState(nextSession);
+
+      const reorderIntent = resolveTerminalTabReorderIntent({
+        clientX: event.clientX,
+        orderedTabIds,
+        sourceTabId: activeSession.tabId,
+        tabGeometries: collectTabGeometries(orderedTabIds, tabElementRefs.current),
+      });
+      if (!reorderIntent) {
+        setDropIndicator(null);
+        return;
+      }
+
+      const nextIndicator: TerminalTabDropIndicator = {
+        placementMode: reorderIntent.placementMode,
+        tabId: reorderIntent.targetTabId,
+      };
+      setDropIndicator((current) =>
+        current?.tabId === nextIndicator.tabId &&
+        current.placementMode === nextIndicator.placementMode
+          ? current
+          : nextIndicator
+      );
+      captureTabRectsBeforeReorder();
+      onRequestReorder(reorderIntent);
+    },
+    [
+      captureTabRectsBeforeReorder,
+      disabled,
+      editingTabId,
+      onRequestReorder,
+      orderedTabIds,
+      resetDragSession,
+      scopeKey,
+      setDragSessionState,
+    ]
+  );
+
+  const handleTabPointerUp = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>, tabId: string): void => {
+      const activeSession = dragSessionRef.current;
+      if (!activeSession || activeSession.pointerId !== event.pointerId) {
+        return;
+      }
+
+      const shouldFocusTab =
+        activeSession.scopeKey === scopeKey &&
+        activeSession.tabId === tabId &&
+        orderedTabIds.includes(tabId) &&
+        canFocusTab &&
+        tabId !== activeTabId &&
+        !disabled &&
+        editingTabId === null;
+      if (shouldFocusTab) {
+        suppressNextTabClickRef.current = true;
+        void onRequestFocus(tabId);
+      }
+      endTabPointerDrag(event);
+    },
+    [
+      activeTabId,
+      canFocusTab,
+      disabled,
+      editingTabId,
+      endTabPointerDrag,
+      onRequestFocus,
+      orderedTabIds,
+      scopeKey,
+    ]
+  );
+
+  const handleTabClick = useCallback(
+    (event: ReactMouseEvent<HTMLButtonElement>, tabId: string): void => {
+      const keyboardInitiated = event.detail === 0;
+      if (!keyboardInitiated && suppressNextTabClickRef.current) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+      if (!disabled && orderedTabIds.includes(tabId)) {
+        void onRequestFocus(tabId);
+      }
+    },
+    [disabled, onRequestFocus, orderedTabIds]
+  );
+
+  const getTabDragOffsetX = useCallback(
+    (tabId: string): number => (dragSession?.tabId === tabId ? dragSession.offsetX : 0),
+    [dragSession]
+  );
+
+  return {
+    draggingTabId,
+    dropIndicator,
+    endTabPointerDrag,
+    getTabDragOffsetX,
+    handleTabClick,
+    handleTabLostPointerCapture,
+    handleTabPointerDown,
+    handleTabPointerMove,
+    handleTabPointerUp,
+    registerTabElement,
+    tabListElementRef,
+  };
+}
+
+function collectTabGeometries(
+  orderedTabIds: readonly string[],
+  tabElements: ReadonlyMap<string, HTMLDivElement>
+): TerminalTabGeometry[] {
+  return orderedTabIds.flatMap((tabId) => {
+    const rect = tabElements.get(tabId)?.getBoundingClientRect();
+    return rect ? [{ left: rect.left, tabId, width: rect.width }] : [];
+  });
+}
+
+function releasePointerCapture(session: TerminalTabPointerDragSession): void {
+  try {
+    session.captureElement.releasePointerCapture(session.pointerId);
+  } catch {
+    // Capture may already be released by the browser.
+  }
+}
+
+function shouldIgnoreTerminalTabDragTarget(target: HTMLElement): boolean {
+  return Boolean(target.closest('[data-terminal-tab-drag-ignore="true"],input,textarea,select,a'));
+}

--- a/src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx
+++ b/src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx
@@ -77,7 +77,7 @@ import {
   type TerminalMuxCommands,
   useTerminalMuxTabLifecycle,
 } from '../hooks/useTerminalMuxTabLifecycle';
-import { useTerminalTabReorderMotion } from '../hooks/useTerminalTabReorderMotion';
+import { useTerminalTabPointerReorder } from '../hooks/useTerminalTabPointerReorder';
 import {
   DEFAULT_TERMINAL_APPEARANCE_SETTINGS,
   normalizeTerminalAppearanceSettings,
@@ -104,10 +104,7 @@ import {
   reorderTerminalTabsById,
   resolveTerminalTabColor,
   TERMINAL_TAB_COLOR_OPTIONS,
-  type TerminalMuxTab,
   type TerminalTabColorId,
-  type TerminalTabDropIndicator,
-  type TerminalTabPointerDrag,
   type TerminalTabPreferences,
   type TerminalWorkspaceSnapshot,
 } from '../model/terminalTabPreferences';
@@ -122,6 +119,7 @@ import type {
   TerminalWorkspaceBootstrap,
   TerminalWorkspaceBootstrapRequest,
 } from '../../contracts';
+import type { TerminalTabReorderIntent } from '../utils/terminalTabPointerReorder';
 
 export interface TerminalWorkspacePanelProps {
   teamName: string;
@@ -854,13 +852,6 @@ const TerminalMuxTabs = ({
   const [tabPreferences, setTabPreferences] = useState<TerminalTabPreferences>(() =>
     readStoredTerminalTabPreferences(teamName)
   );
-  const [draggingTabId, setDraggingTabId] = useState<string | null>(null);
-  const [dropIndicator, setDropIndicator] = useState<TerminalTabDropIndicator | null>(null);
-  const [tabPointerDrag, setTabPointerDrag] = useState<TerminalTabPointerDrag | null>(null);
-  const suppressNextTabClickRef = useRef(false);
-  const tabListElementRef = useRef<HTMLDivElement | null>(null);
-  const tabElementRefs = useRef<Map<string, HTMLDivElement>>(new Map());
-  const tabPointerDragRef = useRef<TerminalTabPointerDrag | null>(null);
   const topology = snapshot.attachedSession?.topology ?? null;
   const controls = resolveTerminalTopologyControlState(snapshot);
   const tabs = topology?.tabs ?? [];
@@ -870,7 +861,10 @@ const TerminalMuxTabs = ({
     () => orderTerminalTabsByPreference(visibleTabs, tabPreferences.order),
     [tabPreferences.order, visibleTabs]
   );
-  const orderedVisibleTabIdsKey = orderedVisibleTabs.map((tab) => tab.tab_id).join('\u001f');
+  const orderedVisibleTabIds = useMemo(
+    () => orderedVisibleTabs.map((tab) => tab.tab_id),
+    [orderedVisibleTabs]
+  );
   const prewarmedTab = tabs.find(isPrewarmedTerminalTab) ?? null;
   const activeSessionId = controls.activeSessionId;
   const activeTabId =
@@ -914,16 +908,6 @@ const TerminalMuxTabs = ({
     onSettingsOpenChange,
     onTabContentPendingChange,
   });
-  const { captureTabRectsBeforeReorder, clearCapturedTabRects } = useTerminalTabReorderMotion({
-    draggingTabId,
-    orderedTabIdsKey: orderedVisibleTabIdsKey,
-    tabElementRefs,
-  });
-
-  const setTabPointerDragState = useCallback((nextDrag: TerminalTabPointerDrag | null): void => {
-    tabPointerDragRef.current = nextDrag;
-    setTabPointerDrag(nextDrag);
-  }, []);
 
   const updateTabPreferences = useCallback(
     (updater: (current: TerminalTabPreferences) => TerminalTabPreferences): void => {
@@ -939,14 +923,50 @@ const TerminalMuxTabs = ({
     [teamName]
   );
 
-  const registerTabElement = useCallback((tabId: string, element: HTMLDivElement | null): void => {
-    if (element) {
-      tabElementRefs.current.set(tabId, element);
-      return;
-    }
+  const reorderTabs = useCallback(
+    ({ placementMode, sourceTabId, targetTabId }: TerminalTabReorderIntent): void => {
+      updateTabPreferences((current) => {
+        const nextOrder = reorderTerminalTabsById(
+          current.order,
+          visibleTabs,
+          sourceTabId,
+          targetTabId,
+          placementMode
+        );
+        if (areStringArraysEqual(current.order, nextOrder)) {
+          return current;
+        }
+        return {
+          ...current,
+          order: nextOrder,
+        };
+      });
+    },
+    [updateTabPreferences, visibleTabs]
+  );
 
-    tabElementRefs.current.delete(tabId);
-  }, []);
+  const {
+    draggingTabId,
+    dropIndicator,
+    endTabPointerDrag,
+    getTabDragOffsetX,
+    handleTabClick,
+    handleTabLostPointerCapture,
+    handleTabPointerDown,
+    handleTabPointerMove,
+    handleTabPointerUp,
+    registerTabElement,
+    tabListElementRef,
+  } = useTerminalTabPointerReorder({
+    activeTabId,
+    canFocusTab: controls.canFocusTab,
+    disabled: busy,
+    editingTabId,
+    orderedTabIds: orderedVisibleTabIds,
+    scopeKey: `${teamName}\u001f${activeSessionId ?? ''}`,
+    onRequestFocus: focusTab,
+    onRequestReorder: reorderTabs,
+  });
 
   useEffect(() => {
     setTabPreferences(readStoredTerminalTabPreferences(teamName));
@@ -968,231 +988,6 @@ const TerminalMuxTabs = ({
         [tabId]: colorId,
       },
     }));
-  };
-
-  const reorderTabs = (
-    sourceTabId: string,
-    targetTabId: string,
-    placementMode: 'before' | 'after'
-  ): void => {
-    if (sourceTabId === targetTabId) {
-      return;
-    }
-
-    captureTabRectsBeforeReorder();
-    updateTabPreferences((current) => {
-      const nextOrder = reorderTerminalTabsById(
-        current.order,
-        visibleTabs,
-        sourceTabId,
-        targetTabId,
-        placementMode
-      );
-      if (areStringArraysEqual(current.order, nextOrder)) {
-        return current;
-      }
-      return {
-        ...current,
-        order: nextOrder,
-      };
-    });
-  };
-
-  const getTabReorderTarget = useCallback(
-    (sourceTabId: string, clientX: number): TerminalTabDropIndicator | null => {
-      const candidates = orderedVisibleTabs
-        .filter((tab) => tab.tab_id !== sourceTabId)
-        .map((tab) => {
-          const element = tabElementRefs.current.get(tab.tab_id);
-          const rect = element?.getBoundingClientRect();
-          return rect
-            ? {
-                centerX: rect.left + rect.width / 2,
-                left: rect.left,
-                tabId: tab.tab_id,
-              }
-            : null;
-        })
-        .filter(
-          (
-            candidate
-          ): candidate is {
-            centerX: number;
-            left: number;
-            tabId: string;
-          } => candidate !== null
-        )
-        .sort((left, right) => left.left - right.left);
-
-      if (candidates.length === 0) {
-        return null;
-      }
-
-      const beforeCandidate = candidates.find((candidate) => clientX < candidate.centerX);
-      if (beforeCandidate) {
-        return { placementMode: 'before', tabId: beforeCandidate.tabId };
-      }
-
-      return { placementMode: 'after', tabId: candidates[candidates.length - 1].tabId };
-    },
-    [orderedVisibleTabs]
-  );
-
-  const endTabPointerDrag = useCallback(
-    (event?: React.PointerEvent<HTMLDivElement>): void => {
-      const activeDrag = tabPointerDragRef.current;
-      if (event && activeDrag?.pointerId !== event.pointerId) {
-        return;
-      }
-
-      if (event && activeDrag?.active) {
-        event.preventDefault();
-      }
-
-      if (event) {
-        try {
-          event.currentTarget.releasePointerCapture(event.pointerId);
-        } catch {
-          // Pointer capture can already be released by the browser.
-        }
-      }
-
-      setTabPointerDragState(null);
-      setDraggingTabId(null);
-      setDropIndicator(null);
-      clearCapturedTabRects();
-      window.setTimeout(() => {
-        suppressNextTabClickRef.current = false;
-      }, 0);
-    },
-    [clearCapturedTabRects, setTabPointerDragState]
-  );
-
-  const handleTabPointerDown = (
-    event: React.PointerEvent<HTMLDivElement>,
-    tab: TerminalMuxTab
-  ): void => {
-    const target = event.target;
-    if (
-      event.button !== 0 ||
-      !event.isPrimary ||
-      editingTabId === tab.tab_id ||
-      busy ||
-      (target instanceof HTMLElement && shouldIgnoreTerminalTabDragTarget(target))
-    ) {
-      return;
-    }
-
-    const rect = event.currentTarget.getBoundingClientRect();
-    setTabPointerDragState({
-      active: false,
-      grabOffsetX: event.clientX - rect.left,
-      offsetX: 0,
-      pointerId: event.pointerId,
-      startClientX: event.clientX,
-      startClientY: event.clientY,
-      tabId: tab.tab_id,
-    });
-    setDropIndicator(null);
-
-    try {
-      event.currentTarget.setPointerCapture(event.pointerId);
-    } catch {
-      // Some test environments do not implement pointer capture.
-    }
-  };
-
-  const handleTabPointerMove = (event: React.PointerEvent<HTMLDivElement>): void => {
-    const activeDrag = tabPointerDragRef.current;
-    if (!activeDrag || activeDrag.pointerId !== event.pointerId) {
-      return;
-    }
-
-    const deltaX = event.clientX - activeDrag.startClientX;
-    const deltaY = event.clientY - activeDrag.startClientY;
-    const shouldStartDrag =
-      activeDrag.active || (Math.abs(deltaX) >= 4 && Math.abs(deltaX) >= Math.abs(deltaY));
-    if (!shouldStartDrag) {
-      return;
-    }
-
-    event.preventDefault();
-    suppressNextTabClickRef.current = true;
-    setDraggingTabId(activeDrag.tabId);
-
-    const element = tabElementRefs.current.get(activeDrag.tabId);
-    const rect = element?.getBoundingClientRect();
-    if (!rect) {
-      return;
-    }
-
-    const baseLeft = rect.left - activeDrag.offsetX;
-    const tabListRect = tabListElementRef.current?.getBoundingClientRect();
-    const unclampedLeft = event.clientX - activeDrag.grabOffsetX;
-    const clampedLeft = tabListRect
-      ? Math.min(
-          Math.max(unclampedLeft, tabListRect.left),
-          Math.max(tabListRect.left, tabListRect.right - rect.width)
-        )
-      : unclampedLeft;
-    const nextDrag = {
-      ...activeDrag,
-      active: true,
-      offsetX: clampedLeft - baseLeft,
-    };
-
-    setTabPointerDragState(nextDrag);
-
-    const reorderTarget = getTabReorderTarget(activeDrag.tabId, event.clientX);
-    if (!reorderTarget) {
-      setDropIndicator(null);
-      return;
-    }
-
-    const nextOrder = reorderTerminalTabsById(
-      tabPreferences.order,
-      visibleTabs,
-      activeDrag.tabId,
-      reorderTarget.tabId,
-      reorderTarget.placementMode
-    );
-    if (
-      areStringArraysEqual(
-        orderedVisibleTabs.map((tab) => tab.tab_id),
-        nextOrder
-      )
-    ) {
-      setDropIndicator(null);
-      return;
-    }
-
-    setDropIndicator((current) =>
-      current?.tabId === reorderTarget.tabId &&
-      current.placementMode === reorderTarget.placementMode
-        ? current
-        : reorderTarget
-    );
-    reorderTabs(activeDrag.tabId, reorderTarget.tabId, reorderTarget.placementMode);
-  };
-
-  const handleTabPointerUp = (
-    event: React.PointerEvent<HTMLDivElement>,
-    tab: TerminalMuxTab
-  ): void => {
-    const activeDrag = tabPointerDragRef.current;
-    const shouldFocusTab =
-      activeDrag?.pointerId === event.pointerId &&
-      activeDrag.tabId === tab.tab_id &&
-      controls.canFocusTab &&
-      tab.tab_id !== activeTabId &&
-      !busy;
-
-    if (shouldFocusTab) {
-      suppressNextTabClickRef.current = true;
-      void focusTab(tab.tab_id);
-    }
-
-    endTabPointerDrag(event);
   };
 
   return (
@@ -1255,8 +1050,7 @@ const TerminalMuxTabs = ({
                         '--tp-tab-border-bottom': active ? 'transparent' : color.border,
                       } as React.CSSProperties)
                     : undefined;
-                const dragOffsetX =
-                  tabPointerDrag?.tabId === tab.tab_id ? tabPointerDrag.offsetX : 0;
+                const dragOffsetX = getTabDragOffsetX(tab.tab_id);
                 const tabStyle =
                   dragOffsetX !== 0
                     ? ({
@@ -1290,10 +1084,11 @@ const TerminalMuxTabs = ({
                             : undefined
                         }
                         data-terminal-tab-id={tab.tab_id}
+                        onLostPointerCapture={handleTabLostPointerCapture}
                         onPointerCancel={endTabPointerDrag}
-                        onPointerDown={(event) => handleTabPointerDown(event, tab)}
+                        onPointerDown={(event) => handleTabPointerDown(event, tab.tab_id)}
                         onPointerMove={handleTabPointerMove}
-                        onPointerUp={(event) => handleTabPointerUp(event, tab)}
+                        onPointerUp={(event) => handleTabPointerUp(event, tab.tab_id)}
                         style={tabStyle}
                       >
                         {dropIndicator?.tabId === tab.tab_id && draggingTabId !== tab.tab_id ? (
@@ -1337,14 +1132,7 @@ const TerminalMuxTabs = ({
                               data-testid="agent-team-terminal-mux-tab"
                               disabled={busy}
                               role="tab"
-                              onClick={(event) => {
-                                if (suppressNextTabClickRef.current) {
-                                  event.preventDefault();
-                                  event.stopPropagation();
-                                  return;
-                                }
-                                void focusTab(tab.tab_id);
-                              }}
+                              onClick={(event) => handleTabClick(event, tab.tab_id)}
                               onDoubleClick={(event) => {
                                 event.preventDefault();
                                 startRenameTab(tab, label);
@@ -1773,10 +1561,6 @@ function getTerminalBackgroundRepeat(fit: TerminalBackgroundImageFit): string {
 
 function getTerminalBackgroundPosition(fit: TerminalBackgroundImageFit): string {
   return fit === 'tile' ? 'top left' : 'center';
-}
-
-function shouldIgnoreTerminalTabDragTarget(target: HTMLElement): boolean {
-  return Boolean(target.closest('[data-terminal-tab-drag-ignore="true"],input,textarea,select,a'));
 }
 
 function formatThemeLabel(t: TeamTFunction, displayName: string, themeId: string): string {

--- a/src/features/terminal-workspace/renderer/utils/terminalTabPointerReorder.ts
+++ b/src/features/terminal-workspace/renderer/utils/terminalTabPointerReorder.ts
@@ -1,0 +1,82 @@
+export type TerminalTabReorderPlacement = 'before' | 'after';
+
+export interface TerminalTabReorderIntent {
+  placementMode: TerminalTabReorderPlacement;
+  sourceTabId: string;
+  targetTabId: string;
+}
+
+export interface TerminalTabGeometry {
+  left: number;
+  tabId: string;
+  width: number;
+}
+
+export function resolveTerminalTabReorderIntent({
+  clientX,
+  orderedTabIds,
+  sourceTabId,
+  tabGeometries,
+}: Readonly<{
+  clientX: number;
+  orderedTabIds: readonly string[];
+  sourceTabId: string;
+  tabGeometries: readonly TerminalTabGeometry[];
+}>): TerminalTabReorderIntent | null {
+  if (!Number.isFinite(clientX) || !orderedTabIds.includes(sourceTabId)) {
+    return null;
+  }
+
+  const tabOrder = new Map(orderedTabIds.map((tabId, index) => [tabId, index]));
+  const candidates = tabGeometries
+    .filter(
+      ({ left, tabId, width }) =>
+        tabId !== sourceTabId &&
+        tabOrder.has(tabId) &&
+        Number.isFinite(left) &&
+        Number.isFinite(width) &&
+        width >= 0
+    )
+    .toSorted(
+      (left, right) =>
+        left.left - right.left ||
+        (tabOrder.get(left.tabId) ?? Number.MAX_SAFE_INTEGER) -
+          (tabOrder.get(right.tabId) ?? Number.MAX_SAFE_INTEGER)
+    );
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  const beforeCandidate = candidates.find(({ left, width }) => clientX < left + width / 2);
+  const target = beforeCandidate ?? candidates[candidates.length - 1];
+  if (!target) {
+    return null;
+  }
+
+  const intent: TerminalTabReorderIntent = {
+    placementMode: beforeCandidate ? 'before' : 'after',
+    sourceTabId,
+    targetTabId: target.tabId,
+  };
+  return wouldTerminalTabOrderChange(orderedTabIds, intent) ? intent : null;
+}
+
+export function wouldTerminalTabOrderChange(
+  orderedTabIds: readonly string[],
+  intent: TerminalTabReorderIntent
+): boolean {
+  const sourceIndex = orderedTabIds.indexOf(intent.sourceTabId);
+  const targetIndex = orderedTabIds.indexOf(intent.targetTabId);
+  if (sourceIndex < 0 || targetIndex < 0 || sourceIndex === targetIndex) {
+    return false;
+  }
+
+  const withoutSource = orderedTabIds.filter((tabId) => tabId !== intent.sourceTabId);
+  const targetIndexWithoutSource = withoutSource.indexOf(intent.targetTabId);
+  const insertionIndex =
+    intent.placementMode === 'after' ? targetIndexWithoutSource + 1 : targetIndexWithoutSource;
+  const reordered = [...withoutSource];
+  reordered.splice(insertionIndex, 0, intent.sourceTabId);
+
+  return reordered.some((tabId, index) => tabId !== orderedTabIds[index]);
+}

--- a/test/renderer/features/terminal-workspace/terminalTabPointerReorder.test.ts
+++ b/test/renderer/features/terminal-workspace/terminalTabPointerReorder.test.ts
@@ -1,0 +1,121 @@
+import {
+  resolveTerminalTabReorderIntent,
+  wouldTerminalTabOrderChange,
+} from '@features/terminal-workspace/renderer/utils/terminalTabPointerReorder';
+import { describe, expect, it } from 'vitest';
+
+const ORDER = ['tab-1', 'tab-2', 'tab-3'];
+const GEOMETRIES = [
+  { left: 0, tabId: 'tab-1', width: 80 },
+  { left: 100, tabId: 'tab-2', width: 80 },
+  { left: 200, tabId: 'tab-3', width: 80 },
+];
+
+describe('terminal tab pointer reorder geometry', () => {
+  it('resolves before and after placement from visual tab centers', () => {
+    expect(
+      resolveTerminalTabReorderIntent({
+        clientX: 220,
+        orderedTabIds: ORDER,
+        sourceTabId: 'tab-1',
+        tabGeometries: GEOMETRIES,
+      })
+    ).toEqual({
+      placementMode: 'before',
+      sourceTabId: 'tab-1',
+      targetTabId: 'tab-3',
+    });
+    expect(
+      resolveTerminalTabReorderIntent({
+        clientX: 260,
+        orderedTabIds: ORDER,
+        sourceTabId: 'tab-1',
+        tabGeometries: GEOMETRIES,
+      })
+    ).toEqual({
+      placementMode: 'after',
+      sourceTabId: 'tab-1',
+      targetTabId: 'tab-3',
+    });
+  });
+
+  it('uses measured visual order instead of trusting object insertion order', () => {
+    expect(
+      resolveTerminalTabReorderIntent({
+        clientX: 120,
+        orderedTabIds: ORDER,
+        sourceTabId: 'tab-3',
+        tabGeometries: [GEOMETRIES[2]!, GEOMETRIES[1]!, GEOMETRIES[0]!],
+      })
+    ).toEqual({
+      placementMode: 'before',
+      sourceTabId: 'tab-3',
+      targetTabId: 'tab-2',
+    });
+  });
+
+  it('returns no intent for an adjacent no-op placement', () => {
+    expect(
+      resolveTerminalTabReorderIntent({
+        clientX: 110,
+        orderedTabIds: ORDER,
+        sourceTabId: 'tab-1',
+        tabGeometries: GEOMETRIES,
+      })
+    ).toBeNull();
+    expect(
+      resolveTerminalTabReorderIntent({
+        clientX: 60,
+        orderedTabIds: ORDER,
+        sourceTabId: 'tab-2',
+        tabGeometries: GEOMETRIES,
+      })
+    ).toBeNull();
+  });
+
+  it('rejects stale sources, unusable coordinates, and missing candidates', () => {
+    expect(
+      resolveTerminalTabReorderIntent({
+        clientX: 100,
+        orderedTabIds: ORDER,
+        sourceTabId: 'removed-tab',
+        tabGeometries: GEOMETRIES,
+      })
+    ).toBeNull();
+    expect(
+      resolveTerminalTabReorderIntent({
+        clientX: Number.NaN,
+        orderedTabIds: ORDER,
+        sourceTabId: 'tab-1',
+        tabGeometries: GEOMETRIES,
+      })
+    ).toBeNull();
+    expect(
+      resolveTerminalTabReorderIntent({
+        clientX: 100,
+        orderedTabIds: ['tab-1'],
+        sourceTabId: 'tab-1',
+        tabGeometries: [GEOMETRIES[0]!],
+      })
+    ).toBeNull();
+  });
+
+  it('detects order changes without mutating the caller-owned order', () => {
+    const order = [...ORDER];
+    expect(
+      wouldTerminalTabOrderChange(order, {
+        placementMode: 'after',
+        sourceTabId: 'tab-1',
+        targetTabId: 'tab-3',
+      })
+    ).toBe(true);
+    expect(
+      wouldTerminalTabOrderChange(order, {
+        placementMode: 'before',
+        sourceTabId: 'tab-1',
+        targetTabId: 'tab-2',
+      })
+    ).toBe(false);
+    expect(order).toEqual(ORDER);
+  });
+});

--- a/test/renderer/features/terminal-workspace/useTerminalTabPointerReorder.test.tsx
+++ b/test/renderer/features/terminal-workspace/useTerminalTabPointerReorder.test.tsx
@@ -1,0 +1,477 @@
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import {
+  useTerminalTabPointerReorder,
+  type UseTerminalTabPointerReorderOptions,
+  type UseTerminalTabPointerReorderResult,
+} from '@features/terminal-workspace/renderer/hooks/useTerminalTabPointerReorder';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent } from 'react';
+
+const ORDERED_TAB_IDS = ['tab-1', 'tab-2', 'tab-3'];
+
+describe('useTerminalTabPointerReorder', () => {
+  let controls: UseTerminalTabPointerReorderResult | null;
+  let host: HTMLDivElement;
+  let options: UseTerminalTabPointerReorderOptions;
+  let root: Root;
+  let tabElements: Map<string, TestTabElement>;
+
+  function Harness(props: UseTerminalTabPointerReorderOptions): null {
+    controls = useTerminalTabPointerReorder(props);
+    return null;
+  }
+
+  beforeEach(async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => createMediaQueryList())
+    );
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+    controls = null;
+    options = createOptions();
+    tabElements = new Map([
+      ['tab-1', createTabElement(0)],
+      ['tab-2', createTabElement(100)],
+      ['tab-3', createTabElement(200)],
+    ]);
+    await render();
+    registerTabs();
+  });
+
+  afterEach(async () => {
+    if (host.isConnected) {
+      await act(async () => {
+        root.unmount();
+      });
+      host.remove();
+    }
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('emits a narrow reorder intent, focuses the dropped tab, and suppresses its trailing click', () => {
+    const source = requiredTab('tab-1');
+    const down = createPointerEvent(source.element, {
+      clientX: 10,
+      pointerId: 1,
+    });
+    const move = createPointerEvent(source.element, {
+      clientX: 260,
+      pointerId: 1,
+    });
+
+    act(() => {
+      requiredControls().handleTabPointerDown(down.event, 'tab-1');
+      requiredControls().handleTabPointerMove(move.event);
+    });
+
+    expect(source.setPointerCapture).toHaveBeenCalledWith(1);
+    expect(move.preventDefault).toHaveBeenCalledOnce();
+    expect(requiredControls().draggingTabId).toBe('tab-1');
+    expect(requiredControls().getTabDragOffsetX('tab-1')).toBe(200);
+    expect(requiredControls().dropIndicator).toEqual({
+      placementMode: 'after',
+      tabId: 'tab-3',
+    });
+    expect(options.onRequestReorder).toHaveBeenCalledWith({
+      placementMode: 'after',
+      sourceTabId: 'tab-1',
+      targetTabId: 'tab-3',
+    });
+
+    const up = createPointerEvent(source.element, {
+      clientX: 260,
+      pointerId: 1,
+    });
+    act(() => requiredControls().handleTabPointerUp(up.event, 'tab-1'));
+
+    expect(options.onRequestFocus).toHaveBeenCalledOnce();
+    expect(options.onRequestFocus).toHaveBeenCalledWith('tab-1');
+    expect(source.releasePointerCapture).toHaveBeenCalledWith(1);
+    expect(requiredControls().draggingTabId).toBeNull();
+
+    const trailingClick = createMouseEvent(1);
+    act(() => requiredControls().handleTabClick(trailingClick.event, 'tab-1'));
+    expect(trailingClick.preventDefault).toHaveBeenCalledOnce();
+    expect(trailingClick.stopPropagation).toHaveBeenCalledOnce();
+    expect(options.onRequestFocus).toHaveBeenCalledOnce();
+  });
+
+  it('keeps the first pointer as the exclusive drag owner', () => {
+    const first = requiredTab('tab-1');
+    const second = requiredTab('tab-2');
+
+    act(() => {
+      requiredControls().handleTabPointerDown(
+        createPointerEvent(first.element, { clientX: 10, pointerId: 1 }).event,
+        'tab-1'
+      );
+      requiredControls().handleTabPointerDown(
+        createPointerEvent(second.element, {
+          clientX: 110,
+          isPrimary: true,
+          pointerId: 2,
+        }).event,
+        'tab-2'
+      );
+      requiredControls().handleTabPointerMove(
+        createPointerEvent(second.element, { clientX: 260, pointerId: 2 }).event
+      );
+    });
+
+    expect(first.setPointerCapture).toHaveBeenCalledOnce();
+    expect(second.setPointerCapture).not.toHaveBeenCalled();
+    expect(options.onRequestReorder).not.toHaveBeenCalled();
+
+    act(() =>
+      requiredControls().handleTabPointerMove(
+        createPointerEvent(first.element, { clientX: 260, pointerId: 1 }).event
+      )
+    );
+    expect(options.onRequestReorder).toHaveBeenCalledOnce();
+  });
+
+  it('cancels on lost pointer capture and ignores later events from that pointer', () => {
+    const source = requiredTab('tab-1');
+    beginActiveDrag(source, 1);
+    vi.mocked(options.onRequestReorder).mockClear();
+
+    act(() =>
+      requiredControls().handleTabLostPointerCapture(
+        createPointerEvent(source.element, { clientX: 260, pointerId: 1 }).event
+      )
+    );
+    expect(requiredControls().draggingTabId).toBeNull();
+    expect(source.releasePointerCapture).not.toHaveBeenCalled();
+
+    act(() => {
+      requiredControls().handleTabPointerMove(
+        createPointerEvent(source.element, { clientX: 120, pointerId: 1 }).event
+      );
+      requiredControls().handleTabPointerUp(
+        createPointerEvent(source.element, { clientX: 120, pointerId: 1 }).event,
+        'tab-1'
+      );
+    });
+    expect(options.onRequestReorder).not.toHaveBeenCalled();
+    expect(options.onRequestFocus).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      label: 'session scope changes',
+      patch: { scopeKey: 'team-a/session-b' },
+    },
+    {
+      label: 'the controller becomes busy',
+      patch: { disabled: true },
+    },
+    {
+      label: 'rename mode starts',
+      patch: { editingTabId: 'tab-2' },
+    },
+    {
+      label: 'the source tab is removed',
+      patch: { orderedTabIds: ['tab-2', 'tab-3'] },
+    },
+  ])('cancels the owned pointer when $label', async ({ patch }) => {
+    const source = requiredTab('tab-1');
+    beginActiveDrag(source, 1);
+    vi.mocked(options.onRequestReorder).mockClear();
+
+    await render(patch);
+
+    expect(source.releasePointerCapture).toHaveBeenCalledWith(1);
+    expect(requiredControls().draggingTabId).toBeNull();
+    act(() =>
+      requiredControls().handleTabPointerMove(
+        createPointerEvent(source.element, { clientX: 120, pointerId: 1 }).event
+      )
+    );
+    expect(options.onRequestReorder).not.toHaveBeenCalled();
+  });
+
+  it('releases pointer capture without committing state after unmount', async () => {
+    const source = requiredTab('tab-1');
+    beginActiveDrag(source, 1);
+
+    await act(async () => {
+      root.unmount();
+    });
+    host.remove();
+
+    expect(source.releasePointerCapture).toHaveBeenCalledWith(1);
+  });
+
+  it('protects a newer pointer session from stale click-reset timers', () => {
+    vi.useFakeTimers();
+    const first = requiredTab('tab-1');
+    const second = requiredTab('tab-3');
+
+    act(() => {
+      requiredControls().handleTabPointerDown(
+        createPointerEvent(first.element, { clientX: 10, pointerId: 1 }).event,
+        'tab-1'
+      );
+      requiredControls().handleTabPointerUp(
+        createPointerEvent(first.element, { clientX: 10, pointerId: 1 }).event,
+        'tab-1'
+      );
+      requiredControls().handleTabPointerDown(
+        createPointerEvent(second.element, { clientX: 210, pointerId: 2 }).event,
+        'tab-3'
+      );
+      vi.runOnlyPendingTimers();
+      requiredControls().handleTabPointerUp(
+        createPointerEvent(second.element, { clientX: 210, pointerId: 2 }).event,
+        'tab-3'
+      );
+    });
+    expect(options.onRequestFocus).toHaveBeenCalledTimes(2);
+
+    const trailingClick = createMouseEvent(1);
+    act(() => requiredControls().handleTabClick(trailingClick.event, 'tab-3'));
+    expect(trailingClick.preventDefault).toHaveBeenCalledOnce();
+    expect(options.onRequestFocus).toHaveBeenCalledTimes(2);
+  });
+
+  it('allows a keyboard-generated tab click while pointer click suppression is pending', () => {
+    vi.useFakeTimers();
+    const source = requiredTab('tab-1');
+    act(() => {
+      requiredControls().handleTabPointerDown(
+        createPointerEvent(source.element, { clientX: 10, pointerId: 1 }).event,
+        'tab-1'
+      );
+      requiredControls().handleTabPointerUp(
+        createPointerEvent(source.element, { clientX: 10, pointerId: 1 }).event,
+        'tab-1'
+      );
+    });
+    expect(options.onRequestFocus).toHaveBeenCalledOnce();
+
+    const keyboardClick = createMouseEvent(0);
+    act(() => requiredControls().handleTabClick(keyboardClick.event, 'tab-1'));
+
+    expect(keyboardClick.preventDefault).not.toHaveBeenCalled();
+    expect(options.onRequestFocus).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps keyboard tab navigation available while another tab is being renamed', async () => {
+    await render({ editingTabId: 'tab-2' });
+
+    const keyboardClick = createMouseEvent(0);
+    act(() => requiredControls().handleTabClick(keyboardClick.event, 'tab-1'));
+
+    expect(keyboardClick.preventDefault).not.toHaveBeenCalled();
+    expect(options.onRequestFocus).toHaveBeenCalledWith('tab-1');
+  });
+
+  it('ignores close controls and vertical gestures without capturing a drag', () => {
+    const source = requiredTab('tab-1');
+    const closeButton = document.createElement('button');
+    closeButton.dataset.terminalTabDragIgnore = 'true';
+    source.element.appendChild(closeButton);
+
+    act(() =>
+      requiredControls().handleTabPointerDown(
+        createPointerEvent(source.element, {
+          clientX: 10,
+          pointerId: 1,
+          target: closeButton,
+        }).event,
+        'tab-1'
+      )
+    );
+    expect(source.setPointerCapture).not.toHaveBeenCalled();
+
+    act(() => {
+      requiredControls().handleTabPointerDown(
+        createPointerEvent(source.element, { clientX: 10, pointerId: 2 }).event,
+        'tab-1'
+      );
+      requiredControls().handleTabPointerMove(
+        createPointerEvent(source.element, {
+          clientX: 13,
+          clientY: 30,
+          pointerId: 2,
+        }).event
+      );
+    });
+    expect(requiredControls().draggingTabId).toBeNull();
+    expect(options.onRequestReorder).not.toHaveBeenCalled();
+  });
+
+  async function render(patch: Partial<UseTerminalTabPointerReorderOptions> = {}): Promise<void> {
+    options = { ...options, ...patch };
+    await act(async () => {
+      root.render(React.createElement(Harness, options));
+      await Promise.resolve();
+    });
+  }
+
+  function registerTabs(): void {
+    const list = createTabElement(0, 280);
+    act(() => {
+      requiredControls().tabListElementRef.current = list.element;
+      tabElements.forEach(({ element }, tabId) => {
+        requiredControls().registerTabElement(tabId, element);
+      });
+    });
+  }
+
+  function beginActiveDrag(source: TestTabElement, pointerId: number): void {
+    act(() => {
+      requiredControls().handleTabPointerDown(
+        createPointerEvent(source.element, { clientX: 10, pointerId }).event,
+        'tab-1'
+      );
+      requiredControls().handleTabPointerMove(
+        createPointerEvent(source.element, { clientX: 260, pointerId }).event
+      );
+    });
+    expect(requiredControls().draggingTabId).toBe('tab-1');
+  }
+
+  function requiredControls(): UseTerminalTabPointerReorderResult {
+    if (!controls) {
+      throw new Error('Tab reorder controls are not mounted');
+    }
+    return controls;
+  }
+
+  function requiredTab(tabId: string): TestTabElement {
+    const tab = tabElements.get(tabId);
+    if (!tab) {
+      throw new Error(`Unknown test tab: ${tabId}`);
+    }
+    return tab;
+  }
+});
+
+function createOptions(): UseTerminalTabPointerReorderOptions {
+  return {
+    activeTabId: 'tab-2',
+    canFocusTab: true,
+    disabled: false,
+    editingTabId: null,
+    orderedTabIds: ORDERED_TAB_IDS,
+    scopeKey: 'team-a/session-a',
+    onRequestFocus: vi.fn(),
+    onRequestReorder: vi.fn(),
+  };
+}
+
+interface TestTabElement {
+  element: HTMLDivElement;
+  releasePointerCapture: ReturnType<typeof vi.fn>;
+  setPointerCapture: ReturnType<typeof vi.fn>;
+}
+
+function createTabElement(left: number, width = 80): TestTabElement {
+  const element = document.createElement('div');
+  const setPointerCapture = vi.fn();
+  const releasePointerCapture = vi.fn();
+  Object.defineProperties(element, {
+    getBoundingClientRect: {
+      configurable: true,
+      value: vi.fn(() => createRect(left, width)),
+    },
+    releasePointerCapture: {
+      configurable: true,
+      value: releasePointerCapture,
+    },
+    setPointerCapture: {
+      configurable: true,
+      value: setPointerCapture,
+    },
+  });
+  return { element, releasePointerCapture, setPointerCapture };
+}
+
+function createPointerEvent(
+  currentTarget: HTMLDivElement,
+  {
+    clientX,
+    clientY = 10,
+    isPrimary = true,
+    pointerId,
+    target = currentTarget,
+  }: Readonly<{
+    clientX: number;
+    clientY?: number;
+    isPrimary?: boolean;
+    pointerId: number;
+    target?: EventTarget;
+  }>
+): {
+  event: ReactPointerEvent<HTMLDivElement>;
+  preventDefault: ReturnType<typeof vi.fn>;
+} {
+  const preventDefault = vi.fn();
+  return {
+    event: {
+      button: 0,
+      clientX,
+      clientY,
+      currentTarget,
+      isPrimary,
+      pointerId,
+      preventDefault,
+      target,
+    } as unknown as ReactPointerEvent<HTMLDivElement>,
+    preventDefault,
+  };
+}
+
+function createMouseEvent(detail: number): {
+  event: ReactMouseEvent<HTMLButtonElement>;
+  preventDefault: ReturnType<typeof vi.fn>;
+  stopPropagation: ReturnType<typeof vi.fn>;
+} {
+  const preventDefault = vi.fn();
+  const stopPropagation = vi.fn();
+  return {
+    event: {
+      detail,
+      preventDefault,
+      stopPropagation,
+    } as unknown as ReactMouseEvent<HTMLButtonElement>,
+    preventDefault,
+    stopPropagation,
+  };
+}
+
+function createRect(left: number, width: number): DOMRect {
+  return {
+    bottom: 40,
+    height: 30,
+    left,
+    right: left + width,
+    toJSON: () => ({}),
+    top: 10,
+    width,
+    x: left,
+    y: 10,
+  };
+}
+
+function createMediaQueryList(): MediaQueryList {
+  return {
+    addEventListener: vi.fn(),
+    addListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+    matches: false,
+    media: '(prefers-reduced-motion: reduce)',
+    onchange: null,
+    removeEventListener: vi.fn(),
+    removeListener: vi.fn(),
+  };
+}


### PR DESCRIPTION
## Summary

- move pointer drag ownership, geometry, capture, cancellation, and reorder orchestration into a focused hook
- keep reorder geometry and placement decisions in pure utilities
- preserve keyboard click behavior, active tab focus, and preference persistence through narrow callbacks
- cancel drag safely on lost capture, scope/session changes, busy/edit states, source removal, and unmount
- reduce TerminalWorkspacePanel from 1792 to 1576 lines and lower its legacy cap

## Verification

- 188/188 full Terminal renderer tests on the exact merged #378 head
- native TypeScript 7 typecheck
- ESLint and Prettier
- source-size ratchet against canonical base f35604139
- independent audit: no P1-P3 findings

Desktop/runtime E2E is intentionally deferred until the final TerminalWorkspacePanel slice is below 800 lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pointer-based terminal tab reordering with drag indicators and before/after placement.
  * Preserved focus behavior after moving tabs and prevented accidental activation clicks.
  * Improved handling for cancelled, invalid, or interrupted drag interactions.

* **Bug Fixes**
  * Prevented tab reordering from starting on close controls or unintended vertical gestures.

* **Tests**
  * Added coverage for reorder intent, pointer interactions, focus, cancellation, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->