### PR TITLE
chore(reviewrouter): sync investigation runtime hotfix

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -21,9 +21,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@8b6db5bab48dae15d350e6ff0fb8a488410e65fb
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@435348257ed61be7d026a51670a428f47bfe0232
     with:
-      runtime_ref: "8b6db5bab48dae15d350e6ff0fb8a488410e65fb"
+      runtime_ref: "435348257ed61be7d026a51670a428f47bfe0232"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ format('{0}', github.event.pull_request.number) }}
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@8b6db5bab48dae15d350e6ff0fb8a488410e65fb
+        uses: 777genius/review-router@435348257ed61be7d026a51670a428f47bfe0232
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"


### PR DESCRIPTION
Pins the E11 ReviewRouter workflow and runtime to the verified bounded-budget hotfix release.

No auth generation or secret namespace changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated review and authentication workflows to a newer release.
  * Improved workflow runtime version alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->