### PR TITLE
chore(review): pin terminal outcome release

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -30,9 +30,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@91a4a4931c72c980ae4b9fc726e81bb8dcf9a57f
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@53fb554b0aa721c50ed820127c9b0ae032256bb5
     with:
-      runtime_ref: "91a4a4931c72c980ae4b9fc726e81bb8dcf9a57f"
+      runtime_ref: "53fb554b0aa721c50ed820127c9b0ae032256bb5"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ inputs.pr_number }}
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@91a4a4931c72c980ae4b9fc726e81bb8dcf9a57f
+        uses: 777genius/review-router@53fb554b0aa721c50ed820127c9b0ae032256bb5
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"


### PR DESCRIPTION
Pins the stable ReviewRouter control workflow, runtime, and refresh action to release 53fb554b. This keeps default-branch dispatch independent from stacked PR base branches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the automated review workflow to use a newer, fixed version.
  * Improved consistency and reliability of review execution by pinning to the updated workflow reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->