### PR TITLE
chore(reviewrouter): update all runtime refs

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -30,9 +30,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@ad7b3f9683ef94b48bb6402a5f52d96ccf786400
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@4d09dcc1f757341645b756f1b9bfeec248a20e58
     with:
-      runtime_ref: "ad7b3f9683ef94b48bb6402a5f52d96ccf786400"
+      runtime_ref: "4d09dcc1f757341645b756f1b9bfeec248a20e58"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ inputs.pr_number }}

--- a/.github/workflows/reviewrouter-interaction.yml
+++ b/.github/workflows/reviewrouter-interaction.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.event_name == 'workflow_dispatch' || ((github.event_name != 'issue_comment' || github.event.issue.pull_request) && github.event.comment.user.type != 'Bot') }}
     env:
-      RR_RUNTIME_REF: "ad7b3f9683ef94b48bb6402a5f52d96ccf786400"
+      RR_RUNTIME_REF: "4d09dcc1f757341645b756f1b9bfeec248a20e58"
       REVIEWROUTER_API_URL: "https://api.reviewrouter.site"
       REVIEWROUTER_OIDC_AUDIENCE: "reviewrouter"
       REVIEWROUTER_RUNTIME_CONFIG_MODE: "oidc"


### PR DESCRIPTION
## Summary
- update ReviewRouter interaction runtime ref to 4d09dcc1f757341645b756f1b9bfeec248a20e58
- update the reusable T0 workflow ref and runtime_ref to the same SHA
- keep the direct Codex OAuth action pin on the same SHA

## Why
The previous pin update changed only the direct action use. Manual /rr review still used the old interaction runtime ref and fell back to static config.

## Tests
- not run, workflow pin only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the ReviewRouter runtime reference used by automated review and interaction workflows.
  * No user-facing functionality or workflow behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->