### PR TITLE
chore(review): update ReviewRouter runtime

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -30,9 +30,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@9970005ccbb058e3b6933a8a0ff034f459538ecc
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@05fd6e32337e406f4e77148552b60861eea54a02
     with:
-      runtime_ref: "9970005ccbb058e3b6933a8a0ff034f459538ecc"
+      runtime_ref: "05fd6e32337e406f4e77148552b60861eea54a02"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ inputs.pr_number }}
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@9970005ccbb058e3b6933a8a0ff034f459538ecc
+        uses: 777genius/review-router@05fd6e32337e406f4e77148552b60861eea54a02
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"

--- a/.github/workflows/reviewrouter-interaction.yml
+++ b/.github/workflows/reviewrouter-interaction.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.event_name == 'workflow_dispatch' || ((github.event_name != 'issue_comment' || github.event.issue.pull_request) && github.event.comment.user.type != 'Bot') }}
     env:
-      RR_RUNTIME_REF: "9970005ccbb058e3b6933a8a0ff034f459538ecc"
+      RR_RUNTIME_REF: "05fd6e32337e406f4e77148552b60861eea54a02"
       REVIEWROUTER_API_URL: "https://api.reviewrouter.site"
       REVIEWROUTER_OIDC_AUDIENCE: "reviewrouter"
       REVIEWROUTER_RUNTIME_CONFIG_MODE: "oidc"


### PR DESCRIPTION
## Summary
- pin managed Codex review workflow to ReviewRouter `05fd6e32337e406f4e77148552b60861eea54a02`
- pin interaction dispatch to the same exact runtime revision

## Verification
- both workflow files parse as valid YAML
- all four runtime references use the same full SHA
- previous runtime SHA is absent from the managed workflows
- production release is registered and all Render services are live on the same ref

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated review and interaction workflows to use the latest pinned ReviewRouter revision.
  * Improved consistency across workflow jobs by aligning their runtime references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->