### PR TITLE
refactor(terminal-workspace): remove final oversized panel boundary

### DIFF
--- a/scripts/ci/source-file-size-legacy.json
+++ b/scripts/ci/source-file-size-legacy.json
@@ -46,7 +46,6 @@
   "src/features/team-lifecycle/contracts/team-lifecycle-read.ts": 816,
   "src/features/team-lifecycle/main/infrastructure/TeamDirectoryLifecycleAdapter.ts": 1606,
   "src/features/team-runtime-control/core/application/planning/createCompositeRuntimePlan.ts": 1195,
-  "src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx": 1028,
   "src/features/token-usage/core/domain/snapshotProjection.ts": 937,
   "src/features/token-usage/renderer/adapters/tokenUsageViewModel.ts": 1481,
   "src/features/token-usage/renderer/ui/TokenUsageDashboard.tsx": 2170,

--- a/src/features/terminal-workspace/renderer/adapters/terminalWorkspaceExternalNavigation.ts
+++ b/src/features/terminal-workspace/renderer/adapters/terminalWorkspaceExternalNavigation.ts
@@ -1,0 +1,10 @@
+export const TERMINAL_PLATFORM_REPOSITORY_URL = 'https://github.com/777genius/terminal-platform';
+
+export function openTerminalPlatformRepository(): void {
+  if (window.electronAPI?.openExternal) {
+    void window.electronAPI.openExternal(TERMINAL_PLATFORM_REPOSITORY_URL);
+    return;
+  }
+
+  window.open(TERMINAL_PLATFORM_REPOSITORY_URL, '_blank', 'noopener,noreferrer');
+}

--- a/src/features/terminal-workspace/renderer/adapters/terminalWorkspacePreferencesStorage.ts
+++ b/src/features/terminal-workspace/renderer/adapters/terminalWorkspacePreferencesStorage.ts
@@ -1,0 +1,113 @@
+import {
+  DEFAULT_TERMINAL_APPEARANCE_SETTINGS,
+  normalizeTerminalAppearanceSettings,
+  type TerminalAppearanceSettings,
+} from '../model/terminalAppearanceSettings';
+
+export type TerminalWorkspacePreferenceKey =
+  | 'appearance-settings'
+  | 'font-scale'
+  | 'line-wrap'
+  | 'theme';
+
+export interface TerminalWorkspacePreferencesStorage {
+  readonly getItem: (key: string) => string | null;
+  readonly setItem: (key: string, value: string) => void;
+}
+
+export function createTerminalWorkspacePreferenceKey(
+  teamName: string,
+  key: TerminalWorkspacePreferenceKey
+): string {
+  return `agent-teams:terminal-workspace:${teamName}:${key}`;
+}
+
+export function readStoredTerminalPreference(
+  teamName: string,
+  key: TerminalWorkspacePreferenceKey,
+  storage: TerminalWorkspacePreferencesStorage | null = resolveBrowserStorage()
+): string | null {
+  if (!storage) {
+    return null;
+  }
+
+  try {
+    return storage.getItem(createTerminalWorkspacePreferenceKey(teamName, key));
+  } catch {
+    return null;
+  }
+}
+
+export function readStoredTerminalBooleanPreference(
+  teamName: string,
+  key: TerminalWorkspacePreferenceKey,
+  storage?: TerminalWorkspacePreferencesStorage | null
+): boolean | null {
+  const value = readStoredTerminalPreference(
+    teamName,
+    key,
+    storage === undefined ? resolveBrowserStorage() : storage
+  );
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  return null;
+}
+
+export function readStoredTerminalAppearanceSettings(
+  teamName: string,
+  storage?: TerminalWorkspacePreferencesStorage | null
+): TerminalAppearanceSettings {
+  const raw = readStoredTerminalPreference(
+    teamName,
+    'appearance-settings',
+    storage === undefined ? resolveBrowserStorage() : storage
+  );
+  if (!raw) {
+    return DEFAULT_TERMINAL_APPEARANCE_SETTINGS;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return normalizeTerminalAppearanceSettings(parsed);
+  } catch {
+    return DEFAULT_TERMINAL_APPEARANCE_SETTINGS;
+  }
+}
+
+export function persistTerminalPreference(
+  teamName: string,
+  key: TerminalWorkspacePreferenceKey,
+  value: string,
+  storage: TerminalWorkspacePreferencesStorage | null = resolveBrowserStorage()
+): void {
+  if (!storage) {
+    return;
+  }
+
+  try {
+    storage.setItem(createTerminalWorkspacePreferenceKey(teamName, key), value);
+  } catch {
+    // Best-effort UI preference persistence.
+  }
+}
+
+export function persistTerminalAppearanceSettings(
+  teamName: string,
+  settings: TerminalAppearanceSettings,
+  storage: TerminalWorkspacePreferencesStorage | null = resolveBrowserStorage()
+): void {
+  persistTerminalPreference(
+    teamName,
+    'appearance-settings',
+    JSON.stringify(normalizeTerminalAppearanceSettings(settings)),
+    storage
+  );
+}
+
+function resolveBrowserStorage(): TerminalWorkspacePreferencesStorage | null {
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}

--- a/src/features/terminal-workspace/renderer/ui/TerminalWorkingDirectoryBar.tsx
+++ b/src/features/terminal-workspace/renderer/ui/TerminalWorkingDirectoryBar.tsx
@@ -1,0 +1,58 @@
+import { useAppTranslation } from '@features/localization/renderer';
+import { Folder, GitBranch, Github } from 'lucide-react';
+
+import { formatWorkingDirectory } from '../model/terminalPathPresentation';
+
+import { TerminalButtonTooltip } from './TerminalButtonTooltip';
+
+export interface TerminalWorkingDirectoryBarProps {
+  projectPath?: string | null;
+  gitBranch?: string | null;
+  onOpenTerminalPlatformRepository: () => void;
+}
+
+export const TerminalWorkingDirectoryBar = ({
+  projectPath,
+  gitBranch,
+  onOpenTerminalPlatformRepository,
+}: TerminalWorkingDirectoryBarProps): React.JSX.Element => {
+  const { t } = useAppTranslation('team');
+  const defaultDirectory = t('terminalWorkspace.shellDefaultDirectory');
+  const label = formatWorkingDirectory(projectPath, defaultDirectory);
+
+  return (
+    <div
+      className="flex min-h-6 min-w-0 items-center justify-between gap-3 bg-transparent px-3 text-[11px] text-slate-400"
+      data-testid="agent-team-terminal-working-directory"
+    >
+      <div className="flex min-w-0 items-center gap-1">
+        <Folder size={12} className="shrink-0 text-slate-500" />
+        <span className="sr-only">{t('terminalWorkspace.currentWorkingDirectory')}</span>
+        <TerminalButtonTooltip label={projectPath || defaultDirectory}>
+          <span className="min-w-0 truncate font-mono text-slate-300">{label}</span>
+        </TerminalButtonTooltip>
+        {gitBranch ? (
+          <TerminalButtonTooltip
+            label={t('terminalWorkspace.gitBranchTitle', { branch: gitBranch })}
+          >
+            <span className="inline-flex max-w-[14rem] shrink-0 items-center gap-1 rounded-full border border-white/10 bg-white/[0.035] px-1.5 py-0.5 font-mono text-[10px] text-slate-300">
+              <GitBranch size={11} className="shrink-0 text-slate-500" />
+              <span className="min-w-0 truncate">{gitBranch}</span>
+            </span>
+          </TerminalButtonTooltip>
+        ) : null}
+      </div>
+      <TerminalButtonTooltip label={t('terminalWorkspace.openTerminalPlatformRepository')}>
+        <button
+          type="button"
+          className="ml-auto inline-flex shrink-0 items-center gap-1.5 rounded-full border border-white/10 bg-white/[0.025] px-2 py-0.5 text-[10px] font-medium text-slate-400 transition-colors hover:border-sky-300/30 hover:bg-sky-300/10 hover:text-slate-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sky-300/60"
+          aria-label={t('terminalWorkspace.openTerminalPlatformRepository')}
+          onClick={onOpenTerminalPlatformRepository}
+        >
+          <span>{t('terminalWorkspace.poweredByTerminalPlatform')}</span>
+          <Github size={11} className="shrink-0" />
+        </button>
+      </TerminalButtonTooltip>
+    </div>
+  );
+};

