### PR TITLE
chore(reviewrouter): activate Codex auth epoch 11

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -1,4 +1,4 @@
-name: ReviewRouter Codex OAuth [namespace=sns_caca870a3ac5317ad5c74369deaca804;epoch=10;secret=REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E10_caca870a3ac5317ad5c74369deaca804]
+name: ReviewRouter Codex OAuth [namespace=sns_2542d05001717b0d7f23bdd8d2bba662;epoch=11;secret=REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E11_2542d05001717b0d7f23bdd8d2bba662]
 
 run-name: ${{ format('ReviewRouter review PR {0} at {1}', github.event.pull_request.number, github.event.pull_request.head.sha) }}
 
@@ -21,9 +21,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@80bdf5251f5440c845dba4248f2b281f36b67bbb
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@8b6db5bab48dae15d350e6ff0fb8a488410e65fb
     with:
-      runtime_ref: "80bdf5251f5440c845dba4248f2b281f36b67bbb"
+      runtime_ref: "8b6db5bab48dae15d350e6ff0fb8a488410e65fb"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ format('{0}', github.event.pull_request.number) }}
@@ -33,7 +33,7 @@ jobs:
       max_changed_lines: ${{ vars.REVIEW_ROUTER_MAX_CHANGED_LINES }}
       review_timeout_minutes: ${{ fromJSON(vars.REVIEW_ROUTER_TIMEOUT_MINUTES || '60') }}
     secrets:
-      CODEX_AUTH_JSON: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E10_caca870a3ac5317ad5c74369deaca804 }}
+      CODEX_AUTH_JSON: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E11_2542d05001717b0d7f23bdd8d2bba662 }}
 
   codex-refresh:
     name: codex-refresh
@@ -48,10 +48,10 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@80bdf5251f5440c845dba4248f2b281f36b67bbb
+        uses: 777genius/review-router@8b6db5bab48dae15d350e6ff0fb8a488410e65fb
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"
           provider-instance-id: "codex-rotating:1163183284"
           workflow-schema-version: "4"
-          auth-json: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E10_caca870a3ac5317ad5c74369deaca804 }}
+          auth-json: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E11_2542d05001717b0d7f23bdd8d2bba662 }}


### PR DESCRIPTION
## Summary
- activate generation-aware Codex auth epoch E11
- pin review and refresh workflows to registered Action `8b6db5bab48dae15d350e6ff0fb8a488410e65fb`
- keep E10 active until this workflow source is merged and E11 is attested

Generated through the official rotating-auth reseed flow using the existing dedicated ReviewRouter auth. No auth payload is stored in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated review workflow authentication metadata.
  * Refreshed workflow action and runtime references for improved maintenance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->