### PR TITLE
chore(review): pin default-branch runtime release 62673985

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -30,9 +30,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@a196ead4f11398b233a4392da729119fdc01c10e
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@626739854b5c67d94b3f0118738c106b4a232c41
     with:
-      runtime_ref: "a196ead4f11398b233a4392da729119fdc01c10e"
+      runtime_ref: "626739854b5c67d94b3f0118738c106b4a232c41"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ inputs.pr_number }}
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@a196ead4f11398b233a4392da729119fdc01c10e
+        uses: 777genius/review-router@626739854b5c67d94b3f0118738c106b4a232c41
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"

--- a/.github/workflows/reviewrouter-interaction.yml
+++ b/.github/workflows/reviewrouter-interaction.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.event_name == 'workflow_dispatch' || ((github.event_name != 'issue_comment' || github.event.issue.pull_request) && github.event.comment.user.type != 'Bot') }}
     env:
-      RR_RUNTIME_REF: "a196ead4f11398b233a4392da729119fdc01c10e"
+      RR_RUNTIME_REF: "626739854b5c67d94b3f0118738c106b4a232c41"
       REVIEWROUTER_API_URL: "https://api.reviewrouter.site"
       REVIEWROUTER_OIDC_AUDIENCE: "reviewrouter"
       REVIEWROUTER_RUNTIME_CONFIG_MODE: "oidc"


### PR DESCRIPTION
Pins the default-branch workflow_dispatch path to the same immutable ReviewRouter release already deployed and pinned on dev.\n\nThis is required because GitHub executes dispatched ReviewRouter workflows from the repository default branch. All four workflow/runtime references now resolve to 626739854b5c67d94b3f0118738c106b4a232c41.