--- a/src/features/terminal-workspace/renderer/ui/TerminalWorkspaceFeedback.tsx
+++ b/src/features/terminal-workspace/renderer/ui/TerminalWorkspaceFeedback.tsx
@@ -1,0 +1,53 @@
+import { useAppTranslation } from '@features/localization/renderer';
+import { cn } from '@renderer/lib/utils';
+
+export const TerminalTabContentSkeleton = (): React.JSX.Element => {
+  const { t } = useAppTranslation('team');
+
+  return (
+    <div
+      className="pointer-events-none absolute inset-0 z-20 border-t border-white/10 bg-[#080c14] px-6 py-5 backdrop-blur-xl"
+      data-testid="agent-team-terminal-content-skeleton"
+      aria-label={t('terminalWorkspace.loadingTerminalTab')}
+    >
+      <div className="flex h-full flex-col justify-end gap-6">
+        {[0, 1, 2].map((sectionIndex) => (
+          <div key={sectionIndex} className="space-y-3 border-t border-white/[0.06] pt-4">
+            <div className="h-3 w-2/3 max-w-[34rem] animate-pulse rounded bg-white/10" />
+            <div className="h-4 w-1/2 max-w-[24rem] animate-pulse rounded bg-white/[0.15]" />
+            <div className="h-3 w-1/3 max-w-[18rem] animate-pulse rounded bg-white/[0.08]" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export const TerminalWorkspaceStatus = ({
+  icon,
+  title,
+  detail,
+  tone = 'neutral',
+}: {
+  icon: React.ReactNode;
+  title: string;
+  detail: string;
+  tone?: 'neutral' | 'danger';
+}): React.JSX.Element => (
+  <div
+    className={cn(
+      'flex min-h-[30rem] items-center justify-center rounded border border-dashed p-6 text-center',
+      tone === 'danger'
+        ? 'border-red-500/30 bg-red-500/5 text-red-300'
+        : 'border-white/10 bg-white/[0.03] text-text-secondary'
+    )}
+  >
+    <div className="max-w-lg">
+      <div className="border-current/20 mx-auto mb-3 flex size-9 items-center justify-center rounded-md border bg-black/20">
+        {icon}
+      </div>
+      <p className="text-sm font-medium text-current">{title}</p>
+      <p className="mt-1 text-xs leading-5 text-text-muted">{detail}</p>
+    </div>
+  </div>
+);

--- a/src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx
+++ b/src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx
@@ -11,64 +11,54 @@ import { createPortal } from 'react-dom';
 
 import { useAppTranslation } from '@features/localization/renderer';
 import { cn } from '@renderer/lib/utils';
-import { terminalPlatformThemeManifests } from '@terminal-platform/design-tokens';
 import { createWorkspaceWebSocketTransport } from '@terminal-platform/workspace-adapter-websocket';
-import {
-  createWorkspaceKernel,
-  terminalPlatformTerminalFontScales,
-  type WorkspaceKernel,
-} from '@terminal-platform/workspace-core';
+import { createWorkspaceKernel, type WorkspaceKernel } from '@terminal-platform/workspace-core';
 import {
   TerminalCommandDock,
   TerminalScreen,
   TerminalWorkspace,
   useWorkspaceSnapshot,
 } from '@terminal-platform/workspace-react';
-import {
-  AlertTriangle,
-  Folder,
-  GitBranch,
-  Github,
-  Loader2,
-  RefreshCw,
-  Square,
-  Terminal,
-} from 'lucide-react';
+import { AlertTriangle, Loader2, RefreshCw, Square, Terminal } from 'lucide-react';
 
 import { readStoredTerminalCommandHistory } from '../adapters/terminalCommandHistoryStorage';
+import { openTerminalPlatformRepository } from '../adapters/terminalWorkspaceExternalNavigation';
+import {
+  persistTerminalAppearanceSettings,
+  persistTerminalPreference,
+  readStoredTerminalAppearanceSettings,
+  readStoredTerminalBooleanPreference,
+  readStoredTerminalPreference,
+} from '../adapters/terminalWorkspacePreferencesStorage';
 import { useTerminalCommandAutocomplete } from '../hooks/useTerminalCommandAutocomplete';
 import { useTerminalCommandContextMenu } from '../hooks/useTerminalCommandContextMenu';
 import { useTerminalCommandHistoryPersistence } from '../hooks/useTerminalCommandHistoryPersistence';
 import { useTerminalCommandRuns } from '../hooks/useTerminalCommandRuns';
 import {
-  DEFAULT_TERMINAL_APPEARANCE_SETTINGS,
   normalizeTerminalAppearanceSettings,
-  resolveTerminalBackgroundImageUrl,
   type TerminalAppearanceSettings,
-  type TerminalBackgroundImageFit,
 } from '../model/terminalAppearanceSettings';
 import {
   createTerminalCommandScreenLines,
   TERMINAL_COMMAND_HISTORY_LIMIT,
 } from '../model/terminalCommandRuns';
-import {
-  formatTerminalPromptLabel,
-  formatWorkingDirectory,
-} from '../model/terminalPathPresentation';
+import { formatTerminalPromptLabel } from '../model/terminalPathPresentation';
+import { createTerminalAppearanceStyle } from '../view-models/terminalAppearanceStyle';
 
 import { TerminalButtonTooltip } from './TerminalButtonTooltip';
 import { TerminalCommandContextMenu } from './TerminalCommandContextMenu';
 import { TerminalMuxTabs } from './TerminalMuxTabs';
+import { TerminalWorkingDirectoryBar } from './TerminalWorkingDirectoryBar';
+import { TerminalTabContentSkeleton, TerminalWorkspaceStatus } from './TerminalWorkspaceFeedback';
 import {
-  type TerminalWorkspaceSettingsActionId,
-  TerminalWorkspaceSettingsView,
-} from './TerminalWorkspaceSettingsView';
+  type TerminalWorkspaceSettingsOperations,
+  TerminalWorkspaceSettingsPage,
+} from './TerminalWorkspaceSettingsPage';
 
 import type {
   TerminalWorkspaceBootstrap,
   TerminalWorkspaceBootstrapRequest,
 } from '../../contracts';
-import type { TerminalWorkspaceSnapshot } from '../model/terminalTabPreferences';
 
 export interface TerminalWorkspacePanelProps {
   teamName: string;
@@ -87,14 +77,12 @@ export interface TerminalWorkspacePanelProps {
   stopTeamRuntime: (teamName: string) => Promise<void>;
 }
 
-const TERMINAL_PLATFORM_GITHUB_URL = 'https://github.com/777genius/terminal-platform';
 type TerminalScreenElementHandle = ComponentRef<typeof TerminalScreen> & {
   followOutput?: boolean;
   requestUpdate?: () => void;
   scrollToLatestOutput?: () => void;
 };
 type TerminalCommandDockElementHandle = ComponentRef<typeof TerminalCommandDock>;
-type TeamTFunction = ReturnType<typeof useAppTranslation>['t'];
 
 export const TerminalWorkspacePanel = (props: TerminalWorkspacePanelProps): React.JSX.Element => (
   <TerminalWorkspacePanelTeamScope key={props.teamName} {...props} />
@@ -164,9 +152,9 @@ const TerminalWorkspacePanelTeamScope = ({
         controlUrl: bootstrap.controlPlaneUrl,
         streamUrl: bootstrap.sessionStreamUrl,
       }),
-      initialThemeId: readStoredValue(storageKey(teamName, 'theme')),
-      initialTerminalFontScale: readStoredValue(storageKey(teamName, 'font-scale')),
-      initialTerminalLineWrap: readStoredBoolean(storageKey(teamName, 'line-wrap')),
+      initialThemeId: readStoredTerminalPreference(teamName, 'theme'),
+      initialTerminalFontScale: readStoredTerminalPreference(teamName, 'font-scale'),
+      initialTerminalLineWrap: readStoredTerminalBooleanPreference(teamName, 'line-wrap'),
       initialCommandHistoryEntries: readStoredTerminalCommandHistory(teamName),
       commandHistoryLimit: TERMINAL_COMMAND_HISTORY_LIMIT,
     });
@@ -392,6 +380,17 @@ const TerminalWorkspaceKernelView = ({
     },
     []
   );
+  const settingsOperations = useMemo<TerminalWorkspaceSettingsOperations>(
+    () => ({
+      reconnect: () => kernel.commands.bootstrap(),
+      refreshSessions: () => kernel.commands.refreshSessions(),
+      stopRuntime: () => onStopRuntime(),
+      setFontScale: (fontScale) => kernel.commands.setTerminalFontScale(fontScale),
+      setLineWrap: (lineWrap) => kernel.commands.setTerminalLineWrap(lineWrap),
+      setTheme: (themeId) => kernel.commands.setTheme(themeId),
+    }),
+    [kernel.commands, onStopRuntime]
+  );
 
   const scrollTerminalToLatest = useCallback((): void => {
     const scroll = (): void => {
@@ -475,12 +474,12 @@ const TerminalWorkspaceKernelView = ({
   }, [kernel]);
 
   useEffect(() => {
-    persistValue(storageKey(teamName, 'theme'), snapshot.theme.themeId);
+    persistTerminalPreference(teamName, 'theme', snapshot.theme.themeId);
   }, [snapshot.theme.themeId, teamName]);
 
   useEffect(() => {
-    persistValue(storageKey(teamName, 'font-scale'), terminalDisplay.fontScale);
-    persistValue(storageKey(teamName, 'line-wrap'), String(terminalDisplay.lineWrap));
+    persistTerminalPreference(teamName, 'font-scale', terminalDisplay.fontScale);
+    persistTerminalPreference(teamName, 'line-wrap', String(terminalDisplay.lineWrap));
   }, [teamName, terminalDisplay.fontScale, terminalDisplay.lineWrap]);
 
   useTerminalCommandHistoryPersistence({
@@ -676,12 +675,15 @@ const TerminalWorkspaceKernelView = ({
       {settingsOpen ? (
         <TerminalWorkspaceSettingsPage
           appearanceSettings={appearanceSettings}
-          kernel={kernel}
+          display={{
+            fontScale: terminalDisplay.fontScale,
+            lineWrap: terminalDisplay.lineWrap,
+            themeId: snapshot.theme.themeId,
+          }}
+          operations={settingsOperations}
           onAppearanceSettingsChange={updateAppearanceSettings}
           onClose={() => onSettingsOpenChange?.(false)}
           onReload={onReload}
-          onStopRuntime={onStopRuntime}
-          snapshot={snapshot}
         />
       ) : (
         <TerminalWorkspace
@@ -714,7 +716,11 @@ const TerminalWorkspaceKernelView = ({
             {showTerminalContentSkeleton ? <TerminalTabContentSkeleton /> : null}
           </div>
           <div slot="command-dock" className="grid min-w-0 shrink-0 grid-rows-[auto_auto]">
-            <TerminalWorkingDirectoryBar projectPath={projectPath} gitBranch={gitBranch} />
+            <TerminalWorkingDirectoryBar
+              projectPath={projectPath}
+              gitBranch={gitBranch}
+              onOpenTerminalPlatformRepository={openTerminalPlatformRepository}
+            />
             <TerminalCommandDock
               ref={setCommandDockElement}
               autoFocusInput
@@ -742,287 +748,3 @@ const TerminalWorkspaceKernelView = ({
     </div>
   );
 };
-
-const TerminalTabContentSkeleton = (): React.JSX.Element => {
-  const { t } = useAppTranslation('team');
-
-  return (
-    <div
-      className="pointer-events-none absolute inset-0 z-20 border-t border-white/10 bg-[#080c14] px-6 py-5 backdrop-blur-xl"
-      data-testid="agent-team-terminal-content-skeleton"
-      aria-label={t('terminalWorkspace.loadingTerminalTab')}
-    >
-      <div className="flex h-full flex-col justify-end gap-6">
-        {[0, 1, 2].map((sectionIndex) => (
-          <div key={sectionIndex} className="space-y-3 border-t border-white/[0.06] pt-4">
-            <div className="h-3 w-2/3 max-w-[34rem] animate-pulse rounded bg-white/10" />
-            <div className="h-4 w-1/2 max-w-[24rem] animate-pulse rounded bg-white/[0.15]" />
-            <div className="h-3 w-1/3 max-w-[18rem] animate-pulse rounded bg-white/[0.08]" />
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-};
-
-const TerminalWorkingDirectoryBar = ({
-  projectPath,
-  gitBranch,
-}: {
-  projectPath?: string | null;
-  gitBranch?: string | null;
-}): React.JSX.Element => {
-  const { t } = useAppTranslation('team');
-  const label = formatWorkingDirectory(projectPath, t('terminalWorkspace.shellDefaultDirectory'));
-  const openTerminalPlatformRepository = useCallback((): void => {
-    if (window.electronAPI?.openExternal) {
-      void window.electronAPI.openExternal(TERMINAL_PLATFORM_GITHUB_URL);
-      return;
-    }
-
-    window.open(TERMINAL_PLATFORM_GITHUB_URL, '_blank', 'noopener,noreferrer');
-  }, []);
-
-  return (
-    <div
-      className="flex min-h-6 min-w-0 items-center justify-between gap-3 bg-transparent px-3 text-[11px] text-slate-400"
-      data-testid="agent-team-terminal-working-directory"
-      title={projectPath || t('terminalWorkspace.shellDefaultDirectory')}
-    >
-      <div className="flex min-w-0 items-center gap-1">
-        <Folder size={12} className="shrink-0 text-slate-500" />
-        <span className="sr-only">{t('terminalWorkspace.currentWorkingDirectory')}</span>
-        <span className="min-w-0 truncate font-mono text-slate-300">{label}</span>
-        {gitBranch ? (
-          <span
-            className="inline-flex max-w-[14rem] shrink-0 items-center gap-1 rounded-full border border-white/10 bg-white/[0.035] px-1.5 py-0.5 font-mono text-[10px] text-slate-300"
-            title={t('terminalWorkspace.gitBranchTitle', { branch: gitBranch })}
-          >
-            <GitBranch size={11} className="shrink-0 text-slate-500" />
-            <span className="min-w-0 truncate">{gitBranch}</span>
-          </span>
-        ) : null}
-      </div>
-      <button
-        type="button"
-        className="ml-auto inline-flex shrink-0 items-center gap-1.5 rounded-full border border-white/10 bg-white/[0.025] px-2 py-0.5 text-[10px] font-medium text-slate-400 transition-colors hover:border-sky-300/30 hover:bg-sky-300/10 hover:text-slate-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sky-300/60"
-        aria-label={t('terminalWorkspace.openTerminalPlatformRepository')}
-        title={t('terminalWorkspace.openTerminalPlatformRepository')}
-        onClick={openTerminalPlatformRepository}
-      >
-        <span>{t('terminalWorkspace.poweredByTerminalPlatform')}</span>
-        <Github size={11} className="shrink-0" />
-      </button>
-    </div>
-  );
-};
-
-const TerminalWorkspaceSettingsPage = ({
-  appearanceSettings,
-  kernel,
-  onAppearanceSettingsChange,
-  onClose,
-  onReload,
-  onStopRuntime,
-  snapshot,
-}: {
-  appearanceSettings: TerminalAppearanceSettings;
-  kernel: WorkspaceKernel;
-  onAppearanceSettingsChange: (updates: Partial<TerminalAppearanceSettings>) => void;
-  onClose: () => void;
-  onReload: () => void;
-  onStopRuntime: () => Promise<void>;
-  snapshot: TerminalWorkspaceSnapshot;
-}): React.JSX.Element => {
-  const { t } = useAppTranslation('team');
-  const [pendingAction, setPendingAction] = useState<TerminalWorkspaceSettingsActionId | null>(
-    null
-  );
-  const display = snapshot.terminalDisplay;
-
-  const runAction = async (
-    actionId: TerminalWorkspaceSettingsActionId,
-    action: () => Promise<void> | void
-  ): Promise<void> => {
-    setPendingAction(actionId);
-    try {
-      await action();
-    } catch {
-      // Kernel diagnostics already surface command failures in the terminal workspace.
-    } finally {
-      setPendingAction(null);
-    }
-  };
-
-  return (
-    <TerminalWorkspaceSettingsView
-      appearanceSettings={appearanceSettings}
-      display={{
-        fontScale: display.fontScale,
-        lineWrap: display.lineWrap,
-        themeId: snapshot.theme.themeId,
-      }}
-      fontScaleOptions={terminalPlatformTerminalFontScales.map((fontScale) => ({
-        id: fontScale,
-        label: formatFontScaleLabel(t, fontScale),
-      }))}
-      onAppearanceSettingsChange={onAppearanceSettingsChange}
-      onClose={onClose}
-      onFontScaleChange={(fontScale) => kernel.commands.setTerminalFontScale(fontScale)}
-      onLineWrapChange={(lineWrap) => kernel.commands.setTerminalLineWrap(lineWrap)}
-      onReconnect={() => void runAction('bootstrap', () => kernel.commands.bootstrap())}
-      onRefreshSessions={() =>
-        void runAction('refresh-sessions', () => kernel.commands.refreshSessions())
-      }
-      onReload={onReload}
-      onResetAppearance={() => onAppearanceSettingsChange(DEFAULT_TERMINAL_APPEARANCE_SETTINGS)}
-      onStopRuntime={() => void runAction('stop-runtime', onStopRuntime)}
-      onThemeChange={(themeId) => kernel.commands.setTheme(themeId)}
-      pendingAction={pendingAction}
-      themeOptions={terminalPlatformThemeManifests.map((theme) => ({
-        id: theme.id,
-        label: formatThemeLabel(t, theme.displayName, theme.id),
-      }))}
-    />
-  );
-};
-const TerminalWorkspaceStatus = ({
-  icon,
-  title,
-  detail,
-  tone = 'neutral',
-}: {
-  icon: React.ReactNode;
-  title: string;
-  detail: string;
-  tone?: 'neutral' | 'danger';
-}): React.JSX.Element => {
-  return (
-    <div
-      className={cn(
-        'flex min-h-[30rem] items-center justify-center rounded border border-dashed p-6 text-center',
-        tone === 'danger'
-          ? 'border-red-500/30 bg-red-500/5 text-red-300'
-          : 'border-white/10 bg-white/[0.03] text-text-secondary'
-      )}
-    >
-      <div className="max-w-lg">
-        <div className="border-current/20 mx-auto mb-3 flex size-9 items-center justify-center rounded-md border bg-black/20">
-          {icon}
-        </div>
-        <p className="text-sm font-medium text-current">{title}</p>
-        <p className="mt-1 text-xs leading-5 text-text-muted">{detail}</p>
-      </div>
-    </div>
-  );
-};
-
-function storageKey(teamName: string, key: string): string {
-  return `agent-teams:terminal-workspace:${teamName}:${key}`;
-}
-
-function readStoredValue(key: string): string | null {
-  try {
-    return window.localStorage.getItem(key);
-  } catch {
-    return null;
-  }
-}
-
-function readStoredBoolean(key: string): boolean | null {
-  const value = readStoredValue(key);
-  if (value === 'true') return true;
-  if (value === 'false') return false;
-  return null;
-}
-
-function readStoredTerminalAppearanceSettings(teamName: string): TerminalAppearanceSettings {
-  const raw = readStoredValue(storageKey(teamName, 'appearance-settings'));
-  if (!raw) return DEFAULT_TERMINAL_APPEARANCE_SETTINGS;
-
-  try {
-    const parsed: unknown = JSON.parse(raw);
-    return normalizeTerminalAppearanceSettings(parsed);
-  } catch {
-    return DEFAULT_TERMINAL_APPEARANCE_SETTINGS;
-  }
-}
-
-function persistValue(key: string, value: string): void {
-  try {
-    window.localStorage.setItem(key, value);
-  } catch {
-    // Best-effort UI preference persistence.
-  }
-}
-
-function persistTerminalAppearanceSettings(
-  teamName: string,
-  settings: TerminalAppearanceSettings
-): void {
-  try {
-    window.localStorage.setItem(
-      storageKey(teamName, 'appearance-settings'),
-      JSON.stringify(normalizeTerminalAppearanceSettings(settings))
-    );
-  } catch {
-    // Best-effort appearance preference persistence.
-  }
-}
-
-function createTerminalAppearanceStyle(settings: TerminalAppearanceSettings): CSSProperties {
-  const normalizedSettings = normalizeTerminalAppearanceSettings(settings);
-  const imageUrl = resolveTerminalBackgroundImageUrl(normalizedSettings.backgroundImageUrl);
-  const hasImage = normalizedSettings.backgroundMode === 'image' && imageUrl.length > 0;
-  return {
-    '--agent-terminal-font-size': `${normalizedSettings.fontSizePx}px`,
-    '--agent-terminal-panel-opacity': String(normalizedSettings.opacityPercent / 100),
-    '--agent-terminal-background-color': normalizedSettings.backgroundColor,
-    '--agent-terminal-background-image': hasImage ? createCssUrl(imageUrl) : 'none',
-    '--agent-terminal-background-position': getTerminalBackgroundPosition(
-      normalizedSettings.backgroundImageFit
-    ),
-    '--agent-terminal-background-repeat': getTerminalBackgroundRepeat(
-      normalizedSettings.backgroundImageFit
-    ),
-    '--agent-terminal-background-size': getTerminalBackgroundSize(
-      normalizedSettings.backgroundImageFit
-    ),
-    '--agent-terminal-backdrop-blur': `${normalizedSettings.backdropBlurPx}px`,
-    '--agent-terminal-background-image-blur': hasImage
-      ? `${normalizedSettings.backdropBlurPx}px`
-      : '0px',
-    '--agent-terminal-image-dim-opacity':
-      hasImage && normalizedSettings.dimBackgroundImage ? '0.42' : '0',
-  } as CSSProperties;
-}
-
-function createCssUrl(value: string): string {
-  return `url("${value.replace(/["\\\n\r]/gu, '')}")`;
-}
-
-function getTerminalBackgroundSize(fit: TerminalBackgroundImageFit): string {
-  if (fit === 'stretch') return '100% 100%';
-  if (fit === 'tile' || fit === 'center') return 'auto';
-  return fit;
-}
-
-function getTerminalBackgroundRepeat(fit: TerminalBackgroundImageFit): string {
-  return fit === 'tile' ? 'repeat' : 'no-repeat';
-}
-
-function getTerminalBackgroundPosition(fit: TerminalBackgroundImageFit): string {
-  return fit === 'tile' ? 'top left' : 'center';
-}
-
-function formatThemeLabel(t: TeamTFunction, displayName: string, themeId: string): string {
-  if (themeId === 'terminal-platform-default') return t('terminalWorkspace.themeDark');
-  if (themeId === 'terminal-platform-light') return t('terminalWorkspace.themeLight');
-  return displayName.replace(/^Terminal Platform\s*/i, '').trim() || displayName;
-}
-
-function formatFontScaleLabel(t: TeamTFunction, fontScale: string): string {
-  if (fontScale === 'compact') return t('terminalWorkspace.fontScaleCompact');
-  if (fontScale === 'large') return t('terminalWorkspace.fontScaleLarge');
-  return t('terminalWorkspace.fontScaleDefault');
-}

--- a/src/features/terminal-workspace/renderer/ui/TerminalWorkspaceSettingsPage.tsx
+++ b/src/features/terminal-workspace/renderer/ui/TerminalWorkspaceSettingsPage.tsx
@@ -1,0 +1,105 @@
+import { useState } from 'react';
+
+import { useAppTranslation } from '@features/localization/renderer';
+import { terminalPlatformThemeManifests } from '@terminal-platform/design-tokens';
+import { terminalPlatformTerminalFontScales } from '@terminal-platform/workspace-core';
+
+import {
+  DEFAULT_TERMINAL_APPEARANCE_SETTINGS,
+  type TerminalAppearanceSettings,
+} from '../model/terminalAppearanceSettings';
+
+import {
+  type TerminalWorkspaceSettingsActionId,
+  TerminalWorkspaceSettingsView,
+} from './TerminalWorkspaceSettingsView';
+
+type TeamTFunction = ReturnType<typeof useAppTranslation>['t'];
+
+export interface TerminalWorkspaceSettingsOperations {
+  readonly reconnect: () => Promise<void>;
+  readonly refreshSessions: () => Promise<void>;
+  readonly stopRuntime: () => Promise<void>;
+  readonly setFontScale: (fontScale: string) => void;
+  readonly setLineWrap: (lineWrap: boolean) => void;
+  readonly setTheme: (themeId: string) => void;
+}
+
+export interface TerminalWorkspaceSettingsPageProps {
+  appearanceSettings: TerminalAppearanceSettings;
+  display: {
+    fontScale: string;
+    lineWrap: boolean;
+    themeId: string;
+  };
+  operations: TerminalWorkspaceSettingsOperations;
+  onAppearanceSettingsChange: (updates: Partial<TerminalAppearanceSettings>) => void;
+  onClose: () => void;
+  onReload: () => void;
+}
+
+export const TerminalWorkspaceSettingsPage = ({
+  appearanceSettings,
+  display,
+  operations,
+  onAppearanceSettingsChange,
+  onClose,
+  onReload,
+}: TerminalWorkspaceSettingsPageProps): React.JSX.Element => {
+  const { t } = useAppTranslation('team');
+  const [pendingAction, setPendingAction] = useState<TerminalWorkspaceSettingsActionId | null>(
+    null
+  );
+
+  const runAction = async (
+    actionId: TerminalWorkspaceSettingsActionId,
+    action: () => Promise<void>
+  ): Promise<void> => {
+    setPendingAction(actionId);
+    try {
+      await action();
+    } catch {
+      // Kernel diagnostics already surface command failures in the terminal workspace.
+    } finally {
+      setPendingAction(null);
+    }
+  };
+
+  return (
+    <TerminalWorkspaceSettingsView
+      appearanceSettings={appearanceSettings}
+      display={display}
+      fontScaleOptions={terminalPlatformTerminalFontScales.map((fontScale) => ({
+        id: fontScale,
+        label: formatFontScaleLabel(t, fontScale),
+      }))}
+      onAppearanceSettingsChange={onAppearanceSettingsChange}
+      onClose={onClose}
+      onFontScaleChange={operations.setFontScale}
+      onLineWrapChange={operations.setLineWrap}
+      onReconnect={() => void runAction('bootstrap', operations.reconnect)}
+      onRefreshSessions={() => void runAction('refresh-sessions', operations.refreshSessions)}
+      onReload={onReload}
+      onResetAppearance={() => onAppearanceSettingsChange(DEFAULT_TERMINAL_APPEARANCE_SETTINGS)}
+      onStopRuntime={() => void runAction('stop-runtime', operations.stopRuntime)}
+      onThemeChange={operations.setTheme}
+      pendingAction={pendingAction}
+      themeOptions={terminalPlatformThemeManifests.map((theme) => ({
+        id: theme.id,
+        label: formatThemeLabel(t, theme.displayName, theme.id),
+      }))}
+    />
+  );
+};
+
+function formatThemeLabel(t: TeamTFunction, displayName: string, themeId: string): string {
+  if (themeId === 'terminal-platform-default') return t('terminalWorkspace.themeDark');
+  if (themeId === 'terminal-platform-light') return t('terminalWorkspace.themeLight');
+  return displayName.replace(/^Terminal Platform\s*/i, '').trim() || displayName;
+}
+
+function formatFontScaleLabel(t: TeamTFunction, fontScale: string): string {
+  if (fontScale === 'compact') return t('terminalWorkspace.fontScaleCompact');
+  if (fontScale === 'large') return t('terminalWorkspace.fontScaleLarge');
+  return t('terminalWorkspace.fontScaleDefault');
+}

--- a/src/features/terminal-workspace/renderer/ui/TerminalWorkspaceSettingsPage.tsx
+++ b/src/features/terminal-workspace/renderer/ui/TerminalWorkspaceSettingsPage.tsx
@@ -61,7 +61,7 @@ export const TerminalWorkspaceSettingsPage = ({
     } catch {
       // Kernel diagnostics already surface command failures in the terminal workspace.
     } finally {
-      setPendingAction(null);
+      setPendingAction((current) => (current === actionId ? null : current));
     }
   };
 

--- a/src/features/terminal-workspace/renderer/view-models/terminalAppearanceStyle.ts
+++ b/src/features/terminal-workspace/renderer/view-models/terminalAppearanceStyle.ts
@@ -1,0 +1,54 @@
+import {
+  normalizeTerminalAppearanceSettings,
+  resolveTerminalBackgroundImageUrl,
+  type TerminalAppearanceSettings,
+  type TerminalBackgroundImageFit,
+} from '../model/terminalAppearanceSettings';
+
+import type { CSSProperties } from 'react';
+
+export function createTerminalAppearanceStyle(settings: TerminalAppearanceSettings): CSSProperties {
+  const normalizedSettings = normalizeTerminalAppearanceSettings(settings);
+  const imageUrl = resolveTerminalBackgroundImageUrl(normalizedSettings.backgroundImageUrl);
+  const hasImage = normalizedSettings.backgroundMode === 'image' && imageUrl.length > 0;
+
+  return {
+    '--agent-terminal-font-size': `${normalizedSettings.fontSizePx}px`,
+    '--agent-terminal-panel-opacity': String(normalizedSettings.opacityPercent / 100),
+    '--agent-terminal-background-color': normalizedSettings.backgroundColor,
+    '--agent-terminal-background-image': hasImage ? createCssUrl(imageUrl) : 'none',
+    '--agent-terminal-background-position': getTerminalBackgroundPosition(
+      normalizedSettings.backgroundImageFit
+    ),
+    '--agent-terminal-background-repeat': getTerminalBackgroundRepeat(
+      normalizedSettings.backgroundImageFit
+    ),
+    '--agent-terminal-background-size': getTerminalBackgroundSize(
+      normalizedSettings.backgroundImageFit
+    ),
+    '--agent-terminal-backdrop-blur': `${normalizedSettings.backdropBlurPx}px`,
+    '--agent-terminal-background-image-blur': hasImage
+      ? `${normalizedSettings.backdropBlurPx}px`
+      : '0px',
+    '--agent-terminal-image-dim-opacity':
+      hasImage && normalizedSettings.dimBackgroundImage ? '0.42' : '0',
+  } as CSSProperties;
+}
+
+function createCssUrl(value: string): string {
+  return `url("${value.replace(/["\\\n\r]/gu, '')}")`;
+}
+
+function getTerminalBackgroundSize(fit: TerminalBackgroundImageFit): string {
+  if (fit === 'stretch') return '100% 100%';
+  if (fit === 'tile' || fit === 'center') return 'auto';
+  return fit;
+}
+
+function getTerminalBackgroundRepeat(fit: TerminalBackgroundImageFit): string {
+  return fit === 'tile' ? 'repeat' : 'no-repeat';
+}
+
+function getTerminalBackgroundPosition(fit: TerminalBackgroundImageFit): string {
+  return fit === 'tile' ? 'top left' : 'center';
+}

--- a/test/renderer/features/terminal-workspace/TerminalWorkspaceSettingsPage.test.tsx
+++ b/test/renderer/features/terminal-workspace/TerminalWorkspaceSettingsPage.test.tsx
@@ -134,6 +134,36 @@ describe('TerminalWorkspaceSettingsPage', () => {
     expect(currentViewProps().pendingAction).toBeNull();
   });
 
+  it('keeps the newer pending action when an earlier operation settles', async () => {
+    const reconnect = createDeferred<void>();
+    const stopRuntime = createDeferred<void>();
+    operations.reconnect.mockReturnValueOnce(reconnect.promise);
+    operations.stopRuntime.mockReturnValueOnce(stopRuntime.promise);
+    await renderPage();
+
+    act(() => {
+      currentViewProps().onReconnect();
+    });
+    expect(currentViewProps().pendingAction).toBe('bootstrap');
+
+    act(() => {
+      currentViewProps().onStopRuntime();
+    });
+    expect(currentViewProps().pendingAction).toBe('stop-runtime');
+
+    reconnect.resolve(undefined);
+    await act(async () => {
+      await flushMicrotasks();
+    });
+    expect(currentViewProps().pendingAction).toBe('stop-runtime');
+
+    stopRuntime.resolve(undefined);
+    await act(async () => {
+      await flushMicrotasks();
+    });
+    expect(currentViewProps().pendingAction).toBeNull();
+  });
+
   async function renderPage(): Promise<void> {
     await act(async () => {
       root.render(

--- a/test/renderer/features/terminal-workspace/TerminalWorkspaceSettingsPage.test.tsx
+++ b/test/renderer/features/terminal-workspace/TerminalWorkspaceSettingsPage.test.tsx
@@ -1,0 +1,189 @@
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { DEFAULT_TERMINAL_APPEARANCE_SETTINGS } from '@features/terminal-workspace/renderer/model/terminalAppearanceSettings';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { TerminalWorkspaceSettingsViewProps } from '@features/terminal-workspace/renderer/ui/TerminalWorkspaceSettingsView';
+import type { Mock } from 'vitest';
+
+const settingsFixture = vi.hoisted(() => ({
+  props: null as TerminalWorkspaceSettingsViewProps | null,
+}));
+
+vi.mock('@features/localization/renderer', () => ({
+  useAppTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@terminal-platform/design-tokens', () => ({
+  terminalPlatformThemeManifests: [
+    { displayName: 'Terminal Platform Dark', id: 'terminal-platform-default' },
+    { displayName: 'Terminal Platform Light', id: 'terminal-platform-light' },
+  ],
+}));
+
+vi.mock('@terminal-platform/workspace-core', () => ({
+  terminalPlatformTerminalFontScales: ['compact', 'default', 'large'],
+}));
+
+vi.mock('@features/terminal-workspace/renderer/ui/TerminalWorkspaceSettingsView', async () => {
+  const ReactModule = await import('react');
+  return {
+    TerminalWorkspaceSettingsView: (props: TerminalWorkspaceSettingsViewProps) => {
+      settingsFixture.props = props;
+      return ReactModule.createElement('div', {
+        'data-testid': 'mock-terminal-workspace-settings-view',
+      });
+    },
+  };
+});
+
+import { TerminalWorkspaceSettingsPage } from '@features/terminal-workspace/renderer/ui/TerminalWorkspaceSettingsPage';
+
+describe('TerminalWorkspaceSettingsPage', () => {
+  let host: HTMLDivElement;
+  let root: Root;
+  let operations: {
+    reconnect: Mock<() => Promise<void>>;
+    refreshSessions: Mock<() => Promise<void>>;
+    stopRuntime: Mock<() => Promise<void>>;
+    setFontScale: Mock<(fontScale: string) => void>;
+    setLineWrap: Mock<(lineWrap: boolean) => void>;
+    setTheme: Mock<(themeId: string) => void>;
+  };
+  let onAppearanceSettingsChange: ReturnType<typeof vi.fn>;
+  let onClose: ReturnType<typeof vi.fn>;
+  let onReload: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    settingsFixture.props = null;
+    host = document.createElement('div');
+    document.body.append(host);
+    root = createRoot(host);
+    operations = {
+      reconnect: vi.fn().mockResolvedValue(undefined),
+      refreshSessions: vi.fn().mockResolvedValue(undefined),
+      stopRuntime: vi.fn().mockResolvedValue(undefined),
+      setFontScale: vi.fn(),
+      setLineWrap: vi.fn(),
+      setTheme: vi.fn(),
+    };
+    onAppearanceSettingsChange = vi.fn();
+    onClose = vi.fn();
+    onReload = vi.fn();
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    host.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it('routes every setting through the narrow operations port and page callbacks', async () => {
+    await renderPage();
+    const props = currentViewProps();
+
+    props.onFontScaleChange('large');
+    props.onLineWrapChange(true);
+    props.onThemeChange('terminal-platform-light');
+    props.onAppearanceSettingsChange({ fontSizePx: 18 });
+    props.onResetAppearance();
+    props.onClose();
+    props.onReload();
+    await runAsyncAction(props.onReconnect);
+    await runAsyncAction(currentViewProps().onRefreshSessions);
+    await runAsyncAction(currentViewProps().onStopRuntime);
+
+    expect(operations.setFontScale).toHaveBeenCalledWith('large');
+    expect(operations.setLineWrap).toHaveBeenCalledWith(true);
+    expect(operations.setTheme).toHaveBeenCalledWith('terminal-platform-light');
+    expect(operations.reconnect).toHaveBeenCalledOnce();
+    expect(operations.refreshSessions).toHaveBeenCalledOnce();
+    expect(operations.stopRuntime).toHaveBeenCalledOnce();
+    expect(onAppearanceSettingsChange).toHaveBeenNthCalledWith(1, { fontSizePx: 18 });
+    expect(onAppearanceSettingsChange).toHaveBeenNthCalledWith(
+      2,
+      DEFAULT_TERMINAL_APPEARANCE_SETTINGS
+    );
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(onReload).toHaveBeenCalledOnce();
+    expect(currentViewProps().pendingAction).toBeNull();
+  });
+
+  it('clears the pending action when an operation rejects', async () => {
+    const reconnect = createDeferred<void>();
+    operations.reconnect.mockReturnValueOnce(reconnect.promise);
+    await renderPage();
+
+    act(() => {
+      currentViewProps().onReconnect();
+    });
+    expect(currentViewProps().pendingAction).toBe('bootstrap');
+
+    reconnect.reject(new Error('transport unavailable'));
+    await act(async () => {
+      await flushMicrotasks();
+    });
+
+    expect(currentViewProps().pendingAction).toBeNull();
+  });
+
+  async function renderPage(): Promise<void> {
+    await act(async () => {
+      root.render(
+        <TerminalWorkspaceSettingsPage
+          appearanceSettings={DEFAULT_TERMINAL_APPEARANCE_SETTINGS}
+          display={{
+            fontScale: 'default',
+            lineWrap: false,
+            themeId: 'terminal-platform-default',
+          }}
+          operations={operations}
+          onAppearanceSettingsChange={onAppearanceSettingsChange}
+          onClose={onClose}
+          onReload={onReload}
+        />
+      );
+      await flushMicrotasks();
+    });
+  }
+});
+
+function currentViewProps(): TerminalWorkspaceSettingsViewProps {
+  if (!settingsFixture.props) {
+    throw new Error('TerminalWorkspaceSettingsView props were not captured');
+  }
+  return settingsFixture.props;
+}
+
+async function runAsyncAction(action: () => void): Promise<void> {
+  await act(async () => {
+    action();
+    await flushMicrotasks();
+  });
+}
+
+function createDeferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}

--- a/test/renderer/features/terminal-workspace/terminalAppearanceStyle.test.ts
+++ b/test/renderer/features/terminal-workspace/terminalAppearanceStyle.test.ts
@@ -1,0 +1,91 @@
+import { DEFAULT_TERMINAL_APPEARANCE_SETTINGS } from '@features/terminal-workspace/renderer/model/terminalAppearanceSettings';
+import { createTerminalAppearanceStyle } from '@features/terminal-workspace/renderer/view-models/terminalAppearanceStyle';
+import { describe, expect, it } from 'vitest';
+
+describe('terminal appearance style', () => {
+  it('projects solid appearance values without activating a configured image', () => {
+    const style = asCustomProperties(
+      createTerminalAppearanceStyle({
+        ...DEFAULT_TERMINAL_APPEARANCE_SETTINGS,
+        backgroundColor: '#123456',
+        backgroundImageUrl: 'https://example.test/background.jpg',
+        backgroundMode: 'solid',
+        backdropBlurPx: 12,
+        fontSizePx: 18,
+        opacityPercent: 63,
+      })
+    );
+
+    expect(style).toMatchObject({
+      '--agent-terminal-backdrop-blur': '12px',
+      '--agent-terminal-background-color': '#123456',
+      '--agent-terminal-background-image': 'none',
+      '--agent-terminal-background-image-blur': '0px',
+      '--agent-terminal-font-size': '18px',
+      '--agent-terminal-image-dim-opacity': '0',
+      '--agent-terminal-panel-opacity': '0.63',
+    });
+  });
+
+  it.each([
+    ['cover', 'cover', 'no-repeat', 'center'],
+    ['contain', 'contain', 'no-repeat', 'center'],
+    ['stretch', '100% 100%', 'no-repeat', 'center'],
+    ['tile', 'auto', 'repeat', 'top left'],
+    ['center', 'auto', 'no-repeat', 'center'],
+  ] as const)(
+    'projects the %s image fit and image dimming',
+    (backgroundImageFit, size, repeat, position) => {
+      const style = asCustomProperties(
+        createTerminalAppearanceStyle({
+          ...DEFAULT_TERMINAL_APPEARANCE_SETTINGS,
+          backgroundImageFit,
+          backgroundImageUrl: 'https://example.test/background image.jpg',
+          backgroundMode: 'image',
+          backdropBlurPx: 7,
+          dimBackgroundImage: true,
+        })
+      );
+
+      expect(style['--agent-terminal-background-image']).toBe(
+        'url("https://example.test/background%20image.jpg")'
+      );
+      expect(style['--agent-terminal-background-size']).toBe(size);
+      expect(style['--agent-terminal-background-repeat']).toBe(repeat);
+      expect(style['--agent-terminal-background-position']).toBe(position);
+      expect(style['--agent-terminal-background-image-blur']).toBe('7px');
+      expect(style['--agent-terminal-image-dim-opacity']).toBe('0.42');
+    }
+  );
+
+  it('disables image-only styles for unsafe URLs and when dimming is off', () => {
+    const unsafeStyle = asCustomProperties(
+      createTerminalAppearanceStyle({
+        ...DEFAULT_TERMINAL_APPEARANCE_SETTINGS,
+        backgroundImageUrl: 'file:///etc/passwd',
+        backgroundMode: 'image',
+        backdropBlurPx: 20,
+      })
+    );
+    const undimmedStyle = asCustomProperties(
+      createTerminalAppearanceStyle({
+        ...DEFAULT_TERMINAL_APPEARANCE_SETTINGS,
+        backgroundImageUrl: 'https://example.test/background.jpg',
+        backgroundMode: 'image',
+        dimBackgroundImage: false,
+      })
+    );
+
+    expect(unsafeStyle['--agent-terminal-background-image']).toBe('none');
+    expect(unsafeStyle['--agent-terminal-background-image-blur']).toBe('0px');
+    expect(unsafeStyle['--agent-terminal-image-dim-opacity']).toBe('0');
+    expect(undimmedStyle['--agent-terminal-background-image']).toContain(
+      'https://example.test/background.jpg'
+    );
+    expect(undimmedStyle['--agent-terminal-image-dim-opacity']).toBe('0');
+  });
+});
+
+function asCustomProperties(style: React.CSSProperties): Readonly<Record<string, string>> {
+  return style as Readonly<Record<string, string>>;
+}

--- a/test/renderer/features/terminal-workspace/terminalWorkspaceExternalNavigation.test.ts
+++ b/test/renderer/features/terminal-workspace/terminalWorkspaceExternalNavigation.test.ts
@@ -1,0 +1,55 @@
+import {
+  openTerminalPlatformRepository,
+  TERMINAL_PLATFORM_REPOSITORY_URL,
+} from '@features/terminal-workspace/renderer/adapters/terminalWorkspaceExternalNavigation';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('terminal workspace external navigation', () => {
+  let originalElectronApiDescriptor: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    originalElectronApiDescriptor = Object.getOwnPropertyDescriptor(window, 'electronAPI');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (originalElectronApiDescriptor) {
+      Object.defineProperty(window, 'electronAPI', originalElectronApiDescriptor);
+    } else {
+      Reflect.deleteProperty(window, 'electronAPI');
+    }
+  });
+
+  it('uses the Electron external navigation bridge when available', () => {
+    const openExternal = vi.fn().mockResolvedValue(undefined);
+    const browserOpen = vi.spyOn(window, 'open').mockReturnValue(null);
+    setElectronApi({ openExternal });
+
+    openTerminalPlatformRepository();
+
+    expect(openExternal).toHaveBeenCalledWith(TERMINAL_PLATFORM_REPOSITORY_URL);
+    expect(browserOpen).not.toHaveBeenCalled();
+  });
+
+  it('opens a browser popup synchronously when the Electron bridge is unavailable', () => {
+    const browserOpen = vi.spyOn(window, 'open').mockReturnValue(null);
+    setElectronApi(undefined);
+
+    openTerminalPlatformRepository();
+
+    expect(browserOpen).toHaveBeenCalledWith(
+      TERMINAL_PLATFORM_REPOSITORY_URL,
+      '_blank',
+      'noopener,noreferrer'
+    );
+  });
+});
+
+function setElectronApi(
+  value: Pick<NonNullable<typeof window.electronAPI>, 'openExternal'> | undefined
+): void {
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    value: value as typeof window.electronAPI,
+  });
+}

--- a/test/renderer/features/terminal-workspace/terminalWorkspacePreferencesStorage.test.ts
+++ b/test/renderer/features/terminal-workspace/terminalWorkspacePreferencesStorage.test.ts
@@ -1,0 +1,94 @@
+import {
+  createTerminalWorkspacePreferenceKey,
+  persistTerminalAppearanceSettings,
+  persistTerminalPreference,
+  readStoredTerminalAppearanceSettings,
+  readStoredTerminalBooleanPreference,
+  readStoredTerminalPreference,
+  type TerminalWorkspacePreferencesStorage,
+} from '@features/terminal-workspace/renderer/adapters/terminalWorkspacePreferencesStorage';
+import { DEFAULT_TERMINAL_APPEARANCE_SETTINGS } from '@features/terminal-workspace/renderer/model/terminalAppearanceSettings';
+import { describe, expect, it, vi } from 'vitest';
+
+describe('terminal workspace preferences storage', () => {
+  it('isolates preferences and appearance settings by team', () => {
+    const storage = createMemoryStorage();
+    const teamAAppearance = {
+      ...DEFAULT_TERMINAL_APPEARANCE_SETTINGS,
+      backgroundColor: '#112233',
+      fontSizePx: 18,
+    };
+    const teamBAppearance = {
+      ...DEFAULT_TERMINAL_APPEARANCE_SETTINGS,
+      backgroundColor: '#445566',
+      fontSizePx: 21,
+    };
+
+    persistTerminalPreference('team-a', 'theme', 'terminal-platform-light', storage);
+    persistTerminalPreference('team-b', 'theme', 'terminal-platform-default', storage);
+    persistTerminalPreference('team-a', 'line-wrap', 'true', storage);
+    persistTerminalAppearanceSettings('team-a', teamAAppearance, storage);
+    persistTerminalAppearanceSettings('team-b', teamBAppearance, storage);
+
+    expect(readStoredTerminalPreference('team-a', 'theme', storage)).toBe(
+      'terminal-platform-light'
+    );
+    expect(readStoredTerminalPreference('team-b', 'theme', storage)).toBe(
+      'terminal-platform-default'
+    );
+    expect(readStoredTerminalBooleanPreference('team-a', 'line-wrap', storage)).toBe(true);
+    expect(readStoredTerminalBooleanPreference('team-b', 'line-wrap', storage)).toBeNull();
+    expect(readStoredTerminalAppearanceSettings('team-a', storage)).toEqual(teamAAppearance);
+    expect(readStoredTerminalAppearanceSettings('team-b', storage)).toEqual(teamBAppearance);
+    expect(createTerminalWorkspacePreferenceKey('team-a', 'theme')).not.toBe(
+      createTerminalWorkspacePreferenceKey('team-b', 'theme')
+    );
+  });
+
+  it('falls back safely for corrupt or unavailable storage', () => {
+    const corruptStorage = createMemoryStorage();
+    corruptStorage.setItem(
+      createTerminalWorkspacePreferenceKey('team-a', 'appearance-settings'),
+      '{not-json'
+    );
+    const unavailableStorage: TerminalWorkspacePreferencesStorage = {
+      getItem: vi.fn(() => {
+        throw new Error('storage unavailable');
+      }),
+      setItem: vi.fn(() => {
+        throw new Error('storage unavailable');
+      }),
+    };
+
+    expect(readStoredTerminalAppearanceSettings('team-a', corruptStorage)).toBe(
+      DEFAULT_TERMINAL_APPEARANCE_SETTINGS
+    );
+    expect(readStoredTerminalAppearanceSettings('team-a', unavailableStorage)).toBe(
+      DEFAULT_TERMINAL_APPEARANCE_SETTINGS
+    );
+    expect(readStoredTerminalPreference('team-a', 'theme', unavailableStorage)).toBeNull();
+    expect(
+      readStoredTerminalBooleanPreference('team-a', 'line-wrap', unavailableStorage)
+    ).toBeNull();
+    expect(() =>
+      persistTerminalPreference('team-a', 'theme', 'terminal-platform-light', unavailableStorage)
+    ).not.toThrow();
+    expect(() =>
+      persistTerminalAppearanceSettings(
+        'team-a',
+        DEFAULT_TERMINAL_APPEARANCE_SETTINGS,
+        unavailableStorage
+      )
+    ).not.toThrow();
+  });
+});
+
+function createMemoryStorage(): TerminalWorkspacePreferencesStorage {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => {
+      values.set(key, value);
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- move team-scoped terminal preference storage into an adapter
- move appearance CSS projection into a pure view model
- extract settings orchestration behind a narrow operations port without passing WorkspaceKernel
- extract stateless feedback and working-directory UI into leaf views
- route external navigation through a desktop/browser adapter and shared Radix tooltips
- reduce TerminalWorkspacePanel from 1028 to 750 lines
- remove TerminalWorkspacePanel from the legacy source-size exceptions

## Verification

- 208/208 full Terminal renderer tests on the exact merged #380 head
- hosted renderer boundary scanner
- native TypeScript 7 typecheck
- fast and type-aware ESLint, Prettier, diff-check
- source-size ratchet: 170 remaining legacy exceptions, 800-line production limit
- independent audit, P3 tooltip fix, and re-audit: no remaining P1-P3 findings

Desktop/runtime E2E will run once after this final code PR is merged, using only a fresh sandbox test project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a terminal workspace settings page for appearance, font scaling, themes, and line wrapping.
  * Terminal appearance is now styled with support for background images (fit/positioning), blur, and dimming.
  * Added working-directory + Git branch display, plus a shortcut to the terminal platform repository.
  * Introduced reusable loading/status UI states.
* **Bug Fixes**
  * Improved resilience when browser storage is unavailable or corrupted.
  * Prevented unsafe `file://` background image usage.
* **Tests**
  * Added/expanded coverage for settings actions, preference storage, external navigation, and appearance styling.
* **Chores**
  * Updated legacy CI source-file size mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->