### PR TITLE
chore(review): update default action release

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -30,9 +30,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@53fb554b0aa721c50ed820127c9b0ae032256bb5
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@a1801a93cb7a22149bd8d28fe99d77e4bed6b5ef
     with:
-      runtime_ref: "53fb554b0aa721c50ed820127c9b0ae032256bb5"
+      runtime_ref: "a1801a93cb7a22149bd8d28fe99d77e4bed6b5ef"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ inputs.pr_number }}
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@53fb554b0aa721c50ed820127c9b0ae032256bb5
+        uses: 777genius/review-router@a1801a93cb7a22149bd8d28fe99d77e4bed6b5ef
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"


### PR DESCRIPTION
## Summary
- update the default-branch managed T0 workflow to ReviewRouter Action a1801a93cb7a22149bd8d28fe99d77e4bed6b5ef
- keep runtime and OAuth refresh pinned to the same exact release

GitHub resolves workflow_dispatch definitions from the default branch, so this pin is required even for reviews targeting dev.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated code review and refresh workflow references to newer versions.
  * No changes were made to workflow behavior, inputs, or environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->