### PR TITLE
chore(review): activate ReviewRouter v1.0.125 on dev

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -1,22 +1,10 @@
-name: ReviewRouter Codex OAuth
+name: ReviewRouter Codex OAuth [namespace=sns_07a4cfd6470672de9fb4e21cbaf03910;epoch=1;secret=REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E1_07a4cfd6470672de9fb4e21cbaf03910]
 
-run-name: ${{ inputs.review_request_id != '' && format('ReviewRouter review {0}', inputs.review_request_id) || 'ReviewRouter Codex OAuth maintenance' }}
+run-name: ${{ format('ReviewRouter review PR {0} at {1}', github.event.pull_request.number, github.event.pull_request.head.sha) }}
 
 on:
-  workflow_dispatch:
-    inputs:
-      review_request_id:
-        description: Durable ReviewRouter request identity
-        required: false
-        type: string
-      pr_number:
-        description: Pull request number selected by ReviewRouter
-        required: false
-        type: string
-      review_head_sha:
-        description: Expected pull request head selected by ReviewRouter
-        required: false
-        type: string
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
   schedule:
     - cron: "17 */6 * * *"
 
@@ -25,24 +13,27 @@ permissions: {}
 jobs:
   codex-review:
     name: codex-review
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.review_request_id != '' && inputs.pr_number != '' && inputs.review_head_sha != '' }}
+    if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.type != 'Bot' && (github.event.pull_request.draft == false || vars.REVIEW_ROUTER_REVIEW_DRAFTS == 'true') }}
+    concurrency:
+      group: reviewrouter-codex-oauth-${{ github.repository_id }}-codex-rotating-1163183284
+      cancel-in-progress: false
     permissions:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@626739854b5c67d94b3f0118738c106b4a232c41
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@338bc3b6b763a4cf7e9b4515ed3294e7cdceb112
     with:
-      runtime_ref: "626739854b5c67d94b3f0118738c106b4a232c41"
+      runtime_ref: "338bc3b6b763a4cf7e9b4515ed3294e7cdceb112"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
-      pr_number: ${{ inputs.pr_number }}
-      review_head_sha: ${{ inputs.review_head_sha }}
+      pr_number: ${{ format('{0}', github.event.pull_request.number) }}
+      review_head_sha: ${{ github.event.pull_request.head.sha }}
       provider_instance_id: "codex-rotating:1163183284"
-      workflow_schema_version: 1
+      workflow_schema_version: 4
       max_changed_lines: ${{ vars.REVIEW_ROUTER_MAX_CHANGED_LINES }}
       review_timeout_minutes: ${{ fromJSON(vars.REVIEW_ROUTER_TIMEOUT_MINUTES || '60') }}
     secrets:
-      CODEX_AUTH_JSON: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON }}
+      CODEX_AUTH_JSON: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E1_07a4cfd6470672de9fb4e21cbaf03910 }}
 
   codex-refresh:
     name: codex-refresh
@@ -51,16 +42,16 @@ jobs:
     concurrency:
       group: reviewrouter-codex-oauth-${{ github.repository_id }}-codex-rotating-1163183284
       cancel-in-progress: false
-    if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.review_request_id == '') }}
+    if: ${{ github.event_name == 'schedule' }}
     permissions:
       id-token: write
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@626739854b5c67d94b3f0118738c106b4a232c41
+        uses: 777genius/review-router@338bc3b6b763a4cf7e9b4515ed3294e7cdceb112
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"
           provider-instance-id: "codex-rotating:1163183284"
-          workflow-schema-version: "1"
-          auth-json: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON }}
+          workflow-schema-version: "4"
+          auth-json: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E1_07a4cfd6470672de9fb4e21cbaf03910 }}


### PR DESCRIPTION
Applies the same attested schema-v4 ReviewRouter workflow to dev so existing and future PRs targeting dev receive generation-aware Codex reviews.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Automated review checks now run for eligible pull request activity.
  - Draft pull requests and automated bot activity are filtered appropriately.
  - Review run names now reflect the triggering event for clearer tracking.
  - Scheduled authentication refreshes continue running with updated configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->