### PR TITLE
chore(review): pin ReviewRouter release fe1db2c0

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -30,9 +30,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@240e3495843318f140e3281f72238859bb372e5d
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@fe1db2c03f9efb83c309970e9f23bc758daaf73e
     with:
-      runtime_ref: "240e3495843318f140e3281f72238859bb372e5d"
+      runtime_ref: "fe1db2c03f9efb83c309970e9f23bc758daaf73e"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ inputs.pr_number }}
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@240e3495843318f140e3281f72238859bb372e5d
+        uses: 777genius/review-router@fe1db2c03f9efb83c309970e9f23bc758daaf73e
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"


### PR DESCRIPTION
## Summary
- pin the reusable ReviewRouter workflow to immutable release fe1db2c0
- pin runtime_ref and refresh action to the same attested commit

## Verification
- canonical workflow source metadata validation passed
- producer release review-action-v2-fe1db2c0 is registered in production
- API and worker allowlist/attestation deploys are live

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated review and refresh workflows to use newer versions of their configured actions.
  * Preserved existing workflow settings and behavior while improving compatibility with the updated automation components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->