### PR TITLE
fix(review): pin refined investigation action

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -21,9 +21,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@9bac08daa9ff4a2f0e3c1edf82c36938d64134a8
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@b12b076e7e961ef1c717e805ef8aae2793f9fcd1
     with:
-      runtime_ref: "9bac08daa9ff4a2f0e3c1edf82c36938d64134a8"
+      runtime_ref: "b12b076e7e961ef1c717e805ef8aae2793f9fcd1"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ format('{0}', github.event.pull_request.number) }}
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@9bac08daa9ff4a2f0e3c1edf82c36938d64134a8
+        uses: 777genius/review-router@b12b076e7e961ef1c717e805ef8aae2793f9fcd1
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"


### PR DESCRIPTION
## Summary
- pin the reusable ReviewRouter workflow, runtime ref, and refresh Action to the same immutable release
- activate bounded search refinement before investigation receipts are issued

## Validation
- Action release b12b076e7e961ef1c717e805ef8aae2793f9fcd1 passed hosted Action CI
- paired Action-to-SaaS investigation E2E passed
- release registration succeeded against production PG17
- API, worker, and web production deployments are live

This PR changes only the immutable ReviewRouter pin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal review automation to use the latest workflow and authentication actions.
  * No user-facing features or behavior were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->