### PR TITLE
chore(review): activate Codex auth epoch 6

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -1,4 +1,4 @@
-name: ReviewRouter Codex OAuth [namespace=sns_69c382e2f47618c2e3b8922da21dee46;epoch=5;secret=REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E5_69c382e2f47618c2e3b8922da21dee46]
+name: ReviewRouter Codex OAuth [namespace=sns_9a50d90d72d37b99be67b2f430987351;epoch=6;secret=REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E6_9a50d90d72d37b99be67b2f430987351]
 
 run-name: ${{ format('ReviewRouter review PR {0} at {1}', github.event.pull_request.number, github.event.pull_request.head.sha) }}
 
@@ -33,7 +33,7 @@ jobs:
       max_changed_lines: ${{ vars.REVIEW_ROUTER_MAX_CHANGED_LINES }}
       review_timeout_minutes: ${{ fromJSON(vars.REVIEW_ROUTER_TIMEOUT_MINUTES || '60') }}
     secrets:
-      CODEX_AUTH_JSON: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E5_69c382e2f47618c2e3b8922da21dee46 }}
+      CODEX_AUTH_JSON: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E6_9a50d90d72d37b99be67b2f430987351 }}
 
   codex-refresh:
     name: codex-refresh
@@ -54,4 +54,4 @@ jobs:
           api-url: "https://api.reviewrouter.site"
           provider-instance-id: "codex-rotating:1163183284"
           workflow-schema-version: "4"
-          auth-json: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E5_69c382e2f47618c2e3b8922da21dee46 }}
+          auth-json: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E6_9a50d90d72d37b99be67b2f430987351 }}


### PR DESCRIPTION
Activates the fresh generation-aware Codex OAuth namespace for the new immutable ReviewRouter runtime. No auth payload is committed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Rotated the authentication credentials used by automated code review workflows.
  * Updated related workflow references while preserving existing triggers, permissions, and job behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->