### PR TITLE
chore(review): activate auth epoch 3

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -1,4 +1,4 @@
-name: ReviewRouter Codex OAuth [namespace=sns_b475f3b7bbf6041889d8b19ec5bbb87c;epoch=2;secret=REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E2_b475f3b7bbf6041889d8b19ec5bbb87c]
+name: ReviewRouter Codex OAuth [namespace=sns_00267308f3105698b128af17ba760cb9;epoch=3;secret=REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E3_00267308f3105698b128af17ba760cb9]
 
 run-name: ${{ format('ReviewRouter review PR {0} at {1}', github.event.pull_request.number, github.event.pull_request.head.sha) }}
 
@@ -33,7 +33,7 @@ jobs:
       max_changed_lines: ${{ vars.REVIEW_ROUTER_MAX_CHANGED_LINES }}
       review_timeout_minutes: ${{ fromJSON(vars.REVIEW_ROUTER_TIMEOUT_MINUTES || '60') }}
     secrets:
-      CODEX_AUTH_JSON: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E2_b475f3b7bbf6041889d8b19ec5bbb87c }}
+      CODEX_AUTH_JSON: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E3_00267308f3105698b128af17ba760cb9 }}
 
   codex-refresh:
     name: codex-refresh
@@ -54,4 +54,4 @@ jobs:
           api-url: "https://api.reviewrouter.site"
           provider-instance-id: "codex-rotating:1163183284"
           workflow-schema-version: "4"
-          auth-json: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E2_b475f3b7bbf6041889d8b19ec5bbb87c }}
+          auth-json: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E3_00267308f3105698b128af17ba760cb9 }}


### PR DESCRIPTION
Bind the canonical ReviewRouter workflow to the generation-aware epoch 3 secret created by the supported reseed flow.

No auth payload is copied into the repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication configuration for automated review workflows.
  * Refreshed OAuth metadata and credentials used by scheduled and reusable review jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->