### PR TITLE
fix: second round of critical review findings for the hosted-web branch

### DIFF
--- a/src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx
+++ b/src/features/terminal-workspace/renderer/ui/TerminalWorkspacePanel.tsx
@@ -429,7 +429,7 @@ const TerminalWorkspaceKernelView = ({
   });
   const { autocompleteSuggestion } = useTerminalCommandAutocomplete({
     commandHistory: snapshot.commandHistory.entries,
-    commandRuns,
+    commandRuns: activeCommandRuns,
     cwd: projectPath,
     eventSource: commandDockElement,
     paneId: activeCommandPaneId,

--- a/src/main/composition/hosted/hostedLifecycleOrchestratorReadiness.ts
+++ b/src/main/composition/hosted/hostedLifecycleOrchestratorReadiness.ts
@@ -24,6 +24,18 @@ const OWNER_SESSION_PATTERN = /^owner-session_[A-Za-z0-9][A-Za-z0-9._-]{7,127}$/
 const OWNER_PROOF_KEY_PATTERN = /^[0-9a-f]{64}$/;
 const OWNER_PROOF_DOMAIN = 'agent-teams.hosted-lifecycle.owner-proof/v1';
 
+/**
+ * A consumed or replayed classification means this exact authenticated binding
+ * can never complete an admission again (its markers are durably committed),
+ * so retrying it only livelocks; the launcher must issue a fresh binding.
+ */
+function isSpentOwnerBindingError(error: unknown): boolean {
+  return (
+    error instanceof HostedLifecycleOwnerBindingConsumedError ||
+    (error instanceof Error && error.message === 'hosted-lifecycle-orchestrator-session-replayed')
+  );
+}
+
 export type OrchestratorLifecycleOwnerProofKey = string & {
   readonly __brand: 'OrchestratorLifecycleOwnerProofKey';
 };
@@ -650,10 +662,7 @@ export class HostedLifecycleOrchestratorReadiness {
     try {
       await readiness.acquire();
     } catch (error) {
-      if (
-        readiness.admissionConsumed ||
-        error instanceof HostedLifecycleOwnerBindingConsumedError
-      ) {
+      if (readiness.admissionConsumed || isSpentOwnerBindingError(error)) {
         readiness.close();
         throw error;
       }
@@ -740,7 +749,7 @@ export class HostedLifecycleOrchestratorReadiness {
     this.retryTimer = setTimeout(() => {
       this.retryTimer = null;
       void this.acquire().catch((error: unknown) => {
-        if (error instanceof HostedLifecycleOwnerBindingConsumedError) {
+        if (isSpentOwnerBindingError(error)) {
           this.failStop();
           return;
         }

--- a/src/main/services/team/provisioning/HostedApprovalRuntimeAdmissionStateStore.ts
+++ b/src/main/services/team/provisioning/HostedApprovalRuntimeAdmissionStateStore.ts
@@ -138,10 +138,12 @@ async function validateCommitLock(
     const before = await lstat(lockPath, { bigint: true });
     handle = await open(
       lockPath,
-      constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_DIRECTORY
+      constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0) | (constants.O_DIRECTORY ?? 0)
     );
-    await handle.chmod(0o700);
-    await handle.sync();
+    if (process.platform !== 'win32') {
+      await handle.chmod(0o700);
+      await handle.sync();
+    }
     const opened = await handle.stat({ bigint: true });
     const membership = await lstat(lockPath, { bigint: true });
     if (
@@ -154,9 +156,13 @@ async function validateCommitLock(
       opened.ino !== membership.ino ||
       opened.uid !== BigInt(directory.identity.uid) ||
       opened.gid !== BigInt(directory.identity.gid) ||
-      (opened.mode & 0o777n) !== 0o700n ||
-      opened.nlink !== 2n ||
-      (await readdir(`/proc/self/fd/${handle.fd}`)).length !== 0
+      (process.platform !== 'win32' &&
+        ((opened.mode & 0o777n) !== 0o700n || opened.nlink !== 2n)) ||
+      // /proc-anchored listing is Linux-only; elsewhere the dev/ino membership
+      // checks above pin lockPath to the opened handle, so the plain path is
+      // the best available anchor.
+      (await readdir(process.platform === 'linux' ? `/proc/self/fd/${handle.fd}` : lockPath))
+        .length !== 0
     ) {
       throw new Error('hosted-approval-runtime-state-lock-invalid');
     }

--- a/src/main/services/team/provisioning/HostedApprovalRuntimeDescriptorStorage.ts
+++ b/src/main/services/team/provisioning/HostedApprovalRuntimeDescriptorStorage.ts
@@ -328,13 +328,17 @@ async function syncDirectoryHandleTolerant(directory: TrustedDirectoryCapability
     await directory.handle.sync();
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code;
+    // Linux (hosted production) keeps every fsync failure fatal, exactly as
+    // before the portable fallback; only desktop platforms tolerate the
+    // filesystem reporting directory fsync as unsupported.
     const unsupported =
-      code === 'EINVAL' ||
-      code === 'ENOSYS' ||
-      code === 'ENOTSUP' ||
-      code === 'EOPNOTSUPP' ||
-      (process.platform === 'win32' &&
-        (code === 'EACCES' || code === 'EPERM' || code === 'EISDIR' || code === 'EBADF'));
+      process.platform !== 'linux' &&
+      (code === 'EINVAL' ||
+        code === 'ENOSYS' ||
+        code === 'ENOTSUP' ||
+        code === 'EOPNOTSUPP' ||
+        (process.platform === 'win32' &&
+          (code === 'EACCES' || code === 'EPERM' || code === 'EISDIR' || code === 'EBADF')));
     if (!unsupported) throw error;
   }
 }

--- a/src/main/services/team/provisioning/HostedApprovalRuntimeDescriptorStorage.ts
+++ b/src/main/services/team/provisioning/HostedApprovalRuntimeDescriptorStorage.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { constants } from 'node:fs';
-import { isAbsolute, normalize, resolve } from 'node:path';
+import { isAbsolute, join, normalize, resolve } from 'node:path';
 
 import type { Stats } from 'node:fs';
 import type { FileHandle } from 'node:fs/promises';
@@ -22,12 +22,23 @@ export interface TrustedDirectoryCapability {
   }>;
 }
 
+/**
+ * True when descriptor paths can be anchored to /proc/self/fd, making every
+ * operation immune to directory replacement (Linux only). Other desktop
+ * platforms fall back to canonical plain paths: symbolic links are still
+ * rejected at the target, but ancestor-swap protection is best-effort — the
+ * accepted trade-off for the desktop app, where the teams directory is owned
+ * by the local user.
+ */
+function hasProcAnchoredDescriptorPaths(): boolean {
+  return process.platform === 'linux';
+}
+
 /** Opens, pins, and validates a private directory without following any path component alias. */
 export async function openTrustedDirectoryCapability(
   expectedPath: string
 ): Promise<TrustedDirectoryCapability> {
   if (
-    process.platform !== 'linux' ||
     !isAbsolute(expectedPath) ||
     normalize(expectedPath) !== expectedPath ||
     resolve(expectedPath) !== expectedPath ||
@@ -35,25 +46,39 @@ export async function openTrustedDirectoryCapability(
   ) {
     throw new Error('hosted-approval-runtime-directory-path-invalid');
   }
-  const { open, realpath } = await import('node:fs/promises');
+  const { lstat, open, realpath } = await import('node:fs/promises');
   let handle: FileHandle | null = null;
   try {
+    if (!hasProcAnchoredDescriptorPaths()) {
+      // O_NOFOLLOW degrades to 0 on win32; reject a symlinked final component
+      // explicitly before opening (ancestors may legitimately be symlinks,
+      // e.g. /tmp and /var on macOS).
+      const preOpen = await lstat(expectedPath);
+      if (preOpen.isSymbolicLink()) {
+        throw new Error('hosted-approval-runtime-directory-capability-invalid');
+      }
+    }
     handle = await open(
       expectedPath,
-      constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_DIRECTORY
+      constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0) | (constants.O_DIRECTORY ?? 0)
     );
     const stat = await handle.stat();
-    const canonicalPath = await realpath(`/proc/self/fd/${handle.fd}`);
+    const canonicalPath = hasProcAnchoredDescriptorPaths()
+      ? await realpath(`/proc/self/fd/${handle.fd}`)
+      : await realpath(expectedPath);
     const uid = process.getuid?.();
     const gid = process.getgid?.();
     if (
       !stat.isDirectory() ||
       stat.isSymbolicLink() ||
       stat.ino === 0 ||
-      canonicalPath !== expectedPath ||
-      (stat.mode & 0o777) !== DIRECTORY_MODE ||
+      (hasProcAnchoredDescriptorPaths() && canonicalPath !== expectedPath) ||
+      (process.platform !== 'win32' && (stat.mode & 0o777) !== DIRECTORY_MODE) ||
       (uid !== undefined && stat.uid !== uid) ||
-      (gid !== undefined && stat.gid !== gid)
+      // BSD group inheritance (macOS): a directory under /tmp inherits gid
+      // wheel regardless of the process egid; mode 0700 already denies the
+      // group, so the strict gid match stays Linux-only.
+      (hasProcAnchoredDescriptorPaths() && gid !== undefined && stat.gid !== gid)
     ) {
       throw new Error('hosted-approval-runtime-directory-capability-invalid');
     }
@@ -81,7 +106,9 @@ export async function validateTrustedDirectoryCapability(
   const { realpath } = await import('node:fs/promises');
   const [stat, canonicalPath] = await Promise.all([
     capability.handle.stat(),
-    realpath(`/proc/self/fd/${capability.handle.fd}`),
+    hasProcAnchoredDescriptorPaths()
+      ? realpath(`/proc/self/fd/${capability.handle.fd}`)
+      : realpath(capability.identity.canonicalPath),
   ]);
   if (
     !stat.isDirectory() ||
@@ -91,7 +118,7 @@ export async function validateTrustedDirectoryCapability(
     stat.uid !== capability.identity.uid ||
     stat.gid !== capability.identity.gid ||
     (stat.mode & 0o777) !== capability.identity.mode ||
-    capability.identity.mode !== DIRECTORY_MODE ||
+    (process.platform !== 'win32' && capability.identity.mode !== DIRECTORY_MODE) ||
     canonicalPath !== capability.identity.canonicalPath
   ) {
     throw new Error('hosted-approval-runtime-directory-capability-invalid');
@@ -172,7 +199,7 @@ export async function descriptorAnchoredReplace(
     await assertTargetUnchanged(directory, targetPath, targetIdentity);
     await assertPathNamesOpenFile(directory, temporaryName, temporaryIdentity);
     await rename(temporaryPath, targetPath);
-    await directory.handle.sync();
+    await syncDirectoryHandleTolerant(directory);
     await assertPathNamesOpenFile(directory, name, temporaryIdentity);
     const published = await descriptorAnchoredRead(directory, name);
     if (published !== body) {
@@ -249,7 +276,7 @@ export async function descriptorAnchoredUnlink(
     if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
     removed = false;
   }
-  await directory.handle.sync();
+  await syncDirectoryHandleTolerant(directory);
   const { lstat } = await import('node:fs/promises');
   try {
     await lstat(descriptorPath(directory, name));
@@ -283,14 +310,33 @@ async function assertPathNamesOpenFile(
 }
 
 function descriptorPath(directory: TrustedDirectoryCapability, name: string): string {
-  if (process.platform !== 'linux' || !SAFE_NAME.test(name) || name === '.' || name === '..') {
+  if (!SAFE_NAME.test(name) || name === '.' || name === '..') {
     throw new Error('hosted-approval-runtime-descriptor-storage-unavailable');
+  }
+  if (!hasProcAnchoredDescriptorPaths()) {
+    return join(directory.identity.canonicalPath, name);
   }
   return `/proc/self/fd/${directory.handle.fd}/${name}`;
 }
 
 async function assertDirectoryUnchanged(directory: TrustedDirectoryCapability): Promise<void> {
   await validateTrustedDirectoryCapability(directory);
+}
+
+async function syncDirectoryHandleTolerant(directory: TrustedDirectoryCapability): Promise<void> {
+  try {
+    await directory.handle.sync();
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    const unsupported =
+      code === 'EINVAL' ||
+      code === 'ENOSYS' ||
+      code === 'ENOTSUP' ||
+      code === 'EOPNOTSUPP' ||
+      (process.platform === 'win32' &&
+        (code === 'EACCES' || code === 'EPERM' || code === 'EISDIR' || code === 'EBADF'));
+    if (!unsupported) throw error;
+  }
 }
 
 function assertTrustedFile(
@@ -304,7 +350,7 @@ function assertTrustedFile(
     stat.nlink !== 1 ||
     stat.uid !== directory.identity.uid ||
     stat.gid !== directory.identity.gid ||
-    (stat.mode & 0o777) !== FILE_MODE ||
+    (process.platform !== 'win32' && (stat.mode & 0o777) !== FILE_MODE) ||
     stat.size < 0 ||
     stat.size > maximumBytes
   ) {
@@ -323,7 +369,7 @@ function assertTrustedFileBigInt(
     stat.nlink !== 1n ||
     stat.uid !== BigInt(directory.identity.uid) ||
     stat.gid !== BigInt(directory.identity.gid) ||
-    (stat.mode & 0o777n) !== BigInt(FILE_MODE) ||
+    (process.platform !== 'win32' && (stat.mode & 0o777n) !== BigInt(FILE_MODE)) ||
     stat.size < 0n ||
     stat.size > BigInt(maximumBytes)
   ) {

--- a/src/main/utils/bestEffortDurableDirectory.ts
+++ b/src/main/utils/bestEffortDurableDirectory.ts
@@ -101,6 +101,25 @@ export async function readRegularFileNoFollowBestEffortAsync(
   }
 }
 
+export async function readJsonDataEnvelopeNoFollowAsync(filePath: string): Promise<unknown> {
+  const parsed = JSON.parse(await readRegularFileNoFollowBestEffortAsync(filePath)) as unknown;
+  return parsed &&
+    typeof parsed === 'object' &&
+    !Array.isArray(parsed) &&
+    Object.prototype.hasOwnProperty.call(parsed, 'data')
+    ? (parsed as { data: unknown }).data
+    : parsed;
+}
+
+export async function readOptionalJsonNoFollowAsync(filePath: string): Promise<unknown | null> {
+  try {
+    return JSON.parse(await readRegularFileNoFollowBestEffortAsync(filePath)) as unknown;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw error;
+  }
+}
+
 async function syncDirectoryBestEffort(dirPath: string, strict: boolean): Promise<void> {
   let handle: fs.promises.FileHandle | null = null;
   try {

--- a/src/main/utils/durableDetachedRemoval.ts
+++ b/src/main/utils/durableDetachedRemoval.ts
@@ -1,4 +1,5 @@
 import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 import { type DurablePathIdentity, getDurablePathIdentity } from './durablePathIdentity';
 
@@ -28,6 +29,42 @@ type DurableDetachedPathValidator = (
 function isMissing(error: unknown): boolean {
   const code = (error as NodeJS.ErrnoException).code;
   return code === 'ENOENT' || code === 'ENOTDIR';
+}
+
+/**
+ * Reconciles a public-name reservation junction left behind when a process
+ * died between publishing the reservation and closing it. Without this, a
+ * resumed removal deletes the detached object but leaves the public name
+ * pointing at an orphaned reservation directory, so a later same-name create
+ * collides with a phantom entry. Only a symlink that provably targets this
+ * removal's own `.<name>.replacement.<uuid>` sibling is touched.
+ */
+export async function reconcileDetachedRemovalPublicReservation(input: {
+  readonly targetPath: string;
+  readonly parentDirectory: string;
+  readonly settleReservation: (reservationPath: string) => Promise<void>;
+}): Promise<void> {
+  let linkStats: fs.Stats;
+  try {
+    linkStats = await fs.promises.lstat(input.targetPath);
+  } catch (error) {
+    if (!isMissing(error)) throw error;
+    return;
+  }
+  if (!linkStats.isSymbolicLink()) return;
+  const reservationPrefix = `.${path.basename(input.targetPath)}.replacement.`;
+  const resolved = path.resolve(
+    input.parentDirectory,
+    await fs.promises.readlink(input.targetPath)
+  );
+  if (
+    path.dirname(resolved) !== path.resolve(input.parentDirectory) ||
+    !path.basename(resolved).startsWith(reservationPrefix)
+  ) {
+    return;
+  }
+  await fs.promises.unlink(input.targetPath);
+  await input.settleReservation(resolved);
 }
 
 /**

--- a/src/main/utils/durablePathOperations.ts
+++ b/src/main/utils/durablePathOperations.ts
@@ -6,11 +6,13 @@ export * from './durablePathIdentity';
 
 import {
   hasStrictIdentityStableDirectorySupport,
-  readRegularFileNoFollowBestEffortAsync,
   removeDirectoryEntriesExceptBestEffortAsync,
   withBestEffortDirectoryTreeAsync,
 } from './bestEffortDurableDirectory';
-import { resumeDeterministicDetachedRemoval } from './durableDetachedRemoval';
+import {
+  reconcileDetachedRemovalPublicReservation,
+  resumeDeterministicDetachedRemoval,
+} from './durableDetachedRemoval';
 import {
   type DurablePathIdentity,
   getDurablePathIdentity,
@@ -239,33 +241,11 @@ export async function withIdentityStableIndexedDirectoryLocksAsync<T>(
     { create: true }
   );
 }
-export async function readRegularFileNoFollowAsync(
-  filePath: string,
-  encoding: BufferEncoding = 'utf8'
-): Promise<string> {
-  // Portable on every platform: O_NOFOLLOW/O_NONBLOCK degrade to 0 where the
-  // constants do not exist and the lstat pre-check rejects symbolic links there.
-  return readRegularFileNoFollowBestEffortAsync(filePath, encoding);
-}
-
-export async function readJsonDataEnvelopeNoFollowAsync(filePath: string): Promise<unknown> {
-  const parsed = JSON.parse(await readRegularFileNoFollowAsync(filePath)) as unknown;
-  return parsed &&
-    typeof parsed === 'object' &&
-    !Array.isArray(parsed) &&
-    Object.prototype.hasOwnProperty.call(parsed, 'data')
-    ? (parsed as { data: unknown }).data
-    : parsed;
-}
-
-export async function readOptionalJsonNoFollowAsync(filePath: string): Promise<unknown | null> {
-  try {
-    return JSON.parse(await readRegularFileNoFollowAsync(filePath)) as unknown;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
-    throw error;
-  }
-}
+export {
+  readJsonDataEnvelopeNoFollowAsync,
+  readOptionalJsonNoFollowAsync,
+  readRegularFileNoFollowBestEffortAsync as readRegularFileNoFollowAsync,
+} from './bestEffortDurableDirectory';
 
 export async function removeDirectoryEntriesExceptAsync(
   directoryPath: string,
@@ -722,8 +702,21 @@ export async function removePathWithIdentityFenceAsync(
     }
   };
 
-  const resumeProofBackedRemoval = (): Promise<AtomicPathRemovalResult> => {
-    if (!options.proofHooks) return Promise.resolve('missing');
+  const resumeProofBackedRemoval = async (): Promise<AtomicPathRemovalResult> => {
+    if (!options.proofHooks) return 'missing';
+    if (options.reservePublicDirectory) {
+      // A crash between reservation publish and close leaves a dangling
+      // junction at the public name; free or settle it before resuming.
+      await reconcileDetachedRemovalPublicReservation({
+        targetPath,
+        parentDirectory: dir,
+        settleReservation: async (reservationPath) => {
+          await syncDirectory(dir, options.durability === 'strict');
+          publicReservationPath = reservationPath;
+          await settlePublicReservation();
+        },
+      });
+    }
     return resumeDeterministicDetachedRemoval({
       detachedPath,
       removalOptions,

--- a/test/main/utils/durableDetachedRemoval.test.ts
+++ b/test/main/utils/durableDetachedRemoval.test.ts
@@ -1,0 +1,88 @@
+import { lstat, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { removePathWithIdentityFenceAsync } from '@main/utils/durablePathOperations';
+
+const cleanup: string[] = [];
+
+afterEach(async () => {
+  for (const path of cleanup.splice(0)) {
+    await rm(path, { recursive: true, force: true });
+  }
+});
+
+async function crashScene(): Promise<{
+  dir: string;
+  targetPath: string;
+  detachedPath: string;
+  reservationPath: string;
+}> {
+  const dir = await mkdtemp(join(tmpdir(), 'detached-resume-'));
+  cleanup.push(dir);
+  const targetPath = join(dir, 'team-a');
+  const detachedPath = join(dir, '.team-a.deleting.resume');
+  const reservationPath = join(dir, '.team-a.replacement.crashed');
+  await mkdir(detachedPath);
+  await writeFile(join(detachedPath, 'state.json'), '{}\n', 'utf8');
+  await mkdir(reservationPath);
+  await symlink(reservationPath, targetPath, 'junction');
+  return { dir, targetPath, detachedPath, reservationPath };
+}
+
+function resumeOptions(detachedPath: string) {
+  return {
+    recursive: true,
+    force: true,
+    reservePublicDirectory: true,
+    proofHooks: {
+      detachedPath,
+      onDetachedValidated: async () => undefined,
+      onRemovalDurable: async () => undefined,
+    },
+  };
+}
+
+describe('resumed detached removal with a public reservation', () => {
+  it('settles the dangling reservation junction left by a crash', async () => {
+    const { targetPath, detachedPath, reservationPath } = await crashScene();
+
+    const result = await removePathWithIdentityFenceAsync(targetPath, resumeOptions(detachedPath));
+
+    expect(result).toBe('deleted');
+    await expect(lstat(targetPath)).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(lstat(detachedPath)).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(lstat(reservationPath)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('republishes reservation contents written during the crash window', async () => {
+    const { targetPath, detachedPath, reservationPath } = await crashScene();
+    await writeFile(join(reservationPath, 'written-via-junction.json'), '{"kept":true}\n', 'utf8');
+
+    const result = await removePathWithIdentityFenceAsync(targetPath, resumeOptions(detachedPath));
+
+    expect(result).toBe('deleted');
+    const republished = await lstat(targetPath);
+    expect(republished.isDirectory()).toBe(true);
+    expect(republished.isSymbolicLink()).toBe(false);
+    await expect(readFile(join(targetPath, 'written-via-junction.json'), 'utf8')).resolves.toBe(
+      '{"kept":true}\n'
+    );
+  });
+
+  it('leaves an unrelated symlink at the public name untouched', async () => {
+    const { dir, targetPath, detachedPath } = await crashScene();
+    const unrelated = join(dir, 'unrelated-target');
+    await mkdir(unrelated);
+    await rm(targetPath);
+    await symlink(unrelated, targetPath, 'junction');
+
+    const result = await removePathWithIdentityFenceAsync(targetPath, resumeOptions(detachedPath));
+
+    expect(result).toBe('deleted');
+    const stillLinked = await lstat(targetPath);
+    expect(stillLinked.isSymbolicLink()).toBe(true);
+  });
+});


### PR DESCRIPTION
Second review round over #252, focused on the areas the first round did not cover (newly added team services, the hosted composition internals, the durable-fs utilities) plus an adversarial re-check of the first-round fixes. Five commits:

- **Desktop team lifecycle on macOS and Windows** - the hosted-approval descriptor storage anchored every path to /proc/self/fd and hard-required Linux, but the production disabled coordinator awaits a revoke before every team lifecycle effect, so create/launch/stop/cancel and graceful shutdown rejected on darwin and win32 (this was also the root cause behind most of the previously red approval tests on a Mac). Linux keeps the /proc anchoring; other platforms fall back to canonical plain paths with symlink rejection at the target, a Linux-only strict gid match (BSD group inheritance hands /tmp directories gid wheel), and win32 skips POSIX mode/nlink/dir-fsync checks NTFS cannot satisfy. The commit-lock emptiness check lists the pinned plain path off Linux.
- **Owner-binding livelock in hosted readiness** - a transient write failure between the two ordered marker publishes leaves the authenticated binding durably spent; recovery finds no pending markers and the replay guard rejects the session forever, but the retry loop only fail-stopped on the consumed-error class, so it relaunched the same spent binding every backoff interval without escalating owner loss. The replayed classification is now terminal too, letting the launcher issue a fresh binding.
- **Dangling reservation junction after a crashed team deletion** - the resumed proof-backed removal only handled the detached object, so a crash between publishing and closing the public-name reservation left ~/.claude/teams/<team> as a symlink to an orphaned reservation directory: later same-name creates collided and scans surfaced a phantom empty team. The resume now settles the junction first (empty reservations are removed, contents written through the junction are republished, unrelated symlinks stay untouched), with a focused regression test.
- **Revert of the autocomplete pool change from the previous round** - scoping autocomplete to the active pane was a deliberate decision (ae5847421) pinned by a fixture-e2e test, not a regression; the revert restores the intended behavior and fixes the one CI failure the previous round introduced.

Verified locally: typecheck, source-file-size guard, and 818 tests across the affected zones (approvals publisher/production composition now green on macOS, readiness, OpenCode reader, durable utils, terminal workspace). A fresh-eyes adversarial pass over all first-round fixes found no further issues; the canonical-JSON sweep confirmed every persisted byte producer and validator now sorts identically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal command autocomplete accuracy by limiting suggestions to the active session.
  - Prevented replayed hosted sessions from entering unnecessary retry loops.
  - Improved cross-platform handling for trusted directories and approval state validation, including Windows support.
  - Strengthened recovery after interrupted directory removal and reservation cleanup.

- **Reliability**
  - Added safer JSON file reading that avoids following symlinks.
  - Preserved valid data and unrelated links during interrupted cleanup and republishing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->