### PR TITLE
chore(review): pin model provenance runtime

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -30,9 +30,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@b08e2032f54d430903d04a92dfa9af5fd723c1f7
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@a196ead4f11398b233a4392da729119fdc01c10e
     with:
-      runtime_ref: "b08e2032f54d430903d04a92dfa9af5fd723c1f7"
+      runtime_ref: "a196ead4f11398b233a4392da729119fdc01c10e"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ inputs.pr_number }}
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@b08e2032f54d430903d04a92dfa9af5fd723c1f7
+        uses: 777genius/review-router@a196ead4f11398b233a4392da729119fdc01c10e
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"

--- a/.github/workflows/reviewrouter-interaction.yml
+++ b/.github/workflows/reviewrouter-interaction.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.event_name == 'workflow_dispatch' || ((github.event_name != 'issue_comment' || github.event.issue.pull_request) && github.event.comment.user.type != 'Bot') }}
     env:
-      RR_RUNTIME_REF: "b08e2032f54d430903d04a92dfa9af5fd723c1f7"
+      RR_RUNTIME_REF: "a196ead4f11398b233a4392da729119fdc01c10e"
       REVIEWROUTER_API_URL: "https://api.reviewrouter.site"
       REVIEWROUTER_OIDC_AUDIENCE: "reviewrouter"
       REVIEWROUTER_RUNTIME_CONFIG_MODE: "oidc"


### PR DESCRIPTION
## Summary
- pin the reusable T0 workflow to ReviewRouter `a196ead4`
- pin the runtime input, OAuth refresh action, and interaction workflow to the same immutable SHA

## Verification
- both workflows parse as YAML
- all four runtime bindings use the exact release SHA
- no workflow behavior changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated review workflow components to newer pinned versions.
  * Refreshed the workflow runtime reference while preserving existing jobs, permissions, and conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->