### PR TITLE
fix: critical review findings for the hosted-web branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "check:workspace:ci": "pnpm typecheck:workspace && pnpm test:workspace:ci && pnpm build:workspace && pnpm --filter agent-teams-mcp test:e2e",
     "check": "pnpm guard:source-file-size && pnpm guard:feature-architecture && pnpm guard:team-provisioning-architecture && pnpm check:workspace && pnpm lint && pnpm lint:mcp",
     "check:ci": "pnpm guard:source-file-size && pnpm guard:feature-architecture && pnpm guard:team-provisioning-architecture && pnpm check:workspace:ci && pnpm lint && pnpm lint:mcp",
-    "validate:ci": "pnpm guard:hosted-phase0-evidence && pnpm guard:source-file-size:ci && pnpm guard:feature-architecture && pnpm guard:team-provisioning-architecture && pnpm typecheck:workspace && pnpm build:workspace && pnpm --filter agent-teams-mcp test:e2e",
+    "validate:ci": "pnpm guard:source-file-size:ci && pnpm guard:hosted-phase0-evidence && pnpm guard:feature-architecture && pnpm guard:team-provisioning-architecture && pnpm typecheck:workspace && pnpm build:workspace && pnpm --filter agent-teams-mcp test:e2e",
     "fix": "pnpm lint:fix && pnpm format",
     "quality": "pnpm check && pnpm format:check && npx knip",
     "guard:feature-architecture": "node ./scripts/ci/verify-feature-architecture.mjs",

--- a/scripts/ci/source-file-size-baseline.json
+++ b/scripts/ci/source-file-size-baseline.json
@@ -55,7 +55,7 @@
     "src/main/services/team/opencode/delivery/RuntimeDeliveryJournal.ts": 1442,
     "src/main/services/team/opencode/delivery/RuntimeDeliveryService.ts": 801,
     "src/main/services/team/opencode/permissions/RuntimePermission.ts": 964,
-    "src/main/services/team/opencode/store/OpenCodeRuntimeManifestEvidenceReader.ts": 1081,
+    "src/main/services/team/opencode/store/OpenCodeRuntimeManifestEvidenceReader.ts": 1077,
     "src/main/services/team/opencode/store/RuntimeStoreManifest.ts": 1210,
     "src/main/services/team/provisioning/TeamProvisioningBootstrapTranscript.ts": 1661,
     "src/main/services/team/provisioning/TeamProvisioningInboxRelayPolicy.ts": 890,

--- a/scripts/ci/source-file-size-legacy.json
+++ b/scripts/ci/source-file-size-legacy.json
@@ -52,7 +52,7 @@
   "src/main/services/team/opencode/delivery/RuntimeDeliveryJournal.ts": 1442,
   "src/main/services/team/opencode/delivery/RuntimeDeliveryService.ts": 801,
   "src/main/services/team/opencode/permissions/RuntimePermission.ts": 964,
-  "src/main/services/team/opencode/store/OpenCodeRuntimeManifestEvidenceReader.ts": 1081,
+  "src/main/services/team/opencode/store/OpenCodeRuntimeManifestEvidenceReader.ts": 1077,
   "src/main/services/team/opencode/store/RuntimeStoreManifest.ts": 1210,
   "src/main/services/team/provisioning/TeamProvisioningBootstrapTranscript.ts": 1661,
   "src/main/services/team/provisioning/TeamProvisioningInboxRelayPolicy.ts": 890,

