### PR TITLE
fix(review): pin refined investigation action on dev

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -21,9 +21,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@da20c20adf0f9ff637291c9947ff71bf00b30005
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@b12b076e7e961ef1c717e805ef8aae2793f9fcd1
     with:
-      runtime_ref: "da20c20adf0f9ff637291c9947ff71bf00b30005"
+      runtime_ref: "b12b076e7e961ef1c717e805ef8aae2793f9fcd1"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ format('{0}', github.event.pull_request.number) }}
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@da20c20adf0f9ff637291c9947ff71bf00b30005
+        uses: 777genius/review-router@b12b076e7e961ef1c717e805ef8aae2793f9fcd1
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"


### PR DESCRIPTION
## Summary
- pin the dev base workflow, runtime ref, and refresh Action to the registered immutable release
- keep pull_request_target reviews into dev on the same ReviewRouter generation as main

## Validation
- Action CI passed
- paired Action-to-SaaS investigation E2E passed
- production release registration and deployment succeeded

This PR changes only three immutable SHA pins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated review workflow and refresh action to their latest pinned versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->