### PR TITLE
chore(reviewrouter): pin runtime to 86c0d7d8

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -30,9 +30,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@1a43118a7b8b095f551c489c2bc903ded03b14e3
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@86c0d7d8d44636d0a3b47c0df78ab29be233a549
     with:
-      runtime_ref: "1a43118a7b8b095f551c489c2bc903ded03b14e3"
+      runtime_ref: "86c0d7d8d44636d0a3b47c0df78ab29be233a549"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ inputs.pr_number }}
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@1a43118a7b8b095f551c489c2bc903ded03b14e3
+        uses: 777genius/review-router@86c0d7d8d44636d0a3b47c0df78ab29be233a549
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"

--- a/.github/workflows/reviewrouter-interaction.yml
+++ b/.github/workflows/reviewrouter-interaction.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.event_name == 'workflow_dispatch' || ((github.event_name != 'issue_comment' || github.event.issue.pull_request) && github.event.comment.user.type != 'Bot') }}
     env:
-      RR_RUNTIME_REF: "1a43118a7b8b095f551c489c2bc903ded03b14e3"
+      RR_RUNTIME_REF: "86c0d7d8d44636d0a3b47c0df78ab29be233a549"
       REVIEWROUTER_API_URL: "https://api.reviewrouter.site"
       REVIEWROUTER_OIDC_AUDIENCE: "reviewrouter"
       REVIEWROUTER_RUNTIME_CONFIG_MODE: "oidc"


### PR DESCRIPTION
## Summary
- update ReviewRouter Codex workflow reusable runtime ref to 86c0d7d8
- update interaction runtime ref to the same public action SHA

## Verification
- git diff --check
- rg confirms old ReviewRouter SHA is gone from workflows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated review and interaction workflows to use a newer pinned runtime version.
  * No user-facing feature or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->