### PR TITLE
chore(review): pin reuse diagnostics runtime

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@0444b663c96569fffd613fef3114a4cbc8f8bddf
+        uses: 777genius/review-router@8318fc141f31398817f9721d40d1bf5a8e8d9fb2
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"

--- a/.github/workflows/reviewrouter-interaction.yml
+++ b/.github/workflows/reviewrouter-interaction.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.event_name == 'workflow_dispatch' || ((github.event_name != 'issue_comment' || github.event.issue.pull_request) && github.event.comment.user.type != 'Bot') }}
     env:
-      RR_RUNTIME_REF: "0444b663c96569fffd613fef3114a4cbc8f8bddf"
+      RR_RUNTIME_REF: "8318fc141f31398817f9721d40d1bf5a8e8d9fb2"
       REVIEWROUTER_API_URL: "https://api.reviewrouter.site"
       REVIEWROUTER_OIDC_AUDIENCE: "reviewrouter"
       REVIEWROUTER_RUNTIME_CONFIG_MODE: "oidc"


### PR DESCRIPTION
## Summary

- pin ReviewRouter to immutable runtime release `8318fc141f31398817f9721d40d1bf5a8e8d9fb2`
- expose safe evidence-reuse denial diagnostics for the bounded E2E smoke

## Validation

- `git diff --check`
- `actionlint .github/workflows/reviewrouter-codex.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated review workflows to use newer pinned action/runtime versions.
  * No user-facing product behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->