### PR TITLE
fix(review): activate rotating auth epoch 7

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -1,4 +1,4 @@
-name: ReviewRouter Codex OAuth [namespace=sns_9a50d90d72d37b99be67b2f430987351;epoch=6;secret=REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E6_9a50d90d72d37b99be67b2f430987351]
+name: ReviewRouter Codex OAuth [namespace=sns_8dd67514be058b2be31bd3a677abfe53;epoch=7;secret=REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E7_8dd67514be058b2be31bd3a677abfe53]
 
 run-name: ${{ format('ReviewRouter review PR {0} at {1}', github.event.pull_request.number, github.event.pull_request.head.sha) }}
 
@@ -33,7 +33,7 @@ jobs:
       max_changed_lines: ${{ vars.REVIEW_ROUTER_MAX_CHANGED_LINES }}
       review_timeout_minutes: ${{ fromJSON(vars.REVIEW_ROUTER_TIMEOUT_MINUTES || '60') }}
     secrets:
-      CODEX_AUTH_JSON: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E6_9a50d90d72d37b99be67b2f430987351 }}
+      CODEX_AUTH_JSON: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E7_8dd67514be058b2be31bd3a677abfe53 }}
 
   codex-refresh:
     name: codex-refresh
@@ -54,4 +54,4 @@ jobs:
           api-url: "https://api.reviewrouter.site"
           provider-instance-id: "codex-rotating:1163183284"
           workflow-schema-version: "4"
-          auth-json: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E6_9a50d90d72d37b99be67b2f430987351 }}
+          auth-json: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E7_8dd67514be058b2be31bd3a677abfe53 }}


### PR DESCRIPTION
Updates the ReviewRouter workflow attestation to the generation-aware E7 namespace created by the supported reseed flow. No auth material is stored in git.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow authentication references to use the latest credential configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->