### PR TITLE
chore(reviewrouter): update runtime refs

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -30,9 +30,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@4d09dcc1f757341645b756f1b9bfeec248a20e58
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@1a43118a7b8b095f551c489c2bc903ded03b14e3
     with:
-      runtime_ref: "4d09dcc1f757341645b756f1b9bfeec248a20e58"
+      runtime_ref: "1a43118a7b8b095f551c489c2bc903ded03b14e3"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ inputs.pr_number }}
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@4d09dcc1f757341645b756f1b9bfeec248a20e58
+        uses: 777genius/review-router@1a43118a7b8b095f551c489c2bc903ded03b14e3
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"

--- a/.github/workflows/reviewrouter-interaction.yml
+++ b/.github/workflows/reviewrouter-interaction.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.event_name == 'workflow_dispatch' || ((github.event_name != 'issue_comment' || github.event.issue.pull_request) && github.event.comment.user.type != 'Bot') }}
     env:
-      RR_RUNTIME_REF: "4d09dcc1f757341645b756f1b9bfeec248a20e58"
+      RR_RUNTIME_REF: "1a43118a7b8b095f551c489c2bc903ded03b14e3"
       REVIEWROUTER_API_URL: "https://api.reviewrouter.site"
       REVIEWROUTER_OIDC_AUDIENCE: "reviewrouter"
       REVIEWROUTER_RUNTIME_CONFIG_MODE: "oidc"


### PR DESCRIPTION
## Summary
- update ReviewRouter interaction, reusable T0 workflow, runtime_ref and direct action pin to 1a43118a7b8b095f551c489c2bc903ded03b14e3
- picks up stale publication handling so duplicate/stale publication races do not leave failure status on a successfully reviewed PR

## Tests
- not run, workflow pin only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow integrations to use the latest ReviewRouter runtime revisions.
  * Refreshed the interaction workflow’s runtime reference for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->