### PR TITLE
chore(review): pin terminal status runtime

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -30,9 +30,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@a9df633cb0890263d27dc5e132bfc3f45fc347f6
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@2e68346d453c0be211af09b1488db7de40aa92c8
     with:
-      runtime_ref: "a9df633cb0890263d27dc5e132bfc3f45fc347f6"
+      runtime_ref: "2e68346d453c0be211af09b1488db7de40aa92c8"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ inputs.pr_number }}
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@a9df633cb0890263d27dc5e132bfc3f45fc347f6
+        uses: 777genius/review-router@2e68346d453c0be211af09b1488db7de40aa92c8
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"

--- a/.github/workflows/reviewrouter-interaction.yml
+++ b/.github/workflows/reviewrouter-interaction.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.event_name == 'workflow_dispatch' || ((github.event_name != 'issue_comment' || github.event.issue.pull_request) && github.event.comment.user.type != 'Bot') }}
     env:
-      RR_RUNTIME_REF: "a9df633cb0890263d27dc5e132bfc3f45fc347f6"
+      RR_RUNTIME_REF: "2e68346d453c0be211af09b1488db7de40aa92c8"
       REVIEWROUTER_API_URL: "https://api.reviewrouter.site"
       REVIEWROUTER_OIDC_AUDIENCE: "reviewrouter"
       REVIEWROUTER_RUNTIME_CONFIG_MODE: "oidc"


### PR DESCRIPTION
Updates ReviewRouter workflow pins to the released terminal status runtime.\n\nThis keeps the client workflows aligned with the deployed control plane action ref so terminal outcomes can publish clear PR comments and commit statuses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the ReviewRouter automation workflows to use the latest approved runtime revision.
  * Kept OAuth, refresh, and interaction workflow behavior unchanged aside from the runtime update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->