### PR TITLE
chore(reviewrouter): update runtime pin

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@ad7b3f9683ef94b48bb6402a5f52d96ccf786400
+        uses: 777genius/review-router@4d09dcc1f757341645b756f1b9bfeec248a20e58
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"


### PR DESCRIPTION
## Summary
- update ReviewRouter reusable action pin to 4d09dcc1f757341645b756f1b9bfeec248a20e58
- pick up v2 success status cleanup so stale ReviewRouter failure contexts do not linger after a successful review

## Tests
- not run, workflow pin only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated OAuth refresh workflow to use a newer action version.
  * Existing refresh settings and behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->