### PR TITLE
chore(review): pin ReviewRouter v1.0.127 on dev

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@3fc3ce29652809531dda4204d4b62e05f82bf4d3
+        uses: 777genius/review-router@0c8bcbb56cbc3561b1c0ef7a64475d87bf178950
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"


### PR DESCRIPTION
Updates the generated ReviewRouter workflow to the immutable v1.0.127 Action commit.

The rotating auth namespace and epoch are unchanged. After merge, the existing namespace will be activated against the new trusted default-branch workflow source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the scheduled authentication refresh process to use a newer review-routing release.
  * No user-facing feature or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->