### PR TITLE
refactor(terminal-workspace): extract mux tabs

### DIFF
--- a/scripts/ci/source-file-size-legacy.json
+++ b/scripts/ci/source-file-size-legacy.json
@@ -46,7 +46,7 @@
   "src/features/team-lifecycle/contracts/team-lifecycle-read.ts": 816,
   "src/features/team-lifecycle/main/infrastructure/TeamDirectoryLifecycleAdapter.ts": 1606,
   "src/features/team-runtime-control/core/application/planning/createCompositeRuntimePlan.ts": 1195,
-  "src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx": 1576,
+  "src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx": 1028,
   "src/features/token-usage/core/domain/snapshotProjection.ts": 937,
   "src/features/token-usage/renderer/adapters/tokenUsageViewModel.ts": 1481,
   "src/features/token-usage/renderer/ui/TokenUsageDashboard.tsx": 2170,

--- a/src/features/terminal-workspace/renderer/hooks/useTerminalMuxTabsController.ts
+++ b/src/features/terminal-workspace/renderer/hooks/useTerminalMuxTabsController.ts
@@ -19,6 +19,7 @@ import {
   createTerminalMuxTabsViewModel,
   resolveTerminalTabStripKeyboardIntent,
   type TerminalMuxTabsViewModel,
+  type TerminalTabStripFocusTarget,
 } from '../view-models/terminalMuxTabs';
 
 import { type TerminalMuxCommands, useTerminalMuxTabLifecycle } from './useTerminalMuxTabLifecycle';
