### PR TITLE
chore(reviewrouter): activate Codex auth epoch 10

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -1,4 +1,4 @@
-name: ReviewRouter Codex OAuth [namespace=sns_fc02e80eb6840567dee448d81aba42d4;epoch=9;secret=REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E9_fc02e80eb6840567dee448d81aba42d4]
+name: ReviewRouter Codex OAuth [namespace=sns_caca870a3ac5317ad5c74369deaca804;epoch=10;secret=REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E10_caca870a3ac5317ad5c74369deaca804]
 
 run-name: ${{ format('ReviewRouter review PR {0} at {1}', github.event.pull_request.number, github.event.pull_request.head.sha) }}
 
@@ -21,9 +21,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@d4908b2529b61d1a900224da2744bfeba60d60b0
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@80bdf5251f5440c845dba4248f2b281f36b67bbb
     with:
-      runtime_ref: "d4908b2529b61d1a900224da2744bfeba60d60b0"
+      runtime_ref: "80bdf5251f5440c845dba4248f2b281f36b67bbb"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ format('{0}', github.event.pull_request.number) }}
@@ -33,7 +33,7 @@ jobs:
       max_changed_lines: ${{ vars.REVIEW_ROUTER_MAX_CHANGED_LINES }}
       review_timeout_minutes: ${{ fromJSON(vars.REVIEW_ROUTER_TIMEOUT_MINUTES || '60') }}
     secrets:
-      CODEX_AUTH_JSON: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E9_fc02e80eb6840567dee448d81aba42d4 }}
+      CODEX_AUTH_JSON: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E10_caca870a3ac5317ad5c74369deaca804 }}
 
   codex-refresh:
     name: codex-refresh
@@ -48,10 +48,10 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@d4908b2529b61d1a900224da2744bfeba60d60b0
+        uses: 777genius/review-router@80bdf5251f5440c845dba4248f2b281f36b67bbb
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"
           provider-instance-id: "codex-rotating:1163183284"
           workflow-schema-version: "4"
-          auth-json: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E9_fc02e80eb6840567dee448d81aba42d4 }}
+          auth-json: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E10_caca870a3ac5317ad5c74369deaca804 }}


### PR DESCRIPTION
## Summary\n- activate Codex rotating auth generation E10 for 777genius/agent-teams-ai\n- pin review and refresh jobs to registered ReviewRouter Action 80bdf5251f5440c845dba4248f2b281f36b67bbb\n- keep E9 active until the E10 workflow source is merged and attested\n\nGenerated through the generation-aware reseed flow with the existing dedicated ReviewRouter auth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated review and authentication workflow configurations.
  * Refreshed scheduled OAuth credentials and workflow runtime references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->