### PR TITLE
chore(review): pin context gateway v3 release on main

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -30,9 +30,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@a1801a93cb7a22149bd8d28fe99d77e4bed6b5ef
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@67749e0a8995b29b164d3c10d30764381fb520f7
     with:
-      runtime_ref: "a1801a93cb7a22149bd8d28fe99d77e4bed6b5ef"
+      runtime_ref: "67749e0a8995b29b164d3c10d30764381fb520f7"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ inputs.pr_number }}
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@a1801a93cb7a22149bd8d28fe99d77e4bed6b5ef
+        uses: 777genius/review-router@67749e0a8995b29b164d3c10d30764381fb520f7
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"


### PR DESCRIPTION
Pins the default-branch workflow_dispatch path to the same immutable context-gateway-v3 release already validated and merged into dev.