### PR TITLE
chore(review): pin server admission release

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -30,9 +30,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@28254d50e5c71f9964c01c13b774cdf641248df2
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@c9d2ccb661b29f5a4e4f0123a9507a7818d402e3
     with:
-      runtime_ref: "28254d50e5c71f9964c01c13b774cdf641248df2"
+      runtime_ref: "c9d2ccb661b29f5a4e4f0123a9507a7818d402e3"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ inputs.pr_number }}
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@28254d50e5c71f9964c01c13b774cdf641248df2
+        uses: 777genius/review-router@c9d2ccb661b29f5a4e4f0123a9507a7818d402e3
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"


### PR DESCRIPTION
## Summary
- pin all ReviewRouter workflow entry points to the registered server-admission Action release
- keep the existing review policy and triggers unchanged

## Verification
- exact Action commit is registered in the ReviewRouter production control plane
- workflow YAML parsed successfully
- all three Action references use the same immutable SHA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated review workflow to use a newer version of its review tooling.
  * Refreshed both review and refresh automation paths while preserving existing workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->