### PR TITLE
chore(review): update ReviewRouter runtime

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -30,9 +30,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@66f992c46597b2975802a7abfe722fb537dc2f4c
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@9970005ccbb058e3b6933a8a0ff034f459538ecc
     with:
-      runtime_ref: "66f992c46597b2975802a7abfe722fb537dc2f4c"
+      runtime_ref: "9970005ccbb058e3b6933a8a0ff034f459538ecc"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ inputs.pr_number }}
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@66f992c46597b2975802a7abfe722fb537dc2f4c
+        uses: 777genius/review-router@9970005ccbb058e3b6933a8a0ff034f459538ecc
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"

--- a/.github/workflows/reviewrouter-interaction.yml
+++ b/.github/workflows/reviewrouter-interaction.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.event_name == 'workflow_dispatch' || ((github.event_name != 'issue_comment' || github.event.issue.pull_request) && github.event.comment.user.type != 'Bot') }}
     env:
-      RR_RUNTIME_REF: "66f992c46597b2975802a7abfe722fb537dc2f4c"
+      RR_RUNTIME_REF: "9970005ccbb058e3b6933a8a0ff034f459538ecc"
       REVIEWROUTER_API_URL: "https://api.reviewrouter.site"
       REVIEWROUTER_OIDC_AUDIENCE: "reviewrouter"
       REVIEWROUTER_RUNTIME_CONFIG_MODE: "oidc"


### PR DESCRIPTION
## Summary
- pin ReviewRouter review, refresh, and interaction workflows to `9970005ccbb058e3b6933a8a0ff034f459538ecc`
- includes serialized context attestation recording and explicit low-signal coverage policy

## Verification
- all four runtime references resolve to the merged immutable commit
- both workflow files parse as YAML
- source runtime CI: https://github.com/777genius/review-router/actions/runs/30465633360


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated review and interaction workflows to use the latest runtime version.
  * No changes were made to workflow triggers, permissions, scheduling, or processing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->