### PR TITLE
chore(review): pin eager context witness release

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -30,9 +30,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@cfdb0469eb7fd9782edd1307bcfdd877413afb41
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@91a4a4931c72c980ae4b9fc726e81bb8dcf9a57f
     with:
-      runtime_ref: "cfdb0469eb7fd9782edd1307bcfdd877413afb41"
+      runtime_ref: "91a4a4931c72c980ae4b9fc726e81bb8dcf9a57f"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ inputs.pr_number }}
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@cfdb0469eb7fd9782edd1307bcfdd877413afb41
+        uses: 777genius/review-router@91a4a4931c72c980ae4b9fc726e81bb8dcf9a57f
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"


### PR DESCRIPTION
## Summary
- pin the managed ReviewRouter reusable workflow to `91a4a4931c72c980ae4b9fc726e81bb8dcf9a57f`
- pin `runtime_ref` and OAuth refresh action to the same immutable release
- keep the existing review model, timeout, and admission settings unchanged

## Verification
- exactly three managed workflow refs use the release SHA
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pinned ReviewRouter workflow and action versions.
  * No changes to application functionality, settings, permissions, or job behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->