### PR TITLE
chore(review): pin ReviewRouter v1.0.127 on main

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@3fc3ce29652809531dda4204d4b62e05f82bf4d3
+        uses: 777genius/review-router@0c8bcbb56cbc3561b1c0ef7a64475d87bf178950
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"

--- a/package.json
+++ b/package.json
@@ -432,7 +432,7 @@
       }
     ]
   },
-  "packageManager": "pnpm@11.13.0+sha512.88d94724d8f2e6c186744a5584c6e59ecac869ec7ba15e9cb4cd628e8dc7066820b2481d8ee3b51ea8da323a7378068aa58c556a3720d32b7c20a051d088363a",
+  "packageManager": "pnpm@11.22.0+sha512.1ff870c4c6133dfd88fb2afc46dd13d47f09c9794b438c6fdb47ca98caf3bc16381ee0be93a091b8e3824cf01f889f46d7d9e20910fb0be1ab0fb5baa80dd621",
   "knip": {
     "entry": [
       "src/main/index.ts",


### PR DESCRIPTION
Updates the generated ReviewRouter workflow to the immutable v1.0.127 Action commit.

The rotating auth namespace and epoch are unchanged. After merge, the existing namespace will be activated against the new trusted default-branch workflow source.

Also aligns main with dev on pnpm 11.22.0 because pnpm 11.13.0 is an upstream-blocked broken release and prevented every CI job from starting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the scheduled authentication refresh process to use a newer review-routing service version.
  * Updated project tooling to improve the reliability of automated development and release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->