@@ -56,6 +57,7 @@ export interface TerminalMuxTabsController {
   endTabPointerDrag: (event?: ReactPointerEvent<HTMLDivElement>) => void;
   error: string | null;
   getTabDragOffsetX: (tabId: string) => number;
+  handleSettingsTabKeyDown: (event: ReactKeyboardEvent<HTMLButtonElement>) => void;
   handleTabClick: (event: ReactMouseEvent<HTMLButtonElement>, tabId: string) => void;
   handleTabKeyDown: (event: ReactKeyboardEvent<HTMLButtonElement>, tabId: string) => void;
   handleTabLostPointerCapture: (event: ReactPointerEvent<HTMLDivElement>) => void;
@@ -69,6 +71,7 @@ export interface TerminalMuxTabsController {
   requestCloseTab: (tab: TerminalMuxTab) => Promise<void>;
   setEditingTitle: (title: string) => void;
   setTabColor: (tabId: string, colorId: TerminalTabColorId) => void;
+  settingsTabButtonRef: RefObject<HTMLButtonElement | null>;
   startRenameTab: (tab: TerminalMuxTab, label: string) => void;
   tabListElementRef: RefObject<HTMLDivElement | null>;
   viewModel: TerminalMuxTabsViewModel;
@@ -86,6 +89,7 @@ export function useTerminalMuxTabsController({
   const [tabPreferences, setTabPreferences] = useState<TerminalTabPreferences>(() =>
     readStoredTerminalTabPreferences(teamName)
   );
+  const settingsTabButtonRef = useRef<HTMLButtonElement | null>(null);
   const tabButtonElementsRef = useRef<Map<string, HTMLButtonElement>>(new Map());
   const viewModel = useMemo(
     () =>
@@ -195,25 +199,56 @@ export function useTerminalMuxTabsController({
     []
   );
 
-  const handleTabKeyDown = useCallback(
-    (event: ReactKeyboardEvent<HTMLButtonElement>, tabId: string): void => {
+  const handleTabStripKeyDown = useCallback(
+    (
+      event: ReactKeyboardEvent<HTMLButtonElement>,
+      currentTarget: TerminalTabStripFocusTarget
+    ): void => {
       if (busy || editingTabId !== null || !viewModel.canFocusTab) {
         return;
       }
       const intent = resolveTerminalTabStripKeyboardIntent(
         event.key,
-        tabId,
-        viewModel.orderedVisibleTabIds
+        currentTarget,
+        viewModel.orderedVisibleTabIds,
+        settingsOpen
       );
       if (!intent) {
         return;
       }
 
       event.preventDefault();
-      tabButtonElementsRef.current.get(intent.targetTabId)?.focus();
-      void focusTab(intent.targetTabId);
+      if (intent.target.kind === 'settings') {
+        settingsTabButtonRef.current?.focus();
+        onSettingsOpenChange?.(true);
+        return;
+      }
+      tabButtonElementsRef.current.get(intent.target.tabId)?.focus();
+      void focusTab(intent.target.tabId);
     },
-    [busy, editingTabId, focusTab, viewModel.canFocusTab, viewModel.orderedVisibleTabIds]
+    [
+      busy,
+      editingTabId,
+      focusTab,
+      onSettingsOpenChange,
+      settingsOpen,
+      viewModel.canFocusTab,
+      viewModel.orderedVisibleTabIds,
+    ]
+  );
+
+  const handleTabKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLButtonElement>, tabId: string): void => {
+      handleTabStripKeyDown(event, { kind: 'terminal', tabId });
+    },
+    [handleTabStripKeyDown]
+  );
+
+  const handleSettingsTabKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLButtonElement>): void => {
+      handleTabStripKeyDown(event, { kind: 'settings' });
+    },
+    [handleTabStripKeyDown]
   );
 
   const setTabColor = useCallback(
@@ -244,6 +279,7 @@ export function useTerminalMuxTabsController({
     endTabPointerDrag: pointerReorder.endTabPointerDrag,
     error: lifecycle.error,
     getTabDragOffsetX: pointerReorder.getTabDragOffsetX,
+    handleSettingsTabKeyDown,
     handleTabClick: pointerReorder.handleTabClick,
     handleTabKeyDown,
     handleTabLostPointerCapture: pointerReorder.handleTabLostPointerCapture,
@@ -257,6 +293,7 @@ export function useTerminalMuxTabsController({
     requestCloseTab: lifecycle.requestCloseTab,
     setEditingTitle: lifecycle.setEditingTitle,
     setTabColor,
+    settingsTabButtonRef,
     startRenameTab: lifecycle.startRenameTab,
     tabListElementRef: pointerReorder.tabListElementRef,
     viewModel,

--- a/src/features/terminal-workspace/renderer/hooks/useTerminalMuxTabsController.ts
+++ b/src/features/terminal-workspace/renderer/hooks/useTerminalMuxTabsController.ts
@@ -1,0 +1,264 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import {
+  persistTerminalTabPreferences,
+  readStoredTerminalTabPreferences,
+} from '../adapters/terminalTabPreferencesStorage';
+import {
+  areStringArraysEqual,
+  areTerminalTabPreferencesEqual,
+  normalizeTerminalTabPreferences,
+  reorderTerminalTabsById,
+  type TerminalMuxTab,
+  type TerminalTabColorId,
+  type TerminalTabDropIndicator,
+  type TerminalTabPreferences,
+  type TerminalWorkspaceSnapshot,
+} from '../model/terminalTabPreferences';
+import {
+  createTerminalMuxTabsViewModel,
+  resolveTerminalTabStripKeyboardIntent,
+  type TerminalMuxTabsViewModel,
+} from '../view-models/terminalMuxTabs';
+
+import { type TerminalMuxCommands, useTerminalMuxTabLifecycle } from './useTerminalMuxTabLifecycle';
+import { useTerminalTabPointerReorder } from './useTerminalTabPointerReorder';
+
+import type {
+  KeyboardEvent as ReactKeyboardEvent,
+  MouseEvent as ReactMouseEvent,
+  PointerEvent as ReactPointerEvent,
+  RefObject,
+} from 'react';
+
+export interface UseTerminalMuxTabsControllerOptions {
+  commands: TerminalMuxCommands;
+  placement: 'console' | 'sheet-header';
+  settingsOpen: boolean;
+  snapshot: TerminalWorkspaceSnapshot;
+  teamName: string;
+  onSettingsOpenChange?: (open: boolean) => void;
+  onTabContentPendingChange?: (pending: boolean) => void;
+}
+
+export interface TerminalMuxTabsController {
+  busy: boolean;
+  cancelRenameTab: () => void;
+  closeCandidate: TerminalMuxTab | null;
+  commitRenameTab: () => Promise<void>;
+  confirmCloseCandidate: () => Promise<void>;
+  createTab: () => Promise<void>;
+  dismissCloseCandidate: () => void;
+  draggingTabId: string | null;
+  dropIndicator: TerminalTabDropIndicator | null;
+  editingTabId: string | null;
+  editingTitle: string;
+  endTabPointerDrag: (event?: ReactPointerEvent<HTMLDivElement>) => void;
+  error: string | null;
+  getTabDragOffsetX: (tabId: string) => number;
+  handleTabClick: (event: ReactMouseEvent<HTMLButtonElement>, tabId: string) => void;
+  handleTabKeyDown: (event: ReactKeyboardEvent<HTMLButtonElement>, tabId: string) => void;
+  handleTabLostPointerCapture: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  handleTabPointerDown: (event: ReactPointerEvent<HTMLDivElement>, tabId: string) => void;
+  handleTabPointerMove: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  handleTabPointerUp: (event: ReactPointerEvent<HTMLDivElement>, tabId: string) => void;
+  pendingAction: string | null;
+  registerTabButtonElement: (tabId: string, element: HTMLButtonElement | null) => void;
+  registerTabElement: (tabId: string, element: HTMLDivElement | null) => void;
+  renameInputRef: RefObject<HTMLInputElement | null>;
+  requestCloseTab: (tab: TerminalMuxTab) => Promise<void>;
+  setEditingTitle: (title: string) => void;
+  setTabColor: (tabId: string, colorId: TerminalTabColorId) => void;
+  startRenameTab: (tab: TerminalMuxTab, label: string) => void;
+  tabListElementRef: RefObject<HTMLDivElement | null>;
+  viewModel: TerminalMuxTabsViewModel;
+}
+
+export function useTerminalMuxTabsController({
+  commands,
+  placement,
+  settingsOpen,
+  snapshot,
+  teamName,
+  onSettingsOpenChange,
+  onTabContentPendingChange,
+}: UseTerminalMuxTabsControllerOptions): TerminalMuxTabsController {
+  const [tabPreferences, setTabPreferences] = useState<TerminalTabPreferences>(() =>
+    readStoredTerminalTabPreferences(teamName)
+  );
+  const tabButtonElementsRef = useRef<Map<string, HTMLButtonElement>>(new Map());
+  const viewModel = useMemo(
+    () =>
+      createTerminalMuxTabsViewModel({
+        placement,
+        preferences: tabPreferences,
+        settingsOpen,
+        snapshot,
+      }),
+    [placement, settingsOpen, snapshot, tabPreferences]
+  );
+  const lifecycle = useTerminalMuxTabLifecycle({
+    activeSessionId: viewModel.activeSessionId,
+    activeTabId: viewModel.activeTabId,
+    activeVisibleTabId: viewModel.activeVisibleTabId,
+    canCloseVisibleTabs: viewModel.canCloseVisibleTabs,
+    canCreateTab: viewModel.canCreateTab,
+    canFocusTab: viewModel.canFocusTab,
+    canRenameTab: viewModel.canRenameTab,
+    commands,
+    orderedVisibleTabs: viewModel.orderedVisibleTabs,
+    prewarmedTab: viewModel.prewarmedTab,
+    snapshot,
+    tabsCount: viewModel.tabsCount,
+    visibleTabs: viewModel.visibleTabs,
+    onSettingsOpenChange,
+    onTabContentPendingChange,
+  });
+  const { busy, editingTabId, focusTab } = lifecycle;
+
+  const updateTabPreferences = useCallback(
+    (updater: (current: TerminalTabPreferences) => TerminalTabPreferences): void => {
+      setTabPreferences((current) => {
+        const next = updater(current);
+        if (areTerminalTabPreferencesEqual(current, next)) {
+          return current;
+        }
+        persistTerminalTabPreferences(teamName, next);
+        return next;
+      });
+    },
+    [teamName]
+  );
+
+  const reorderTabs = useCallback(
+    ({
+      placementMode,
+      sourceTabId,
+      targetTabId,
+    }: Readonly<{
+      placementMode: 'before' | 'after';
+      sourceTabId: string;
+      targetTabId: string;
+    }>): void => {
+      updateTabPreferences((current) => {
+        const nextOrder = reorderTerminalTabsById(
+          current.order,
+          viewModel.visibleTabs,
+          sourceTabId,
+          targetTabId,
+          placementMode
+        );
+        if (areStringArraysEqual(current.order, nextOrder)) {
+          return current;
+        }
+        return {
+          ...current,
+          order: nextOrder,
+        };
+      });
+    },
+    [updateTabPreferences, viewModel.visibleTabs]
+  );
+
+  const pointerReorder = useTerminalTabPointerReorder({
+    activeTabId: viewModel.activeTabId,
+    canFocusTab: viewModel.canFocusTab,
+    disabled: busy,
+    editingTabId,
+    orderedTabIds: viewModel.orderedVisibleTabIds,
+    scopeKey: `${teamName}\u001f${viewModel.activeSessionId ?? ''}`,
+    onRequestFocus: focusTab,
+    onRequestReorder: reorderTabs,
+  });
+
+  useEffect(() => {
+    setTabPreferences(readStoredTerminalTabPreferences(teamName));
+  }, [teamName]);
+
+  useEffect(() => {
+    if (viewModel.visibleTabs.length === 0) {
+      return;
+    }
+    updateTabPreferences((current) =>
+      normalizeTerminalTabPreferences(current, viewModel.visibleTabs)
+    );
+  }, [updateTabPreferences, viewModel.visibleTabIdsKey, viewModel.visibleTabs]);
+
+  const registerTabButtonElement = useCallback(
+    (tabId: string, element: HTMLButtonElement | null): void => {
+      if (element) {
+        tabButtonElementsRef.current.set(tabId, element);
+        return;
+      }
+      tabButtonElementsRef.current.delete(tabId);
+    },
+    []
+  );
+
+  const handleTabKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLButtonElement>, tabId: string): void => {
+      if (busy || editingTabId !== null || !viewModel.canFocusTab) {
+        return;
+      }
+      const intent = resolveTerminalTabStripKeyboardIntent(
+        event.key,
+        tabId,
+        viewModel.orderedVisibleTabIds
+      );
+      if (!intent) {
+        return;
+      }
+
+      event.preventDefault();
+      tabButtonElementsRef.current.get(intent.targetTabId)?.focus();
+      void focusTab(intent.targetTabId);
+    },
+    [busy, editingTabId, focusTab, viewModel.canFocusTab, viewModel.orderedVisibleTabIds]
+  );
+
+  const setTabColor = useCallback(
+    (tabId: string, colorId: TerminalTabColorId): void => {
+      updateTabPreferences((current) => ({
+        ...current,
+        colors: {
+          ...current.colors,
+          [tabId]: colorId,
+        },
+      }));
+    },
+    [updateTabPreferences]
+  );
+
+  return {
+    busy: lifecycle.busy,
+    cancelRenameTab: lifecycle.cancelRenameTab,
+    closeCandidate: lifecycle.closeCandidate,
+    commitRenameTab: lifecycle.commitRenameTab,
+    confirmCloseCandidate: lifecycle.confirmCloseCandidate,
+    createTab: lifecycle.createTab,
+    dismissCloseCandidate: lifecycle.dismissCloseCandidate,
+    draggingTabId: pointerReorder.draggingTabId,
+    dropIndicator: pointerReorder.dropIndicator,
+    editingTabId: lifecycle.editingTabId,
+    editingTitle: lifecycle.editingTitle,
+    endTabPointerDrag: pointerReorder.endTabPointerDrag,
+    error: lifecycle.error,
+    getTabDragOffsetX: pointerReorder.getTabDragOffsetX,
+    handleTabClick: pointerReorder.handleTabClick,
+    handleTabKeyDown,
+    handleTabLostPointerCapture: pointerReorder.handleTabLostPointerCapture,
+    handleTabPointerDown: pointerReorder.handleTabPointerDown,
+    handleTabPointerMove: pointerReorder.handleTabPointerMove,
+    handleTabPointerUp: pointerReorder.handleTabPointerUp,
+    pendingAction: lifecycle.pendingAction,
+    registerTabButtonElement,
+    registerTabElement: pointerReorder.registerTabElement,
+    renameInputRef: lifecycle.renameInputRef,
+    requestCloseTab: lifecycle.requestCloseTab,
+    setEditingTitle: lifecycle.setEditingTitle,
+    setTabColor,
+    startRenameTab: lifecycle.startRenameTab,
+    tabListElementRef: pointerReorder.tabListElementRef,
+    viewModel,
+  };
+}

--- a/src/features/terminal-workspace/renderer/ui/TerminalButtonTooltip.tsx
+++ b/src/features/terminal-workspace/renderer/ui/TerminalButtonTooltip.tsx
@@ -1,0 +1,16 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from '@renderer/components/ui/tooltip';
+
+export const TerminalButtonTooltip = ({
+  children,
+  label,
+  side = 'top',
+}: Readonly<{
+  children: React.ReactElement;
+  label: string;
+  side?: 'top' | 'right' | 'bottom' | 'left';
+}>): React.JSX.Element => (
+  <Tooltip>
+    <TooltipTrigger asChild>{children}</TooltipTrigger>
+    <TooltipContent side={side}>{label}</TooltipContent>
+  </Tooltip>
+);

--- a/src/features/terminal-workspace/renderer/ui/TerminalMuxTabs.tsx
+++ b/src/features/terminal-workspace/renderer/ui/TerminalMuxTabs.tsx
@@ -1,0 +1,69 @@
+import { useAppTranslation } from '@features/localization/renderer';
+
+import { type TerminalMuxCommands } from '../hooks/useTerminalMuxTabLifecycle';
+import { useTerminalMuxTabsController } from '../hooks/useTerminalMuxTabsController';
+import {
+  getTerminalTabColorLabelKey,
+  type TerminalWorkspaceSnapshot,
+} from '../model/terminalTabPreferences';
+
+import { TerminalMuxTabsView } from './TerminalMuxTabsView';
+
+export interface TerminalMuxTabsProps {
+  commands: TerminalMuxCommands;
+  settingsOpen?: boolean;
+  snapshot: TerminalWorkspaceSnapshot;
+  teamName: string;
+  onSettingsOpenChange?: (open: boolean) => void;
+  onTabContentPendingChange?: (pending: boolean) => void;
+  placement?: 'console' | 'sheet-header';
+}
+
+export const TerminalMuxTabs = ({
+  commands,
+  settingsOpen = false,
+  snapshot,
+  teamName,
+  onSettingsOpenChange,
+  onTabContentPendingChange,
+  placement = 'console',
+}: TerminalMuxTabsProps): React.JSX.Element => {
+  const { t } = useAppTranslation('team');
+  const controller = useTerminalMuxTabsController({
+    commands,
+    placement,
+    settingsOpen,
+    snapshot,
+    teamName,
+    onSettingsOpenChange,
+    onTabContentPendingChange,
+  });
+
+  return (
+    <TerminalMuxTabsView
+      controller={controller}
+      copy={{
+        cancel: t('terminalWorkspace.cancel'),
+        chooseColor: t('terminalWorkspace.chooseColor'),
+        closeSettings: t('terminalWorkspace.closeTerminalSettings'),
+        closeSettingsTab: t('terminalWorkspace.closeTerminalSettingsTab'),
+        closeTab: t('terminalWorkspace.closeTab'),
+        closeTabDialogDescription: t('terminalWorkspace.closeTerminalTabDialogDescription'),
+        closeTabDialogTitle: t('terminalWorkspace.closeTerminalTabDialogTitle'),
+        createTab: t('terminalWorkspace.createTerminalTab'),
+        editTabTitle: t('terminalWorkspace.editTerminalTabTitle'),
+        noTabs: t('terminalWorkspace.noTerminalTabs'),
+        renameTab: t('terminalWorkspace.renameTab'),
+        settingsTab: t('terminalWorkspace.settingsTab'),
+        tabColor: t('terminalWorkspace.tabColor'),
+        tabs: t('terminalWorkspace.terminalTabs'),
+        tabsUnavailable: t('terminalWorkspace.terminalTabsUnavailable'),
+        closeTabLabel: (tabLabel) => t('terminalWorkspace.closeTerminalTab', { tab: tabLabel }),
+        colorLabel: (colorId) => t(getTerminalTabColorLabelKey(colorId)),
+        unavailableCloseTabLabel: () => t('terminalWorkspace.createAnotherTabBeforeClosing'),
+      }}
+      settingsOpen={settingsOpen}
+      onSettingsOpenChange={onSettingsOpenChange}
+    />
+  );
+};

--- a/src/features/terminal-workspace/renderer/ui/TerminalMuxTabsView.tsx
+++ b/src/features/terminal-workspace/renderer/ui/TerminalMuxTabsView.tsx
@@ -1,0 +1,409 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@renderer/components/ui/alert-dialog';
+import { Button } from '@renderer/components/ui/button';
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuLabel,
+  ContextMenuSeparator,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuTrigger,
+} from '@renderer/components/ui/context-menu';
+import { cn } from '@renderer/lib/utils';
+import { Check, Loader2, Palette, Pencil, Plus, X } from 'lucide-react';
+
+import {
+  TERMINAL_TAB_COLOR_OPTIONS,
+  type TerminalTabColorId,
+} from '../model/terminalTabPreferences';
+
+import { TerminalButtonTooltip } from './TerminalButtonTooltip';
+
+import type { TerminalMuxTabsController } from '../hooks/useTerminalMuxTabsController';
+
+export interface TerminalMuxTabsCopy {
+  cancel: string;
+  chooseColor: string;
+  closeSettings: string;
+  closeSettingsTab: string;
+  closeTab: string;
+  closeTabDialogDescription: string;
+  closeTabDialogTitle: string;
+  createTab: string;
+  editTabTitle: string;
+  noTabs: string;
+  renameTab: string;
+  settingsTab: string;
+  tabColor: string;
+  tabs: string;
+  tabsUnavailable: string;
+  closeTabLabel: (tabLabel: string) => string;
+  colorLabel: (colorId: TerminalTabColorId) => string;
+  unavailableCloseTabLabel: () => string;
+}
+
+export interface TerminalMuxTabsViewProps {
+  controller: TerminalMuxTabsController;
+  copy: TerminalMuxTabsCopy;
+  settingsOpen: boolean;
+  onSettingsOpenChange?: (open: boolean) => void;
+}
+
+export const TerminalMuxTabsView = ({
+  controller,
+  copy,
+  settingsOpen,
+  onSettingsOpenChange,
+}: TerminalMuxTabsViewProps): React.JSX.Element => {
+  const {
+    busy,
+    cancelRenameTab,
+    closeCandidate,
+    commitRenameTab,
+    confirmCloseCandidate,
+    createTab,
+    dismissCloseCandidate,
+    draggingTabId,
+    dropIndicator,
+    editingTabId,
+    editingTitle,
+    endTabPointerDrag,
+    error,
+    getTabDragOffsetX,
+    handleTabClick,
+    handleTabKeyDown,
+    handleTabLostPointerCapture,
+    handleTabPointerDown,
+    handleTabPointerMove,
+    handleTabPointerUp,
+    pendingAction,
+    registerTabButtonElement,
+    registerTabElement,
+    renameInputRef,
+    requestCloseTab,
+    setEditingTitle,
+    setTabColor,
+    startRenameTab,
+    tabListElementRef,
+    viewModel,
+  } = controller;
+  const {
+    canCloseVisibleTabs,
+    canCreateTab,
+    canRenameTab,
+    headerPlacement,
+    tabItems,
+    visibleTabs,
+  } = viewModel;
+
+  return (
+    <>
+      <div
+        className={cn(
+          'min-w-0 shrink-0',
+          headerPlacement
+            ? 'bg-transparent px-0 pt-0'
+            : 'border-b border-white/10 bg-[#0b0f16] px-2 pt-1'
+        )}
+        data-testid="agent-team-terminal-mux-tabs"
+        onPointerDown={(event) => {
+          const target = event.target;
+          if (target instanceof HTMLElement && target.closest('button,input')) {
+            event.stopPropagation();
+          }
+        }}
+      >
+        <div
+          className={cn(
+            'flex min-w-0 gap-1',
+            headerPlacement ? 'min-h-7 items-end' : 'min-h-8 items-end'
+          )}
+        >
+          <div
+            className="flex min-w-0 flex-1 items-end gap-1 overflow-x-auto"
+            ref={tabListElementRef}
+            role="tablist"
+            aria-label={copy.tabs}
+            tabIndex={-1}
+          >
+            {visibleTabs.length === 0 ? (
+              headerPlacement ? (
+                <span className="sr-only">{copy.noTabs}</span>
+              ) : (
+                <span className="px-2 py-1.5 text-xs text-slate-500">{copy.noTabs}</span>
+              )
+            ) : (
+              tabItems.map(({ active, color, explicitColorId, id, label, tab }) => {
+                const pendingClose = pendingAction === `close-tab:${id}`;
+                const closeLabel = canCloseVisibleTabs
+                  ? copy.closeTabLabel(label)
+                  : copy.unavailableCloseTabLabel();
+                const editing = editingTabId === id;
+                const tabColorStyle =
+                  active || explicitColorId
+                    ? ({
+                        backgroundColor: color.background,
+                        '--tp-tab-border': color.border,
+                        '--tp-tab-border-bottom': active ? 'transparent' : color.border,
+                      } as React.CSSProperties)
+                    : undefined;
+                const dragOffsetX = getTabDragOffsetX(id);
+                const tabStyle =
+                  dragOffsetX !== 0
+                    ? ({
+                        ...(tabColorStyle ?? {}),
+                        transform: `translateX(${dragOffsetX}px)`,
+                      } as React.CSSProperties)
+                    : tabColorStyle;
+
+                return (
+                  <ContextMenu key={id}>
+                    <ContextMenuTrigger asChild>
+                      <div
+                        ref={(element) => registerTabElement(id, element)}
+                        className={cn(
+                          'group relative inline-grid h-7 shrink-0 touch-none select-none grid-cols-[minmax(0,1fr)] overflow-hidden border text-xs transition-[background-color,border-color,box-shadow,opacity] duration-150 ease-out will-change-transform',
+                          headerPlacement
+                            ? 'max-w-40 rounded-b-none rounded-t-md'
+                            : 'max-w-44 rounded-b-none rounded-t-md',
+                          active
+                            ? 'relative z-10 text-slate-100 shadow-[inset_0_1px_0_rgba(255,255,255,0.12)]'
+                            : 'border-white/10 bg-white/[0.035] text-slate-400 hover:bg-white/[0.075] hover:text-slate-200',
+                          (active || explicitColorId) &&
+                            'border-[var(--tp-tab-border)] border-b-[var(--tp-tab-border-bottom)]',
+                          draggingTabId === id &&
+                            'z-30 cursor-grabbing shadow-[0_10px_26px_rgba(0,0,0,0.34)]'
+                        )}
+                        data-active={active}
+                        data-dragging={draggingTabId === id}
+                        data-drop-placement={
+                          dropIndicator?.tabId === id ? dropIndicator.placementMode : undefined
+                        }
+                        data-terminal-tab-id={id}
+                        onLostPointerCapture={handleTabLostPointerCapture}
+                        onPointerCancel={endTabPointerDrag}
+                        onPointerDown={(event) => handleTabPointerDown(event, id)}
+                        onPointerMove={handleTabPointerMove}
+                        onPointerUp={(event) => handleTabPointerUp(event, id)}
+                        style={tabStyle}
+                      >
+                        {dropIndicator?.tabId === id && draggingTabId !== id ? (
+                          <span
+                            className={cn(
+                              'pointer-events-none absolute bottom-0 top-1 z-30 w-0.5 rounded-full bg-sky-300/90 shadow-[0_0_10px_rgba(125,211,252,0.75)]',
+                              dropIndicator.placementMode === 'before' ? '-left-px' : '-right-px'
+                            )}
+                            data-testid="agent-team-terminal-tab-drop-indicator"
+                          />
+                        ) : null}
+                        {editing ? (
+                          <div className="inline-flex min-w-0 items-center gap-1.5 px-1.5">
+                            <Pencil size={12} className="shrink-0 text-slate-400" />
+                            <input
+                              ref={renameInputRef}
+                              className="h-5 min-w-0 flex-1 rounded border border-white/15 bg-black/35 px-1 font-mono text-[12px] text-slate-100 outline-none ring-0 focus:border-sky-400/60"
+                              value={editingTitle}
+                              aria-label={copy.editTabTitle}
+                              data-testid="agent-team-terminal-tab-title-input"
+                              onBlur={() => void commitRenameTab()}
+                              onChange={(event) => setEditingTitle(event.target.value)}
+                              onKeyDown={(event) => {
+                                if (event.key === 'Enter') {
+                                  event.preventDefault();
+                                  void commitRenameTab();
+                                }
+                                if (event.key === 'Escape') {
+                                  event.preventDefault();
+                                  cancelRenameTab();
+                                }
+                              }}
+                            />
+                          </div>
+                        ) : (
+                          <TerminalButtonTooltip label={tab.title?.trim() || id}>
+                            <button
+                              ref={(element) => registerTabButtonElement(id, element)}
+                              type="button"
+                              className="inline-flex min-w-0 items-center gap-1.5 px-2 pr-7 text-left"
+                              aria-selected={active}
+                              data-testid="agent-team-terminal-mux-tab"
+                              data-terminal-tab-button-id={id}
+                              disabled={busy}
+                              role="tab"
+                              tabIndex={active ? 0 : -1}
+                              onClick={(event) => handleTabClick(event, id)}
+                              onDoubleClick={(event) => {
+                                event.preventDefault();
+                                startRenameTab(tab, label);
+                              }}
+                              onKeyDown={(event) => handleTabKeyDown(event, id)}
+                            >
+                              <span className="min-w-0 truncate">{label}</span>
+                            </button>
+                          </TerminalButtonTooltip>
+                        )}
+                        {!editing ? (
+                          <TerminalButtonTooltip label={closeLabel}>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              className={cn(
+                                'pointer-events-none absolute bottom-0 right-0 top-0 z-20 h-7 w-7 rounded-none border-0 bg-transparent p-0 text-slate-500 opacity-0 transition-[background-color,color,opacity] duration-150 hover:bg-red-500/10 hover:text-red-300 disabled:cursor-not-allowed disabled:opacity-0 group-focus-within:pointer-events-auto group-focus-within:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100',
+                                pendingClose && 'pointer-events-auto opacity-100'
+                              )}
+                              aria-label={copy.closeTabLabel(label)}
+                              data-terminal-tab-drag-ignore="true"
+                              data-testid="agent-team-terminal-close-mux-tab"
+                              disabled={!canCloseVisibleTabs || (busy && !pendingClose)}
+                              onPointerDown={(event) => event.stopPropagation()}
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                void requestCloseTab(tab);
+                              }}
+                            >
+                              {pendingClose ? (
+                                <Loader2 size={11} className="animate-spin" />
+                              ) : (
+                                <X size={12} />
+                              )}
+                            </Button>
+                          </TerminalButtonTooltip>
+                        ) : null}
+                      </div>
+                    </ContextMenuTrigger>
+                    <ContextMenuContent alignOffset={-4} className="w-48">
+                      <ContextMenuItem
+                        disabled={!canRenameTab || busy}
+                        onSelect={() => startRenameTab(tab, label)}
+                      >
+                        <Pencil size={13} />
+                        {copy.renameTab}
+                      </ContextMenuItem>
+                      <ContextMenuSeparator />
+                      <ContextMenuSub>
+                        <ContextMenuSubTrigger>
+                          <Palette size={13} />
+                          {copy.tabColor}
+                        </ContextMenuSubTrigger>
+                        <ContextMenuSubContent className="w-44">
+                          <ContextMenuLabel>{copy.chooseColor}</ContextMenuLabel>
+                          {TERMINAL_TAB_COLOR_OPTIONS.map((option) => (
+                            <ContextMenuItem
+                              key={option.id}
+                              onSelect={() => setTabColor(id, option.id)}
+                            >
+                              <span
+                                className="size-2.5 shrink-0 rounded-full"
+                                style={{ backgroundColor: option.accent }}
+                              />
+                              <span className="min-w-0 flex-1">{copy.colorLabel(option.id)}</span>
+                              {color.id === option.id ? <Check size={13} /> : null}
+                            </ContextMenuItem>
+                          ))}
+                        </ContextMenuSubContent>
+                      </ContextMenuSub>
+                    </ContextMenuContent>
+                  </ContextMenu>
+                );
+              })
+            )}
+            {settingsOpen ? (
+              <div
+                className={cn(
+                  'group relative z-10 inline-grid h-7 max-w-44 shrink-0 select-none grid-cols-[minmax(0,1fr)] overflow-hidden rounded-b-none rounded-t-md border border-sky-400/55 border-b-transparent bg-sky-400/15 text-xs text-slate-100 shadow-[inset_0_1px_0_rgba(255,255,255,0.12)]',
+                  headerPlacement ? 'max-w-40' : 'max-w-44'
+                )}
+                data-testid="agent-team-terminal-settings-tab"
+              >
+                <button
+                  type="button"
+                  className="inline-flex min-w-0 items-center gap-1.5 px-2 pr-7 text-left"
+                  aria-selected="true"
+                  role="tab"
+                  tabIndex={0}
+                  onClick={() => onSettingsOpenChange?.(true)}
+                >
+                  <Palette size={13} className="shrink-0 text-sky-200" />
+                  <span className="min-w-0 truncate">{copy.settingsTab}</span>
+                </button>
+                <TerminalButtonTooltip label={copy.closeSettings}>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="absolute bottom-0 right-0 top-0 h-7 w-7 rounded-none border-0 bg-transparent p-0 text-slate-400 transition-colors hover:bg-red-500/10 hover:text-red-300"
+                    aria-label={copy.closeSettingsTab}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onSettingsOpenChange?.(false);
+                    }}
+                  >
+                    <X size={12} />
+                  </Button>
+                </TerminalButtonTooltip>
+              </div>
+            ) : null}
+            <TerminalButtonTooltip label={canCreateTab ? copy.createTab : copy.tabsUnavailable}>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="size-7 shrink-0 rounded-b-none rounded-t-md border border-white/10 bg-white/[0.04] p-0 text-slate-400 transition-colors hover:bg-white/[0.08] hover:text-slate-100 disabled:cursor-not-allowed disabled:opacity-45"
+                aria-label={copy.createTab}
+                data-testid="agent-team-terminal-new-mux-tab"
+                disabled={busy || !canCreateTab}
+                onClick={() => void createTab()}
+              >
+                {pendingAction === 'new-tab' || pendingAction === 'activate-prewarmed-tab' ? (
+                  <Loader2 size={14} className="animate-spin" />
+                ) : (
+                  <Plus size={15} />
+                )}
+              </Button>
+            </TerminalButtonTooltip>
+          </div>
+        </div>
+
+        {error ? (
+          <div className="px-2 py-1 text-xs text-red-300" role="alert">
+            {error}
+          </div>
+        ) : null}
+      </div>
+
+      <AlertDialog
+        open={closeCandidate !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            dismissCloseCandidate();
+          }
+        }}
+      >
+        <AlertDialogContent className="max-w-md bg-[#10141d]">
+          <AlertDialogHeader>
+            <AlertDialogTitle>{copy.closeTabDialogTitle}</AlertDialogTitle>
+            <AlertDialogDescription>{copy.closeTabDialogDescription}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{copy.cancel}</AlertDialogCancel>
+            <AlertDialogAction onClick={() => void confirmCloseCandidate()}>
+              {copy.closeTab}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+};

--- a/src/features/terminal-workspace/renderer/ui/TerminalMuxTabsView.tsx
+++ b/src/features/terminal-workspace/renderer/ui/TerminalMuxTabsView.tsx
@@ -81,6 +81,7 @@ export const TerminalMuxTabsView = ({
     endTabPointerDrag,
     error,
     getTabDragOffsetX,
+    handleSettingsTabKeyDown,
     handleTabClick,
     handleTabKeyDown,
     handleTabLostPointerCapture,
@@ -94,6 +95,7 @@ export const TerminalMuxTabsView = ({
     requestCloseTab,
     setEditingTitle,
     setTabColor,
+    settingsTabButtonRef,
     startRenameTab,
     tabListElementRef,
     viewModel,
@@ -328,12 +330,14 @@ export const TerminalMuxTabsView = ({
                 data-testid="agent-team-terminal-settings-tab"
               >
                 <button
+                  ref={settingsTabButtonRef}
                   type="button"
                   className="inline-flex min-w-0 items-center gap-1.5 px-2 pr-7 text-left"
                   aria-selected="true"
                   role="tab"
                   tabIndex={0}
                   onClick={() => onSettingsOpenChange?.(true)}
+                  onKeyDown={handleSettingsTabKeyDown}
                 >
                   <Palette size={13} className="shrink-0 text-sky-200" />
                   <span className="min-w-0 truncate">{copy.settingsTab}</span>

--- a/src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx
+++ b/src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx
@@ -10,29 +10,6 @@ import {
 import { createPortal } from 'react-dom';
 
 import { useAppTranslation } from '@features/localization/renderer';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@renderer/components/ui/alert-dialog';
-import { Button } from '@renderer/components/ui/button';
-import {
-  ContextMenu,
-  ContextMenuContent,
-  ContextMenuItem,
-  ContextMenuLabel,
-  ContextMenuSeparator,
-  ContextMenuSub,
-  ContextMenuSubContent,
-  ContextMenuSubTrigger,
-  ContextMenuTrigger,
-} from '@renderer/components/ui/context-menu';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@renderer/components/ui/tooltip';
 import { cn } from '@renderer/lib/utils';
 import { terminalPlatformThemeManifests } from '@terminal-platform/design-tokens';
 import { createWorkspaceWebSocketTransport } from '@terminal-platform/workspace-adapter-websocket';
@@ -42,7 +19,6 @@ import {
   type WorkspaceKernel,
 } from '@terminal-platform/workspace-core';
 import {
-  resolveTerminalTopologyControlState,
   TerminalCommandDock,
   TerminalScreen,
   TerminalWorkspace,
@@ -50,34 +26,20 @@ import {
 } from '@terminal-platform/workspace-react';
 import {
   AlertTriangle,
-  Check,
   Folder,
   GitBranch,
   Github,
   Loader2,
-  Palette,
-  Pencil,
-  Plus,
   RefreshCw,
   Square,
   Terminal,
-  X,
 } from 'lucide-react';
 
 import { readStoredTerminalCommandHistory } from '../adapters/terminalCommandHistoryStorage';
-import {
-  persistTerminalTabPreferences,
-  readStoredTerminalTabPreferences,
-} from '../adapters/terminalTabPreferencesStorage';
 import { useTerminalCommandAutocomplete } from '../hooks/useTerminalCommandAutocomplete';
 import { useTerminalCommandContextMenu } from '../hooks/useTerminalCommandContextMenu';
 import { useTerminalCommandHistoryPersistence } from '../hooks/useTerminalCommandHistoryPersistence';
 import { useTerminalCommandRuns } from '../hooks/useTerminalCommandRuns';
-import {
-  type TerminalMuxCommands,
-  useTerminalMuxTabLifecycle,
-} from '../hooks/useTerminalMuxTabLifecycle';
-import { useTerminalTabPointerReorder } from '../hooks/useTerminalTabPointerReorder';
 import {
   DEFAULT_TERMINAL_APPEARANCE_SETTINGS,
   normalizeTerminalAppearanceSettings,
@@ -93,23 +55,10 @@ import {
   formatTerminalPromptLabel,
   formatWorkingDirectory,
 } from '../model/terminalPathPresentation';
-import {
-  areStringArraysEqual,
-  areTerminalTabPreferencesEqual,
-  formatMuxTabTitle,
-  getTerminalTabColorLabelKey,
-  isPrewarmedTerminalTab,
-  normalizeTerminalTabPreferences,
-  orderTerminalTabsByPreference,
-  reorderTerminalTabsById,
-  resolveTerminalTabColor,
-  TERMINAL_TAB_COLOR_OPTIONS,
-  type TerminalTabColorId,
-  type TerminalTabPreferences,
-  type TerminalWorkspaceSnapshot,
-} from '../model/terminalTabPreferences';
 
+import { TerminalButtonTooltip } from './TerminalButtonTooltip';
 import { TerminalCommandContextMenu } from './TerminalCommandContextMenu';
+import { TerminalMuxTabs } from './TerminalMuxTabs';
 import {
   type TerminalWorkspaceSettingsActionId,
   TerminalWorkspaceSettingsView,
@@ -119,7 +68,7 @@ import type {
   TerminalWorkspaceBootstrap,
   TerminalWorkspaceBootstrapRequest,
 } from '../../contracts';
-import type { TerminalTabReorderIntent } from '../utils/terminalTabPointerReorder';
+import type { TerminalWorkspaceSnapshot } from '../model/terminalTabPreferences';
 
 export interface TerminalWorkspacePanelProps {
   teamName: string;
@@ -146,21 +95,6 @@ type TerminalScreenElementHandle = ComponentRef<typeof TerminalScreen> & {
 };
 type TerminalCommandDockElementHandle = ComponentRef<typeof TerminalCommandDock>;
 type TeamTFunction = ReturnType<typeof useAppTranslation>['t'];
-
-const TerminalButtonTooltip = ({
-  children,
-  label,
-  side = 'top',
-}: Readonly<{
-  children: React.ReactElement;
-  label: string;
-  side?: 'top' | 'right' | 'bottom' | 'left';
-}>): React.JSX.Element => (
-  <Tooltip>
-    <TooltipTrigger asChild>{children}</TooltipTrigger>
-    <TooltipContent side={side}>{label}</TooltipContent>
-  </Tooltip>
-);
 
 export const TerminalWorkspacePanel = (props: TerminalWorkspacePanelProps): React.JSX.Element => (
   <TerminalWorkspacePanelTeamScope key={props.teamName} {...props} />
@@ -828,488 +762,6 @@ const TerminalTabContentSkeleton = (): React.JSX.Element => {
         ))}
       </div>
     </div>
-  );
-};
-
-const TerminalMuxTabs = ({
-  commands,
-  settingsOpen = false,
-  snapshot,
-  teamName,
-  onSettingsOpenChange,
-  onTabContentPendingChange,
-  placement = 'console',
-}: {
-  commands: TerminalMuxCommands;
-  settingsOpen?: boolean;
-  snapshot: TerminalWorkspaceSnapshot;
-  teamName: string;
-  onSettingsOpenChange?: (open: boolean) => void;
-  onTabContentPendingChange?: (pending: boolean) => void;
-  placement?: 'console' | 'sheet-header';
-}): React.JSX.Element => {
-  const { t } = useAppTranslation('team');
-  const [tabPreferences, setTabPreferences] = useState<TerminalTabPreferences>(() =>
-    readStoredTerminalTabPreferences(teamName)
-  );
-  const topology = snapshot.attachedSession?.topology ?? null;
-  const controls = resolveTerminalTopologyControlState(snapshot);
-  const tabs = topology?.tabs ?? [];
-  const visibleTabs = tabs.filter((tab) => !isPrewarmedTerminalTab(tab));
-  const visibleTabIdsKey = visibleTabs.map((tab) => tab.tab_id).join('\u001f');
-  const orderedVisibleTabs = useMemo(
-    () => orderTerminalTabsByPreference(visibleTabs, tabPreferences.order),
-    [tabPreferences.order, visibleTabs]
-  );
-  const orderedVisibleTabIds = useMemo(
-    () => orderedVisibleTabs.map((tab) => tab.tab_id),
-    [orderedVisibleTabs]
-  );
-  const prewarmedTab = tabs.find(isPrewarmedTerminalTab) ?? null;
-  const activeSessionId = controls.activeSessionId;
-  const activeTabId =
-    controls.activeTab?.tab_id ?? topology?.focused_tab ?? tabs[0]?.tab_id ?? null;
-  const activeVisibleTabId = visibleTabs.some((tab) => tab.tab_id === activeTabId)
-    ? activeTabId
-    : (visibleTabs[0]?.tab_id ?? null);
-  const headerPlacement = placement === 'sheet-header';
-  const canCloseVisibleTabs = controls.canCloseTab && visibleTabs.length > 1;
-  const {
-    busy,
-    cancelRenameTab,
-    closeCandidate,
-    commitRenameTab,
-    confirmCloseCandidate,
-    createTab,
-    dismissCloseCandidate,
-    editingTabId,
-    editingTitle,
-    error,
-    focusTab,
-    pendingAction,
-    renameInputRef,
-    requestCloseTab,
-    setEditingTitle,
-    startRenameTab,
-  } = useTerminalMuxTabLifecycle({
-    activeSessionId,
-    activeTabId,
-    activeVisibleTabId,
-    canCloseVisibleTabs,
-    canCreateTab: controls.canCreateTab,
-    canFocusTab: controls.canFocusTab,
-    canRenameTab: controls.canRenameTab,
-    commands,
-    orderedVisibleTabs,
-    prewarmedTab,
-    snapshot,
-    tabsCount: tabs.length,
-    visibleTabs,
-    onSettingsOpenChange,
-    onTabContentPendingChange,
-  });
-
-  const updateTabPreferences = useCallback(
-    (updater: (current: TerminalTabPreferences) => TerminalTabPreferences): void => {
-      setTabPreferences((current) => {
-        const next = updater(current);
-        if (areTerminalTabPreferencesEqual(current, next)) {
-          return current;
-        }
-        persistTerminalTabPreferences(teamName, next);
-        return next;
-      });
-    },
-    [teamName]
-  );
-
-  const reorderTabs = useCallback(
-    ({ placementMode, sourceTabId, targetTabId }: TerminalTabReorderIntent): void => {
-      updateTabPreferences((current) => {
-        const nextOrder = reorderTerminalTabsById(
-          current.order,
-          visibleTabs,
-          sourceTabId,
-          targetTabId,
-          placementMode
-        );
-        if (areStringArraysEqual(current.order, nextOrder)) {
-          return current;
-        }
-        return {
-          ...current,
-          order: nextOrder,
-        };
-      });
-    },
-    [updateTabPreferences, visibleTabs]
-  );
-
-  const {
-    draggingTabId,
-    dropIndicator,
-    endTabPointerDrag,
-    getTabDragOffsetX,
-    handleTabClick,
-    handleTabLostPointerCapture,
-    handleTabPointerDown,
-    handleTabPointerMove,
-    handleTabPointerUp,
-    registerTabElement,
-    tabListElementRef,
-  } = useTerminalTabPointerReorder({
-    activeTabId,
-    canFocusTab: controls.canFocusTab,
-    disabled: busy,
-    editingTabId,
-    orderedTabIds: orderedVisibleTabIds,
-    scopeKey: `${teamName}\u001f${activeSessionId ?? ''}`,
-    onRequestFocus: focusTab,
-    onRequestReorder: reorderTabs,
-  });
-
-  useEffect(() => {
-    setTabPreferences(readStoredTerminalTabPreferences(teamName));
-  }, [teamName]);
-
-  useEffect(() => {
-    if (visibleTabs.length === 0) {
-      return;
-    }
-
-    updateTabPreferences((current) => normalizeTerminalTabPreferences(current, visibleTabs));
-  }, [updateTabPreferences, visibleTabIdsKey, visibleTabs]);
-
-  const setTabColor = (tabId: string, colorId: TerminalTabColorId): void => {
-    updateTabPreferences((current) => ({
-      ...current,
-      colors: {
-        ...current.colors,
-        [tabId]: colorId,
-      },
-    }));
-  };
-
-  return (
-    <>
-      <div
-        className={cn(
-          'min-w-0 shrink-0',
-          headerPlacement
-            ? 'bg-transparent px-0 pt-0'
-            : 'border-b border-white/10 bg-[#0b0f16] px-2 pt-1'
-        )}
-        data-testid="agent-team-terminal-mux-tabs"
-        onPointerDown={(event) => {
-          const target = event.target;
-          if (target instanceof HTMLElement && target.closest('button,input')) {
-            event.stopPropagation();
-          }
-        }}
-      >
-        <div
-          className={cn(
-            'flex min-w-0 gap-1',
-            headerPlacement ? 'min-h-7 items-end' : 'min-h-8 items-end'
-          )}
-        >
-          <div
-            className={cn(
-              'flex min-w-0 flex-1 gap-1 overflow-x-auto',
-              headerPlacement ? 'items-end' : 'items-end'
-            )}
-            ref={tabListElementRef}
-            role="tablist"
-            aria-label={t('terminalWorkspace.terminalTabs')}
-            tabIndex={-1}
-          >
-            {visibleTabs.length === 0 ? (
-              headerPlacement ? (
-                <span className="sr-only">{t('terminalWorkspace.noTerminalTabs')}</span>
-              ) : (
-                <span className="px-2 py-1.5 text-xs text-slate-500">
-                  {t('terminalWorkspace.noTerminalTabs')}
-                </span>
-              )
-            ) : (
-              orderedVisibleTabs.map((tab, index) => {
-                const label = formatMuxTabTitle(tab, index);
-                const active = !settingsOpen && tab.tab_id === activeVisibleTabId;
-                const pendingClose = pendingAction === `close-tab:${tab.tab_id}`;
-                const closeLabel = canCloseVisibleTabs
-                  ? t('terminalWorkspace.closeTerminalTab', { tab: label })
-                  : t('terminalWorkspace.createAnotherTabBeforeClosing');
-                const explicitColorId = tabPreferences.colors[tab.tab_id];
-                const color = resolveTerminalTabColor(explicitColorId);
-                const editing = editingTabId === tab.tab_id;
-                const tabColorStyle =
-                  active || explicitColorId
-                    ? ({
-                        backgroundColor: color.background,
-                        '--tp-tab-border': color.border,
-                        '--tp-tab-border-bottom': active ? 'transparent' : color.border,
-                      } as React.CSSProperties)
-                    : undefined;
-                const dragOffsetX = getTabDragOffsetX(tab.tab_id);
-                const tabStyle =
-                  dragOffsetX !== 0
-                    ? ({
-                        ...(tabColorStyle ?? {}),
-                        transform: `translateX(${dragOffsetX}px)`,
-                      } as React.CSSProperties)
-                    : tabColorStyle;
-                return (
-                  <ContextMenu key={tab.tab_id}>
-                    <ContextMenuTrigger asChild>
-                      <div
-                        ref={(element) => registerTabElement(tab.tab_id, element)}
-                        className={cn(
-                          'group relative inline-grid h-7 shrink-0 touch-none select-none grid-cols-[minmax(0,1fr)] overflow-hidden border text-xs transition-[background-color,border-color,box-shadow,opacity] duration-150 ease-out will-change-transform',
-                          headerPlacement
-                            ? 'max-w-40 rounded-b-none rounded-t-md'
-                            : 'max-w-44 rounded-b-none rounded-t-md',
-                          active
-                            ? 'relative z-10 text-slate-100 shadow-[inset_0_1px_0_rgba(255,255,255,0.12)]'
-                            : 'border-white/10 bg-white/[0.035] text-slate-400 hover:bg-white/[0.075] hover:text-slate-200',
-                          (active || explicitColorId) &&
-                            'border-[var(--tp-tab-border)] border-b-[var(--tp-tab-border-bottom)]',
-                          draggingTabId === tab.tab_id &&
-                            'z-30 cursor-grabbing shadow-[0_10px_26px_rgba(0,0,0,0.34)]'
-                        )}
-                        data-active={active}
-                        data-dragging={draggingTabId === tab.tab_id}
-                        data-drop-placement={
-                          dropIndicator?.tabId === tab.tab_id
-                            ? dropIndicator.placementMode
-                            : undefined
-                        }
-                        data-terminal-tab-id={tab.tab_id}
-                        onLostPointerCapture={handleTabLostPointerCapture}
-                        onPointerCancel={endTabPointerDrag}
-                        onPointerDown={(event) => handleTabPointerDown(event, tab.tab_id)}
-                        onPointerMove={handleTabPointerMove}
-                        onPointerUp={(event) => handleTabPointerUp(event, tab.tab_id)}
-                        style={tabStyle}
-                      >
-                        {dropIndicator?.tabId === tab.tab_id && draggingTabId !== tab.tab_id ? (
-                          <span
-                            className={cn(
-                              'pointer-events-none absolute bottom-0 top-1 z-30 w-0.5 rounded-full bg-sky-300/90 shadow-[0_0_10px_rgba(125,211,252,0.75)]',
-                              dropIndicator.placementMode === 'before' ? '-left-px' : '-right-px'
-                            )}
-                            data-testid="agent-team-terminal-tab-drop-indicator"
-                          />
-                        ) : null}
-                        {editing ? (
-                          <div className="inline-flex min-w-0 items-center gap-1.5 px-1.5">
-                            <Pencil size={12} className="shrink-0 text-slate-400" />
-                            <input
-                              ref={renameInputRef}
-                              className="h-5 min-w-0 flex-1 rounded border border-white/15 bg-black/35 px-1 font-mono text-[12px] text-slate-100 outline-none ring-0 focus:border-sky-400/60"
-                              value={editingTitle}
-                              aria-label={t('terminalWorkspace.editTerminalTabTitle')}
-                              data-testid="agent-team-terminal-tab-title-input"
-                              onBlur={() => void commitRenameTab()}
-                              onChange={(event) => setEditingTitle(event.target.value)}
-                              onKeyDown={(event) => {
-                                if (event.key === 'Enter') {
-                                  event.preventDefault();
-                                  void commitRenameTab();
-                                }
-                                if (event.key === 'Escape') {
-                                  event.preventDefault();
-                                  cancelRenameTab();
-                                }
-                              }}
-                            />
-                          </div>
-                        ) : (
-                          <TerminalButtonTooltip label={tab.title?.trim() || tab.tab_id}>
-                            <button
-                              type="button"
-                              className="inline-flex min-w-0 items-center gap-1.5 px-2 pr-7 text-left"
-                              aria-selected={active}
-                              data-testid="agent-team-terminal-mux-tab"
-                              disabled={busy}
-                              role="tab"
-                              onClick={(event) => handleTabClick(event, tab.tab_id)}
-                              onDoubleClick={(event) => {
-                                event.preventDefault();
-                                startRenameTab(tab, label);
-                              }}
-                            >
-                              <span className="min-w-0 truncate">{label}</span>
-                            </button>
-                          </TerminalButtonTooltip>
-                        )}
-                        {!editing ? (
-                          <TerminalButtonTooltip label={closeLabel}>
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="sm"
-                              className={cn(
-                                'pointer-events-none absolute bottom-0 right-0 top-0 z-20 h-7 w-7 rounded-none border-0 bg-transparent p-0 text-slate-500 opacity-0 transition-[background-color,color,opacity] duration-150 hover:bg-red-500/10 hover:text-red-300 disabled:cursor-not-allowed disabled:opacity-0 group-focus-within:pointer-events-auto group-focus-within:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100',
-                                pendingClose && 'pointer-events-auto opacity-100'
-                              )}
-                              aria-label={t('terminalWorkspace.closeTerminalTab', { tab: label })}
-                              data-terminal-tab-drag-ignore="true"
-                              data-testid="agent-team-terminal-close-mux-tab"
-                              disabled={!canCloseVisibleTabs || (busy && !pendingClose)}
-                              onPointerDown={(event) => {
-                                event.stopPropagation();
-                              }}
-                              onClick={(event) => {
-                                event.stopPropagation();
-                                void requestCloseTab(tab);
-                              }}
-                            >
-                              {pendingClose ? (
-                                <Loader2 size={11} className="animate-spin" />
-                              ) : (
-                                <X size={12} />
-                              )}
-                            </Button>
-                          </TerminalButtonTooltip>
-                        ) : null}
-                      </div>
-                    </ContextMenuTrigger>
-                    <ContextMenuContent alignOffset={-4} className="w-48">
-                      <ContextMenuItem
-                        disabled={!controls.canRenameTab || busy}
-                        onSelect={() => startRenameTab(tab, label)}
-                      >
-                        <Pencil size={13} />
-                        {t('terminalWorkspace.renameTab')}
-                      </ContextMenuItem>
-                      <ContextMenuSeparator />
-                      <ContextMenuSub>
-                        <ContextMenuSubTrigger>
-                          <Palette size={13} />
-                          {t('terminalWorkspace.tabColor')}
-                        </ContextMenuSubTrigger>
-                        <ContextMenuSubContent className="w-44">
-                          <ContextMenuLabel>{t('terminalWorkspace.chooseColor')}</ContextMenuLabel>
-                          {TERMINAL_TAB_COLOR_OPTIONS.map((option) => (
-                            <ContextMenuItem
-                              key={option.id}
-                              onSelect={() => setTabColor(tab.tab_id, option.id)}
-                            >
-                              <span
-                                className="size-2.5 shrink-0 rounded-full"
-                                style={{ backgroundColor: option.accent }}
-                              />
-                              <span className="min-w-0 flex-1">
-                                {t(getTerminalTabColorLabelKey(option.id))}
-                              </span>
-                              {color.id === option.id ? <Check size={13} /> : null}
-                            </ContextMenuItem>
-                          ))}
-                        </ContextMenuSubContent>
-                      </ContextMenuSub>
-                    </ContextMenuContent>
-                  </ContextMenu>
-                );
-              })
-            )}
-            {settingsOpen ? (
-              <div
-                className={cn(
-                  'group relative z-10 inline-grid h-7 max-w-44 shrink-0 select-none grid-cols-[minmax(0,1fr)] overflow-hidden rounded-b-none rounded-t-md border border-sky-400/55 border-b-transparent bg-sky-400/15 text-xs text-slate-100 shadow-[inset_0_1px_0_rgba(255,255,255,0.12)]',
-                  headerPlacement ? 'max-w-40' : 'max-w-44'
-                )}
-                data-testid="agent-team-terminal-settings-tab"
-              >
-                <button
-                  type="button"
-                  className="inline-flex min-w-0 items-center gap-1.5 px-2 pr-7 text-left"
-                  aria-selected="true"
-                  role="tab"
-                  onClick={() => onSettingsOpenChange?.(true)}
-                >
-                  <Palette size={13} className="shrink-0 text-sky-200" />
-                  <span className="min-w-0 truncate">{t('terminalWorkspace.settingsTab')}</span>
-                </button>
-                <TerminalButtonTooltip label={t('terminalWorkspace.closeTerminalSettings')}>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    className="absolute bottom-0 right-0 top-0 h-7 w-7 rounded-none border-0 bg-transparent p-0 text-slate-400 transition-colors hover:bg-red-500/10 hover:text-red-300"
-                    aria-label={t('terminalWorkspace.closeTerminalSettingsTab')}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      onSettingsOpenChange?.(false);
-                    }}
-                  >
-                    <X size={12} />
-                  </Button>
-                </TerminalButtonTooltip>
-              </div>
-            ) : null}
-            <TerminalButtonTooltip
-              label={
-                controls.canCreateTab
-                  ? t('terminalWorkspace.createTerminalTab')
-                  : t('terminalWorkspace.terminalTabsUnavailable')
-              }
-            >
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className={cn(
-                  'size-7 shrink-0 border border-white/10 bg-white/[0.04] p-0 text-slate-400 transition-colors hover:bg-white/[0.08] hover:text-slate-100 disabled:cursor-not-allowed disabled:opacity-45',
-                  'rounded-b-none rounded-t-md'
-                )}
-                aria-label={t('terminalWorkspace.createTerminalTab')}
-                data-testid="agent-team-terminal-new-mux-tab"
-                disabled={busy || !controls.canCreateTab}
-                onClick={() => void createTab()}
-              >
-                {pendingAction === 'new-tab' || pendingAction === 'activate-prewarmed-tab' ? (
-                  <Loader2 size={14} className="animate-spin" />
-                ) : (
-                  <Plus size={15} />
-                )}
-              </Button>
-            </TerminalButtonTooltip>
-          </div>
-        </div>
-
-        {error ? (
-          <div className="px-2 py-1 text-xs text-red-300" role="alert">
-            {error}
-          </div>
-        ) : null}
-      </div>
-
-      <AlertDialog
-        open={closeCandidate !== null}
-        onOpenChange={(open) => {
-          if (!open) {
-            dismissCloseCandidate();
-          }
-        }}
-      >
-        <AlertDialogContent className="max-w-md bg-[#10141d]">
-          <AlertDialogHeader>
-            <AlertDialogTitle>
-              {t('terminalWorkspace.closeTerminalTabDialogTitle')}
-            </AlertDialogTitle>
-            <AlertDialogDescription>
-              {t('terminalWorkspace.closeTerminalTabDialogDescription')}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>{t('terminalWorkspace.cancel')}</AlertDialogCancel>
-            <AlertDialogAction onClick={() => void confirmCloseCandidate()}>
-              {t('terminalWorkspace.closeTab')}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </>
   );
 };
 

--- a/src/features/terminal-workspace/renderer/view-models/terminalMuxTabs.ts
+++ b/src/features/terminal-workspace/renderer/view-models/terminalMuxTabs.ts
@@ -46,9 +46,18 @@ export interface CreateTerminalMuxTabsViewModelOptions {
   snapshot: TerminalWorkspaceSnapshot;
 }
 
+export type TerminalTabStripFocusTarget =
+  | Readonly<{
+      kind: 'settings';
+    }>
+  | Readonly<{
+      kind: 'terminal';
+      tabId: string;
+    }>;
+
 export type TerminalTabStripKeyboardIntent =
   | Readonly<{
-      targetTabId: string;
+      target: TerminalTabStripFocusTarget;
     }>
   | undefined;
 
@@ -100,33 +109,53 @@ export function createTerminalMuxTabsViewModel({
 
 export function resolveTerminalTabStripKeyboardIntent(
   key: string,
-  currentTabId: string,
-  orderedTabIds: readonly string[]
+  currentTarget: TerminalTabStripFocusTarget,
+  orderedTabIds: readonly string[],
+  settingsOpen = false
 ): TerminalTabStripKeyboardIntent {
-  const currentIndex = orderedTabIds.indexOf(currentTabId);
-  if (currentIndex < 0 || orderedTabIds.length === 0) {
+  const orderedTargets: TerminalTabStripFocusTarget[] = orderedTabIds.map((tabId) => ({
+    kind: 'terminal',
+    tabId,
+  }));
+  if (settingsOpen) {
+    orderedTargets.push({ kind: 'settings' });
+  }
+  const currentIndex = orderedTargets.findIndex((target) =>
+    areTerminalTabStripTargetsEqual(target, currentTarget)
+  );
+  if (currentIndex < 0 || orderedTargets.length === 0) {
     return undefined;
   }
 
   let targetIndex: number;
   switch (key) {
     case 'ArrowLeft':
-      targetIndex = (currentIndex - 1 + orderedTabIds.length) % orderedTabIds.length;
+      targetIndex = (currentIndex - 1 + orderedTargets.length) % orderedTargets.length;
       break;
     case 'ArrowRight':
-      targetIndex = (currentIndex + 1) % orderedTabIds.length;
+      targetIndex = (currentIndex + 1) % orderedTargets.length;
       break;
     case 'Home':
       targetIndex = 0;
       break;
     case 'End':
-      targetIndex = orderedTabIds.length - 1;
+      targetIndex = orderedTargets.length - 1;
       break;
     default:
       return undefined;
   }
 
   return {
-    targetTabId: orderedTabIds[targetIndex],
+    target: orderedTargets[targetIndex],
   };
+}
+
+function areTerminalTabStripTargetsEqual(
+  left: TerminalTabStripFocusTarget,
+  right: TerminalTabStripFocusTarget
+): boolean {
+  return (
+    left.kind === right.kind &&
+    (left.kind === 'settings' || (right.kind === 'terminal' && left.tabId === right.tabId))
+  );
 }

--- a/src/features/terminal-workspace/renderer/view-models/terminalMuxTabs.ts
+++ b/src/features/terminal-workspace/renderer/view-models/terminalMuxTabs.ts
@@ -1,0 +1,132 @@
+import { resolveTerminalTopologyControlState } from '@terminal-platform/workspace-react';
+
+import {
+  formatMuxTabTitle,
+  isPrewarmedTerminalTab,
+  orderTerminalTabsByPreference,
+  resolveTerminalTabColor,
+  type TerminalMuxTab,
+  type TerminalTabColorId,
+  type TerminalTabColorOption,
+  type TerminalTabPreferences,
+  type TerminalWorkspaceSnapshot,
+} from '../model/terminalTabPreferences';
+
+export interface TerminalMuxTabItemViewModel {
+  active: boolean;
+  color: TerminalTabColorOption;
+  explicitColorId: TerminalTabColorId | undefined;
+  id: string;
+  label: string;
+  tab: TerminalMuxTab;
+}
+
+export interface TerminalMuxTabsViewModel {
+  activeSessionId: string | null;
+  activeTabId: string | null;
+  activeVisibleTabId: string | null;
+  canCloseVisibleTabs: boolean;
+  canCreateTab: boolean;
+  canFocusTab: boolean;
+  canRenameTab: boolean;
+  headerPlacement: boolean;
+  orderedVisibleTabIds: string[];
+  orderedVisibleTabs: TerminalMuxTab[];
+  prewarmedTab: TerminalMuxTab | null;
+  tabItems: TerminalMuxTabItemViewModel[];
+  tabsCount: number;
+  visibleTabIdsKey: string;
+  visibleTabs: TerminalMuxTab[];
+}
+
+export interface CreateTerminalMuxTabsViewModelOptions {
+  placement: 'console' | 'sheet-header';
+  preferences: TerminalTabPreferences;
+  settingsOpen: boolean;
+  snapshot: TerminalWorkspaceSnapshot;
+}
+
+export type TerminalTabStripKeyboardIntent =
+  | Readonly<{
+      targetTabId: string;
+    }>
+  | undefined;
+
+export function createTerminalMuxTabsViewModel({
+  placement,
+  preferences,
+  settingsOpen,
+  snapshot,
+}: CreateTerminalMuxTabsViewModelOptions): TerminalMuxTabsViewModel {
+  const topology = snapshot.attachedSession?.topology ?? null;
+  const controls = resolveTerminalTopologyControlState(snapshot);
+  const tabs = topology?.tabs ?? [];
+  const visibleTabs = tabs.filter((tab) => !isPrewarmedTerminalTab(tab));
+  const orderedVisibleTabs = orderTerminalTabsByPreference(visibleTabs, preferences.order);
+  const activeTabId =
+    controls.activeTab?.tab_id ?? topology?.focused_tab ?? tabs[0]?.tab_id ?? null;
+  const activeVisibleTabId = visibleTabs.some((tab) => tab.tab_id === activeTabId)
+    ? activeTabId
+    : (visibleTabs[0]?.tab_id ?? null);
+
+  return {
+    activeSessionId: controls.activeSessionId,
+    activeTabId,
+    activeVisibleTabId,
+    canCloseVisibleTabs: controls.canCloseTab && visibleTabs.length > 1,
+    canCreateTab: controls.canCreateTab,
+    canFocusTab: controls.canFocusTab,
+    canRenameTab: controls.canRenameTab,
+    headerPlacement: placement === 'sheet-header',
+    orderedVisibleTabIds: orderedVisibleTabs.map((tab) => tab.tab_id),
+    orderedVisibleTabs,
+    prewarmedTab: tabs.find(isPrewarmedTerminalTab) ?? null,
+    tabItems: orderedVisibleTabs.map((tab, index) => {
+      const explicitColorId = preferences.colors[tab.tab_id];
+      return {
+        active: !settingsOpen && tab.tab_id === activeVisibleTabId,
+        color: resolveTerminalTabColor(explicitColorId),
+        explicitColorId,
+        id: tab.tab_id,
+        label: formatMuxTabTitle(tab, index),
+        tab,
+      };
+    }),
+    tabsCount: tabs.length,
+    visibleTabIdsKey: visibleTabs.map((tab) => tab.tab_id).join('\u001f'),
+    visibleTabs,
+  };
+}
+
+export function resolveTerminalTabStripKeyboardIntent(
+  key: string,
+  currentTabId: string,
+  orderedTabIds: readonly string[]
+): TerminalTabStripKeyboardIntent {
+  const currentIndex = orderedTabIds.indexOf(currentTabId);
+  if (currentIndex < 0 || orderedTabIds.length === 0) {
+    return undefined;
+  }
+
+  let targetIndex: number;
+  switch (key) {
+    case 'ArrowLeft':
+      targetIndex = (currentIndex - 1 + orderedTabIds.length) % orderedTabIds.length;
+      break;
+    case 'ArrowRight':
+      targetIndex = (currentIndex + 1) % orderedTabIds.length;
+      break;
+    case 'Home':
+      targetIndex = 0;
+      break;
+    case 'End':
+      targetIndex = orderedTabIds.length - 1;
+      break;
+    default:
+      return undefined;
+  }
+
+  return {
+    targetTabId: orderedTabIds[targetIndex],
+  };
+}

--- a/test/renderer/features/terminal-workspace/TerminalWorkspacePanel.fixture-e2e.test.tsx
+++ b/test/renderer/features/terminal-workspace/TerminalWorkspacePanel.fixture-e2e.test.tsx
@@ -1087,6 +1087,43 @@ describe('terminal workspace panel fixture-e2e', () => {
     expect(document.body.textContent).not.toContain('__tp_prewarmed_shell__');
   });
 
+  it('uses roving tab focus and keyboard navigation for the terminal tab strip', async () => {
+    nextSnapshot = createWorkspaceSnapshot({
+      tabs: [
+        createTab('tab-1', 'Build', 'pane-build'),
+        createTab('tab-2', 'Logs', 'pane-logs'),
+        createTab('tab-3', 'Deploy', 'pane-deploy'),
+      ],
+    });
+
+    await renderPanel();
+    const kernel = currentKernel();
+    kernel.commands.dispatchMuxCommand.mockClear();
+    const buildTab = getTabButton('Build');
+    const logsTab = getTabButton('Logs');
+
+    expect(buildTab.tabIndex).toBe(0);
+    expect(logsTab.tabIndex).toBe(-1);
+
+    await act(async () => {
+      buildTab.focus();
+      buildTab.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          bubbles: true,
+          cancelable: true,
+          key: 'ArrowRight',
+        })
+      );
+      await flushMicrotasks();
+    });
+
+    expect(document.activeElement).toBe(logsTab);
+    expect(kernel.commands.dispatchMuxCommand).toHaveBeenCalledWith('session-1', {
+      kind: 'focus_tab',
+      tab_id: 'tab-2',
+    });
+  });
+
   it('keeps terminal tab close buttons hover-only and avoids mixed border style shorthands', async () => {
     window.localStorage.setItem(
       storageKey('tab-preferences'),

--- a/test/renderer/features/terminal-workspace/TerminalWorkspacePanel.fixture-e2e.test.tsx
+++ b/test/renderer/features/terminal-workspace/TerminalWorkspacePanel.fixture-e2e.test.tsx
@@ -1124,6 +1124,40 @@ describe('terminal workspace panel fixture-e2e', () => {
     });
   });
 
+  it('moves keyboard focus from the open settings tab back to a terminal tab', async () => {
+    nextSnapshot = createWorkspaceSnapshot({
+      focusedTabId: 'tab-2',
+      tabs: [createTab('tab-1', 'Build', 'pane-build'), createTab('tab-2', 'Logs', 'pane-logs')],
+    });
+
+    await renderPanel({ settingsOpen: true });
+    const kernel = currentKernel();
+    kernel.commands.dispatchMuxCommand.mockClear();
+    const settingsTab = document.querySelector<HTMLButtonElement>(
+      '[data-testid="agent-team-terminal-settings-tab"] [role="tab"]'
+    );
+    if (!settingsTab) {
+      throw new Error('Missing terminal settings tab button');
+    }
+    const logsTab = getTabButton('Logs');
+
+    await act(async () => {
+      settingsTab.focus();
+      settingsTab.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          bubbles: true,
+          cancelable: true,
+          key: 'ArrowLeft',
+        })
+      );
+      await flushMicrotasks();
+    });
+
+    expect(document.activeElement).toBe(logsTab);
+    expect(onSettingsOpenChange).toHaveBeenCalledWith(false);
+    expect(kernel.commands.dispatchMuxCommand).not.toHaveBeenCalled();
+  });
+
   it('keeps terminal tab close buttons hover-only and avoids mixed border style shorthands', async () => {
     window.localStorage.setItem(
       storageKey('tab-preferences'),

--- a/test/renderer/features/terminal-workspace/terminalMuxTabsViewModel.test.ts
+++ b/test/renderer/features/terminal-workspace/terminalMuxTabsViewModel.test.ts
@@ -1,0 +1,167 @@
+import {
+  createTerminalMuxTabsViewModel,
+  resolveTerminalTabStripKeyboardIntent,
+} from '@features/terminal-workspace/renderer/view-models/terminalMuxTabs';
+import {
+  PREWARMED_TERMINAL_TAB_TITLE,
+  type TerminalMuxTab,
+  type TerminalTabPreferences,
+  type TerminalWorkspaceSnapshot,
+} from '@features/terminal-workspace/renderer/model/terminalTabPreferences';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@terminal-platform/workspace-react', () => ({
+  resolveTerminalTopologyControlState: (snapshot: MockSnapshot) => snapshot.__controls,
+}));
+
+describe('terminal mux tabs view model', () => {
+  it('projects visible tabs, preferences, capabilities, and active presentation', () => {
+    const build = createTab('tab-build', 'Build');
+    const logs = createTab('tab-logs', 'Logs');
+    const prewarmed = createTab('tab-prewarmed', PREWARMED_TERMINAL_TAB_TITLE);
+    const snapshot = createSnapshot({
+      activeTab: logs,
+      tabs: [build, logs, prewarmed],
+    });
+    const preferences: TerminalTabPreferences = {
+      colors: {
+        'tab-build': 'amber',
+      },
+      order: ['tab-logs', 'tab-build', 'tab-prewarmed'],
+      version: 1,
+    };
+
+    const model = createTerminalMuxTabsViewModel({
+      placement: 'sheet-header',
+      preferences,
+      settingsOpen: false,
+      snapshot,
+    });
+
+    expect(model.activeSessionId).toBe('session-1');
+    expect(model.activeTabId).toBe('tab-logs');
+    expect(model.canCloseVisibleTabs).toBe(true);
+    expect(model.headerPlacement).toBe(true);
+    expect(model.prewarmedTab).toBe(prewarmed);
+    expect(model.orderedVisibleTabIds).toEqual(['tab-logs', 'tab-build']);
+    expect(
+      model.tabItems.map(({ active, explicitColorId, id, label }) => ({
+        active,
+        explicitColorId,
+        id,
+        label,
+      }))
+    ).toEqual([
+      {
+        active: true,
+        explicitColorId: undefined,
+        id: 'tab-logs',
+        label: 'Logs',
+      },
+      {
+        active: false,
+        explicitColorId: 'amber',
+        id: 'tab-build',
+        label: 'Build',
+      },
+    ]);
+  });
+
+  it('keeps terminal tabs inactive while the settings tab owns selection', () => {
+    const tab = createTab('tab-1', 'Shell');
+    const model = createTerminalMuxTabsViewModel({
+      placement: 'console',
+      preferences: {
+        colors: {},
+        order: [],
+        version: 1,
+      },
+      settingsOpen: true,
+      snapshot: createSnapshot({
+        activeTab: tab,
+        tabs: [tab],
+      }),
+    });
+
+    expect(model.tabItems[0]?.active).toBe(false);
+    expect(model.canCloseVisibleTabs).toBe(false);
+  });
+});
+
+describe('terminal tab strip keyboard intent', () => {
+  const tabIds = ['tab-1', 'tab-2', 'tab-3'];
+
+  it('wraps arrow navigation and resolves Home and End', () => {
+    expect(resolveTerminalTabStripKeyboardIntent('ArrowLeft', 'tab-1', tabIds)).toEqual({
+      targetTabId: 'tab-3',
+    });
+    expect(resolveTerminalTabStripKeyboardIntent('ArrowRight', 'tab-3', tabIds)).toEqual({
+      targetTabId: 'tab-1',
+    });
+    expect(resolveTerminalTabStripKeyboardIntent('Home', 'tab-2', tabIds)).toEqual({
+      targetTabId: 'tab-1',
+    });
+    expect(resolveTerminalTabStripKeyboardIntent('End', 'tab-1', tabIds)).toEqual({
+      targetTabId: 'tab-3',
+    });
+  });
+
+  it('ignores unrelated keys and tabs outside the current strip', () => {
+    expect(resolveTerminalTabStripKeyboardIntent('Enter', 'tab-1', tabIds)).toBeUndefined();
+    expect(resolveTerminalTabStripKeyboardIntent('ArrowRight', 'missing', tabIds)).toBeUndefined();
+    expect(resolveTerminalTabStripKeyboardIntent('ArrowRight', 'tab-1', [])).toBeUndefined();
+  });
+});
+
+interface MockSnapshot extends TerminalWorkspaceSnapshot {
+  __controls: {
+    activeSessionId: string;
+    activeTab: TerminalMuxTab | null;
+    canCloseTab: boolean;
+    canCreateTab: boolean;
+    canFocusTab: boolean;
+    canRenameTab: boolean;
+  };
+}
+
+function createSnapshot({
+  activeTab,
+  tabs,
+}: {
+  activeTab: TerminalMuxTab | null;
+  tabs: TerminalMuxTab[];
+}): TerminalWorkspaceSnapshot {
+  return {
+    __controls: {
+      activeSessionId: 'session-1',
+      activeTab,
+      canCloseTab: true,
+      canCreateTab: true,
+      canFocusTab: true,
+      canRenameTab: true,
+    },
+    attachedSession: {
+      focused_screen: null,
+      session_id: 'session-1',
+      topology: {
+        focused_tab: activeTab?.tab_id ?? '',
+        tabs,
+      },
+    },
+  } as unknown as MockSnapshot;
+}
+
+function createTab(tabId: string, title: string): TerminalMuxTab {
+  return {
+    active: false,
+    focused_pane: `pane-${tabId}`,
+    root: {
+      cwd: '/fixtures/terminal-mux-tabs',
+      kind: 'leaf',
+      pane_id: `pane-${tabId}`,
+      title,
+    },
+    tab_id: tabId,
+    title,
+  } as TerminalMuxTab;
+}

--- a/test/renderer/features/terminal-workspace/terminalMuxTabsViewModel.test.ts
+++ b/test/renderer/features/terminal-workspace/terminalMuxTabsViewModel.test.ts
@@ -1,13 +1,13 @@
 import {
-  createTerminalMuxTabsViewModel,
-  resolveTerminalTabStripKeyboardIntent,
-} from '@features/terminal-workspace/renderer/view-models/terminalMuxTabs';
-import {
   PREWARMED_TERMINAL_TAB_TITLE,
   type TerminalMuxTab,
   type TerminalTabPreferences,
   type TerminalWorkspaceSnapshot,
 } from '@features/terminal-workspace/renderer/model/terminalTabPreferences';
+import {
+  createTerminalMuxTabsViewModel,
+  resolveTerminalTabStripKeyboardIntent,
+} from '@features/terminal-workspace/renderer/view-models/terminalMuxTabs';
 import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('@terminal-platform/workspace-react', () => ({
@@ -90,26 +90,58 @@ describe('terminal mux tabs view model', () => {
 
 describe('terminal tab strip keyboard intent', () => {
   const tabIds = ['tab-1', 'tab-2', 'tab-3'];
+  const terminalTarget = (tabId: string) => ({ kind: 'terminal' as const, tabId });
 
   it('wraps arrow navigation and resolves Home and End', () => {
-    expect(resolveTerminalTabStripKeyboardIntent('ArrowLeft', 'tab-1', tabIds)).toEqual({
-      targetTabId: 'tab-3',
+    expect(
+      resolveTerminalTabStripKeyboardIntent('ArrowLeft', terminalTarget('tab-1'), tabIds)
+    ).toEqual({
+      target: terminalTarget('tab-3'),
     });
-    expect(resolveTerminalTabStripKeyboardIntent('ArrowRight', 'tab-3', tabIds)).toEqual({
-      targetTabId: 'tab-1',
+    expect(
+      resolveTerminalTabStripKeyboardIntent('ArrowRight', terminalTarget('tab-3'), tabIds)
+    ).toEqual({
+      target: terminalTarget('tab-1'),
     });
-    expect(resolveTerminalTabStripKeyboardIntent('Home', 'tab-2', tabIds)).toEqual({
-      targetTabId: 'tab-1',
+    expect(resolveTerminalTabStripKeyboardIntent('Home', terminalTarget('tab-2'), tabIds)).toEqual({
+      target: terminalTarget('tab-1'),
     });
-    expect(resolveTerminalTabStripKeyboardIntent('End', 'tab-1', tabIds)).toEqual({
-      targetTabId: 'tab-3',
+    expect(resolveTerminalTabStripKeyboardIntent('End', terminalTarget('tab-1'), tabIds)).toEqual({
+      target: terminalTarget('tab-3'),
+    });
+  });
+
+  it('includes the open settings tab in the same roving keyboard order', () => {
+    expect(
+      resolveTerminalTabStripKeyboardIntent('ArrowRight', terminalTarget('tab-3'), tabIds, true)
+    ).toEqual({
+      target: { kind: 'settings' },
+    });
+    expect(
+      resolveTerminalTabStripKeyboardIntent('ArrowLeft', { kind: 'settings' }, tabIds, true)
+    ).toEqual({
+      target: terminalTarget('tab-3'),
+    });
+    expect(
+      resolveTerminalTabStripKeyboardIntent('Home', { kind: 'settings' }, tabIds, true)
+    ).toEqual({
+      target: terminalTarget('tab-1'),
     });
   });
 
   it('ignores unrelated keys and tabs outside the current strip', () => {
-    expect(resolveTerminalTabStripKeyboardIntent('Enter', 'tab-1', tabIds)).toBeUndefined();
-    expect(resolveTerminalTabStripKeyboardIntent('ArrowRight', 'missing', tabIds)).toBeUndefined();
-    expect(resolveTerminalTabStripKeyboardIntent('ArrowRight', 'tab-1', [])).toBeUndefined();
+    expect(
+      resolveTerminalTabStripKeyboardIntent('Enter', terminalTarget('tab-1'), tabIds)
+    ).toBeUndefined();
+    expect(
+      resolveTerminalTabStripKeyboardIntent('ArrowRight', terminalTarget('missing'), tabIds)
+    ).toBeUndefined();
+    expect(
+      resolveTerminalTabStripKeyboardIntent('ArrowRight', terminalTarget('tab-1'), [])
+    ).toBeUndefined();
+    expect(
+      resolveTerminalTabStripKeyboardIntent('ArrowRight', { kind: 'settings' }, tabIds)
+    ).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

- project terminal mux tab state through a pure view model
- compose lifecycle, pointer reorder, and preference persistence in a focused controller with narrow command ports
- move tab-strip markup into a JSX-only view and thin composition component
- preserve rename, close, color, drag, prewarm, and focus behavior without passing WorkspaceKernel
- include the open settings tab in shared roving Arrow/Home/End keyboard navigation
- reduce TerminalWorkspacePanel from 1576 to 1028 lines and lower its legacy cap

## Verification

- 195/195 full Terminal renderer tests on the exact merged #379 head
- native TypeScript 7 typecheck
- type-aware production and focused unit ESLint, fast lint for the legacy fixture, Prettier
- source-size ratchet against canonical base 504191b3a
- independent audit and re-audit after keyboard fix: no remaining P1-P3 findings

Desktop/runtime E2E is intentionally deferred until the final TerminalWorkspacePanel slice is below 800 lines.