### PR TITLE
chore(review): pin reviewrouter runtime diagnostics

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -30,9 +30,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@3339cf8ca861698aefe335f68a771a455d7e03ae
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@86fec09d2a51872d55c06aa6b1970fc6bef116a2
     with:
-      runtime_ref: "3339cf8ca861698aefe335f68a771a455d7e03ae"
+      runtime_ref: "86fec09d2a51872d55c06aa6b1970fc6bef116a2"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ inputs.pr_number }}
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@3339cf8ca861698aefe335f68a771a455d7e03ae
+        uses: 777genius/review-router@86fec09d2a51872d55c06aa6b1970fc6bef116a2
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"

--- a/.github/workflows/reviewrouter-interaction.yml
+++ b/.github/workflows/reviewrouter-interaction.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.event_name == 'workflow_dispatch' || ((github.event_name != 'issue_comment' || github.event.issue.pull_request) && github.event.comment.user.type != 'Bot') }}
     env:
-      RR_RUNTIME_REF: "3339cf8ca861698aefe335f68a771a455d7e03ae"
+      RR_RUNTIME_REF: "86fec09d2a51872d55c06aa6b1970fc6bef116a2"
       REVIEWROUTER_API_URL: "https://api.reviewrouter.site"
       REVIEWROUTER_OIDC_AUDIENCE: "reviewrouter"
       REVIEWROUTER_RUNTIME_CONFIG_MODE: "oidc"


### PR DESCRIPTION
## Summary
- pin ReviewRouter codex reusable workflow to 86fec09d
- pin ReviewRouter interaction runtime to the same revision

## Verification
- rg confirmed no old ReviewRouter runtime SHA remains in the workflows
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated review and interaction workflows to use the latest runtime version.
  * No changes to user-facing functionality or application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->