### PR TITLE
chore(reviewrouter): activate auth epoch 12

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -1,4 +1,4 @@
-name: ReviewRouter Codex OAuth [namespace=sns_2542d05001717b0d7f23bdd8d2bba662;epoch=11;secret=REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E11_2542d05001717b0d7f23bdd8d2bba662]
+name: ReviewRouter Codex OAuth [namespace=sns_a8bc9a995965fe8c394a100bf08ce60a;epoch=12;secret=REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E12_a8bc9a995965fe8c394a100bf08ce60a]
 
 run-name: ${{ format('ReviewRouter review PR {0} at {1}', github.event.pull_request.number, github.event.pull_request.head.sha) }}
 
@@ -33,7 +33,7 @@ jobs:
       max_changed_lines: ${{ vars.REVIEW_ROUTER_MAX_CHANGED_LINES }}
       review_timeout_minutes: ${{ fromJSON(vars.REVIEW_ROUTER_TIMEOUT_MINUTES || '60') }}
     secrets:
-      CODEX_AUTH_JSON: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E11_2542d05001717b0d7f23bdd8d2bba662 }}
+      CODEX_AUTH_JSON: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E12_a8bc9a995965fe8c394a100bf08ce60a }}
 
   codex-refresh:
     name: codex-refresh
@@ -54,4 +54,4 @@ jobs:
           api-url: "https://api.reviewrouter.site"
           provider-instance-id: "codex-rotating:1163183284"
           workflow-schema-version: "4"
-          auth-json: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E11_2542d05001717b0d7f23bdd8d2bba662 }}
+          auth-json: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E12_a8bc9a995965fe8c394a100bf08ce60a }}


### PR DESCRIPTION
Attests the new generation-aware E12 namespace after the bounded-budget Action release. The Codex auth payload remains stored only as a versioned GitHub secret.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ReviewRouter authentication configuration to use the latest credential set.
  * Applied the updated configuration to both review processing and scheduled refresh workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->