### PR TITLE
chore(review): pin ReviewRouter runtime to interaction fix

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -30,9 +30,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@0c1608b91ae356a39587b76f51ef57899389d95a
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@3339cf8ca861698aefe335f68a771a455d7e03ae
     with:
-      runtime_ref: "0c1608b91ae356a39587b76f51ef57899389d95a"
+      runtime_ref: "3339cf8ca861698aefe335f68a771a455d7e03ae"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ inputs.pr_number }}
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@0c1608b91ae356a39587b76f51ef57899389d95a
+        uses: 777genius/review-router@3339cf8ca861698aefe335f68a771a455d7e03ae
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"

--- a/.github/workflows/reviewrouter-interaction.yml
+++ b/.github/workflows/reviewrouter-interaction.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.event_name == 'workflow_dispatch' || ((github.event_name != 'issue_comment' || github.event.issue.pull_request) && github.event.comment.user.type != 'Bot') }}
     env:
-      RR_RUNTIME_REF: "2e68346d453c0be211af09b1488db7de40aa92c8"
+      RR_RUNTIME_REF: "3339cf8ca861698aefe335f68a771a455d7e03ae"
       REVIEWROUTER_API_URL: "https://api.reviewrouter.site"
       REVIEWROUTER_OIDC_AUDIENCE: "reviewrouter"
       REVIEWROUTER_RUNTIME_CONFIG_MODE: "oidc"


### PR DESCRIPTION
## Summary
- pin ReviewRouter Codex OAuth workflow to public action SHA 3339cf8c
- pin ReviewRouter Interaction workflow to the same SHA
- keeps review and /rr command runtime versions aligned

## Tests
- git diff --check
- verified both workflows only reference 3339cf8ca861698aefe335f68a771a455d7e03ae

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated ReviewRouter workflow components to use the latest runtime version.
  * Synchronized workflow configuration references for review and interaction processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->