### PR TITLE
chore(reviewrouter): update runtime pin

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -30,9 +30,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@86fec09d2a51872d55c06aa6b1970fc6bef116a2
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@ad7b3f9683ef94b48bb6402a5f52d96ccf786400
     with:
-      runtime_ref: "86fec09d2a51872d55c06aa6b1970fc6bef116a2"
+      runtime_ref: "ad7b3f9683ef94b48bb6402a5f52d96ccf786400"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ inputs.pr_number }}
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@86fec09d2a51872d55c06aa6b1970fc6bef116a2
+        uses: 777genius/review-router@ad7b3f9683ef94b48bb6402a5f52d96ccf786400
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"

--- a/.github/workflows/reviewrouter-interaction.yml
+++ b/.github/workflows/reviewrouter-interaction.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.event_name == 'workflow_dispatch' || ((github.event_name != 'issue_comment' || github.event.issue.pull_request) && github.event.comment.user.type != 'Bot') }}
     env:
-      RR_RUNTIME_REF: "86fec09d2a51872d55c06aa6b1970fc6bef116a2"
+      RR_RUNTIME_REF: "ad7b3f9683ef94b48bb6402a5f52d96ccf786400"
       REVIEWROUTER_API_URL: "https://api.reviewrouter.site"
       REVIEWROUTER_OIDC_AUDIENCE: "reviewrouter"
       REVIEWROUTER_RUNTIME_CONFIG_MODE: "oidc"


### PR DESCRIPTION
## Summary
- update ReviewRouter interaction and Codex OAuth workflow pins to the latest verified public action runtime
- keeps runtime/action refs aligned at ad7b3f9683ef94b48bb6402a5f52d96ccf786400

## Validation
- ruby YAML parse for reviewrouter-interaction.yml and reviewrouter-codex.yml
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated review and interaction workflows to use refreshed runtime versions.
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->