### PR TITLE
chore(review): pin reviewrouter action cleanup runtime

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -30,9 +30,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@2e68346d453c0be211af09b1488db7de40aa92c8
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@0c1608b91ae356a39587b76f51ef57899389d95a
     with:
-      runtime_ref: "2e68346d453c0be211af09b1488db7de40aa92c8"
+      runtime_ref: "0c1608b91ae356a39587b76f51ef57899389d95a"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ inputs.pr_number }}
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@2e68346d453c0be211af09b1488db7de40aa92c8
+        uses: 777genius/review-router@0c1608b91ae356a39587b76f51ef57899389d95a
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"


### PR DESCRIPTION
Updates the hosted ReviewRouter workflow to the public action runtime that hides v2 publication markers and clears stale terminal comments after completed reviews.\n\nRuntime: 777genius/review-router@0c1608b91ae356a39587b76f51ef57899389d95a\n\nLocal check:\n- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated code review workflow to use the latest pinned revision.
  * Updated the workflow’s refresh process to ensure consistent tooling versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->