### PR TITLE
chore(reviewrouter): activate v1.0.131 E13

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -1,4 +1,4 @@
-name: ReviewRouter Codex OAuth [namespace=sns_a8bc9a995965fe8c394a100bf08ce60a;epoch=12;secret=REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E12_a8bc9a995965fe8c394a100bf08ce60a]
+name: ReviewRouter Codex OAuth [namespace=sns_40adf2793e379a80300270ce72b66a56;epoch=13;secret=REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E13_40adf2793e379a80300270ce72b66a56]
 
 run-name: ${{ format('ReviewRouter review PR {0} at {1}', github.event.pull_request.number, github.event.pull_request.head.sha) }}
 
@@ -21,9 +21,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@435348257ed61be7d026a51670a428f47bfe0232
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@ce837abb4d14c09553c0f5a39031902e24d3c10c
     with:
-      runtime_ref: "435348257ed61be7d026a51670a428f47bfe0232"
+      runtime_ref: "ce837abb4d14c09553c0f5a39031902e24d3c10c"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ format('{0}', github.event.pull_request.number) }}
@@ -33,7 +33,7 @@ jobs:
       max_changed_lines: ${{ vars.REVIEW_ROUTER_MAX_CHANGED_LINES }}
       review_timeout_minutes: ${{ fromJSON(vars.REVIEW_ROUTER_TIMEOUT_MINUTES || '60') }}
     secrets:
-      CODEX_AUTH_JSON: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E12_a8bc9a995965fe8c394a100bf08ce60a }}
+      CODEX_AUTH_JSON: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E13_40adf2793e379a80300270ce72b66a56 }}
 
   codex-refresh:
     name: codex-refresh
@@ -48,10 +48,10 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@435348257ed61be7d026a51670a428f47bfe0232
+        uses: 777genius/review-router@ce837abb4d14c09553c0f5a39031902e24d3c10c
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"
           provider-instance-id: "codex-rotating:1163183284"
           workflow-schema-version: "4"
-          auth-json: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E12_a8bc9a995965fe8c394a100bf08ce60a }}
+          auth-json: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E13_40adf2793e379a80300270ce72b66a56 }}


### PR DESCRIPTION
Updates the ReviewRouter consumer workflow to the immutable v1.0.131 Action release and activates the generation-aware E13 secret namespace.\n\nAll reusable workflow, runtime and refresh pins resolve to ce837abb4d14c09553c0f5a39031902e24d3c10c.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated code review workflow to use refreshed authentication credentials.
  * Pinned the workflow to newer runtime components for improved reliability.
  * Preserved existing triggers, permissions, concurrency settings, and job behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->