### PR TITLE
chore(review): pin terminal outcome release

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -30,9 +30,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@020630d0ec136ce4b2c685ccf08f63da01a0f6cd
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@53fb554b0aa721c50ed820127c9b0ae032256bb5
     with:
-      runtime_ref: "020630d0ec136ce4b2c685ccf08f63da01a0f6cd"
+      runtime_ref: "53fb554b0aa721c50ed820127c9b0ae032256bb5"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ inputs.pr_number }}
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@020630d0ec136ce4b2c685ccf08f63da01a0f6cd
+        uses: 777genius/review-router@53fb554b0aa721c50ed820127c9b0ae032256bb5
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"


### PR DESCRIPTION
Pins the dev ReviewRouter workflow, runtime, and refresh action to release 53fb554b so review and token refresh use the same immutable Action build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated review workflow components to newer fixed versions.
  * No changes to review conditions, inputs, secrets, or other configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->