### PR TITLE
chore(review): pin post-admission action release

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -30,9 +30,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@c9d2ccb661b29f5a4e4f0123a9507a7818d402e3
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@020630d0ec136ce4b2c685ccf08f63da01a0f6cd
     with:
-      runtime_ref: "c9d2ccb661b29f5a4e4f0123a9507a7818d402e3"
+      runtime_ref: "020630d0ec136ce4b2c685ccf08f63da01a0f6cd"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ inputs.pr_number }}
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@c9d2ccb661b29f5a4e4f0123a9507a7818d402e3
+        uses: 777genius/review-router@020630d0ec136ce4b2c685ccf08f63da01a0f6cd
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"


### PR DESCRIPTION
Pins the ReviewRouter reusable workflow, runtime, and refresh action to immutable release `020630d0ec136ce4b2c685ccf08f63da01a0f6cd`.

This release moves Codex CLI installation and auth restore behind successful server admission for T0 runs. Oversized or otherwise rejected reviews stop before provider tooling and account usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated review and refresh workflows to use a newer pinned action version.
  * Existing workflow settings and behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->