### PR TITLE
fix(change-review): remount mixed restore files

### DIFF
--- a/src/features/change-review/renderer/hooks/useChangeReviewHistoryMutationController.ts
+++ b/src/features/change-review/renderer/hooks/useChangeReviewHistoryMutationController.ts
@@ -14,6 +14,7 @@ import {
   classifyReviewHistoryRecovery,
   createReviewRedoAction,
   getReviewActionAffectedPaths,
+  getReviewActionsAffectedPaths,
   getReviewDiskMutationExpectedContent,
   resolveReviewFile,
 } from '../utils/changeReviewHistoryMutation';
@@ -192,10 +193,7 @@ export function useChangeReviewHistoryMutationController({
     ): void => {
       applyCommittedState(persistedState, decisionRevision, null);
       if (direction === 'undo') {
-        refreshAfterUndo(
-          diskSnapshots,
-          orderedActions.flatMap((action) => getReviewActionAffectedPaths(action, files))
-        );
+        refreshAfterUndo(diskSnapshots, getReviewActionsAffectedPaths(orderedActions, files));
       } else {
         for (const action of orderedActions) refreshAfterRedo(action);
       }

--- a/src/features/change-review/renderer/hooks/useChangeReviewHistoryMutationController.ts
+++ b/src/features/change-review/renderer/hooks/useChangeReviewHistoryMutationController.ts
@@ -131,7 +131,10 @@ export function useChangeReviewHistoryMutationController({
   );
 
   const refreshAfterUndo = useCallback(
-    (snapshots: readonly ReviewDiskUndoSnapshot[]): void => {
+    (
+      snapshots: readonly ReviewDiskUndoSnapshot[],
+      affectedPaths = snapshots.map((snapshot) => snapshot.filePath)
+    ): void => {
       for (const snapshot of snapshots) {
         const restoreMode =
           snapshot.restoreMode ??
@@ -143,7 +146,7 @@ export function useChangeReviewHistoryMutationController({
         statePort.invalidateResolvedFileContent(snapshot.filePath);
         viewPort.fetchFileContent(teamName, memberName, snapshot.filePath);
       }
-      viewPort.incrementDiscardCounters(snapshots.map((snapshot) => snapshot.filePath));
+      viewPort.incrementDiscardCounters(affectedPaths);
     },
     [memberName, statePort, teamName, viewPort]
   );
@@ -189,13 +192,10 @@ export function useChangeReviewHistoryMutationController({
     ): void => {
       applyCommittedState(persistedState, decisionRevision, null);
       if (direction === 'undo') {
-        if (diskSnapshots.length > 0) {
-          refreshAfterUndo(diskSnapshots);
-        } else {
-          viewPort.incrementDiscardCounters(
-            orderedActions.flatMap((action) => getReviewActionAffectedPaths(action, files))
-          );
-        }
+        refreshAfterUndo(
+          diskSnapshots,
+          orderedActions.flatMap((action) => getReviewActionAffectedPaths(action, files))
+        );
       } else {
         for (const action of orderedActions) refreshAfterRedo(action);
       }

--- a/src/features/change-review/renderer/utils/changeReviewHistoryMutation.ts
+++ b/src/features/change-review/renderer/utils/changeReviewHistoryMutation.ts
@@ -93,8 +93,29 @@ export function getReviewActionAffectedPaths(
   action: ReviewUndoAction,
   files: readonly FileChangeSummary[]
 ): string[] {
-  if (action.kind === 'bulk') return files.map((file) => file.filePath);
+  if (action.kind === 'bulk') {
+    return action.descriptor && 'filePath' in action.descriptor
+      ? [action.descriptor.filePath]
+      : files.map((file) => file.filePath);
+  }
   return [action.kind === 'disk' ? action.action.snapshot.filePath : action.action.filePath];
+}
+
+export function getReviewActionsAffectedPaths(
+  actions: readonly ReviewUndoAction[],
+  files: readonly FileChangeSummary[]
+): string[] {
+  const seenPaths = new Set<string>();
+  const affectedPaths: string[] = [];
+  for (const action of actions) {
+    for (const filePath of getReviewActionAffectedPaths(action, files)) {
+      const normalizedPath = normalizePathForComparison(filePath);
+      if (seenPaths.has(normalizedPath)) continue;
+      seenPaths.add(normalizedPath);
+      affectedPaths.push(filePath);
+    }
+  }
+  return affectedPaths;
 }
 
 export function resolveReviewFile(

--- a/src/features/change-review/renderer/utils/changeReviewHistoryMutation.ts
+++ b/src/features/change-review/renderer/utils/changeReviewHistoryMutation.ts
@@ -112,7 +112,10 @@ export function getReviewActionsAffectedPaths(
       const normalizedPath = normalizePathForComparison(filePath);
       if (seenPaths.has(normalizedPath)) continue;
       seenPaths.add(normalizedPath);
-      affectedPaths.push(filePath);
+      const currentFile = files.find(
+        (file) => normalizePathForComparison(file.filePath) === normalizedPath
+      );
+      affectedPaths.push(currentFile?.filePath ?? filePath);
     }
   }
   return affectedPaths;

--- a/src/renderer/components/team/review/CodeMirrorDiffView.tsx
+++ b/src/renderer/components/team/review/CodeMirrorDiffView.tsx
@@ -790,6 +790,9 @@ export const CodeMirrorDiffView = ({
       if (extRef) {
         (extRef as React.MutableRefObject<EditorView | null>).current = null;
       }
+      // A keyed remount invalidates the old document coordinates and selected text.
+      // Clear the parent-owned action menu before publishing the replacement view.
+      onSelectionChangeRef.current?.(null);
       // Notify parent that the EditorView was destroyed
       onViewChangeRef.current?.(null);
     };

--- a/src/renderer/components/team/review/CodeMirrorDiffView.tsx
+++ b/src/renderer/components/team/review/CodeMirrorDiffView.tsx
@@ -790,10 +790,7 @@ export const CodeMirrorDiffView = ({
       if (extRef) {
         (extRef as React.MutableRefObject<EditorView | null>).current = null;
       }
-      // A keyed remount invalidates the old document coordinates and selected text.
-      // Clear the parent-owned action menu before publishing the replacement view.
       onSelectionChangeRef.current?.(null);
-      // Notify parent that the EditorView was destroyed
       onViewChangeRef.current?.(null);
     };
     // We intentionally rebuild the entire editor when key props change

--- a/src/renderer/components/team/review/ContinuousScrollView.tsx
+++ b/src/renderer/components/team/review/ContinuousScrollView.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import { resolveChangeReviewFileHunkCount as getFileHunkCount } from '@features/change-review';
 import { useAppTranslation } from '@features/localization/renderer';
@@ -199,7 +199,9 @@ export const ContinuousScrollView = ({
   const hunkDecisionsRef = useRef(hunkDecisions);
   const hunkHashesRef = useRef(hunkContextHashesByFile);
   const editedContentsRef = useRef(editedContents);
-  useEffect(() => {
+  // A remounted editor publishes itself from a passive effect. Sync first so it cannot replay
+  // decisions or drafts from the render that triggered the remount.
+  useLayoutEffect(() => {
     fileDecisionsRef.current = fileDecisions;
     hunkDecisionsRef.current = hunkDecisions;
     hunkHashesRef.current = hunkContextHashesByFile;

--- a/src/renderer/components/team/review/ContinuousScrollView.tsx
+++ b/src/renderer/components/team/review/ContinuousScrollView.tsx
@@ -141,6 +141,21 @@ export const ContinuousScrollView = ({
   const fileChunkCounts = useStore((s) => s.fileChunkCounts);
   const [localCollapsedFiles, setLocalCollapsedFiles] = useState<Set<string>>(() => new Set());
   const collapsedFiles = collapsedFilesProp ?? localCollapsedFiles;
+  const activeSelectionFilePathRef = useRef<string | null>(null);
+
+  const handleFileSelectionChange = useCallback(
+    (filePath: string, info: EditorSelectionInfo | null) => {
+      if (info) {
+        activeSelectionFilePathRef.current = filePath;
+        onSelectionChange?.({ ...info, filePath });
+        return;
+      }
+      if (activeSelectionFilePathRef.current !== filePath) return;
+      activeSelectionFilePathRef.current = null;
+      onSelectionChange?.(null);
+    },
+    [onSelectionChange]
+  );
 
   const handleToggleCollapse = useCallback(
     (filePath: string) => {
@@ -345,7 +360,11 @@ export const ContinuousScrollView = ({
                 discardCounter={discardCounters[filePath] ?? 0}
                 autoViewed={autoViewed}
                 isViewed={isViewed}
-                onSelectionChange={onSelectionChange}
+                onSelectionChange={
+                  onSelectionChange
+                    ? (info) => handleFileSelectionChange(filePath, info)
+                    : undefined
+                }
                 globalHunkOffset={globalHunkOffsets?.[filePath] ?? 0}
                 totalReviewHunks={totalReviewHunks}
               />

--- a/test/features/change-review/renderer/useChangeReviewHistoryMutationController.test.tsx
+++ b/test/features/change-review/renderer/useChangeReviewHistoryMutationController.test.tsx
@@ -105,6 +105,17 @@ function diskAction(id = 'disk-1', filePath = '/repo/file.ts'): ReviewUndoAction
   } as ReviewUndoAction;
 }
 
+function fileBulkAction(id = 'file-1', filePath = '/repo/file.ts'): ReviewUndoAction {
+  return {
+    id,
+    createdAt: '2026-07-23T00:00:00.000Z',
+    kind: 'bulk',
+    descriptor: { intent: 'accept-file', filePath },
+    decisionSnapshot: { hunkDecisions: {}, fileDecisions: {} },
+    diskSnapshots: [],
+  };
+}
+
 function persistedState(
   undo: ReviewUndoAction[] = [],
   redo: ReviewRedoAction[] = []
@@ -351,6 +362,54 @@ describe('useChangeReviewHistoryMutationController', () => {
     expect(harness.viewPort.incrementDiscardCounters).toHaveBeenCalledWith([
       '/repo/disk.ts',
       '/repo/hunk.ts',
+    ]);
+  });
+
+  it('remounts only the accepted file when Restore also undoes disk-backed actions', async () => {
+    const acceptedFile = fileBulkAction('file-1', '/repo/accepted.ts');
+    const disk = diskAction('disk-1', '/repo/disk.ts');
+    const harness = createHarness({ undo: [acceptedFile, disk] });
+    vi.mocked(harness.commandPort.restoreHistory).mockResolvedValue({
+      decisionRevision: 5,
+      persistedState: persistedState(),
+      direction: 'undo',
+      actionCount: 2,
+      diskPostimages: [],
+    });
+    harness.files = [
+      {
+        filePath: '/repo/accepted.ts',
+        relativePath: 'accepted.ts',
+        snippets: [],
+        linesAdded: 1,
+        linesRemoved: 0,
+        isNewFile: false,
+      },
+      {
+        filePath: '/repo/disk.ts',
+        relativePath: 'disk.ts',
+        snippets: [],
+        linesAdded: 1,
+        linesRemoved: 0,
+        isNewFile: false,
+      },
+      {
+        filePath: '/repo/unrelated.ts',
+        relativePath: 'unrelated.ts',
+        snippets: [],
+        linesAdded: 1,
+        linesRemoved: 0,
+        isNewFile: false,
+      },
+    ];
+    await renderHarness(harness);
+
+    await act(async () => latest!.restoreHistory({ kind: 'start' }));
+
+    expect(harness.viewPort.incrementDiscardCounters).toHaveBeenCalledOnce();
+    expect(harness.viewPort.incrementDiscardCounters).toHaveBeenCalledWith([
+      '/repo/disk.ts',
+      '/repo/accepted.ts',
     ]);
   });
 

--- a/test/features/change-review/renderer/useChangeReviewHistoryMutationController.test.tsx
+++ b/test/features/change-review/renderer/useChangeReviewHistoryMutationController.test.tsx
@@ -80,16 +80,16 @@ function Probe({ harness }: ProbeProps): React.JSX.Element {
   return <div />;
 }
 
-function hunkAction(id = 'action-1'): ReviewUndoAction {
+function hunkAction(id = 'action-1', filePath = '/repo/file.ts'): ReviewUndoAction {
   return {
     id,
     createdAt: '2026-07-23T00:00:00.000Z',
     kind: 'hunk',
-    action: { filePath: '/repo/file.ts', originalIndex: 0 },
+    action: { filePath, originalIndex: 0 },
   };
 }
 
-function diskAction(id = 'disk-1'): ReviewUndoAction {
+function diskAction(id = 'disk-1', filePath = '/repo/file.ts'): ReviewUndoAction {
   return {
     id,
     createdAt: '2026-07-23T00:00:00.000Z',
@@ -97,7 +97,7 @@ function diskAction(id = 'disk-1'): ReviewUndoAction {
     action: {
       originalIndex: 0,
       snapshot: {
-        filePath: '/repo/file.ts',
+        filePath,
         beforeContent: 'before',
         afterContent: 'after',
       },
@@ -306,6 +306,52 @@ describe('useChangeReviewHistoryMutationController', () => {
     expect(request.expectedTopRedoActionId).toBe(action.id);
     expect(request.expectedDecisionRevision).toBe(4);
     expect(harness.history.completeRedoAction).toHaveBeenCalledWith(redoAction);
+  });
+
+  it('remounts hunk-only files when Restore also undoes disk-backed actions', async () => {
+    const hunk = hunkAction('hunk-1', '/repo/hunk.ts');
+    const disk = diskAction('disk-1', '/repo/disk.ts');
+    const harness = createHarness({ undo: [hunk, disk] });
+    vi.mocked(harness.commandPort.restoreHistory).mockResolvedValue({
+      decisionRevision: 5,
+      persistedState: persistedState(),
+      direction: 'undo',
+      actionCount: 2,
+      diskPostimages: [],
+    });
+    harness.files = [
+      {
+        filePath: '/repo/hunk.ts',
+        relativePath: 'hunk.ts',
+        snippets: [],
+        linesAdded: 1,
+        linesRemoved: 0,
+        isNewFile: false,
+      },
+      {
+        filePath: '/repo/disk.ts',
+        relativePath: 'disk.ts',
+        snippets: [],
+        linesAdded: 1,
+        linesRemoved: 0,
+        isNewFile: false,
+      },
+    ];
+    await renderHarness(harness);
+
+    await act(async () => latest!.restoreHistory({ kind: 'start' }));
+
+    expect(harness.viewPort.fetchFileContent).toHaveBeenCalledTimes(1);
+    expect(harness.viewPort.fetchFileContent).toHaveBeenCalledWith(
+      'team',
+      'member',
+      '/repo/disk.ts'
+    );
+    expect(harness.viewPort.incrementDiscardCounters).toHaveBeenCalledOnce();
+    expect(harness.viewPort.incrementDiscardCounters).toHaveBeenCalledWith([
+      '/repo/disk.ts',
+      '/repo/hunk.ts',
+    ]);
   });
 
   it('retries the original Restore only after a no-journal recovery finishes its busy scope', async () => {

--- a/test/features/change-review/renderer/useChangeReviewHistoryMutationController.test.tsx
+++ b/test/features/change-review/renderer/useChangeReviewHistoryMutationController.test.tsx
@@ -365,9 +365,9 @@ describe('useChangeReviewHistoryMutationController', () => {
     ]);
   });
 
-  it('remounts only the accepted file when Restore also undoes disk-backed actions', async () => {
-    const acceptedFile = fileBulkAction('file-1', '/repo/accepted.ts');
-    const disk = diskAction('disk-1', '/repo/disk.ts');
+  it('remounts only the canonical accepted-file path during mixed Restore', async () => {
+    const acceptedFile = fileBulkAction('file-1', 'c:/repo/accepted.ts');
+    const disk = diskAction('disk-1', 'C:\\Repo\\Accepted.ts');
     const harness = createHarness({ undo: [acceptedFile, disk] });
     vi.mocked(harness.commandPort.restoreHistory).mockResolvedValue({
       decisionRevision: 5,
@@ -378,16 +378,8 @@ describe('useChangeReviewHistoryMutationController', () => {
     });
     harness.files = [
       {
-        filePath: '/repo/accepted.ts',
+        filePath: 'c:/repo/accepted.ts',
         relativePath: 'accepted.ts',
-        snippets: [],
-        linesAdded: 1,
-        linesRemoved: 0,
-        isNewFile: false,
-      },
-      {
-        filePath: '/repo/disk.ts',
-        relativePath: 'disk.ts',
         snippets: [],
         linesAdded: 1,
         linesRemoved: 0,
@@ -408,8 +400,7 @@ describe('useChangeReviewHistoryMutationController', () => {
 
     expect(harness.viewPort.incrementDiscardCounters).toHaveBeenCalledOnce();
     expect(harness.viewPort.incrementDiscardCounters).toHaveBeenCalledWith([
-      '/repo/disk.ts',
-      '/repo/accepted.ts',
+      'c:/repo/accepted.ts',
     ]);
   });
 

--- a/test/renderer/components/team/review/CodeMirrorDiffView.draft.test.tsx
+++ b/test/renderer/components/team/review/CodeMirrorDiffView.draft.test.tsx
@@ -235,4 +235,44 @@ describe('CodeMirrorDiffView draft propagation', () => {
     expect(undoDepth(requireView().state)).toBe(150);
     await act(async () => restarted.unmount());
   });
+
+  it('clears the parent selection action when a keyed editor remounts', async () => {
+    const root = createRoot(container);
+    const actionPayloads: string[] = [];
+
+    function SelectionHarness({ editorKey }: Readonly<{ editorKey: number }>): React.JSX.Element {
+      const [selection, setSelection] = React.useState<{
+        selectedText: string;
+      } | null>({ selectedText: 'stale selection' });
+      return (
+        <>
+          <CodeMirrorDiffView
+            key={editorKey}
+            original="before"
+            modified="after"
+            fileName="file.txt"
+            readOnly={true}
+            collapseUnchanged={false}
+            onSelectionChange={(info) =>
+              setSelection(info ? { selectedText: info.text } : null)
+            }
+          />
+          {selection && (
+            <button type="button" onClick={() => actionPayloads.push(selection.selectedText)}>
+              Create action
+            </button>
+          )}
+        </>
+      );
+    }
+
+    await act(async () => root.render(<SelectionHarness editorKey={0} />));
+    expect(container.querySelector('button')?.textContent).toBe('Create action');
+
+    await act(async () => root.render(<SelectionHarness editorKey={1} />));
+
+    expect(container.querySelector('button')).toBeNull();
+    expect(actionPayloads).toEqual([]);
+    await act(async () => root.unmount());
+  });
 });

--- a/test/renderer/components/team/review/ContinuousScrollView.decisionReplay.test.tsx
+++ b/test/renderer/components/team/review/ContinuousScrollView.decisionReplay.test.tsx
@@ -1,0 +1,169 @@
+import React, { act, useEffect } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ContinuousScrollView } from '../../../../../src/renderer/components/team/review/ContinuousScrollView';
+
+import type { EditorView } from '@codemirror/view';
+import type { FileChangeSummary, FileChangeWithContent, HunkDecision } from '@shared/types';
+
+const replaySpies = vi.hoisted(() => ({
+  acceptAllChunks: vi.fn(),
+  rejectAllChunks: vi.fn(),
+  replayHunkDecisionsSmart: vi.fn(),
+  setFileChunkCount: vi.fn(),
+}));
+
+vi.mock('@features/localization/renderer', () => ({
+  useAppTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@renderer/hooks/useLazyFileContent', () => ({
+  useLazyFileContent: () => ({ registerLazyRef: () => () => undefined }),
+}));
+
+vi.mock('@renderer/hooks/useVisibleFileSection', () => ({
+  useVisibleFileSection: () => ({ registerFileSectionRef: () => () => undefined }),
+}));
+
+vi.mock('@renderer/store', () => ({
+  useStore: (
+    selector: (state: {
+      fileChunkCounts: Record<string, number>;
+      setFileChunkCount: typeof replaySpies.setFileChunkCount;
+    }) => unknown
+  ) =>
+    selector({
+      fileChunkCounts: {},
+      setFileChunkCount: replaySpies.setFileChunkCount,
+    }),
+}));
+
+vi.mock('../../../../../src/renderer/components/team/review/CodeMirrorDiffUtils', () => ({
+  acceptAllChunks: replaySpies.acceptAllChunks,
+  getChunks: () => ({ chunks: [] }),
+  rejectAllChunks: replaySpies.rejectAllChunks,
+  replayHunkDecisionsSmart: replaySpies.replayHunkDecisionsSmart,
+}));
+
+vi.mock('../../../../../src/renderer/components/team/review/FileSectionHeader', () => ({
+  FileSectionHeader: () => null,
+}));
+
+vi.mock('../../../../../src/renderer/components/team/review/FullDiffLoadingBanner', () => ({
+  FullDiffLoadingBanner: () => null,
+}));
+
+vi.mock('../../../../../src/renderer/components/team/review/FileSectionDiff', () => ({
+  FileSectionDiff: ({
+    discardCounter,
+    file,
+    onEditorViewReady,
+  }: {
+    discardCounter: number;
+    file: FileChangeSummary;
+    onEditorViewReady: (filePath: string, view: EditorView | null) => void;
+  }) => {
+    useEffect(() => {
+      const view = { state: {} } as EditorView;
+      onEditorViewReady(file.filePath, view);
+      return () => onEditorViewReady(file.filePath, null);
+    }, [discardCounter, file.filePath, onEditorViewReady]);
+    return null;
+  },
+}));
+
+const file: FileChangeSummary = {
+  filePath: '/repo/file.ts',
+  relativePath: 'file.ts',
+  snippets: [],
+  linesAdded: 1,
+  linesRemoved: 0,
+  isNewFile: false,
+};
+
+const fileContent: FileChangeWithContent = {
+  ...file,
+  originalFullContent: 'before',
+  modifiedFullContent: 'after',
+  contentSource: 'ledger-exact',
+};
+
+const noop = () => undefined;
+
+describe('ContinuousScrollView decision replay', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+  });
+
+  it.each([
+    { decision: 'accepted' as const, replay: replaySpies.acceptAllChunks },
+    { decision: 'rejected' as const, replay: replaySpies.rejectAllChunks },
+  ])('does not replay the previous $decision decision after a restore remount', async (testCase) => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const scrollContainerRef = React.createRef<HTMLDivElement>();
+    const editorViewMapRef = { current: new Map<string, EditorView>() };
+    const isProgrammaticScroll = { current: false };
+
+    const renderView = (
+      fileDecisions: Record<string, HunkDecision>,
+      discardCounter: number
+    ): React.ReactElement => (
+      <ContinuousScrollView
+        files={[file]}
+        fileContents={{ [file.filePath]: fileContent }}
+        fileContentsLoading={{}}
+        reviewExternalChangesByFile={{}}
+        viewedSet={new Set()}
+        editedContents={{}}
+        draftHistoryEntries={{}}
+        hunkDecisions={{}}
+        fileDecisions={fileDecisions}
+        hunkContextHashesByFile={{}}
+        collapseUnchanged={false}
+        applying={false}
+        autoViewed={false}
+        discardCounters={{ [file.filePath]: discardCounter }}
+        onHunkAccepted={noop}
+        onHunkRejected={noop}
+        onFullyViewed={noop}
+        onContentChanged={noop}
+        onSerializedStateChanged={noop}
+        onSerializedStateRestoreError={noop}
+        onDiscard={noop}
+        onSave={noop}
+        onReloadFromDisk={noop}
+        onKeepDraft={noop}
+        onAcceptFile={noop}
+        onRejectFile={noop}
+        onVisibleFileChange={noop}
+        scrollContainerRef={scrollContainerRef}
+        editorViewMapRef={editorViewMapRef}
+        isProgrammaticScroll={isProgrammaticScroll}
+        teamName="test-team"
+        memberName="test-member"
+        fetchFileContent={async () => undefined}
+      />
+    );
+
+    await act(async () =>
+      root.render(renderView({ [file.filePath]: testCase.decision }, 0))
+    );
+    expect(testCase.replay).toHaveBeenCalledTimes(1);
+    vi.clearAllMocks();
+
+    await act(async () => root.render(renderView({}, 1)));
+
+    expect(testCase.replay).not.toHaveBeenCalled();
+    await act(async () => root.unmount());
+    container.remove();
+  });
+});

--- a/test/renderer/components/team/review/ContinuousScrollView.decisionReplay.test.tsx
+++ b/test/renderer/components/team/review/ContinuousScrollView.decisionReplay.test.tsx
@@ -1,7 +1,7 @@
 import React, { act, useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ContinuousScrollView } from '../../../../../src/renderer/components/team/review/ContinuousScrollView';
 
@@ -100,6 +100,10 @@ describe('ContinuousScrollView decision replay', () => {
       callback(0);
       return 1;
     });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it.each([

--- a/test/renderer/components/team/review/ContinuousScrollView.decisionReplay.test.tsx
+++ b/test/renderer/components/team/review/ContinuousScrollView.decisionReplay.test.tsx
@@ -7,11 +7,13 @@ import { ContinuousScrollView } from '../../../../../src/renderer/components/tea
 
 import type { EditorView } from '@codemirror/view';
 import type { FileChangeSummary, FileChangeWithContent, HunkDecision } from '@shared/types';
+import type { EditorSelectionInfo } from '@shared/types/editor';
 
 const replaySpies = vi.hoisted(() => ({
   acceptAllChunks: vi.fn(),
   rejectAllChunks: vi.fn(),
   replayHunkDecisionsSmart: vi.fn(),
+  selectionCallbacks: new Map<string, (info: EditorSelectionInfo | null) => void>(),
   setFileChunkCount: vi.fn(),
 }));
 
@@ -60,16 +62,24 @@ vi.mock('../../../../../src/renderer/components/team/review/FileSectionDiff', ()
     discardCounter,
     file,
     onEditorViewReady,
+    onSelectionChange,
   }: {
     discardCounter: number;
     file: FileChangeSummary;
     onEditorViewReady: (filePath: string, view: EditorView | null) => void;
+    onSelectionChange?: (info: EditorSelectionInfo | null) => void;
   }) => {
+    if (onSelectionChange) replaySpies.selectionCallbacks.set(file.filePath, onSelectionChange);
     useEffect(() => {
       const view = { state: {} } as EditorView;
       onEditorViewReady(file.filePath, view);
-      return () => onEditorViewReady(file.filePath, null);
-    }, [discardCounter, file.filePath, onEditorViewReady]);
+      return () => {
+        onEditorViewReady(file.filePath, null);
+        if (replaySpies.selectionCallbacks.get(file.filePath) === onSelectionChange) {
+          replaySpies.selectionCallbacks.delete(file.filePath);
+        }
+      };
+    }, [discardCounter, file.filePath, onEditorViewReady, onSelectionChange]);
     return null;
   },
 }));
@@ -95,6 +105,7 @@ const noop = () => undefined;
 describe('ContinuousScrollView decision replay', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    replaySpies.selectionCallbacks.clear();
     vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
     vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
       callback(0);
@@ -109,16 +120,83 @@ describe('ContinuousScrollView decision replay', () => {
   it.each([
     { decision: 'accepted' as const, replay: replaySpies.acceptAllChunks },
     { decision: 'rejected' as const, replay: replaySpies.rejectAllChunks },
-  ])('does not replay the previous $decision decision after a restore remount', async (testCase) => {
+  ])(
+    'does not replay the previous $decision decision after a restore remount',
+    async (testCase) => {
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      const root = createRoot(container);
+      const scrollContainerRef = React.createRef<HTMLDivElement>();
+      const editorViewMapRef = { current: new Map<string, EditorView>() };
+      const isProgrammaticScroll = { current: false };
+
+      const renderView = (
+        fileDecisions: Record<string, HunkDecision>,
+        discardCounter: number
+      ): React.ReactElement => (
+        <ContinuousScrollView
+          files={[file]}
+          fileContents={{ [file.filePath]: fileContent }}
+          fileContentsLoading={{}}
+          reviewExternalChangesByFile={{}}
+          viewedSet={new Set()}
+          editedContents={{}}
+          draftHistoryEntries={{}}
+          hunkDecisions={{}}
+          fileDecisions={fileDecisions}
+          hunkContextHashesByFile={{}}
+          collapseUnchanged={false}
+          applying={false}
+          autoViewed={false}
+          discardCounters={{ [file.filePath]: discardCounter }}
+          onHunkAccepted={noop}
+          onHunkRejected={noop}
+          onFullyViewed={noop}
+          onContentChanged={noop}
+          onSerializedStateChanged={noop}
+          onSerializedStateRestoreError={noop}
+          onDiscard={noop}
+          onSave={noop}
+          onReloadFromDisk={noop}
+          onKeepDraft={noop}
+          onAcceptFile={noop}
+          onRejectFile={noop}
+          onVisibleFileChange={noop}
+          scrollContainerRef={scrollContainerRef}
+          editorViewMapRef={editorViewMapRef}
+          isProgrammaticScroll={isProgrammaticScroll}
+          teamName="test-team"
+          memberName="test-member"
+          fetchFileContent={async () => undefined}
+        />
+      );
+
+      await act(async () => root.render(renderView({ [file.filePath]: testCase.decision }, 0)));
+      expect(testCase.replay).toHaveBeenCalledTimes(1);
+      vi.clearAllMocks();
+
+      await act(async () => root.render(renderView({}, 1)));
+
+      expect(testCase.replay).not.toHaveBeenCalled();
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  );
+
+  it('uses current hunk, hash, and draft state for each remounted editor', async () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = createRoot(container);
     const scrollContainerRef = React.createRef<HTMLDivElement>();
     const editorViewMapRef = { current: new Map<string, EditorView>() };
     const isProgrammaticScroll = { current: false };
-
     const renderView = (
-      fileDecisions: Record<string, HunkDecision>,
+      state: {
+        editedContents?: Record<string, string>;
+        fileDecisions?: Record<string, HunkDecision>;
+        hunkContextHashesByFile?: Record<string, Record<number, string>>;
+        hunkDecisions?: Record<string, HunkDecision>;
+      },
       discardCounter: number
     ): React.ReactElement => (
       <ContinuousScrollView
@@ -127,11 +205,11 @@ describe('ContinuousScrollView decision replay', () => {
         fileContentsLoading={{}}
         reviewExternalChangesByFile={{}}
         viewedSet={new Set()}
-        editedContents={{}}
+        editedContents={state.editedContents ?? {}}
         draftHistoryEntries={{}}
-        hunkDecisions={{}}
-        fileDecisions={fileDecisions}
-        hunkContextHashesByFile={{}}
+        hunkDecisions={state.hunkDecisions ?? {}}
+        fileDecisions={state.fileDecisions ?? {}}
+        hunkContextHashesByFile={state.hunkContextHashesByFile ?? {}}
         collapseUnchanged={false}
         applying={false}
         autoViewed={false}
@@ -157,16 +235,136 @@ describe('ContinuousScrollView decision replay', () => {
         fetchFileContent={async () => undefined}
       />
     );
+    const hunkKey = `${file.filePath}:0`;
 
     await act(async () =>
-      root.render(renderView({ [file.filePath]: testCase.decision }, 0))
+      root.render(
+        renderView(
+          {
+            hunkDecisions: { [hunkKey]: 'accepted' },
+            hunkContextHashesByFile: { [file.filePath]: { 0: 'old-hash' } },
+          },
+          0
+        )
+      )
     );
-    expect(testCase.replay).toHaveBeenCalledTimes(1);
+    expect(replaySpies.replayHunkDecisionsSmart).toHaveBeenLastCalledWith(
+      expect.anything(),
+      file.filePath,
+      { [hunkKey]: 'accepted' },
+      { 0: 'old-hash' }
+    );
+
     vi.clearAllMocks();
-
     await act(async () => root.render(renderView({}, 1)));
+    expect(replaySpies.replayHunkDecisionsSmart).toHaveBeenLastCalledWith(
+      expect.anything(),
+      file.filePath,
+      {},
+      undefined
+    );
 
-    expect(testCase.replay).not.toHaveBeenCalled();
+    vi.clearAllMocks();
+    await act(async () =>
+      root.render(
+        renderView(
+          {
+            editedContents: { [file.filePath]: 'draft' },
+            fileDecisions: { [file.filePath]: 'accepted' },
+          },
+          2
+        )
+      )
+    );
+    expect(replaySpies.acceptAllChunks).not.toHaveBeenCalled();
+
+    await act(async () =>
+      root.render(renderView({ fileDecisions: { [file.filePath]: 'accepted' } }, 3))
+    );
+    expect(replaySpies.acceptAllChunks).toHaveBeenCalledTimes(1);
+
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it('ignores stale selection cleanup from a different file editor', async () => {
+    const secondFile: FileChangeSummary = {
+      ...file,
+      filePath: '/repo/second.ts',
+      relativePath: 'second.ts',
+    };
+    const secondContent: FileChangeWithContent = { ...fileContent, ...secondFile };
+    const onSelectionChange = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () =>
+      root.render(
+        <ContinuousScrollView
+          files={[file, secondFile]}
+          fileContents={{
+            [file.filePath]: fileContent,
+            [secondFile.filePath]: secondContent,
+          }}
+          fileContentsLoading={{}}
+          reviewExternalChangesByFile={{}}
+          viewedSet={new Set()}
+          editedContents={{}}
+          draftHistoryEntries={{}}
+          hunkDecisions={{}}
+          fileDecisions={{}}
+          hunkContextHashesByFile={{}}
+          collapseUnchanged={false}
+          applying={false}
+          autoViewed={false}
+          discardCounters={{}}
+          onHunkAccepted={noop}
+          onHunkRejected={noop}
+          onFullyViewed={noop}
+          onContentChanged={noop}
+          onSerializedStateChanged={noop}
+          onSerializedStateRestoreError={noop}
+          onDiscard={noop}
+          onSave={noop}
+          onReloadFromDisk={noop}
+          onKeepDraft={noop}
+          onAcceptFile={noop}
+          onRejectFile={noop}
+          onVisibleFileChange={noop}
+          scrollContainerRef={React.createRef<HTMLDivElement>()}
+          editorViewMapRef={{ current: new Map<string, EditorView>() }}
+          isProgrammaticScroll={{ current: false }}
+          teamName="test-team"
+          memberName="test-member"
+          fetchFileContent={async () => undefined}
+          onSelectionChange={onSelectionChange}
+        />
+      )
+    );
+
+    const firstSelection: EditorSelectionInfo = {
+      text: 'first',
+      filePath: file.filePath,
+      fromLine: 1,
+      toLine: 1,
+      screenRect: { top: 1, right: 2, bottom: 3 },
+    };
+    const secondSelection: EditorSelectionInfo = {
+      ...firstSelection,
+      text: 'second',
+      filePath: secondFile.filePath,
+    };
+    act(() => replaySpies.selectionCallbacks.get(file.filePath)?.(firstSelection));
+    act(() => replaySpies.selectionCallbacks.get(secondFile.filePath)?.(secondSelection));
+    act(() => replaySpies.selectionCallbacks.get(file.filePath)?.(null));
+
+    expect(onSelectionChange).toHaveBeenCalledTimes(2);
+    expect(onSelectionChange).toHaveBeenLastCalledWith(secondSelection);
+
+    act(() => replaySpies.selectionCallbacks.get(secondFile.filePath)?.(null));
+    expect(onSelectionChange).toHaveBeenLastCalledWith(null);
+
     await act(async () => root.unmount());
     container.remove();
   });


### PR DESCRIPTION
## Summary

- Remount every file affected by a mixed Undo history Restore.
- Keep disk invalidation and content fetch limited to disk-backed actions.
- Add a focused regression test for one disk-backed action plus one hunk-only action.

## Root cause

When a Restore range contained at least one disk snapshot, the post-Undo path refreshed only those disk snapshot files. Hunk-only files in the same range received the persisted decision state but did not receive a discard-counter update, so their uncontrolled CodeMirror view could retain stale merge state.

## Validation

- `pnpm exec vitest run test/features/change-review/renderer/useChangeReviewHistoryMutationController.test.tsx`
- `pnpm typecheck`
- `pnpm lint:fast:files -- src/features/change-review/renderer/hooks/useChangeReviewHistoryMutationController.ts test/features/change-review/renderer/useChangeReviewHistoryMutationController.test.tsx`
- Independent read-only review completed.

## Integration freeze

SERIAL FREEZE: Draft only. Do not merge this PR until the canonical `refactor/hosted-web-feature-boundaries` integration owner explicitly lifts the freeze and revalidates the live base head.

The branch was created from exact base `082bf7e8fd426578905efaab97645bd6ef98b31c`. This PR does not update or merge the canonical branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restore undo flows now consistently refresh affected content and update discard counters for both disk-backed and hunk-only changes, even when no disk snapshots exist.
  * Diff editor remounts now reliably clear parent selection/action state, preventing stale actions.
  * Continuous scrolling editors now avoid replaying outdated decisions after remounts and scope selection updates to the active file.
  * Bulk change affected-path detection is now more precise when a specific file is provided.
* **Tests**
  * Expanded restore and replay coverage, including canonical path handling and updated undo-action test helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->