### PR TITLE
chore(review): pin deterministic witness release

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -30,9 +30,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@c14383fec1772312fa4cfe349fb6eb419de49e6f
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@cfdb0469eb7fd9782edd1307bcfdd877413afb41
     with:
-      runtime_ref: "c14383fec1772312fa4cfe349fb6eb419de49e6f"
+      runtime_ref: "cfdb0469eb7fd9782edd1307bcfdd877413afb41"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ inputs.pr_number }}
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@c14383fec1772312fa4cfe349fb6eb419de49e6f
+        uses: 777genius/review-router@cfdb0469eb7fd9782edd1307bcfdd877413afb41
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"


### PR DESCRIPTION
Pins the managed ReviewRouter workflow, runtime, and OAuth refresh action to immutable release `cfdb0469eb7fd9782edd1307bcfdd877413afb41`.

This release captures the authenticated `changed_paths` witness at context-gateway startup and includes the extended MCP startup timeout.

Validation:
- exactly three pins updated
- old c143 pin absent from managed workflow
- actionlint (when installed)
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated review and refresh workflows to use the latest validated workflow version.
  * Existing review modes and configuration remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->