### PR TITLE
fix(review): pin reusable runtime to v1.0.128

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -21,9 +21,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@0c8bcbb56cbc3561b1c0ef7a64475d87bf178950
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@da20c20adf0f9ff637291c9947ff71bf00b30005
     with:
-      runtime_ref: "0c8bcbb56cbc3561b1c0ef7a64475d87bf178950"
+      runtime_ref: "da20c20adf0f9ff637291c9947ff71bf00b30005"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ format('{0}', github.event.pull_request.number) }}


### PR DESCRIPTION
## Summary
- pin the reusable review workflow to the same immutable Action SHA as refresh
- align runtime_ref with the paired v1.0.128 release
- satisfy the canonical generation E4 workflow attestation

## Validation
- all three Action references resolve to da20c20adf0f9ff637291c9947ff71bf00b30005
- old Action SHA is absent
- YAML parse and diff check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated review workflow reference to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->