--- a/src/features/coordination-events/main/adapters/output/SqliteCoordinationEventJournal.ts
+++ b/src/features/coordination-events/main/adapters/output/SqliteCoordinationEventJournal.ts
@@ -167,7 +167,11 @@ function normalize(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(normalize);
   if (!value || typeof value !== 'object') throw new TypeError('coordination-event-json-invalid');
   const result: Record<string, unknown> = {};
-  for (const key of Object.keys(value).sort((left, right) => left.localeCompare(right))) {
+  // Code-unit ordering: body_json bytes are persisted and byte-verified on read,
+  // so key order must not depend on the process locale or ICU version.
+  for (const key of Object.keys(value).sort((left, right) =>
+    left < right ? -1 : left > right ? 1 : 0
+  )) {
     const child = (value as Record<string, unknown>)[key];
     if (child !== undefined) result[key] = normalize(child);
   }

--- a/src/features/internal-storage/main/infrastructure/worker/coordinationDurabilityState.ts
+++ b/src/features/internal-storage/main/infrastructure/worker/coordinationDurabilityState.ts
@@ -527,6 +527,12 @@ export function canonicalJson(value: unknown): string {
   return JSON.stringify(normalizeCanonicalValue(value));
 }
 
+// Canonical bytes are persisted and byte-compared on later reads, so key order
+// must not depend on the process locale or ICU version (localeCompare does).
+export function compareCanonicalKeys(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
 export function normalizeCanonicalValue(value: unknown): unknown {
   if (value === null || typeof value === 'string' || typeof value === 'boolean') return value;
   if (typeof value === 'number') {
@@ -539,7 +545,7 @@ export function normalizeCanonicalValue(value: unknown): unknown {
   }
   const record = value as Readonly<Record<string, unknown>>;
   const normalized: Record<string, unknown> = {};
-  for (const key of Object.keys(record).sort((left, right) => left.localeCompare(right))) {
+  for (const key of Object.keys(record).sort(compareCanonicalKeys)) {
     if (record[key] === undefined) continue;
     normalized[key] = normalizeCanonicalValue(record[key]);
   }

--- a/src/features/internal-storage/main/infrastructure/worker/internalStorageMigrationBackfills.ts
+++ b/src/features/internal-storage/main/infrastructure/worker/internalStorageMigrationBackfills.ts
@@ -268,7 +268,11 @@ function normalizeMigrationJson(value: unknown): unknown {
   if (typeof value !== 'object') throw new Error('internal-storage-migration-json-value-invalid');
   const record = value as Readonly<Record<string, unknown>>;
   const normalized: Record<string, unknown> = {};
-  for (const key of Object.keys(record).sort((left, right) => left.localeCompare(right))) {
+  // Code-unit ordering: must produce the same canonical bytes as the event
+  // journal writer regardless of process locale or ICU version.
+  for (const key of Object.keys(record).sort((left, right) =>
+    left < right ? -1 : left > right ? 1 : 0
+  )) {
     if (record[key] !== undefined) normalized[key] = normalizeMigrationJson(record[key]);
   }
   return normalized;

--- a/src/features/internal-storage/main/infrastructure/worker/internalStorageWorkerProtocol.ts
+++ b/src/features/internal-storage/main/infrastructure/worker/internalStorageWorkerProtocol.ts
@@ -753,8 +753,10 @@ function canonicalWorkerJson(value: unknown): string {
   }
   if (Array.isArray(value)) return `[${value.map(canonicalWorkerJson).join(',')}]`;
   const record = exactWorkerRecord(value, 'canonical-value');
+  // Code-unit ordering: validates the same persisted stateJson bytes as the
+  // process-ownership codec, so both must sort keys identically on any locale.
   return `{${Object.keys(record)
-    .sort((left, right) => left.localeCompare(right))
+    .sort((left, right) => (left < right ? -1 : left > right ? 1 : 0))
     .map((key) => `${JSON.stringify(key)}:${canonicalWorkerJson(record[key])}`)
     .join(',')}}`;
 }

--- a/src/features/internal-storage/main/infrastructure/worker/processOwnershipStorageOps.ts
+++ b/src/features/internal-storage/main/infrastructure/worker/processOwnershipStorageOps.ts
@@ -547,8 +547,10 @@ function canonicalJson(value: unknown): string {
   }
   if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
   const record = exactRecord(value, Object.keys(value as object), 'canonical-value');
+  // Code-unit ordering: state_json bytes are persisted and byte-validated on
+  // read, so key order must not depend on the process locale or ICU version.
   return `{${Object.keys(record)
-    .sort((left, right) => left.localeCompare(right))
+    .sort((left, right) => (left < right ? -1 : left > right ? 1 : 0))
     .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`)
     .join(',')}}`;
 }

--- a/src/features/member-work-sync/main/infrastructure/memberWorkSyncSqliteMappers.ts
+++ b/src/features/member-work-sync/main/infrastructure/memberWorkSyncSqliteMappers.ts
@@ -239,7 +239,7 @@ function stableStringify(value: unknown): string {
   }
   const record = value as Record<string, unknown>;
   return `{${Object.keys(record)
-    .sort((a, b) => a.localeCompare(b))
+    .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
     .map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`)
     .join(',')}}`;
 }

--- a/src/features/team-runtime-control/main/adapters/output/process-supervision/processOwnershipStateCodec.ts
+++ b/src/features/team-runtime-control/main/adapters/output/process-supervision/processOwnershipStateCodec.ts
@@ -363,8 +363,10 @@ function canonicalJson(value: unknown): string {
   }
   if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
   const record = plainRecord(value, 'canonical-value');
+  // Code-unit ordering: these canonical bytes are persisted as stateJson and
+  // byte-validated on read, so key order must not depend on locale/ICU.
   return `{${Object.keys(record)
-    .sort((left, right) => left.localeCompare(right))
+    .sort((left, right) => (left < right ? -1 : left > right ? 1 : 0))
     .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`)
     .join(',')}}`;
 }

--- a/src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx
+++ b/src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx
@@ -429,7 +429,7 @@ const TerminalWorkspaceKernelView = ({
   });
   const { autocompleteSuggestion } = useTerminalCommandAutocomplete({
     commandHistory: snapshot.commandHistory.entries,
-    commandRuns: activeCommandRuns,
+    commandRuns,
     cwd: projectPath,
     eventSource: commandDockElement,
     paneId: activeCommandPaneId,

--- a/src/main/services/team/opencode/store/OpenCodeRuntimeManifestEvidenceReader.ts
+++ b/src/main/services/team/opencode/store/OpenCodeRuntimeManifestEvidenceReader.ts
@@ -2,7 +2,6 @@ import { mkdir, readdir, readFile, rm } from 'node:fs/promises';
 
 import { atomicWriteAsync, renamePathWithRetry } from '@main/utils/atomicWrite';
 import {
-  assertIdentityStableDirectoryChildOperationsSupported,
   durablePathExistsAsync,
   readJsonDataEnvelopeNoFollowAsync,
   readOptionalJsonNoFollowAsync,
@@ -811,7 +810,6 @@ export function clearOpenCodeRuntimeLaneStorage(
 export async function clearOpenCodeRuntimeLaneStorage(
   params: ClearOpenCodeRuntimeLaneStorageParams & { expectedRunId?: string }
 ): Promise<void | ClearOpenCodeRuntimeLaneStorageResult> {
-  assertIdentityStableDirectoryChildOperationsSupported();
   return clearLaneStorageUnlocked(params, true);
 }
 // prettier-ignore
@@ -819,7 +817,6 @@ async function clearLaneStorageUnlocked(
   params: ClearOpenCodeRuntimeLaneStorageParams & { expectedRunId?: string }, acquireLifecycleLock = false,
   stableRuntimeDirectory?: string, stableLanesDirectory?: string,
 ): Promise<ClearOpenCodeRuntimeLaneStorageResult> {
-  assertIdentityStableDirectoryChildOperationsSupported();
   return withIdentityStableIndexedDirectoryLocksAsync(
     {
       rootDirectoryPath: stableRuntimeDirectory ?? getOpenCodeTeamRuntimeDirectory(params.teamsBasePath, params.teamName),
@@ -892,7 +889,6 @@ export function getOpenCodeRuntimeLaneLifecycleLockTargetPath(
 // prettier-ignore
 function withOpenCodeRuntimeLaneLifecycleLock<T>(
   params: { teamsBasePath: string; teamName: string; laneId?: string | null }, operation: (stableRuntimeDirectory: string, stableLanesDirectory: string) => Promise<T>): Promise<T> {
-  assertIdentityStableDirectoryChildOperationsSupported();
   const lockTargetPath = getOpenCodeRuntimeLaneLifecycleLockTargetPath(params.teamsBasePath, params.teamName, params.laneId);
   return withIdentityStableDirectoryTreeAsync(
     getOpenCodeTeamRuntimeDirectory(params.teamsBasePath, params.teamName), OPENCODE_TEAM_RUNTIME_LANES_DIR,

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeRuntimeLaneCleanup.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeRuntimeLaneCleanup.ts
@@ -384,13 +384,12 @@ async function stopOpenCodeRuntimeLanesForStoppedTeamLocked(input: {
       );
       continue;
     }
-    const cleared = await clearOpenCodeRuntimeLaneStorage({
-      teamsBasePath,
-      teamName,
-      laneId,
-      ...(expectedRunId ? { expectedRunId } : {}),
-    }).catch(() => false);
-    if (!cleared) {
+    const cleared = await (
+      expectedRunId
+        ? clearOpenCodeRuntimeLaneStorage({ teamsBasePath, teamName, laneId, expectedRunId })
+        : clearOpenCodeRuntimeLaneStorage({ teamsBasePath, teamName, laneId })
+    ).catch(() => false);
+    if (cleared !== 'cleared') {
       ports.logWarning(
         `[${teamName}] OpenCode lane ${laneId} ownership changed before stopped-team storage cleanup; retaining current runtime tracking.`
       );

--- a/src/main/utils/bestEffortDurableDirectory.ts
+++ b/src/main/utils/bestEffortDurableDirectory.ts
@@ -1,0 +1,197 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import {
+  type DurablePathIdentity,
+  getDurablePathIdentity,
+  isSameDurablePathIdentity,
+} from './durablePathIdentity';
+
+import type { DurableDirectoryEntryCleanupResult } from './durablePathOperations';
+
+/**
+ * True when the runtime can bind directory operations to /proc/self/fd paths,
+ * making them immune to ancestor replacement (Linux only). Other platforms use
+ * the best-effort helpers below: symbolic links are still rejected at the
+ * operation target, but ancestor-swap protection is not provided. That is the
+ * accepted trade-off for the desktop app, where the directory tree is owned by
+ * the local user rather than shared with untrusted tenants.
+ */
+export function hasStrictIdentityStableDirectorySupport(): boolean {
+  return (
+    process.platform === 'linux' &&
+    typeof fs.constants.O_DIRECTORY === 'number' &&
+    typeof fs.constants.O_NOFOLLOW === 'number'
+  );
+}
+
+async function assertNotSymbolicLink(targetPath: string, errorPath: string): Promise<fs.Stats> {
+  const stats = await fs.promises.lstat(targetPath);
+  if (stats.isSymbolicLink()) {
+    throw new Error(`Durable directory identity changed during cleanup: ${errorPath}`);
+  }
+  return stats;
+}
+
+/**
+ * Canonicalize a directory path for best-effort operations. Ancestors may
+ * legitimately contain symbolic links (macOS /tmp and /var are symlinks), so
+ * they are resolved with realpath; only the final component is required to be
+ * a real directory rather than a link.
+ */
+async function resolveBestEffortDirectoryAsync(
+  directoryPath: string,
+  options: { create?: boolean; errorPath?: string } = {}
+): Promise<string | null> {
+  const errorPath = options.errorPath ?? directoryPath;
+  let stats: fs.Stats;
+  try {
+    stats = await assertNotSymbolicLink(directoryPath, errorPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    if (!options.create) return null;
+    await fs.promises.mkdir(directoryPath, { recursive: true });
+    stats = await assertNotSymbolicLink(directoryPath, errorPath);
+  }
+  if (!stats.isDirectory()) {
+    throw new Error(`Durable directory identity changed during cleanup: ${errorPath}`);
+  }
+  return fs.promises.realpath(directoryPath);
+}
+
+export async function withBestEffortDirectoryTreeAsync<T>(
+  rootDirectoryPath: string,
+  childDirectoryName: string,
+  operation: (paths: { rootDirectoryPath: string; childDirectoryPath: string }) => Promise<T>,
+  options: { create?: boolean } = {}
+): Promise<T> {
+  const resolvedRoot = await resolveBestEffortDirectoryAsync(rootDirectoryPath, options);
+  if (resolvedRoot === null) {
+    throw new Error(`Identity-stable root directory is missing: ${rootDirectoryPath}`);
+  }
+  const resolvedChild = await resolveBestEffortDirectoryAsync(
+    path.join(resolvedRoot, childDirectoryName),
+    options
+  );
+  if (resolvedChild === null) {
+    throw new Error(`Identity-stable child directory is missing: ${childDirectoryName}`);
+  }
+  return operation({ rootDirectoryPath: resolvedRoot, childDirectoryPath: resolvedChild });
+}
+
+export async function readRegularFileNoFollowBestEffortAsync(
+  filePath: string,
+  encoding: BufferEncoding = 'utf8'
+): Promise<string> {
+  const stats = await fs.promises.lstat(filePath);
+  if (stats.isSymbolicLink() || !stats.isFile()) {
+    throw new Error(`Durable path is not a regular file: ${filePath}`);
+  }
+  const flags =
+    fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0) | (fs.constants.O_NONBLOCK ?? 0);
+  const handle = await fs.promises.open(filePath, flags);
+  try {
+    const openedStats = await handle.stat();
+    if (!openedStats.isFile()) {
+      throw new Error(`Durable path is not a regular file: ${filePath}`);
+    }
+    return await handle.readFile({ encoding });
+  } finally {
+    await handle.close().catch(() => undefined);
+  }
+}
+
+async function syncDirectoryBestEffort(dirPath: string, strict: boolean): Promise<void> {
+  let handle: fs.promises.FileHandle | null = null;
+  try {
+    handle = await fs.promises.open(dirPath, 'r');
+    await handle.sync();
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    const unsupported =
+      code === 'EINVAL' ||
+      code === 'ENOSYS' ||
+      code === 'ENOTSUP' ||
+      code === 'EOPNOTSUPP' ||
+      (process.platform === 'win32' &&
+        (code === 'EACCES' || code === 'EPERM' || code === 'EISDIR' || code === 'EBADF'));
+    if (strict && !unsupported) throw error;
+  } finally {
+    await handle?.close();
+  }
+}
+
+export async function removeDirectoryEntriesExceptBestEffortAsync(
+  directoryPath: string,
+  retainedEntryNames: ReadonlySet<string>,
+  options: {
+    durability?: 'best-effort' | 'strict';
+    displayPath?: string;
+    validateDirectory?: (
+      stableDirectoryPath: string,
+      entries: readonly fs.Dirent[]
+    ) => Promise<boolean>;
+  } = {}
+): Promise<DurableDirectoryEntryCleanupResult> {
+  const strict = options.durability !== 'best-effort';
+  const displayPath = options.displayPath ?? directoryPath;
+  const resolved = await resolveBestEffortDirectoryAsync(directoryPath, {
+    errorPath: displayPath,
+  });
+  if (resolved === null) return 'missing';
+
+  const entries = await fs.promises.readdir(resolved, { withFileTypes: true });
+  const retained: { name: string; identity: DurablePathIdentity; birthtimeMs: number }[] = [];
+
+  const verifyRetainedEntries = async (): Promise<void> => {
+    for (const entry of retained) {
+      const retainedPath = path.join(resolved, entry.name);
+      const stats = await fs.promises.lstat(retainedPath);
+      if (
+        !stats.isFile() ||
+        stats.isSymbolicLink() ||
+        !isSameDurablePathIdentity(getDurablePathIdentity(stats), entry.identity) ||
+        stats.birthtimeMs !== entry.birthtimeMs
+      ) {
+        throw new Error(`Retained directory entry identity changed: ${retainedPath}`);
+      }
+    }
+  };
+
+  for (const entry of entries) {
+    if (!retainedEntryNames.has(entry.name)) continue;
+    const retainedPath = path.join(resolved, entry.name);
+    const stats = await fs.promises.lstat(retainedPath);
+    if (!stats.isFile() || stats.isSymbolicLink()) {
+      throw new Error(`Retained directory entry is not a regular file: ${retainedPath}`);
+    }
+    retained.push({
+      name: entry.name,
+      identity: getDurablePathIdentity(stats),
+      birthtimeMs: stats.birthtimeMs,
+    });
+  }
+  await verifyRetainedEntries();
+
+  if (options.validateDirectory && !(await options.validateDirectory(resolved, entries))) {
+    return 'validation_failed';
+  }
+  await verifyRetainedEntries();
+
+  for (const entry of entries) {
+    if (!retainedEntryNames.has(entry.name) && entry.isDirectory()) {
+      throw new Error(`Durable directory identity changed during cleanup: ${displayPath}`);
+    }
+  }
+  for (const entry of entries) {
+    if (retainedEntryNames.has(entry.name)) continue;
+    try {
+      await fs.promises.unlink(path.join(resolved, entry.name));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+  }
+  await verifyRetainedEntries();
+  await syncDirectoryBestEffort(resolved, strict);
+  return 'cleaned';
+}

--- a/src/main/utils/durablePathOperations.ts
+++ b/src/main/utils/durablePathOperations.ts
@@ -4,6 +4,12 @@ import * as path from 'path';
 
 export * from './durablePathIdentity';
 
+import {
+  hasStrictIdentityStableDirectorySupport,
+  readRegularFileNoFollowBestEffortAsync,
+  removeDirectoryEntriesExceptBestEffortAsync,
+  withBestEffortDirectoryTreeAsync,
+} from './bestEffortDurableDirectory';
 import { resumeDeterministicDetachedRemoval } from './durableDetachedRemoval';
 import {
   type DurablePathIdentity,
@@ -157,6 +163,14 @@ export async function withIdentityStableDirectoryTreeAsync<T>(
   if (path.basename(childDirectoryName) !== childDirectoryName) {
     throw new Error(`Invalid identity-stable child directory name: ${childDirectoryName}`);
   }
+  if (!hasStrictIdentityStableDirectorySupport()) {
+    return withBestEffortDirectoryTreeAsync(
+      rootDirectoryPath,
+      childDirectoryName,
+      operation,
+      options
+    );
+  }
   const rootAccess = await withIdentityStableDirectoryPathAsync(
     rootDirectoryPath,
     async (stableRootDirectoryPath) => {
@@ -203,7 +217,6 @@ export async function withIdentityStableIndexedDirectoryLocksAsync<T>(
       throw new Error(`Invalid identity-stable directory entry name: ${entryName}`);
     }
   }
-  assertIdentityStableDirectoryChildOperationsSupported();
   const runWithLocks = (rootDirectoryPath: string, childDirectoryPath: string) => {
     const runWithIndexLock = () =>
       withLock(path.join(rootDirectoryPath, input.indexFileName), () =>
@@ -230,20 +243,9 @@ export async function readRegularFileNoFollowAsync(
   filePath: string,
   encoding: BufferEncoding = 'utf8'
 ): Promise<string> {
-  assertIdentityStableDirectoryChildOperationsSupported();
-  const handle = await fs.promises.open(
-    filePath,
-    fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW | fs.constants.O_NONBLOCK
-  );
-  try {
-    const stats = await handle.stat();
-    if (!stats.isFile()) {
-      throw new Error(`Durable path is not a regular file: ${filePath}`);
-    }
-    return await handle.readFile({ encoding });
-  } finally {
-    await handle.close().catch(() => undefined);
-  }
+  // Portable on every platform: O_NOFOLLOW/O_NONBLOCK degrade to 0 where the
+  // constants do not exist and the lstat pre-check rejects symbolic links there.
+  return readRegularFileNoFollowBestEffortAsync(filePath, encoding);
 }
 
 export async function readJsonDataEnvelopeNoFollowAsync(filePath: string): Promise<unknown> {
@@ -277,7 +279,9 @@ export async function removeDirectoryEntriesExceptAsync(
     ) => Promise<boolean>;
   } = {}
 ): Promise<DurableDirectoryEntryCleanupResult> {
-  assertIdentityStableDirectoryChildOperationsSupported();
+  if (!hasStrictIdentityStableDirectorySupport()) {
+    return removeDirectoryEntriesExceptBestEffortAsync(directoryPath, retainedEntryNames, options);
+  }
   const strict = options.durability !== 'best-effort';
   const displayPath = options.displayPath ?? directoryPath;
   const access = await withIdentityStableDirectoryPathAsync(

--- a/test/main/services/team/OpenCodeRuntimeManifestEvidenceReader.test.ts
+++ b/test/main/services/team/OpenCodeRuntimeManifestEvidenceReader.test.ts
@@ -1238,7 +1238,7 @@ describe('OpenCodeRuntimeManifestEvidenceReader migration', () => {
     });
   });
 
-  it('fails closed before mutation when identity-stable child operations are unsupported', async () => {
+  it('clears lane storage through the portable best-effort path on non-Linux platforms', async () => {
     const teamName = 'team-unsupported-cleanup';
     const laneId = 'secondary:opencode:unsupported-cleanup';
     const laneDirectory = getOpenCodeTeamRuntimeLaneDirectory(tempDir, teamName, laneId);
@@ -1275,29 +1275,20 @@ describe('OpenCodeRuntimeManifestEvidenceReader migration', () => {
           laneId,
           expectedRunId: 'run-unsupported',
         })
-      ).rejects.toThrow('Identity-stable directory child operations are unsupported on darwin');
+      ).resolves.toBe('cleared');
     } finally {
       Object.defineProperty(process, 'platform', { value: originalPlatform });
     }
 
-    expect((await fs.stat(laneDirectory)).isDirectory()).toBe(true);
-    await expect(fs.readFile(transientPath, 'utf8')).resolves.toBe('transient');
+    await expect(fs.stat(transientPath)).rejects.toMatchObject({ code: 'ENOENT' });
     await expect(
       Promise.all(
         retainedFiles.map((fileName) => fs.readFile(path.join(laneDirectory, fileName), 'utf8'))
       )
     ).resolves.toEqual(retainedFiles.map((fileName) => `retained-${fileName}`));
     await expect(readOpenCodeRuntimeLaneIndex(tempDir, teamName)).resolves.toMatchObject({
-      lanes: {
-        [laneId]: {
-          runId: 'run-unsupported',
-          state: 'active',
-        },
-      },
+      lanes: {},
     });
-    await expect(
-      new OpenCodeRuntimeManifestEvidenceReader({ teamsBasePath: tempDir }).read(teamName, laneId)
-    ).resolves.toMatchObject({ activeRunId: 'run-unsupported' });
   });
 
   it.skipIf(process.platform !== 'linux')(
@@ -1541,165 +1532,168 @@ describe('OpenCodeRuntimeManifestEvidenceReader migration', () => {
     }
   );
 
-  it('keeps journal and tombstone access pending during descriptor-backed cleanup', async () => {
-    const teamName = 'team-descriptor-cleanup-lock';
-    const laneId = 'secondary:opencode:descriptor-cleanup-lock';
-    const laneDirectory = getOpenCodeTeamRuntimeLaneDirectory(tempDir, teamName, laneId);
-    const accessLockTargetPath = getOpenCodeRuntimeLaneLifecycleLockTargetPath(
-      tempDir,
-      teamName,
-      laneId
-    );
-    let nextTombstoneId = 1;
-    const journal = createRuntimeDeliveryJournalStore({
-      filePath: path.join(laneDirectory, 'opencode-delivery-journal.json'),
-      accessLockTargetPath,
-    });
-    const tombstones = createRuntimeRunTombstoneStore({
-      filePath: path.join(laneDirectory, 'opencode-run-tombstones.json'),
-      accessLockTargetPath,
-      idFactory: () => `tombstone-${nextTombstoneId++}`,
-      clock: () => now,
-    });
-    await upsertOpenCodeRuntimeLaneIndexEntry({
-      teamsBasePath: tempDir,
-      teamName,
-      laneId,
-      runId: 'run-detached',
-      state: 'active',
-    });
-    await setOpenCodeRuntimeActiveRunManifest({
-      teamsBasePath: tempDir,
-      teamName,
-      laneId,
-      runId: 'run-detached',
-      clock: () => now,
-    });
-    await journal.begin({
-      idempotencyKey: 'delivery-before-cleanup',
-      payloadHash: 'sha256:delivery-before-cleanup',
-      runId: 'run-detached',
-      teamName,
-      fromMemberName: 'Builder',
-      providerId: 'opencode',
-      runtimeSessionId: 'session-detached',
-      destination: { kind: 'member_inbox', teamName, memberName: 'Reviewer' },
-      destinationMessageId: 'message-before-cleanup',
-      now: now.toISOString(),
-    });
-    await tombstones.add({
-      teamName,
-      runId: 'run-before-cleanup',
-      reason: 'run_replaced',
-    });
+  it.skipIf(process.platform !== 'linux')(
+    'keeps journal and tombstone access pending during descriptor-backed cleanup',
+    async () => {
+      const teamName = 'team-descriptor-cleanup-lock';
+      const laneId = 'secondary:opencode:descriptor-cleanup-lock';
+      const laneDirectory = getOpenCodeTeamRuntimeLaneDirectory(tempDir, teamName, laneId);
+      const accessLockTargetPath = getOpenCodeRuntimeLaneLifecycleLockTargetPath(
+        tempDir,
+        teamName,
+        laneId
+      );
+      let nextTombstoneId = 1;
+      const journal = createRuntimeDeliveryJournalStore({
+        filePath: path.join(laneDirectory, 'opencode-delivery-journal.json'),
+        accessLockTargetPath,
+      });
+      const tombstones = createRuntimeRunTombstoneStore({
+        filePath: path.join(laneDirectory, 'opencode-run-tombstones.json'),
+        accessLockTargetPath,
+        idFactory: () => `tombstone-${nextTombstoneId++}`,
+        clock: () => now,
+      });
+      await upsertOpenCodeRuntimeLaneIndexEntry({
+        teamsBasePath: tempDir,
+        teamName,
+        laneId,
+        runId: 'run-detached',
+        state: 'active',
+      });
+      await setOpenCodeRuntimeActiveRunManifest({
+        teamsBasePath: tempDir,
+        teamName,
+        laneId,
+        runId: 'run-detached',
+        clock: () => now,
+      });
+      await journal.begin({
+        idempotencyKey: 'delivery-before-cleanup',
+        payloadHash: 'sha256:delivery-before-cleanup',
+        runId: 'run-detached',
+        teamName,
+        fromMemberName: 'Builder',
+        providerId: 'opencode',
+        runtimeSessionId: 'session-detached',
+        destination: { kind: 'member_inbox', teamName, memberName: 'Reviewer' },
+        destinationMessageId: 'message-before-cleanup',
+        now: now.toISOString(),
+      });
+      await tombstones.add({
+        teamName,
+        runId: 'run-before-cleanup',
+        reason: 'run_replaced',
+      });
 
-    const originalUnlink = fs.unlink.bind(fs);
-    let signalCleanupMutation!: () => void;
-    let releaseCleanupMutation!: () => void;
-    const cleanupMutation = new Promise<void>((resolve) => {
-      signalCleanupMutation = resolve;
-    });
-    const cleanupMutationRelease = new Promise<void>((resolve) => {
-      releaseCleanupMutation = resolve;
-    });
-    let mutationPaused = false;
-    const unlinkSpy = vi.spyOn(fs, 'unlink').mockImplementation(async (target) => {
-      if (!mutationPaused && target.toString().startsWith('/proc/self/fd/')) {
-        mutationPaused = true;
-        signalCleanupMutation();
-        await cleanupMutationRelease;
+      const originalUnlink = fs.unlink.bind(fs);
+      let signalCleanupMutation!: () => void;
+      let releaseCleanupMutation!: () => void;
+      const cleanupMutation = new Promise<void>((resolve) => {
+        signalCleanupMutation = resolve;
+      });
+      const cleanupMutationRelease = new Promise<void>((resolve) => {
+        releaseCleanupMutation = resolve;
+      });
+      let mutationPaused = false;
+      const unlinkSpy = vi.spyOn(fs, 'unlink').mockImplementation(async (target) => {
+        if (!mutationPaused && target.toString().startsWith('/proc/self/fd/')) {
+          mutationPaused = true;
+          signalCleanupMutation();
+          await cleanupMutationRelease;
+        }
+        return originalUnlink(target);
+      });
+      const readFileSpy = vi.spyOn(fs, 'readFile');
+
+      const cleanup = clearOpenCodeRuntimeLaneStorage({
+        teamsBasePath: tempDir,
+        teamName,
+        laneId,
+        expectedRunId: 'run-detached',
+      });
+      try {
+        await cleanupMutation;
+        readFileSpy.mockClear();
+
+        let journalReadSettled = false;
+        let journalWriteSettled = false;
+        let tombstoneReadSettled = false;
+        let tombstoneWriteSettled = false;
+        const journalRead = journal.list().finally(() => {
+          journalReadSettled = true;
+        });
+        const journalWrite = journal
+          .begin({
+            idempotencyKey: 'delivery-after-cleanup',
+            payloadHash: 'sha256:delivery-after-cleanup',
+            runId: 'run-after-cleanup',
+            teamName,
+            fromMemberName: 'Builder',
+            providerId: 'opencode',
+            runtimeSessionId: 'session-after-cleanup',
+            destination: { kind: 'member_inbox', teamName, memberName: 'Reviewer' },
+            destinationMessageId: 'message-after-cleanup',
+            now: now.toISOString(),
+          })
+          .finally(() => {
+            journalWriteSettled = true;
+          });
+        const tombstoneRead = tombstones.list(teamName).finally(() => {
+          tombstoneReadSettled = true;
+        });
+        const tombstoneWrite = tombstones
+          .add({
+            teamName,
+            runId: 'run-after-cleanup',
+            reason: 'run_replaced',
+          })
+          .finally(() => {
+            tombstoneWriteSettled = true;
+          });
+
+        expect(journalReadSettled).toBe(false);
+        expect(journalWriteSettled).toBe(false);
+        expect(tombstoneReadSettled).toBe(false);
+        expect(tombstoneWriteSettled).toBe(false);
+        expect(readFileSpy).not.toHaveBeenCalled();
+
+        releaseCleanupMutation();
+        await expect(cleanup).resolves.toBe('cleared');
+        await expect(journalRead).resolves.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ idempotencyKey: 'delivery-before-cleanup' }),
+          ])
+        );
+        await expect(journalWrite).resolves.toMatchObject({
+          record: { idempotencyKey: 'delivery-after-cleanup' },
+        });
+        await expect(tombstoneRead).resolves.toEqual(
+          expect.arrayContaining([expect.objectContaining({ runId: 'run-before-cleanup' })])
+        );
+        await expect(tombstoneWrite).resolves.toMatchObject({
+          runId: 'run-after-cleanup',
+        });
+        await expect(journal.list()).resolves.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ idempotencyKey: 'delivery-before-cleanup' }),
+            expect.objectContaining({ idempotencyKey: 'delivery-after-cleanup' }),
+          ])
+        );
+        await expect(tombstones.list(teamName)).resolves.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ runId: 'run-before-cleanup' }),
+            expect.objectContaining({ runId: 'run-after-cleanup' }),
+          ])
+        );
+      } finally {
+        releaseCleanupMutation();
+        readFileSpy.mockRestore();
+        unlinkSpy.mockRestore();
+        await cleanup.catch(() => undefined);
       }
-      return originalUnlink(target);
-    });
-    const readFileSpy = vi.spyOn(fs, 'readFile');
-
-    const cleanup = clearOpenCodeRuntimeLaneStorage({
-      teamsBasePath: tempDir,
-      teamName,
-      laneId,
-      expectedRunId: 'run-detached',
-    });
-    try {
-      await cleanupMutation;
-      readFileSpy.mockClear();
-
-      let journalReadSettled = false;
-      let journalWriteSettled = false;
-      let tombstoneReadSettled = false;
-      let tombstoneWriteSettled = false;
-      const journalRead = journal.list().finally(() => {
-        journalReadSettled = true;
-      });
-      const journalWrite = journal
-        .begin({
-          idempotencyKey: 'delivery-after-cleanup',
-          payloadHash: 'sha256:delivery-after-cleanup',
-          runId: 'run-after-cleanup',
-          teamName,
-          fromMemberName: 'Builder',
-          providerId: 'opencode',
-          runtimeSessionId: 'session-after-cleanup',
-          destination: { kind: 'member_inbox', teamName, memberName: 'Reviewer' },
-          destinationMessageId: 'message-after-cleanup',
-          now: now.toISOString(),
-        })
-        .finally(() => {
-          journalWriteSettled = true;
-        });
-      const tombstoneRead = tombstones.list(teamName).finally(() => {
-        tombstoneReadSettled = true;
-      });
-      const tombstoneWrite = tombstones
-        .add({
-          teamName,
-          runId: 'run-after-cleanup',
-          reason: 'run_replaced',
-        })
-        .finally(() => {
-          tombstoneWriteSettled = true;
-        });
-
-      expect(journalReadSettled).toBe(false);
-      expect(journalWriteSettled).toBe(false);
-      expect(tombstoneReadSettled).toBe(false);
-      expect(tombstoneWriteSettled).toBe(false);
-      expect(readFileSpy).not.toHaveBeenCalled();
-
-      releaseCleanupMutation();
-      await expect(cleanup).resolves.toBe('cleared');
-      await expect(journalRead).resolves.toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ idempotencyKey: 'delivery-before-cleanup' }),
-        ])
-      );
-      await expect(journalWrite).resolves.toMatchObject({
-        record: { idempotencyKey: 'delivery-after-cleanup' },
-      });
-      await expect(tombstoneRead).resolves.toEqual(
-        expect.arrayContaining([expect.objectContaining({ runId: 'run-before-cleanup' })])
-      );
-      await expect(tombstoneWrite).resolves.toMatchObject({
-        runId: 'run-after-cleanup',
-      });
-      await expect(journal.list()).resolves.toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ idempotencyKey: 'delivery-before-cleanup' }),
-          expect.objectContaining({ idempotencyKey: 'delivery-after-cleanup' }),
-        ])
-      );
-      await expect(tombstones.list(teamName)).resolves.toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ runId: 'run-before-cleanup' }),
-          expect.objectContaining({ runId: 'run-after-cleanup' }),
-        ])
-      );
-    } finally {
-      releaseCleanupMutation();
-      readFileSpy.mockRestore();
-      unlinkSpy.mockRestore();
-      await cleanup.catch(() => undefined);
     }
-  });
+  );
 
   it('clears a matching durable owner atomically and is idempotent for that owner', async () => {
     const teamName = 'team-cas-idempotent';


### PR DESCRIPTION
Follow-up fixes for issues found while reviewing #252. Five focused commits, each one self-contained:

- **OpenCode lane store on macOS and Windows** - the identity-stable directory primitives are Linux-only (/proc/self/fd), but the desktop OpenCode launch path goes through them, so launching an OpenCode team on darwin/win32 threw immediately. CI did not catch it because runners are Linux; locally 36 provisioning tests were red on a Mac. Added a portable best-effort mode (realpath for ancestors since /tmp and /var are symlinks on macOS, symlink rejection on target components, identity re-verification of retained entries). The strict Linux path is untouched.
- **Locale-independent canonical JSON** - canonical body_json/state_json bytes are persisted and byte-verified on read, but key ordering used localeCompare, which varies across locales and ICU versions (Swedish v/w collation for example). A locale change between write and read made stored coordination events permanently unreadable with a non-recoverable 503 on the event stream. All four canonicalizers that feed persisted bytes now sort keys by code units. No data migration needed since the store has not shipped outside this branch.
- **Stopped-team lane cleanup TOCTOU** - clearOpenCodeRuntimeLaneStorage now returns 'cleared' | 'owner_changed', but one caller still used the old boolean check, so a truthy 'owner_changed' was treated as success and dropped in-memory tracking for a lane owned by a concurrent relaunch. Now uses the same guard as the other three callers.
- **Terminal autocomplete pool** - the hook extraction narrowed candidates from all command runs to the active pane only, losing suggestions and status-aware suppression from other panes. Restored the full pool; ranking still prioritizes the active pane via samePane/sameSession weights.
- **validate:ci contract** - guard:hosted-phase0-evidence had been prepended ahead of guard:source-file-size:ci, which the architecture suite pins as first, so test:arch:node failed on every checkout. Reordered and tightened the legacy cap for the evidence reader that shrank by four lines.

Verified locally: typecheck, source-file-size guard, eslint (0 errors), the source-file-size architecture suite 15/15, and the affected test zones (~4700 tests) including the previously red 36 OpenCode provisioning tests on macOS.

Known pre-existing reds not touched here: the hosted-approvals R3 area (21 tests), the TeamBackup fault tests on macOS (Linux-oriented fault injection), and the four W1/W2 architecture scans already tracked in the PR description. One note for a separate change: ci.yml never actually runs test:arch:node, so red .mjs architecture suites are only visible locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime storage cleanup across supported platforms, including best-effort handling where strict filesystem capabilities are unavailable.
  * Added safeguards against symbolic links, unexpected directory changes, and unsafe file access during cleanup.
  * Fixed terminal command autocomplete to consider the complete command history.
  * Made canonical data ordering consistent across locales and runtime environments.

* **Tests**
  * Updated cleanup coverage for non-Linux platforms and descriptor-backed storage workflows.

* **Chores**
  * Adjusted CI validation order and refreshed source-size baselines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->