### PR TITLE
refactor(team-provisioning): extract runtime liveness and identity

### DIFF
--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeRuntimeCheckin.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeRuntimeCheckin.ts
@@ -1,5 +1,3 @@
-import { isLeadMember } from '@shared/utils/leadDetection';
-
 import {
   getOpenCodeRuntimeLaneLifecycleLockTargetPath,
   getOpenCodeRuntimeRunTombstonesPath,
@@ -9,9 +7,7 @@ import {
   type RuntimeEvidenceKind,
   RuntimeStaleEvidenceError,
 } from '../opencode/store/RuntimeRunTombstoneStore';
-import { createPersistedLaunchSnapshot } from '../TeamLaunchStateEvaluator';
 
-import { getPersistedLaunchMemberNames } from './TeamProvisioningLaunchStateProjection';
 import { matchesTeamMemberIdentity } from './TeamProvisioningMemberIdentity';
 import { createInitialMemberSpawnStatusEntry } from './TeamProvisioningMemberSpawnStatusPolicy';
 import { resolveEffectiveConfiguredMember } from './TeamProvisioningMemberStatusProjection';
@@ -22,8 +18,10 @@ import {
   resolveOpenCodeRuntimeBootstrapCheckinIdempotencyFromMember,
 } from './TeamProvisioningOpenCodeBootstrapEvidence';
 import { summarizeRuntimeLaunchResultMembers } from './TeamProvisioningOpenCodeRuntimeEvidencePolicy';
-import { shouldEmitOpenCodeRuntimeLivenessMemberSpawnChange } from './TeamProvisioningOpenCodeRuntimeLivenessPolicy';
-import { resolvePersistedRuntimeMemberIdentity } from './TeamProvisioningPersistedRuntimeMemberIdentity';
+import {
+  buildOpenCodeRuntimeMemberLivenessSnapshot,
+  type OpenCodeRuntimeLivenessInput,
+} from './TeamProvisioningOpenCodeRuntimeLiveness';
 import {
   asRuntimeRecord,
   buildRuntimeToolMetadataDiagnostics,
@@ -33,7 +31,6 @@ import {
   optionalRuntimeString,
   parseRuntimeToolMetadata,
   requireRuntimeString,
-  type RuntimeToolMetadata,
 } from './TeamProvisioningRuntimeMetadata';
 
 import type { TeamRuntimeMemberLaunchEvidence } from '../runtime';
@@ -44,7 +41,6 @@ import type {
 } from './TeamProvisioningOpenCodeRuntimeCheckinPorts';
 import type {
   MemberSpawnStatusEntry,
-  PersistedTeamLaunchMemberState,
   PersistedTeamLaunchSnapshot,
   TeamConfig,
   TeamMember,
@@ -52,21 +48,6 @@ import type {
 
 export type { OpenCodeRuntimeControlAck } from '../runtime-control';
 export * from './TeamProvisioningOpenCodeRuntimeCheckinPorts';
-
-interface OpenCodeRuntimeLivenessInput {
-  teamName: string;
-  runId: string;
-  memberName: string;
-  runtimeSessionId: string;
-  observedAt: string;
-  diagnostics: unknown;
-  metadata?: RuntimeToolMetadata;
-  reason: string;
-  requiredIdentity?: {
-    laneId: string;
-    evidenceKind: RuntimeEvidenceKind;
-  };
-}
 
 export interface OpenCodeRuntimeMemberSessionAcceptancePorts {
   readLaunchState(teamName: string): Promise<PersistedTeamLaunchSnapshot | null>;
@@ -574,89 +555,6 @@ export async function updateOpenCodeRuntimeMemberLiveness<Run extends OpenCodeRu
       memberName: input.memberName,
     });
   }
-}
-
-function buildOpenCodeRuntimeMemberLivenessSnapshot<Run extends OpenCodeRuntimeCheckinRun>(
-  input: OpenCodeRuntimeLivenessInput,
-  previous: PersistedTeamLaunchSnapshot | null,
-  ports: Pick<OpenCodeRuntimeCheckinPorts<Run>, 'getTrackedRun' | 'readPersistedRuntimeMembers'>
-): { snapshot: PersistedTeamLaunchSnapshot; shouldEmitMemberSpawnChange: boolean } {
-  const expectedMembers = previous
-    ? getPersistedLaunchMemberNames(previous)
-    : ports
-        .readPersistedRuntimeMembers(input.teamName)
-        .map((member) => (typeof member.name === 'string' ? member.name.trim() : ''))
-        .filter((name) => name.length > 0 && name !== 'user' && !isLeadMember({ name }));
-  const previousMember = previous?.members[input.memberName];
-  const previousRuntimeRunId =
-    typeof previousMember?.runtimeRunId === 'string' ? previousMember.runtimeRunId.trim() : '';
-  const sameRuntimeRun = previousRuntimeRunId.length > 0 && previousRuntimeRunId === input.runId;
-  const shouldEmitMemberSpawnChange = shouldEmitOpenCodeRuntimeLivenessMemberSpawnChange({
-    previousMember,
-    runtimeRunId: input.runId,
-    runtimeSessionId: input.runtimeSessionId,
-    runtimePid: input.metadata?.runtimePid,
-  });
-  const runtimePid =
-    input.metadata?.runtimePid ?? (sameRuntimeRun ? previousMember?.runtimePid : undefined);
-  const pidSource = input.metadata?.runtimePid
-    ? ('runtime_bootstrap' as const)
-    : sameRuntimeRun
-      ? previousMember?.pidSource
-      : undefined;
-  const persistedIdentity = resolvePersistedRuntimeMemberIdentity({
-    memberName: input.memberName,
-    previousMember,
-    trackedRun: ports.getTrackedRun(input.teamName),
-  });
-  const nextMember: PersistedTeamLaunchMemberState = {
-    ...persistedIdentity,
-    ...(previousMember ?? {}),
-    name: input.memberName,
-    launchState: 'confirmed_alive',
-    agentToolAccepted: true,
-    runtimeAlive: true,
-    bootstrapConfirmed: true,
-    hardFailure: false,
-    bootstrapStalled: undefined,
-    runtimePid,
-    runtimeRunId: input.runId,
-    runtimeSessionId: input.runtimeSessionId,
-    livenessKind: 'confirmed_bootstrap',
-    pidSource,
-    runtimeDiagnostic: input.reason,
-    runtimeDiagnosticSeverity: 'info',
-    runtimeLastSeenAt: input.observedAt,
-    firstSpawnAcceptedAt: previousMember?.firstSpawnAcceptedAt ?? input.observedAt,
-    lastHeartbeatAt: input.observedAt,
-    lastRuntimeAliveAt: input.observedAt,
-    lastEvaluatedAt: input.observedAt,
-    sources: {
-      ...(previousMember?.sources ?? {}),
-      nativeHeartbeat: true,
-      processAlive: true,
-    },
-    diagnostics: mergeRuntimeDiagnostics(
-      previousMember?.diagnostics,
-      [
-        ...normalizeRuntimeStringArray(input.diagnostics),
-        ...buildRuntimeToolMetadataDiagnostics(input.metadata),
-      ],
-      input.reason
-    ),
-  };
-  const snapshot = createPersistedLaunchSnapshot({
-    teamName: input.teamName,
-    expectedMembers: [...new Set([...expectedMembers, input.memberName])],
-    leadSessionId: previous?.leadSessionId,
-    launchPhase: previous?.launchPhase ?? 'active',
-    members: {
-      ...(previous?.members ?? {}),
-      [input.memberName]: nextMember,
-    },
-    updatedAt: input.observedAt,
-  });
-  return { snapshot, shouldEmitMemberSpawnChange };
 }
 
 export function applyOpenCodeRuntimeBootstrapCheckinToTrackedRun<

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeRuntimeDelivery.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeRuntimeDelivery.ts
@@ -53,6 +53,13 @@ import {
   recordOpenCodeRuntimeTaskEvent,
 } from './TeamProvisioningOpenCodeRuntimeCheckin';
 import {
+  canonicalizeRuntimeDeliveryJournalDestination,
+  canonicalizeRuntimeDeliveryJournalLocation,
+  getRuntimeDeliveryDestinationTeamName,
+  readRuntimeDeliveryIdentitySources,
+  requireRuntimeDeliveryIdentitySources,
+} from './TeamProvisioningOpenCodeRuntimeDeliveryIdentity';
+import {
   asRuntimeRecord,
   normalizeRuntimeIso,
   requireRuntimeString,
@@ -630,99 +637,6 @@ export async function canonicalizeRuntimeDeliveryJournalRecordIdentities(
     destination: canonicalDestination,
     committedLocation: canonicalCommittedLocation,
   };
-}
-
-interface RuntimeDeliveryIdentitySources {
-  config: TeamConfig;
-  metaMembers: readonly TeamMember[];
-}
-
-async function readRuntimeDeliveryIdentitySources(
-  teamNames: readonly string[],
-  senderTeamName: string,
-  readConfig: (teamName: string) => Promise<TeamConfig | null>,
-  readMetaMembers: (teamName: string) => Promise<readonly TeamMember[]>
-): Promise<Map<string, RuntimeDeliveryIdentitySources>> {
-  const identitySources = new Map<string, RuntimeDeliveryIdentitySources>();
-  await Promise.all(
-    [...new Set(teamNames)].map(async (teamName) => {
-      const [config, metaMembers] = await Promise.all([
-        readConfig(teamName),
-        readMetaMembers(teamName),
-      ]);
-      if (!config || config.deletedAt) {
-        const identityKind = teamName === senderTeamName ? 'sender' : 'target';
-        throw new Error(`Cross-team ${identityKind} identity is unavailable: ${teamName}`);
-      }
-      identitySources.set(teamName, { config, metaMembers });
-    })
-  );
-  return identitySources;
-}
-
-function requireRuntimeDeliveryIdentitySources(
-  identitySources: ReadonlyMap<string, RuntimeDeliveryIdentitySources>,
-  teamName: string,
-  kind: 'sender' | 'target'
-): RuntimeDeliveryIdentitySources {
-  const sources = identitySources.get(teamName);
-  if (!sources) {
-    throw new Error(`Cross-team ${kind} identity is unavailable: ${teamName}`);
-  }
-  return sources;
-}
-
-function getRuntimeDeliveryDestinationTeamName(
-  record: RuntimeDeliveryJournalRecord
-): string | null {
-  if (record.destination.kind === 'user_sent_messages') {
-    return null;
-  }
-  return record.destination.kind === 'member_inbox'
-    ? record.destination.teamName
-    : record.destination.toTeamName;
-}
-
-function canonicalizeRuntimeDeliveryJournalDestination(
-  destination: RuntimeDeliveryJournalRecord['destination'],
-  sources: RuntimeDeliveryIdentitySources
-): RuntimeDeliveryJournalRecord['destination'] {
-  if (destination.kind === 'user_sent_messages') {
-    return destination;
-  }
-  const rawMemberName =
-    destination.kind === 'member_inbox' ? destination.memberName : destination.toMemberName;
-  const canonicalMemberName = resolveCrossTeamRecipientIdentity({
-    sources,
-    rawToMember: rawMemberName,
-  }).memberName;
-  if (canonicalMemberName === rawMemberName) {
-    return destination;
-  }
-  return destination.kind === 'member_inbox'
-    ? { ...destination, memberName: canonicalMemberName }
-    : { ...destination, toMemberName: canonicalMemberName };
-}
-
-function canonicalizeRuntimeDeliveryJournalLocation(
-  location: NonNullable<RuntimeDeliveryJournalRecord['committedLocation']>,
-  sources: RuntimeDeliveryIdentitySources
-): NonNullable<RuntimeDeliveryJournalRecord['committedLocation']> {
-  if (location.kind === 'user_sent_messages') {
-    return location;
-  }
-  const rawMemberName =
-    location.kind === 'member_inbox' ? location.memberName : location.toMemberName;
-  const canonicalMemberName = resolveCrossTeamRecipientIdentity({
-    sources,
-    rawToMember: rawMemberName,
-  }).memberName;
-  if (canonicalMemberName === rawMemberName) {
-    return location;
-  }
-  return location.kind === 'member_inbox'
-    ? { ...location, memberName: canonicalMemberName }
-    : { ...location, toMemberName: canonicalMemberName };
 }
 
 export async function tryGetActiveOpenCodePromptDeliveryRecord(

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeRuntimeDeliveryIdentity.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeRuntimeDeliveryIdentity.ts
@@ -1,0 +1,97 @@
+import { resolveCrossTeamRecipientIdentity } from '../CrossTeamRecipientIdentity';
+
+import type { RuntimeDeliveryJournalRecord } from '../opencode/delivery/RuntimeDeliveryJournal';
+import type { TeamConfig, TeamMember } from '@shared/types';
+
+export interface RuntimeDeliveryIdentitySources {
+  config: TeamConfig;
+  metaMembers: readonly TeamMember[];
+}
+
+export async function readRuntimeDeliveryIdentitySources(
+  teamNames: readonly string[],
+  senderTeamName: string,
+  readConfig: (teamName: string) => Promise<TeamConfig | null>,
+  readMetaMembers: (teamName: string) => Promise<readonly TeamMember[]>
+): Promise<Map<string, RuntimeDeliveryIdentitySources>> {
+  const identitySources = new Map<string, RuntimeDeliveryIdentitySources>();
+  await Promise.all(
+    [...new Set(teamNames)].map(async (teamName) => {
+      const [config, metaMembers] = await Promise.all([
+        readConfig(teamName),
+        readMetaMembers(teamName),
+      ]);
+      if (!config || config.deletedAt) {
+        const identityKind = teamName === senderTeamName ? 'sender' : 'target';
+        throw new Error(`Cross-team ${identityKind} identity is unavailable: ${teamName}`);
+      }
+      identitySources.set(teamName, { config, metaMembers });
+    })
+  );
+  return identitySources;
+}
+
+export function requireRuntimeDeliveryIdentitySources(
+  identitySources: ReadonlyMap<string, RuntimeDeliveryIdentitySources>,
+  teamName: string,
+  kind: 'sender' | 'target'
+): RuntimeDeliveryIdentitySources {
+  const sources = identitySources.get(teamName);
+  if (!sources) {
+    throw new Error(`Cross-team ${kind} identity is unavailable: ${teamName}`);
+  }
+  return sources;
+}
+
+export function getRuntimeDeliveryDestinationTeamName(
+  record: RuntimeDeliveryJournalRecord
+): string | null {
+  if (record.destination.kind === 'user_sent_messages') {
+    return null;
+  }
+  return record.destination.kind === 'member_inbox'
+    ? record.destination.teamName
+    : record.destination.toTeamName;
+}
+
+export function canonicalizeRuntimeDeliveryJournalDestination(
+  destination: RuntimeDeliveryJournalRecord['destination'],
+  sources: RuntimeDeliveryIdentitySources
+): RuntimeDeliveryJournalRecord['destination'] {
+  if (destination.kind === 'user_sent_messages') {
+    return destination;
+  }
+  const rawMemberName =
+    destination.kind === 'member_inbox' ? destination.memberName : destination.toMemberName;
+  const canonicalMemberName = resolveCrossTeamRecipientIdentity({
+    sources,
+    rawToMember: rawMemberName,
+  }).memberName;
+  if (canonicalMemberName === rawMemberName) {
+    return destination;
+  }
+  return destination.kind === 'member_inbox'
+    ? { ...destination, memberName: canonicalMemberName }
+    : { ...destination, toMemberName: canonicalMemberName };
+}
+
+export function canonicalizeRuntimeDeliveryJournalLocation(
+  location: NonNullable<RuntimeDeliveryJournalRecord['committedLocation']>,
+  sources: RuntimeDeliveryIdentitySources
+): NonNullable<RuntimeDeliveryJournalRecord['committedLocation']> {
+  if (location.kind === 'user_sent_messages') {
+    return location;
+  }
+  const rawMemberName =
+    location.kind === 'member_inbox' ? location.memberName : location.toMemberName;
+  const canonicalMemberName = resolveCrossTeamRecipientIdentity({
+    sources,
+    rawToMember: rawMemberName,
+  }).memberName;
+  if (canonicalMemberName === rawMemberName) {
+    return location;
+  }
+  return location.kind === 'member_inbox'
+    ? { ...location, memberName: canonicalMemberName }
+    : { ...location, toMemberName: canonicalMemberName };
+}

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeRuntimeLiveness.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeRuntimeLiveness.ts
@@ -1,0 +1,118 @@
+import { isLeadMember } from '@shared/utils/leadDetection';
+
+import { type RuntimeEvidenceKind } from '../opencode/store/RuntimeRunTombstoneStore';
+import { createPersistedLaunchSnapshot } from '../TeamLaunchStateEvaluator';
+
+import { getPersistedLaunchMemberNames } from './TeamProvisioningLaunchStateProjection';
+import { shouldEmitOpenCodeRuntimeLivenessMemberSpawnChange } from './TeamProvisioningOpenCodeRuntimeLivenessPolicy';
+import { resolvePersistedRuntimeMemberIdentity } from './TeamProvisioningPersistedRuntimeMemberIdentity';
+import {
+  buildRuntimeToolMetadataDiagnostics,
+  mergeRuntimeDiagnostics,
+  normalizeRuntimeStringArray,
+  type RuntimeToolMetadata,
+} from './TeamProvisioningRuntimeMetadata';
+
+import type {
+  OpenCodeRuntimeCheckinPorts,
+  OpenCodeRuntimeCheckinRun,
+} from './TeamProvisioningOpenCodeRuntimeCheckinPorts';
+import type { PersistedTeamLaunchMemberState, PersistedTeamLaunchSnapshot } from '@shared/types';
+
+export interface OpenCodeRuntimeLivenessInput {
+  teamName: string;
+  runId: string;
+  memberName: string;
+  runtimeSessionId: string;
+  observedAt: string;
+  diagnostics: unknown;
+  metadata?: RuntimeToolMetadata;
+  reason: string;
+  requiredIdentity?: {
+    laneId: string;
+    evidenceKind: RuntimeEvidenceKind;
+  };
+}
+
+export function buildOpenCodeRuntimeMemberLivenessSnapshot<Run extends OpenCodeRuntimeCheckinRun>(
+  input: OpenCodeRuntimeLivenessInput,
+  previous: PersistedTeamLaunchSnapshot | null,
+  ports: Pick<OpenCodeRuntimeCheckinPorts<Run>, 'getTrackedRun' | 'readPersistedRuntimeMembers'>
+): { snapshot: PersistedTeamLaunchSnapshot; shouldEmitMemberSpawnChange: boolean } {
+  const expectedMembers = previous
+    ? getPersistedLaunchMemberNames(previous)
+    : ports
+        .readPersistedRuntimeMembers(input.teamName)
+        .map((member) => (typeof member.name === 'string' ? member.name.trim() : ''))
+        .filter((name) => name.length > 0 && name !== 'user' && !isLeadMember({ name }));
+  const previousMember = previous?.members[input.memberName];
+  const previousRuntimeRunId =
+    typeof previousMember?.runtimeRunId === 'string' ? previousMember.runtimeRunId.trim() : '';
+  const sameRuntimeRun = previousRuntimeRunId.length > 0 && previousRuntimeRunId === input.runId;
+  const shouldEmitMemberSpawnChange = shouldEmitOpenCodeRuntimeLivenessMemberSpawnChange({
+    previousMember,
+    runtimeRunId: input.runId,
+    runtimeSessionId: input.runtimeSessionId,
+    runtimePid: input.metadata?.runtimePid,
+  });
+  const runtimePid =
+    input.metadata?.runtimePid ?? (sameRuntimeRun ? previousMember?.runtimePid : undefined);
+  const pidSource = input.metadata?.runtimePid
+    ? ('runtime_bootstrap' as const)
+    : sameRuntimeRun
+      ? previousMember?.pidSource
+      : undefined;
+  const persistedIdentity = resolvePersistedRuntimeMemberIdentity({
+    memberName: input.memberName,
+    previousMember,
+    trackedRun: ports.getTrackedRun(input.teamName),
+  });
+  const nextMember: PersistedTeamLaunchMemberState = {
+    ...persistedIdentity,
+    ...(previousMember ?? {}),
+    name: input.memberName,
+    launchState: 'confirmed_alive',
+    agentToolAccepted: true,
+    runtimeAlive: true,
+    bootstrapConfirmed: true,
+    hardFailure: false,
+    bootstrapStalled: undefined,
+    runtimePid,
+    runtimeRunId: input.runId,
+    runtimeSessionId: input.runtimeSessionId,
+    livenessKind: 'confirmed_bootstrap',
+    pidSource,
+    runtimeDiagnostic: input.reason,
+    runtimeDiagnosticSeverity: 'info',
+    runtimeLastSeenAt: input.observedAt,
+    firstSpawnAcceptedAt: previousMember?.firstSpawnAcceptedAt ?? input.observedAt,
+    lastHeartbeatAt: input.observedAt,
+    lastRuntimeAliveAt: input.observedAt,
+    lastEvaluatedAt: input.observedAt,
+    sources: {
+      ...(previousMember?.sources ?? {}),
+      nativeHeartbeat: true,
+      processAlive: true,
+    },
+    diagnostics: mergeRuntimeDiagnostics(
+      previousMember?.diagnostics,
+      [
+        ...normalizeRuntimeStringArray(input.diagnostics),
+        ...buildRuntimeToolMetadataDiagnostics(input.metadata),
+      ],
+      input.reason
+    ),
+  };
+  const snapshot = createPersistedLaunchSnapshot({
+    teamName: input.teamName,
+    expectedMembers: [...new Set([...expectedMembers, input.memberName])],
+    leadSessionId: previous?.leadSessionId,
+    launchPhase: previous?.launchPhase ?? 'active',
+    members: {
+      ...(previous?.members ?? {}),
+      [input.memberName]: nextMember,
+    },
+    updatedAt: input.observedAt,
+  });
+  return { snapshot, shouldEmitMemberSpawnChange };
+}


### PR DESCRIPTION
Fixes the source-size regression introduced by the reviewed hosted-web integration without changing runtime behavior.

- extracts liveness snapshot composition from RuntimeCheckin
- extracts delivery identity helpers from RuntimeDelivery
- keeps all existing public exports and call paths intact
- changes only the two original modules and two new cohesive modules

Verification:
- pnpm typecheck: passed
- lint:fast:files: passed
- Prettier check: passed
- source-size guard: passed
- focused tests: 133 passed; one pre-existing Darwin-only durable-path test fails because identity-stable directory child operations are intentionally unsupported on Darwin and is covered by Linux CI

Line counts:
- RuntimeCheckin: 807 -> 705
- RuntimeDelivery: 1016 -> 930
- RuntimeLiveness: 118
- RuntimeDeliveryIdentity: 97

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved runtime delivery handling so cross-team destinations and locations consistently use canonical member identities.
  * Added clearer validation when required team configuration or member information is unavailable.
  * Consolidated runtime liveness snapshot processing to improve consistency of member status and diagnostic updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->