### PR TITLE
chore(review): pin stable evidence runtime

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -30,9 +30,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@8318fc141f31398817f9721d40d1bf5a8e8d9fb2
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@b08e2032f54d430903d04a92dfa9af5fd723c1f7
     with:
-      runtime_ref: "8318fc141f31398817f9721d40d1bf5a8e8d9fb2"
+      runtime_ref: "b08e2032f54d430903d04a92dfa9af5fd723c1f7"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ inputs.pr_number }}
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@8318fc141f31398817f9721d40d1bf5a8e8d9fb2
+        uses: 777genius/review-router@b08e2032f54d430903d04a92dfa9af5fd723c1f7
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"

--- a/.github/workflows/reviewrouter-interaction.yml
+++ b/.github/workflows/reviewrouter-interaction.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.event_name == 'workflow_dispatch' || ((github.event_name != 'issue_comment' || github.event.issue.pull_request) && github.event.comment.user.type != 'Bot') }}
     env:
-      RR_RUNTIME_REF: "8318fc141f31398817f9721d40d1bf5a8e8d9fb2"
+      RR_RUNTIME_REF: "b08e2032f54d430903d04a92dfa9af5fd723c1f7"
       REVIEWROUTER_API_URL: "https://api.reviewrouter.site"
       REVIEWROUTER_OIDC_AUDIENCE: "reviewrouter"
       REVIEWROUTER_RUNTIME_CONFIG_MODE: "oidc"


### PR DESCRIPTION
## Summary
- pin the reusable review workflow and runtime input to ReviewRouter b08e2032
- pin OAuth refresh and interaction runtime to the same immutable release

## Verification
- canonical T0 workflow parser passed
- canonical interaction workflow semantic comparison passed
- all four runtime bindings resolve to b08e2032f54d430903d04a92dfa9af5fd723c1f7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated review and interaction workflows to use the latest runtime revision.
  * Ensured related workflow jobs use matching runtime versions for more consistent automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->