### PR TITLE
chore: update ReviewRouter action pin

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -30,9 +30,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@86c0d7d8d44636d0a3b47c0df78ab29be233a549
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@b46dff758e54adcf257d668862f6ccbeffa16910
     with:
-      runtime_ref: "86c0d7d8d44636d0a3b47c0df78ab29be233a549"
+      runtime_ref: "b46dff758e54adcf257d668862f6ccbeffa16910"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ inputs.pr_number }}
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@86c0d7d8d44636d0a3b47c0df78ab29be233a549
+        uses: 777genius/review-router@b46dff758e54adcf257d668862f6ccbeffa16910
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"

--- a/.github/workflows/reviewrouter-interaction.yml
+++ b/.github/workflows/reviewrouter-interaction.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.event_name == 'workflow_dispatch' || ((github.event_name != 'issue_comment' || github.event.issue.pull_request) && github.event.comment.user.type != 'Bot') }}
     env:
-      RR_RUNTIME_REF: "86c0d7d8d44636d0a3b47c0df78ab29be233a549"
+      RR_RUNTIME_REF: "b46dff758e54adcf257d668862f6ccbeffa16910"
       REVIEWROUTER_API_URL: "https://api.reviewrouter.site"
       REVIEWROUTER_OIDC_AUDIENCE: "reviewrouter"
       REVIEWROUTER_RUNTIME_CONFIG_MODE: "oidc"


### PR DESCRIPTION
## Summary
- update ReviewRouter Codex OAuth reusable workflow pin to b46dff758e54adcf257d668862f6ccbeffa16910
- update interaction runtime checkout pin to the same release

## Verification
- git diff --check
- confirmed the previous action SHA no longer appears in ReviewRouter workflows

## Reason
This rolls out the write-once terminal outcome comment fix from 777genius/review-router#76.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated review and interaction workflows to use the latest ReviewRouter runtime version.
  * No user-facing functionality or workflow behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->