### PR TITLE
chore(review): activate ReviewRouter v1.0.126

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -1,4 +1,4 @@
-name: ReviewRouter Codex OAuth [namespace=sns_07a4cfd6470672de9fb4e21cbaf03910;epoch=1;secret=REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E1_07a4cfd6470672de9fb4e21cbaf03910]
+name: ReviewRouter Codex OAuth [namespace=sns_b475f3b7bbf6041889d8b19ec5bbb87c;epoch=2;secret=REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E2_b475f3b7bbf6041889d8b19ec5bbb87c]
 
 run-name: ${{ format('ReviewRouter review PR {0} at {1}', github.event.pull_request.number, github.event.pull_request.head.sha) }}
 
@@ -21,9 +21,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@338bc3b6b763a4cf7e9b4515ed3294e7cdceb112
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@3fc3ce29652809531dda4204d4b62e05f82bf4d3
     with:
-      runtime_ref: "338bc3b6b763a4cf7e9b4515ed3294e7cdceb112"
+      runtime_ref: "3fc3ce29652809531dda4204d4b62e05f82bf4d3"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ format('{0}', github.event.pull_request.number) }}
@@ -33,7 +33,7 @@ jobs:
       max_changed_lines: ${{ vars.REVIEW_ROUTER_MAX_CHANGED_LINES }}
       review_timeout_minutes: ${{ fromJSON(vars.REVIEW_ROUTER_TIMEOUT_MINUTES || '60') }}
     secrets:
-      CODEX_AUTH_JSON: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E1_07a4cfd6470672de9fb4e21cbaf03910 }}
+      CODEX_AUTH_JSON: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E2_b475f3b7bbf6041889d8b19ec5bbb87c }}
 
   codex-refresh:
     name: codex-refresh
@@ -48,10 +48,10 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@338bc3b6b763a4cf7e9b4515ed3294e7cdceb112
+        uses: 777genius/review-router@3fc3ce29652809531dda4204d4b62e05f82bf4d3
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"
           provider-instance-id: "codex-rotating:1163183284"
           workflow-schema-version: "4"
-          auth-json: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E1_07a4cfd6470672de9fb4e21cbaf03910 }}
+          auth-json: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E2_b475f3b7bbf6041889d8b19ec5bbb87c }}


### PR DESCRIPTION
## Summary
- advance the managed ReviewRouter workflow to immutable Action SHA 3fc3ce29652809531dda4204d4b62e05f82bf4d3
- activate rotating Codex auth generation E2
- keep the existing provider identity and schema v4 contract

This is the main-branch half of the rollout; dev receives the same exact workflow separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated code review integration to use refreshed authentication configuration.
  * Updated the underlying integration version while preserving existing permissions, scheduling, and workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->