### PR TITLE
chore: update ReviewRouter action pin

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -30,9 +30,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@b46dff758e54adcf257d668862f6ccbeffa16910
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@66f992c46597b2975802a7abfe722fb537dc2f4c
     with:
-      runtime_ref: "b46dff758e54adcf257d668862f6ccbeffa16910"
+      runtime_ref: "66f992c46597b2975802a7abfe722fb537dc2f4c"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ inputs.pr_number }}
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@b46dff758e54adcf257d668862f6ccbeffa16910
+        uses: 777genius/review-router@66f992c46597b2975802a7abfe722fb537dc2f4c
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"

--- a/.github/workflows/reviewrouter-interaction.yml
+++ b/.github/workflows/reviewrouter-interaction.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.event_name == 'workflow_dispatch' || ((github.event_name != 'issue_comment' || github.event.issue.pull_request) && github.event.comment.user.type != 'Bot') }}
     env:
-      RR_RUNTIME_REF: "b46dff758e54adcf257d668862f6ccbeffa16910"
+      RR_RUNTIME_REF: "66f992c46597b2975802a7abfe722fb537dc2f4c"
       REVIEWROUTER_API_URL: "https://api.reviewrouter.site"
       REVIEWROUTER_OIDC_AUDIENCE: "reviewrouter"
       REVIEWROUTER_RUNTIME_CONFIG_MODE: "oidc"


### PR DESCRIPTION
Updates ReviewRouter workflow pins to 777genius/review-router@66f992c46597b2975802a7abfe722fb537dc2f4c.\n\nThis picks up the terminal outcome publication refactor from review-router#77 after it was merged and rolled out to Render.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the ReviewRouter workflow runtime to a newer pinned version.
  * Refreshed automated review and interaction workflows while preserving existing triggers, permissions, and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->