### PR TITLE
fix(review): deploy T0 bootstrap runtime

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -30,9 +30,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@05fd6e32337e406f4e77148552b60861eea54a02
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@0444b663c96569fffd613fef3114a4cbc8f8bddf
     with:
-      runtime_ref: "05fd6e32337e406f4e77148552b60861eea54a02"
+      runtime_ref: "0444b663c96569fffd613fef3114a4cbc8f8bddf"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ inputs.pr_number }}
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@05fd6e32337e406f4e77148552b60861eea54a02
+        uses: 777genius/review-router@0444b663c96569fffd613fef3114a4cbc8f8bddf
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"

--- a/.github/workflows/reviewrouter-interaction.yml
+++ b/.github/workflows/reviewrouter-interaction.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.event_name == 'workflow_dispatch' || ((github.event_name != 'issue_comment' || github.event.issue.pull_request) && github.event.comment.user.type != 'Bot') }}
     env:
-      RR_RUNTIME_REF: "05fd6e32337e406f4e77148552b60861eea54a02"
+      RR_RUNTIME_REF: "0444b663c96569fffd613fef3114a4cbc8f8bddf"
       REVIEWROUTER_API_URL: "https://api.reviewrouter.site"
       REVIEWROUTER_OIDC_AUDIENCE: "reviewrouter"
       REVIEWROUTER_RUNTIME_CONFIG_MODE: "oidc"


### PR DESCRIPTION
## Summary
- pin ReviewRouter review and interaction workflows to `0444b663c96569fffd613fef3114a4cbc8f8bddf`
- deploy the T0 Codex CLI bootstrap fix found by production smoke run `30476572355`

## Verification
- both workflow YAML files parse successfully
- all four runtime references use the exact immutable SHA
- old runtime SHA is absent from the changed workflows
- production release registration and attestation completed before this pin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated review and interaction workflows to use newer runtime versions.
  * Preserved existing workflow triggers, permissions, settings, and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->