### PR TITLE
chore(review): pin terminal reconciliation runtime

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -21,9 +21,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@a29e058d2614c469e9ad29f62b0201a57f3a2e15
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@9bac08daa9ff4a2f0e3c1edf82c36938d64134a8
     with:
-      runtime_ref: "a29e058d2614c469e9ad29f62b0201a57f3a2e15"
+      runtime_ref: "9bac08daa9ff4a2f0e3c1edf82c36938d64134a8"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ format('{0}', github.event.pull_request.number) }}
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@a29e058d2614c469e9ad29f62b0201a57f3a2e15
+        uses: 777genius/review-router@9bac08daa9ff4a2f0e3c1edf82c36938d64134a8
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"

--- a/.github/workflows/reviewrouter-interaction.yml
+++ b/.github/workflows/reviewrouter-interaction.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: read
       id-token: write
     env:
-      RR_RUNTIME_REF: "a29e058d2614c469e9ad29f62b0201a57f3a2e15"
+      RR_RUNTIME_REF: "9bac08daa9ff4a2f0e3c1edf82c36938d64134a8"
       REVIEWROUTER_API_URL: "https://api.reviewrouter.site"
       REVIEWROUTER_OIDC_AUDIENCE: "reviewrouter"
       REVIEWROUTER_RUNTIME_CONFIG_MODE: "oidc"


### PR DESCRIPTION
## Summary
- pin the rotating Codex reviewer to ReviewRouter runtime 9bac08d
- pin the interaction workflow to the same immutable runtime
- preserve active epoch 5 namespace and canonical workflow semantics

## Validation
- canonical T0 v4 workflow semantic equality: passed
- canonical interaction v2 workflow exact equality: passed
- runtime PR 777genius/review-router#179: merged with full CI and ReviewRouter checks passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated review workflows to use the latest approved configuration.
  * Refreshed workflow runtime references to improve reliability and consistency of automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->